### PR TITLE
Autologin for web-gui and prefix patch for rcd

### DIFF
--- a/cmd/rcd/rcd.go
+++ b/cmd/rcd/rcd.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rclone/rclone/fs/rc/rcflags"
 	"github.com/rclone/rclone/fs/rc/rcserver"
 	"github.com/rclone/rclone/lib/errors"
+	"github.com/rclone/rclone/lib/random"
 	"github.com/spf13/cobra"
 )
 
@@ -54,6 +55,20 @@ See the [rc documentation](/rc/) for more info on the rc flags.
 			if err := checkRelease(rcflags.Opt.WebGUIUpdate); err != nil {
 				log.Fatalf("Error while fetching the latest release of rclone-webui-react %v", err)
 			}
+			if rcflags.Opt.NoAuth {
+				rcflags.Opt.NoAuth = false
+				fs.Infof(nil, "Cannot run web-gui without authentication, using default auth")
+			}
+			if rcflags.Opt.HTTPOptions.BasicUser == "" {
+				rcflags.Opt.HTTPOptions.BasicUser = "gui"
+				fs.Infof("Using default username: %s \n", rcflags.Opt.HTTPOptions.BasicUser)
+			}
+			if rcflags.Opt.HTTPOptions.BasicPass == "" {
+				randomPass := random.String(16)
+				rcflags.Opt.HTTPOptions.BasicPass = randomPass
+				fs.Infof("No password specified. Using random password: %s \n", randomPass)
+			}
+			rcflags.Opt.Serve = true
 		}
 
 		s, err := rcserver.Start(&rcflags.Opt)

--- a/cmd/serve/httplib/httpflags/httpflags.go
+++ b/cmd/serve/httplib/httpflags/httpflags.go
@@ -26,9 +26,8 @@ func AddFlagsPrefix(flagSet *pflag.FlagSet, prefix string, Opt *httplib.Options)
 	flags.StringVarP(flagSet, &Opt.Realm, prefix+"realm", "", Opt.Realm, "realm for authentication")
 	flags.StringVarP(flagSet, &Opt.BasicUser, prefix+"user", "", Opt.BasicUser, "User name for authentication.")
 	flags.StringVarP(flagSet, &Opt.BasicPass, prefix+"pass", "", Opt.BasicPass, "Password for authentication.")
-	if prefix == "" {
-		flags.StringVarP(flagSet, &Opt.Prefix, prefix+"prefix", "", Opt.Prefix, "Prefix for URLs.")
-	}
+	flags.StringVarP(flagSet, &Opt.Prefix, prefix+"prefix", "", Opt.Prefix, "Prefix for URLs.")
+
 }
 
 // AddFlags adds flags for the httplib

--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -2,6 +2,7 @@
 package rcserver
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -89,8 +90,17 @@ func (s *Server) Serve() error {
 		}
 		// Add username, password into the URL if they are set
 		user, pass := s.opt.HTTPOptions.BasicUser, s.opt.HTTPOptions.BasicPass
-		if user != "" || pass != "" {
+		if user != "" && pass != "" {
 			openURL.User = url.UserPassword(user, pass)
+
+			// Base64 encode username and password to be sent through url
+			loginToken := user + ":" + pass
+			parameters := url.Values{}
+			encodedToken := base64.URLEncoding.EncodeToString([]byte(loginToken))
+			fs.Debugf(nil, "login_token %q", encodedToken)
+			parameters.Add("login_token", encodedToken)
+			openURL.RawQuery = parameters.Encode()
+			openURL.RawPath = "/#/login"
 		}
 		// Don't open browser if serving in testing environment.
 		if flag.Lookup("test.v") == nil {

--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -138,7 +138,11 @@ func writeError(path string, in rc.Params, w http.ResponseWriter, err error, sta
 
 // handler reads incoming requests and dispatches them
 func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
-	path := strings.TrimLeft(r.URL.Path, "/")
+	urlPath, ok := s.Path(w, r)
+	if !ok {
+		return
+	}
+	path := strings.TrimLeft(urlPath, "/")
 
 	allowOrigin := rcflags.Opt.AccessControlAllowOrigin
 	if allowOrigin != "" {
@@ -311,6 +315,7 @@ func (s *Server) handleGet(w http.ResponseWriter, r *http.Request, path string) 
 		return
 	case s.files != nil:
 		// Serve the files
+		r.URL.Path = "/" + path
 		s.files.ServeHTTP(w, r)
 		return
 	case path == "" && s.opt.Serve:


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Auto-login makes use of login_token to directly enable rclone-webui-react to login the user without entering any credentials in the browser.

Prefix patch for rcd enables user to use --rc-prefix command with web-gui
