### PR TITLE
[WIP] Adds info regarding rclone version on remote and local

### DIFF
--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -391,7 +391,7 @@ func doConfig(id, name string, m configmap.Mapper, errorHandler func(*http.Reque
 		}
 		if !isLocal() {
 			fmt.Printf("For this to work, you will need rclone available on a machine that has a web browser available.\n")
-			fmt.Printf("Execute the following on your machine (with the same rclone version) :\n")
+			fmt.Printf("Execute the following on your machine (same rclone version recommended) :\n")
 			if changed {
 				fmt.Printf("\trclone authorize %q %q %q\n", id, oauthConfig.ClientID, oauthConfig.ClientSecret)
 			} else {

--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -391,7 +391,7 @@ func doConfig(id, name string, m configmap.Mapper, errorHandler func(*http.Reque
 		}
 		if !isLocal() {
 			fmt.Printf("For this to work, you will need rclone available on a machine that has a web browser available.\n")
-			fmt.Printf("Execute the following on your machine:\n")
+			fmt.Printf("Execute the following on your machine (with the same rclone version) :\n")
 			if changed {
 				fmt.Printf("\trclone authorize %q %q %q\n", id, oauthConfig.ClientID, oauthConfig.ClientSecret)
 			} else {


### PR DESCRIPTION
This is `WIP` and based on feedback from people here I'll update the message and fulfill other requirements once things have been finalized.

#### What is the purpose of this change?

The purpose is to give a helpful message to users in caseof different rclone versions on remote and local which makes the `config` file unusable.

#### Was the change discussed in an issue or in the forum before?

Yes, this has been discussed on `issues` before and that's how I've been able to solve it.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
