### PR TITLE
vfs: completely skip TestCaseSensitivity on Box.com

### DIFF
--- a/vfs/vfs_case_test.go
+++ b/vfs/vfs_case_test.go
@@ -14,6 +14,10 @@ func TestCaseSensitivity(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 
+	if r.Fremote.Features().CaseInsensitive {
+		t.Skip("Can't test case sensitivity - this remote is officially not case-sensitive")
+	}
+
 	// Create test files
 	ctx := context.Background()
 	file1 := r.WriteObject(ctx, "FiLeA", "data1", t1)
@@ -24,6 +28,7 @@ func TestCaseSensitivity(t *testing.T) {
 	// On a case-Sensitive remote this will be a separate file.
 	// On a case-INsensitive remote this file will either not exist
 	// or overwrite file2 depending on how file system diverges.
+	// On a box.com remote this step will even fail.
 	file3 := r.WriteObject(ctx, "FilEb", "data3", t3)
 
 	// Create a case-Sensitive and case-INsensitive VFS
@@ -53,8 +58,7 @@ func TestCaseSensitivity(t *testing.T) {
 
 	// The remaining test is only meaningful on a case-Sensitive file system.
 	if !remoteIsOK {
-		t.Logf("SKIP: TestCaseSensitivity - remote is not fully case-sensitive")
-		return
+		t.Skip("Can't test case sensitivity - this remote doesn't comply as case-sensitive")
 	}
 
 	// Continue with test as the underlying remote is fully case-Sensitive.


### PR DESCRIPTION
#### What is the purpose of this change?

TestCaseSensitivity fails at the preparation stage for a Box.com backend when it tries to create two files with names different by case only. This is not a bug of Box but a rather tough variant of a case-insensitive file system. This PR skips this test early (even before preparation stage) for Box and all officially (according to features) case-insensitive backends.

#### Was the change discussed in an issue or in the forum before?

See https://github.com/rclone/rclone/pull/3504#issuecomment-528364299 and https://github.com/rclone/rclone/pull/3504#issuecomment-528556158

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
