### PR TITLE
Significantly rework testing for march and fix checking subdirs when using --no-traverse

### DIFF
--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -423,6 +423,7 @@ func (m *March) processJob(job listDirJob) ([]listDirJob, error) {
 		if recurse && job.srcDepth > 0 {
 			jobs = append(jobs, listDirJob{
 				srcRemote: src.Remote(),
+				dstRemote: src.Remote(),
 				srcDepth:  job.srcDepth - 1,
 				noDst:     true,
 			})
@@ -436,6 +437,7 @@ func (m *March) processJob(job listDirJob) ([]listDirJob, error) {
 		recurse := m.Callback.DstOnly(dst)
 		if recurse && job.dstDepth > 0 {
 			jobs = append(jobs, listDirJob{
+				srcRemote: dst.Remote(),
 				dstRemote: dst.Remote(),
 				dstDepth:  job.dstDepth - 1,
 				noSrc:     true,

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -348,6 +348,49 @@ func CheckItems(t *testing.T, f fs.Fs, items ...Item) {
 	CheckListingWithPrecision(t, f, items, nil, fs.GetModifyWindow(f))
 }
 
+// CompareItems compares a set of DirEntries to a slice of items and a lit of dirs
+func CompareItems(t *testing.T, entries fs.DirEntries, items []Item, expectedDirs []string, what string) {
+	is := NewItems(items)
+	precision, _ := time.ParseDuration("1s")
+	var objs []fs.Object
+	var dirs []fs.Directory
+	wantListing1, wantListing2 := makeListingFromItems(items)
+	for _, entry := range entries {
+		switch x := entry.(type) {
+		case fs.Directory:
+			dirs = append(dirs, x)
+		case fs.Object:
+			objs = append(objs, x)
+			// do nothing
+		default:
+			t.Fatalf("unknown object type %T", entry)
+		}
+	}
+
+	gotListing := makeListingFromObjects(objs)
+	listingOK := wantListing1 == gotListing || wantListing2 == gotListing
+	assert.True(t, listingOK, fmt.Sprintf("%s not equal, want\n  %s or\n  %s got\n  %s", what, wantListing1, wantListing2, gotListing))
+	for _, obj := range objs {
+		require.NotNil(t, obj)
+		is.Find(t, obj, precision)
+	}
+	is.Done(t)
+	// Check the directories
+	if expectedDirs != nil {
+		expectedDirsCopy := make([]string, len(expectedDirs))
+		for i, dir := range expectedDirs {
+			expectedDirsCopy[i] = WinPath(Normalize(dir))
+		}
+		actualDirs := []string{}
+		for _, dir := range dirs {
+			actualDirs = append(actualDirs, WinPath(Normalize(dir.Remote())))
+		}
+		sort.Strings(actualDirs)
+		sort.Strings(expectedDirsCopy)
+		assert.Equal(t, expectedDirsCopy, actualDirs, "directories not equal")
+	}
+}
+
 // Time parses a time string or logs a fatal error
 func Time(timeString string) time.Time {
 	t, err := time.Parse(time.RFC3339Nano, timeString)


### PR DESCRIPTION
Creating a test-case that would actually catch the no-traverse problem turned out to be a lot more work than I thought. In the end I decided to create to create 2 new test cases that actually invoke march in the same way syncCopyMove does. This requires a bit more helper code than I'm comfortable with but I don't really see a simpler way to catch these types of bugs. Also frustratingly the test framework didn't have a good way of comparing a DirEntries to a slice Items generated by working with the fake test remotes so I added one.  Closes #3336 