### PR TITLE
copyurl: add --auto-filename flag for using file name from url in destination path

### DIFF
--- a/cmd/copyurl/copyurl.go
+++ b/cmd/copyurl/copyurl.go
@@ -4,12 +4,18 @@ import (
 	"context"
 
 	"github.com/rclone/rclone/cmd"
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/spf13/cobra"
 )
 
+var (
+	autoFilename = false
+)
+
 func init() {
 	cmd.Root.AddCommand(commandDefintion)
+	commandDefintion.Flags().BoolVarP(&autoFilename, "auto-filename", "a", autoFilename, "Get the file name from the url and use it for destination file path")
 }
 
 var commandDefintion = &cobra.Command{
@@ -18,13 +24,22 @@ var commandDefintion = &cobra.Command{
 	Long: `
 Download urls content and copy it to destination 
 without saving it in tmp storage.
+
+Setting --auto-filename flag will cause retrieving file name from url and using it in destination path. 
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(2, 2, command, args)
-		fsdst, dstFileName := cmd.NewFsDstFile(args[1:])
+
+		var dstFileName string
+		var fsdst fs.Fs
+		if autoFilename {
+			fsdst = cmd.NewFsDir(args[1:])
+		} else {
+			fsdst, dstFileName = cmd.NewFsDstFile(args[1:])
+		}
 
 		cmd.Run(true, true, command, func() error {
-			_, err := operations.CopyURL(context.Background(), fsdst, dstFileName, args[0])
+			_, err := operations.CopyURL(context.Background(), fsdst, dstFileName, args[0], autoFilename)
 			return err
 		})
 	},

--- a/docs/content/commands/rclone_copyurl.md
+++ b/docs/content/commands/rclone_copyurl.md
@@ -22,7 +22,8 @@ rclone copyurl https://example.com dest:path [flags]
 ### Options
 
 ```
-  -h, --help   help for copyurl
+  -a, --auto-filename   Get the file name from the url and use it for destination file path
+  -h, --help            help for copyurl
 ```
 
 See the [global flags page](/flags/) for global options not listed here.

--- a/fs/operations/rc.go
+++ b/fs/operations/rc.go
@@ -149,7 +149,7 @@ func init() {
 		{name: "rmdirs", title: "Remove all the empty directories in the path", help: "- leaveRoot - boolean, set to true not to delete the root\n"},
 		{name: "delete", title: "Remove files in the path", noRemote: true},
 		{name: "deletefile", title: "Remove the single file pointed to"},
-		{name: "copyurl", title: "Copy the URL to the object", help: "- url - string, URL to read from\n"},
+		{name: "copyurl", title: "Copy the URL to the object", help: "- url - string, URL to read from\n - autoFilename - boolean, set to true to retrieve destination file name from url"},
 		{name: "cleanup", title: "Remove trashed files in the remote or path", noRemote: true},
 	} {
 		op := op
@@ -214,7 +214,9 @@ func rcSingleCommand(ctx context.Context, in rc.Params, name string, noRemote bo
 		if err != nil {
 			return nil, err
 		}
-		_, err = CopyURL(ctx, f, remote, url)
+		autoFilename, _ := in.GetBool("autoFilename")
+
+		_, err = CopyURL(ctx, f, remote, url, autoFilename)
 		return nil, err
 	case "cleanup":
 		return nil, CleanUp(ctx, f)

--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -105,15 +105,37 @@ func TestRcCopyurl(t *testing.T) {
 	defer ts.Close()
 
 	in := rc.Params{
-		"fs":     r.FremoteName,
-		"remote": "file1",
-		"url":    ts.URL,
+		"fs":           r.FremoteName,
+		"remote":       "file1",
+		"url":          ts.URL,
+		"autoFilename": false,
 	}
 	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
-	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{file1}, nil, fs.ModTimeNotSupported)
+	urlFileName := "filename.txt"
+	in = rc.Params{
+		"fs":           r.FremoteName,
+		"remote":       "",
+		"url":          ts.URL + "/" + urlFileName,
+		"autoFilename": true,
+	}
+	out, err = call.Fn(context.Background(), in)
+	require.NoError(t, err)
+	assert.Equal(t, rc.Params(nil), out)
+
+	in = rc.Params{
+		"fs":           r.FremoteName,
+		"remote":       "",
+		"url":          ts.URL,
+		"autoFilename": true,
+	}
+	out, err = call.Fn(context.Background(), in)
+	require.Error(t, err)
+	assert.Equal(t, rc.Params(nil), out)
+
+	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{file1, fstest.NewItem(urlFileName, contents, t1)}, nil, fs.ModTimeNotSupported)
 }
 
 // operations/delete: Remove files in the path


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Add flag for `copyurl` command to allow users don't specify file name in destination path.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
#3420
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)