### PR TITLE
Job id setting

### DIFF
--- a/fs/rc/jobs/job.go
+++ b/fs/rc/jobs/job.go
@@ -59,6 +59,13 @@ func SetOpt(opt *rc.Options) {
 	running.opt = opt
 }
 
+// SetInitialJobID allows for setting jobID before starting any jobs.
+func SetInitialJobID(id int64) {
+	if !atomic.CompareAndSwapInt64(&jobID, 0, id) {
+		panic("Setting jobID is only possible before starting any jobs")
+	}
+}
+
 // kickExpire makes sure Expire is running
 func (jobs *Jobs) kickExpire() {
 	jobs.mu.Lock()

--- a/fs/rc/jobs/job.go
+++ b/fs/rc/jobs/job.go
@@ -10,12 +10,10 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/rclone/rclone/fs/rc"
-
-	"github.com/rclone/rclone/fs/accounting"
-
 	"github.com/pkg/errors"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/accounting"
+	"github.com/rclone/rclone/fs/rc"
 )
 
 // Job describes a asynchronous task started via the rc package


### PR DESCRIPTION
#### What is the purpose of this change?

The goal is to initialise `jobID` in `fs/rc/jobs/`. The intended use case is to always start with a new `jobID` to avoid conflicts upon restarts of rclone.  

#### Was the change discussed in an issue or in the forum before?

No, I consider it low risk and the patch is really small.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
