### PR TITLE
Fix 'compopt: command not found' on autocomplete on macOS

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -67,9 +67,9 @@ __rclone_custom_func() {
                 local reply=${prefix:+$prefix/}$line
                 [[ $reply != $path* ]] || COMPREPLY+=("$reply")
             done < <(rclone lsf "${cur%%:*}:$prefix" 2>/dev/null)
-	    [[ ! ${COMPREPLY[@]} ]] || compopt -o filenames
+	    [[ ! ${COMPREPLY[@]} || $(type -t compopt) != builtin ]] || compopt -o filenames
         fi
-        [[ ! ${COMPREPLY[@]} ]] || compopt -o nospace
+        [[ ! ${COMPREPLY[@]} || $(type -t compopt) != builtin ]] || compopt -o nospace
     fi
 }
 `


### PR DESCRIPTION
As reported in #3489.

#### What is the purpose of this change?

Fixes 'compopt: command not found' on autocomplete on macOS.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/3489#issuecomment-526231994

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
