### PR TITLE
allow usage of -short in the testing framework

### DIFF
--- a/fstest/test_all/config.go
+++ b/fstest/test_all/config.go
@@ -18,6 +18,7 @@ import (
 type Test struct {
 	Path       string // path to the source directory
 	FastList   bool   // if it is possible to add -fast-list to tests
+	Short      bool   // if it is possible to run the test with -short
 	AddBackend bool   // set if Path needs the current backend appending
 	NoRetries  bool   // set if no retries should be performed
 	NoBinary   bool   // set to not build a binary in advance
@@ -31,6 +32,7 @@ type Backend struct {
 	Backend  string   // name of the backend directory
 	Remote   string   // name of the test remote
 	FastList bool     // set to test with -fast-list
+	Short    bool     // set to test with -short
 	OneOnly  bool     // set to run only one backend test at once
 	Ignore   []string // test names to ignore the failure of
 	Tests    []string // paths of tests to run, blank for all
@@ -75,6 +77,7 @@ func (b *Backend) MakeRuns(t *Test) (runs []*Run) {
 			Backend:   b.Backend,
 			Path:      t.Path,
 			FastList:  fastlist,
+			Short:     (b.Short && t.Short),
 			NoRetries: t.NoRetries,
 			OneOnly:   b.OneOnly,
 			NoBinary:  t.NoBinary,

--- a/fstest/test_all/config.yaml
+++ b/fstest/test_all/config.yaml
@@ -2,6 +2,7 @@ tests:
  - path: backend
    addbackend: true
    nobinary:   true
+   short:      true
  - path: fs/operations
    fastlist: true
  - path: fs/sync

--- a/fstest/test_all/run.go
+++ b/fstest/test_all/run.go
@@ -39,6 +39,7 @@ type Run struct {
 	Backend   string // name of the backend
 	Path      string // path to the source directory
 	FastList  bool   // add -fast-list to tests
+	Short     bool   // add -short
 	NoRetries bool   // don't retry if set
 	OneOnly   bool   // only run test for this backend at once
 	NoBinary  bool   // set to not build a binary
@@ -334,6 +335,9 @@ func (r *Run) Init() {
 	}
 	if r.FastList {
 		r.cmdLine = append(r.cmdLine, "-fast-list")
+	}
+	if r.Short {
+		r.cmdLine = append(r.cmdLine, "-short")
 	}
 	r.cmdString = toShell(r.cmdLine)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

this allows to run the testing framework with the `-short` option which disables the chunk tests, this is very useful when constantly running the tests with slow internet
<!--
Describe the changes here
-->
#### Was the change discussed in an issue or in the forum before?
no
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
