### PR TITLE
rcd: Added missing parameter for web-gui info logs.

### DIFF
--- a/cmd/rcd/rcd.go
+++ b/cmd/rcd/rcd.go
@@ -61,7 +61,7 @@ See the [rc documentation](/rc/) for more info on the rc flags.
 			}
 			if rcflags.Opt.HTTPOptions.BasicUser == "" {
 				rcflags.Opt.HTTPOptions.BasicUser = "gui"
-				fs.Infof("Using default username: %s \n", rcflags.Opt.HTTPOptions.BasicUser)
+				fs.Infof(nil, "Using default username: %s \n", rcflags.Opt.HTTPOptions.BasicUser)
 			}
 			if rcflags.Opt.HTTPOptions.BasicPass == "" {
 				randomPass, err := random.Password(128)
@@ -69,7 +69,7 @@ See the [rc documentation](/rc/) for more info on the rc flags.
 					log.Fatalf("Failed to make password: %v", err)
 				}
 				rcflags.Opt.HTTPOptions.BasicPass = randomPass
-				fs.Infof("No password specified. Using random password: %s \n", randomPass)
+				fs.Infof(nil, "No password specified. Using random password: %s \n", randomPass)
 			}
 			rcflags.Opt.Serve = true
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Added nil for the object type while logging to fs.Infof

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?


