### PR TITLE
cache: Clear chunks when info changes

### DIFF
--- a/backend/cache/object.go
+++ b/backend/cache/object.go
@@ -184,7 +184,7 @@ func (o *Object) refreshFromSource(ctx context.Context, force bool) error {
 		return err
 	}
 	o.updateData(ctx, liveObject)
-	o.persist()
+	o.persist(false)
 
 	return nil
 }
@@ -201,7 +201,7 @@ func (o *Object) SetModTime(ctx context.Context, t time.Time) error {
 	}
 
 	o.CacheModTime = t.UnixNano()
-	o.persist()
+	o.persist(true)
 	fs.Debugf(o, "updated ModTime: %v", t)
 
 	return nil
@@ -270,7 +270,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	o.CacheSize = src.Size()
 	o.CacheHashes = make(map[hash.Type]string)
 	o.CacheTs = time.Now()
-	o.persist()
+	o.persist(true)
 
 	return nil
 }
@@ -326,15 +326,15 @@ func (o *Object) Hash(ctx context.Context, ht hash.Type) (string, error) {
 	}
 	o.CacheHashes[ht] = liveHash
 
-	o.persist()
+	o.persist(true)
 	fs.Debugf(o, "object hash cached: %v", liveHash)
 
 	return liveHash, nil
 }
 
 // persist adds this object to the persistent cache
-func (o *Object) persist() *Object {
-	err := o.CacheFs.cache.AddObject(o)
+func (o *Object) persist(noClearChunks bool) *Object {
+	err := o.CacheFs.cache.AddObject(o, noClearChunks)
 	if err != nil {
 		fs.Errorf(o, "failed to cache object: %v", err)
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

If the file is modified from another instance, the cached chunks are not cleared. Cache serves old cached chunks even after info has been updated. 
This patch will clear chunks when info(size, date) changes.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
