### PR TITLE
webdav: new timeformat for SFCC - fixes #3048

### DIFF
--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -19,6 +19,9 @@ const (
 	// The same as time.RFC1123 with optional leading zeros on the date
 	// see https://github.com/ncw/rclone/issues/2574
 	noZerosRFC1123 = "Mon, _2 Jan 2006 15:04:05 MST"
+	// The same as time.RFC1123 with suffixed timezone offset
+	// see https://github.com/ncw/rclone/issues/3048
+	TZOffsetRFC1123 = "Wed, 13 Mar 2019 15:19:49 GMT-00:00"
 )
 
 // Multistatus contains responses returned from an HTTP 207 return code
@@ -172,6 +175,7 @@ var timeFormats = []string{
 	time.UnixDate,  // Wed May 17 15:31:58 UTC 2017 (as used in an internal server)
 	noZerosRFC1123, // Fri, 7 Sep 2018 08:49:58 GMT (as used by server in #2574)
 	time.RFC3339,   // Wed, 31 Oct 2018 13:57:11 CET (as used by komfortcloud.de)
+	TZOffsetRFC1123,// Wed, 13 Mar 2019 15:19:49 GMT-00:00 (as used by Salesforce Commerce Cloud)
 }
 
 var oneTimeError sync.Once

--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -21,7 +21,7 @@ const (
 	noZerosRFC1123 = "Mon, _2 Jan 2006 15:04:05 MST"
 	// The same as time.RFC1123 with suffixed timezone offset
 	// see https://github.com/ncw/rclone/issues/3048
-	TZOffsetRFC1123 = "Wed, 13 Mar 2019 15:19:49 GMT-00:00"
+	TZOffsetRFC1123 = "Mon, 02 Jan 2006 15:04:05 MST-07:00"
 )
 
 // Multistatus contains responses returned from an HTTP 207 return code

--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -175,7 +175,7 @@ var timeFormats = []string{
 	time.UnixDate,  // Wed May 17 15:31:58 UTC 2017 (as used in an internal server)
 	noZerosRFC1123, // Fri, 7 Sep 2018 08:49:58 GMT (as used by server in #2574)
 	time.RFC3339,   // Wed, 31 Oct 2018 13:57:11 CET (as used by komfortcloud.de)
-	TZOffsetRFC1123,// Wed, 13 Mar 2019 15:19:49 GMT-00:00 (as used by Salesforce Commerce Cloud)
+	tzOffsetRFC1123,// Wed, 13 Mar 2019 15:19:49 GMT-00:00 (as used by Salesforce Commerce Cloud)
 }
 
 var oneTimeError sync.Once

--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -170,12 +170,12 @@ func (t *Time) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
 
 // Possible time formats to parse the time with
 var timeFormats = []string{
-	timeFormat,     // Wed, 27 Sep 2017 14:28:34 GMT (as per RFC)
-	time.RFC1123Z,  // Fri, 05 Jan 2018 14:14:38 +0000 (as used by mydrive.ch)
-	time.UnixDate,  // Wed May 17 15:31:58 UTC 2017 (as used in an internal server)
-	noZerosRFC1123, // Fri, 7 Sep 2018 08:49:58 GMT (as used by server in #2574)
-	time.RFC3339,   // Wed, 31 Oct 2018 13:57:11 CET (as used by komfortcloud.de)
-	tzOffsetRFC1123,// Wed, 13 Mar 2019 15:19:49 GMT-00:00 (as used by Salesforce Commerce Cloud)
+	timeFormat,      // Wed, 27 Sep 2017 14:28:34 GMT (as per RFC)
+	time.RFC1123Z,   // Fri, 05 Jan 2018 14:14:38 +0000 (as used by mydrive.ch)
+	time.UnixDate,   // Wed May 17 15:31:58 UTC 2017 (as used in an internal server)
+	noZerosRFC1123,  // Fri, 7 Sep 2018 08:49:58 GMT (as used by server in #2574)
+	time.RFC3339,    // Wed, 31 Oct 2018 13:57:11 CET (as used by komfortcloud.de)
+	tzOffsetRFC1123, // Wed, 13 Mar 2019 15:19:49 GMT-00:00 (as used by Salesforce Commerce Cloud)
 }
 
 var oneTimeError sync.Once

--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -21,7 +21,7 @@ const (
 	noZerosRFC1123 = "Mon, _2 Jan 2006 15:04:05 MST"
 	// The same as time.RFC1123 with suffixed timezone offset
 	// see https://github.com/ncw/rclone/issues/3048
-	TZOffsetRFC1123 = "Mon, 02 Jan 2006 15:04:05 MST-07:00"
+	tzOffsetRFC1123 = "Mon, 02 Jan 2006 15:04:05 MST-07:00"
 )
 
 // Multistatus contains responses returned from an HTTP 207 return code

--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -194,6 +194,13 @@ func (t *Time) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 		return nil
 	}
 
+	// If time has two timezones, eg Salesforce Commerce Cloud
+	// chop one of them off
+	// See: https://github.com/ncw/rclone/issues/3048
+	if strings.HasSuffix(v, "GMT-00:00") {
+		v = v[:len(v)-6]
+	}
+
 	// Parse the time format in multiple possible ways
 	var newT time.Time
 	for _, timeFormat := range timeFormats {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Add additional timezone format to be be able to parse the webdav modification times that Salesforce Commerce Cloud uses

#### Was the change discussed in an issue or in the forum before?

https://github.com/ncw/rclone/issues/3048

#### Checklist

- [*] I have read the [contribution guidelines](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [*] I have added tests for all changes in this PR if appropriate.
- [*] I have added documentation for the changes if appropriate.
- [*] All commit messages are in [house style](https://github.com/ncw/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [*] I'm done, this Pull Request is ready for review :-)
