### PR TITLE
GitHub has a capital H

### DIFF
--- a/docs/content/bugs.md
+++ b/docs/content/bugs.md
@@ -35,7 +35,7 @@ costs more.  It may do in future (probably with a flag).
 
 ## Bugs
 
-Bugs are stored in rclone's Github project:
+Bugs are stored in rclone's GitHub project:
 
 * [Reported bugs](https://github.com/rclone/rclone/issues?q=is%3Aopen+is%3Aissue+label%3Abug)
 * [Known issues](https://github.com/rclone/rclone/issues?q=is%3Aopen+is%3Aissue+milestone%3A%22Known+Problem%22)

--- a/docs/layouts/chrome/menu.html
+++ b/docs/layouts/chrome/menu.html
@@ -20,7 +20,7 @@
         <div class="panel-body">
           <p>
             <i class="fa fa-comments" aria-hidden="true"></i> <a href="https://forum.rclone.org">Rclone forum.</a><br />
-            <i class="fab fa-github" aria-hidden="true"></i> <a href="https://github.com/rclone/rclone">Github project.</a><br />
+            <i class="fab fa-github" aria-hidden="true"></i> <a href="https://github.com/rclone/rclone">GitHub project.</a><br />
             <i class="fab fa-slack" aria-hidden="true"></i> <a href="https://slack-invite.rclone.org/">Rclone slack.</a><br />
             <i class="fa fa-book" aria-hidden="true"></i> <a href="https://github.com/rclone/rclone/wiki">Rclone Wiki.</a><br />
             <i class="fa fa-heart" aria-hidden="true"></i> <a href="/donate/">Donate.</a><br />


### PR DESCRIPTION
Just addressing a pet peeve of mine: "GitHub" is spelled with a capital H.

My text editor also stripped trailing whitespace from all the files it modified. If this is a problem, I can separate that out into a separate commit, separate pull request, or modify my editor to not strip trailing whitespace.