### PR TITLE
docs: fix template argument for mktemp in install.sh

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -25,7 +25,7 @@ fi
 
 
 #create tmp directory and move to it with macOS compatibility fallback
-tmp_dir=`mktemp -d 2>/dev/null || mktemp -d -t 'rclone-install'`; cd $tmp_dir
+tmp_dir=`mktemp -d 2>/dev/null || mktemp -d -t 'rclone-install.XXXXXXXXXX'`; cd $tmp_dir
 
 
 #make sure unzip tool is available and choose one to work with


### PR DESCRIPTION
#### What is the purpose of this change?

Fix the problematic "template" argument for `mktemp` in `install.sh`.

#### Was the change discussed in an issue or in the forum before?

Yes. This PR fixes #3479.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
