### PR TITLE
dlna: correct output for ContentDirectoryService#Browse with BrowseMe…

### DIFF
--- a/cmd/serve/dlna/cds.go
+++ b/cmd/serve/dlna/cds.go
@@ -245,7 +245,15 @@ func (cds *contentDirectoryService) Handle(action string, argsXML []byte, r *htt
 				"UpdateID":       cds.updateIDString(),
 			}, nil
 		case "BrowseMetadata":
-			result, err := xml.Marshal(obj)
+			node, err := cds.vfs.Stat(obj.Path)
+			if err != nil {
+				return nil, err
+			}
+			upnpObject, err := cds.cdsObjectToUpnpavObject(obj, node, host)
+			if err != nil {
+				return nil, err
+			}
+			result, err := xml.Marshal(upnpObject)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
…tadata

We were marshalling the "cds object" instead of the "upnp object".

Fixes #3253  (I think)

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
