### PR TITLE
fs: Export LogPrintf as a variable

### DIFF
--- a/fs/log.go
+++ b/fs/log.go
@@ -75,7 +75,7 @@ var LogPrint = func(level LogLevel, text string) {
 }
 
 // LogPrintf produces a log string from the arguments passed in
-func LogPrintf(level LogLevel, o interface{}, text string, args ...interface{}) {
+var LogPrintf = func(level LogLevel, o interface{}, text string, args ...interface{}) {
 	out := fmt.Sprintf(text, args...)
 
 	if Config.UseJSONLog {


### PR DESCRIPTION
#### What is the purpose of this change?

Similar to `LogPrint`, `LogPrintf` is exported as a variable.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
