### PR TITLE
Attempt to fix #3335

### DIFF
--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -423,6 +423,7 @@ func (m *March) processJob(job listDirJob) ([]listDirJob, error) {
 		if recurse && job.srcDepth > 0 {
 			jobs = append(jobs, listDirJob{
 				srcRemote: src.Remote(),
+				dstRemote: src.Remote(),
 				srcDepth:  job.srcDepth - 1,
 				noDst:     true,
 			})
@@ -436,6 +437,7 @@ func (m *March) processJob(job listDirJob) ([]listDirJob, error) {
 		recurse := m.Callback.DstOnly(dst)
 		if recurse && job.dstDepth > 0 {
 			jobs = append(jobs, listDirJob{
+				srcRemote: dst.Remote(),
 				dstRemote: dst.Remote(),
 				dstDepth:  job.dstDepth - 1,
 				noSrc:     true,


### PR DESCRIPTION
This is an attemp to fix #3335.
With the current implementation march is unable to see subdirectories on a destination remote when used with no traverse. If these directories exist on the source they will be perceived as missing on the destination. The new march job that is created for srcOnly will then attempt to find the files contained in these directories in the root of the destination remote. I'm not entirely sure if this is intended behaviour but currently it causes unnecessary copies. I'm fixing this by setting dstRemote to be equal to srcRemote so that the correct path is checked even if it not necessarily exists. This will have no influence on runs without ``--no-traverse`` and fixes this unwanted behaviour. However in case that the path actually does not exist on destination those files will no longer be checked for in the root dir.