### PR TITLE
mount: Fix typo in argument checking

### DIFF
--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -70,7 +70,7 @@ func mountOptions(device string) (options []fuse.MountOption) {
 	if len(mountlib.ExtraOptions) > 0 {
 		fs.Errorf(nil, "-o/--option not supported with this FUSE backend")
 	}
-	if len(mountlib.ExtraOptions) > 0 {
+	if len(mountlib.ExtraFlags) > 0 {
 		fs.Errorf(nil, "--fuse-flag not supported with this FUSE backend")
 	}
 	return options


### PR DESCRIPTION
#### What is the purpose of this change?

The two `if` should check against `mountlib.ExtraOptions` and `mountlib.ExtraFlags` respectively, instead of checking `mountlib.ExtraOptions` twice.