### PR TITLE
Disable __rclone_custom_func if posix mode is on

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -39,7 +39,7 @@ documentation, changelog and configuration walkthroughs.
 const (
 	bashCompletionFunc = `
 __rclone_custom_func() {
-    if [[ ${#COMPREPLY[@]} -eq 0 ]]; then
+    if [[ ${#COMPREPLY[@]} -eq 0 && :$SHELLOPTS: != *:posix:* ]]; then
         local cur cword prev words
         if declare -F _init_completion > /dev/null; then
             _init_completion -n : || return


### PR DESCRIPTION
A workaround for #3489. Code in `__rclone_custom_func` relies on process substitutions `<(...)` to preserve changes of variables within `while` bodies, which is not supported in the posix mode.

#### What is the purpose of this change?

It partially disables autocomplete if the posix mode is on to avoid confusing errors.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/3489

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
