### PR TITLE
fs/rc/jobs: ExecuteJob propagate the error returned by function

### DIFF
--- a/fs/rc/jobs/job.go
+++ b/fs/rc/jobs/job.go
@@ -29,6 +29,11 @@ type Job struct {
 	Duration  float64   `json:"duration"`
 	Output    rc.Params `json:"output"`
 	Stop      func()    `json:"-"`
+
+	// realErr is the Error before printing it as a string, it's used to return
+	// the real error to the upper application layers while still printing the
+	// string error message.
+	realErr error
 }
 
 // Jobs describes a collection of running tasks
@@ -122,9 +127,11 @@ func (job *Job) finish(out rc.Params, err error) {
 	job.Output = out
 	job.Duration = job.EndTime.Sub(job.StartTime).Seconds()
 	if err != nil {
+		job.realErr = err
 		job.Error = err.Error()
 		job.Success = false
 	} else {
+		job.realErr = nil
 		job.Error = ""
 		job.Success = true
 	}
@@ -221,11 +228,7 @@ func StartAsyncJob(fn rc.Func, in rc.Params) (rc.Params, error) {
 func ExecuteJob(ctx context.Context, fn rc.Func, in rc.Params) (rc.Params, int64, error) {
 	job, ctx := running.NewSyncJob(ctx, in)
 	job.run(ctx, fn, in)
-	var err error
-	if !job.Success {
-		err = errors.New(job.Error)
-	}
-	return job.Output, job.ID, err
+	return job.Output, job.ID, job.realErr
 }
 
 func init() {

--- a/fs/rc/jobs/job_test.go
+++ b/fs/rc/jobs/job_test.go
@@ -213,6 +213,17 @@ func TestExecuteJob(t *testing.T) {
 	assert.Equal(t, int64(1), id)
 }
 
+func TestExecuteJobErrorPropagation(t *testing.T) {
+	jobID = 0
+
+	testErr := errors.New("test error")
+	errorFn := func(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+		return nil, testErr
+	}
+	_, _, err := ExecuteJob(context.Background(), errorFn, rc.Params{})
+	assert.Equal(t, testErr, err)
+}
+
 func TestRcJobStatus(t *testing.T) {
 	jobID = 0
 	_, err := StartAsyncJob(longFn, rc.Params{})


### PR DESCRIPTION
#### What is the purpose of this change?

Without this patch the resulting error is first converted to string and then recreated.
This makes it impossible to use the defined error types to figure out the cause of the error,
and may result in invalid HTTP status codes.

This patch adds a test TestExecuteJobErrorPropagation to validate that the errors are
properly propagated.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
