### PR TITLE
vfs: add flag --vfs-case-insensitive for windows mounts

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,6 +40,7 @@ build_script:
 
 test_script:
 - make GOTAGS=cmount quicktest
+- make GOTAGS=cmount racequicktest
 
 artifacts:
 - path: rclone.exe

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -58,7 +58,6 @@ strategy:
       GO_INSTALL_ARCH: 386
       BUILD_FLAGS: '-include "^windows/386" -cgo'
       MAKE_QUICKTEST: true
-      MAKE_RACEQUICKTEST: true
       DEPLOY: true
     other_os:
       imageName: ubuntu-16.04

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,6 +49,7 @@ strategy:
       GO_VERSION: latest
       BUILD_FLAGS: '-include "^windows/amd64" -cgo'
       MAKE_QUICKTEST: true
+      MAKE_RACEQUICKTEST: true
       DEPLOY: true
     windows_386:
       imageName: windows-2019
@@ -57,6 +58,7 @@ strategy:
       GO_INSTALL_ARCH: 386
       BUILD_FLAGS: '-include "^windows/386" -cgo'
       MAKE_QUICKTEST: true
+      MAKE_RACEQUICKTEST: true
       DEPLOY: true
     other_os:
       imageName: ubuntu-16.04

--- a/docs/content/commands/rclone_mount.md
+++ b/docs/content/commands/rclone_mount.md
@@ -291,16 +291,19 @@ If an upload or download fails it will be retried up to
 rclone mount remote:path /path/to/mountpoint [flags]
 ```
 
-### Case Insensitive Mounts
+### Case Sensitivity
 
-Windows is not like other operating systems supported by rclone.
-Linux and MacOS file systems are case-sensitive: two files can differ
-only by case, and the exact case must be used when opening a file.
+Linux file systems are case-sensitive: two files can differ only
+by case, and the exact case must be used when opening a file.
 
+Windows is not like most other operating systems supported by rclone.
 File systems in modern Windows are case-insensitive but case-preserving:
 although existing files can be opened using any case, the exact case used
 to create the file is preserved and available for programs to query.
 It is not allowed for two files in the same directory to differ only by case.
+
+Usually file systems on MacOS are case-insensitive. It is possible to make MacOS
+file systems case-sensitive but that is not the default
 
 The `--vfs-case-insensitive` mount flag controls how rclone handles these
 two cases. If its value is `false`, rclone passes file names to the mounted
@@ -316,9 +319,13 @@ transparently fixup the name. This fixup happens only when an existing file
 is requested. Case sensitivity of file names created anew by rclone is
 controlled by an underlying mounted file system.
 
-If the flag is not provided on command line, then its default value depends on
-the operating system running rclone: `true` on Windows and `false` otherwise.
-If the flag is provided without a parameter, then its value is `true`.
+Note that case sensitivity of the operating system running rclone (the target)
+may differ from case sensitivity of a file system mounted by rclone (the source).
+The flag controls whether "fixup" is performed to satisfy the target.
+
+If the flag is not provided on command line, then its default value depends
+on the operating system where rclone runs: `true` on Windows and MacOS, `false`
+otherwise. If the flag is provided without a value, then it is `true`.
 
 ### Options
 

--- a/docs/content/commands/rclone_mount.md
+++ b/docs/content/commands/rclone_mount.md
@@ -287,10 +287,38 @@ This mode should support all normal file system operations.
 If an upload or download fails it will be retried up to
 --low-level-retries times.
 
-
 ```
 rclone mount remote:path /path/to/mountpoint [flags]
 ```
+
+### Case Insensitive Mounts
+
+Windows is not like other operating systems supported by rclone.
+Linux and MacOS file systems are case-sensitive: two files can differ
+only by case, and the exact case must be used when opening a file.
+
+File systems in modern Windows are case-insensitive but case-preserving:
+although existing files can be opened using any case, the exact case used
+to create the file is preserved and available for programs to query.
+It is not allowed for two files in the same directory to differ only by case.
+
+The `--vfs-case-insensitive` mount flag controls how rclone handles these
+two cases. If its value is `false`, rclone passes file names to the mounted
+file system as is. If the flag is `true` (or appears without a value on
+command line), rclone may perform a "fixup" as explained below.
+
+The user may specify a file name to open/delete/rename/etc with a case
+different than what is stored on mounted file system. If an argument refers
+to an existing file with exactly the same name, then the case of the existing
+file on the disk will be used. However, if a file name with exactly the same
+name is not found but a name differing only by case exists, rclone will
+transparently fixup the name. This fixup happens only when an existing file
+is requested. Case sensitivity of file names created anew by rclone is
+controlled by an underlying mounted file system.
+
+If the flag is not provided on command line, then its default value depends on
+the operating system running rclone: `true` on Windows and `false` otherwise.
+If the flag is provided without a parameter, then its value is `true`.
 
 ### Options
 
@@ -322,6 +350,7 @@ rclone mount remote:path /path/to/mountpoint [flags]
       --vfs-cache-max-size SizeSuffix          Max total size of objects in the cache. (default off)
       --vfs-cache-mode CacheMode               Cache mode off|minimal|writes|full (default off)
       --vfs-cache-poll-interval duration       Interval to poll the cache for stale objects. (default 1m0s)
+      --vfs-case-insensitive [bool]            Case insensitive mount true|false (default depends on operating system)
       --vfs-read-chunk-size SizeSuffix         Read the source objects in chunks. (default 128M)
       --vfs-read-chunk-size-limit SizeSuffix   If greater than --vfs-read-chunk-size, double the chunk size after each chunk read, until the limit is reached. 'off' is unlimited. (default off)
       --volname string                         Set the volume name (not supported by all OSes).

--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -331,6 +331,23 @@ func (d *Dir) stat(leaf string) (Node, error) {
 		return nil, err
 	}
 	item, ok := d.items[leaf]
+
+	if !ok && d.vfs.Opt.CaseInsensitive {
+		leafLower := strings.ToLower(leaf)
+		for name, node := range d.items {
+			if strings.ToLower(name) == leafLower {
+				if ok {
+					// duplicate case insensitive match is an error
+					ok = false
+					break
+				}
+				// found a case insenstive match
+				ok = true
+				item = node
+			}
+		}
+	}
+
 	if !ok {
 		return nil, ENOENT
 	}

--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -323,6 +323,8 @@ func (d *Dir) readDir() error {
 // stat a single item in the directory
 //
 // returns ENOENT if not found.
+// returns a custom error if directory on a case-insensitive file system
+// contains files with names that differ only by case.
 func (d *Dir) stat(leaf string) (Node, error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -338,8 +340,7 @@ func (d *Dir) stat(leaf string) (Node, error) {
 			if strings.ToLower(name) == leafLower {
 				if ok {
 					// duplicate case insensitive match is an error
-					ok = false
-					break
+					return nil, errors.Errorf("duplicate filename %q detected with --vfs-case-insensitive set", leaf)
 				}
 				// found a case insenstive match
 				ok = true

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -51,6 +51,7 @@ var DefaultOpt = Options{
 	ChunkSize:         128 * fs.MebiByte,
 	ChunkSizeLimit:    -1,
 	CacheMaxSize:      -1,
+	CaseInsensitive:   false,
 }
 
 // Node represents either a directory (*Dir) or a file (*File)
@@ -199,6 +200,7 @@ type Options struct {
 	CacheMaxAge       time.Duration
 	CacheMaxSize      fs.SizeSuffix
 	CachePollInterval time.Duration
+	CaseInsensitive   bool
 }
 
 // New creates a new VFS and root directory.  If opt is nil, then

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -52,7 +52,7 @@ var DefaultOpt = Options{
 	ChunkSize:         128 * fs.MebiByte,
 	ChunkSizeLimit:    -1,
 	CacheMaxSize:      -1,
-	CaseInsensitive:   runtime.GOOS == "windows", // default to true on windows, false otherwise
+	CaseInsensitive:   runtime.GOOS == "windows" || runtime.GOOS == "darwin", // default to true on Windows and Mac, false otherwise
 }
 
 // Node represents either a directory (*Dir) or a file (*File)

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -51,7 +52,7 @@ var DefaultOpt = Options{
 	ChunkSize:         128 * fs.MebiByte,
 	ChunkSizeLimit:    -1,
 	CacheMaxSize:      -1,
-	CaseInsensitive:   false,
+	CaseInsensitive:   runtime.GOOS == "windows", // default to true on windows, false otherwise
 }
 
 // Node represents either a directory (*Dir) or a file (*File)

--- a/vfs/vfs_case_test.go
+++ b/vfs/vfs_case_test.go
@@ -1,0 +1,156 @@
+package vfs
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	"github.com/rclone/rclone/fstest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCaseSensitivity(t *testing.T) {
+	r := fstest.NewRun(t)
+	defer r.Finalise()
+
+	// Create test files
+	ctx := context.Background()
+	file1 := r.WriteObject(ctx, "FiLeA", "data1", t1)
+	file2 := r.WriteObject(ctx, "FiLeB", "data2", t2)
+	fstest.CheckItems(t, r.Fremote, file1, file2)
+
+	// Create file3 with name differing from file2 name only by case.
+	// On a case-Sensitive remote this will be a separate file.
+	// On a case-INsensitive remote this file will either not exist
+	// or overwrite file2 depending on how file system diverges.
+	file3 := r.WriteObject(ctx, "FilEb", "data3", t3)
+
+	// Create a case-Sensitive and case-INsensitive VFS
+	optCS := DefaultOpt
+	optCS.CaseInsensitive = false
+	vfsCS := New(r.Fremote, &optCS)
+
+	optCI := DefaultOpt
+	optCI.CaseInsensitive = true
+	vfsCI := New(r.Fremote, &optCI)
+
+	// Run basic checks that must pass on VFS of any type.
+	assertFileDataVFS(t, vfsCI, "FiLeA", "data1")
+	assertFileDataVFS(t, vfsCS, "FiLeA", "data1")
+
+	// Detect case sensitivity of the underlying remote.
+	remoteIsOK := true
+	if !checkFileDataVFS(t, vfsCS, "FiLeA", "data1") {
+		remoteIsOK = false
+	}
+	if !checkFileDataVFS(t, vfsCS, "FiLeB", "data2") {
+		remoteIsOK = false
+	}
+	if !checkFileDataVFS(t, vfsCS, "FilEb", "data3") {
+		remoteIsOK = false
+	}
+
+	// The remaining test is only meaningful on a case-Sensitive file system.
+	if !remoteIsOK {
+		t.Logf("SKIP: TestCaseSensitivity - remote is not fully case-sensitive")
+		return
+	}
+
+	// Continue with test as the underlying remote is fully case-Sensitive.
+	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+
+	// See how VFS handles case-INsensitive flag
+	assertFileDataVFS(t, vfsCI, "FiLeA", "data1")
+	assertFileDataVFS(t, vfsCI, "fileA", "data1")
+	assertFileDataVFS(t, vfsCI, "filea", "data1")
+	assertFileDataVFS(t, vfsCI, "FILEA", "data1")
+
+	assertFileDataVFS(t, vfsCI, "FiLeB", "data2")
+	assertFileDataVFS(t, vfsCI, "FilEb", "data3")
+
+	fd, err := vfsCI.OpenFile("fileb", os.O_RDONLY, 0777)
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.NotEqual(t, err, ENOENT)
+
+	fd, err = vfsCI.OpenFile("FILEB", os.O_RDONLY, 0777)
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.NotEqual(t, err, ENOENT)
+
+	// Run the same set of checks with case-Sensitive VFS, for comparison.
+	assertFileDataVFS(t, vfsCS, "FiLeA", "data1")
+
+	assertFileAbsentVFS(t, vfsCS, "fileA")
+	assertFileAbsentVFS(t, vfsCS, "filea")
+	assertFileAbsentVFS(t, vfsCS, "FILEA")
+
+	assertFileDataVFS(t, vfsCS, "FiLeB", "data2")
+	assertFileDataVFS(t, vfsCS, "FilEb", "data3")
+
+	assertFileAbsentVFS(t, vfsCS, "fileb")
+	assertFileAbsentVFS(t, vfsCS, "FILEB")
+}
+
+func checkFileDataVFS(t *testing.T, vfs *VFS, name string, expect string) bool {
+	fd, err := vfs.OpenFile(name, os.O_RDONLY, 0777)
+	if fd == nil || err != nil {
+		return false
+	}
+	defer func() {
+		// File must be closed - otherwise Run.cleanUp() will fail on Windows.
+		_ = fd.Close()
+	}()
+
+	fh, ok := fd.(*ReadFileHandle)
+	if !ok {
+		return false
+	}
+
+	size := len(expect)
+	buf := make([]byte, size)
+	num, err := fh.Read(buf)
+	if err != nil || num != size {
+		return false
+	}
+
+	return string(buf) == expect
+}
+
+func assertFileDataVFS(t *testing.T, vfs *VFS, name string, expect string) {
+	fd, errOpen := vfs.OpenFile(name, os.O_RDONLY, 0777)
+	assert.NotNil(t, fd)
+	assert.NoError(t, errOpen)
+
+	defer func() {
+		// File must be closed - otherwise Run.cleanUp() will fail on Windows.
+		if errOpen == nil && fd != nil {
+			_ = fd.Close()
+		}
+	}()
+
+	fh, ok := fd.(*ReadFileHandle)
+	require.True(t, ok)
+
+	size := len(expect)
+	buf := make([]byte, size)
+	numRead, errRead := fh.Read(buf)
+	assert.NoError(t, errRead)
+	assert.Equal(t, numRead, size)
+
+	assert.Equal(t, string(buf), expect)
+}
+
+func assertFileAbsentVFS(t *testing.T, vfs *VFS, name string) {
+	fd, err := vfs.OpenFile(name, os.O_RDONLY, 0777)
+	defer func() {
+		// File must be closed - otherwise Run.cleanUp() will fail on Windows.
+		if err == nil && fd != nil {
+			_ = fd.Close()
+		}
+	}()
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.Equal(t, err, ENOENT)
+}

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io"
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -310,4 +311,108 @@ func TestVFSStatfs(t *testing.T) {
 	assert.Equal(t, used, used2)
 	assert.Equal(t, free, free2)
 	assert.Equal(t, oldTime, vfs.usageTime)
+}
+
+func TestVFSCaseInsensitive(t *testing.T) {
+	r := fstest.NewRun(t)
+	defer r.Finalise()
+
+	if runtime.GOOS == "windows" {
+		t.Logf("Skip TestVFSCaseInsensitive as failure is expected on Windows")
+		return
+	}
+
+	ctx := context.Background()
+	file1 := r.WriteObject(ctx, "FiLeA", "data1", t1)
+	file2 := r.WriteObject(ctx, "FiLeB", "data2", t2)
+	file3 := r.WriteObject(ctx, "FilEb", "data3", t3) // Windows will fail here as these two are local files
+	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+
+	// See how VFS handles case-insensitive flag
+	CaseInsensitiveOpt := DefaultOpt
+	CaseInsensitiveOpt.CaseInsensitive = true
+	vfsCI := New(r.Fremote, &CaseInsensitiveOpt)
+
+	fd, err := vfsCI.OpenFile("FiLeA", os.O_RDONLY, 0777)
+	assertFileData(t, fd, err, "data1")
+
+	fd, err = vfsCI.OpenFile("fileA", os.O_RDONLY, 0777)
+	assertFileData(t, fd, err, "data1")
+
+	fd, err = vfsCI.OpenFile("filea", os.O_RDONLY, 0777)
+	assertFileData(t, fd, err, "data1")
+
+	fd, err = vfsCI.OpenFile("FILEA", os.O_RDONLY, 0777)
+	assertFileData(t, fd, err, "data1")
+
+	fd, err = vfsCI.OpenFile("FiLeB", os.O_RDONLY, 0777)
+	assertFileData(t, fd, err, "data2")
+
+	fd, err = vfsCI.OpenFile("FilEb", os.O_RDONLY, 0777)
+	assertFileData(t, fd, err, "data3")
+
+	fd, err = vfsCI.OpenFile("fileb", os.O_RDONLY, 0777)
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.NotEqual(t, err, ENOENT)
+
+	fd, err = vfsCI.OpenFile("FILEB", os.O_RDONLY, 0777)
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.NotEqual(t, err, ENOENT)
+
+	// Run the same tests with case-sensitive VFS for comparison
+	CaseSensitiveOpt := DefaultOpt
+	CaseSensitiveOpt.CaseInsensitive = false
+	vfsCS := New(r.Fremote, &CaseSensitiveOpt)
+
+	fd, err = vfsCS.OpenFile("FiLeA", os.O_RDONLY, 0777)
+	assertFileData(t, fd, err, "data1")
+
+	fd, err = vfsCS.OpenFile("fileA", os.O_RDONLY, 0777)
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.Equal(t, err, ENOENT)
+
+	fd, err = vfsCS.OpenFile("filea", os.O_RDONLY, 0777)
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.Equal(t, err, ENOENT)
+
+	fd, err = vfsCS.OpenFile("FILEA", os.O_RDONLY, 0777)
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.Equal(t, err, ENOENT)
+
+	fd, err = vfsCS.OpenFile("FiLeB", os.O_RDONLY, 0777)
+	assertFileData(t, fd, err, "data2")
+
+	fd, err = vfsCS.OpenFile("FilEb", os.O_RDONLY, 0777)
+	assertFileData(t, fd, err, "data3")
+
+	fd, err = vfsCS.OpenFile("fileb", os.O_RDONLY, 0777)
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.Equal(t, err, ENOENT)
+
+	fd, err = vfsCS.OpenFile("FILEB", os.O_RDONLY, 0777)
+	assert.Nil(t, fd)
+	assert.Error(t, err)
+	assert.Equal(t, err, ENOENT)
+}
+
+func assertFileData(t *testing.T, fd Handle, err error, data string) {
+	assert.NotNil(t, fd)
+	assert.NoError(t, err)
+
+	fh, ok := fd.(*ReadFileHandle)
+	require.True(t, ok)
+
+	size := len(data)
+	buf := make([]byte, size)
+	num, err := fh.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, num, size)
+
+	assert.Equal(t, string(buf), data)
 }

--- a/vfs/vfsflags/vfsflags.go
+++ b/vfs/vfsflags/vfsflags.go
@@ -32,5 +32,6 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.FVarP(flagSet, &Opt.ChunkSizeLimit, "vfs-read-chunk-size-limit", "", "If greater than --vfs-read-chunk-size, double the chunk size after each chunk read, until the limit is reached. 'off' is unlimited.")
 	flags.FVarP(flagSet, DirPerms, "dir-perms", "", "Directory permissions")
 	flags.FVarP(flagSet, FilePerms, "file-perms", "", "File permissions")
+	flags.BoolVarP(flagSet, &Opt.CaseInsensitive, "vfs-case-insensitive", "", Opt.CaseInsensitive, "If a file name not found, find a case insensitive match.")
 	platformFlags(flagSet)
 }


### PR DESCRIPTION
#### What is the purpose of this change?

This change solves a particular problem with rclone mount.
I use rclone on windows to mount a cloud file archive and need an automated scriptable way to verify file consistency. Windows provides `fciv` for that, a functional equivalent of `sha1sum` / `md5sum` Linux utilties but with a different format of directory checksums. Linux utilities use hex-encoded one-file-per-line format and `fciv` uses base64 encoded xml based format. `fciv ` is used daily by many windows devops to verify large archives for consistency. I use automated powershell scripts to run it against the archive.

However, there is a gotcha: fciv brings file names to lower case for compatibility with previous windows versions. This is not a problem if I mount archive using such programs as WebDrive or NetDrive but breaks with rclone. I tried to tweak a case-insensitivity option in WinFSP, the rclone mount layer for Windows, but to no avail. This patch fixed the problem for me and did not introduce problems with the mount. I believe it can solve other similar use cases, eg. with video or dlna players.

How to reproduce: 
- create a test webdav remote
- open powershell cli window on windows
```
choco install -y fciv
rclone mount webdav_test: m:
cd m:
ls
echo "abc" > TestCase1.txt
fciv.exe TestCase1.txt
```
- fciv fails trying to open `testcase1.txt\*`.
- stop rclone and proceed:
```
rclone mount webdav_test: m: --vfs-case-insensitive
cd m:
fciv.exe TestCase1.txt
```
Now fciv can successfully calculate checksum.

Note: I have not yet added documentation or unit tests for the flag as I think we need to discuss the hack first.

#### Was the change discussed in an issue or in the forum before?

Probably yes, but I cannot find.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
