### PR TITLE
drive: add error for purge with --drive-trashed-only #3407

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1941,6 +1941,9 @@ func (f *Fs) Purge(ctx context.Context) error {
 	if f.root == "" {
 		return errors.New("can't purge root directory")
 	}
+	if f.opt.TrashedOnly {
+		return errors.New("Can't purge with --drive-trashed-only. Use delete if you want to selectively delete files")
+	}
 	err := f.dirCache.FindRoot(ctx, false)
 	if err != nil {
 		return err


### PR DESCRIPTION
Purge should not be used with --drive-trashed-only flag as it leads to
unexpected behavior. After this commit if TrashedOnly option is set to
true, error message is returned.
See also: https://forum.rclone.org/t/drive-trashed-only-weird-occurrence/11066/14

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
- [ ] I have added documentation for the changes if appropriate.
- [ ] I have added tests for all changes in this PR if appropriate.
