### PR TITLE
dlna: count the number of children in the response to BrowseMetadata

### DIFF
--- a/cmd/serve/dlna/cds.go
+++ b/cmd/serve/dlna/cds.go
@@ -77,10 +77,17 @@ func (cds *contentDirectoryService) cdsObjectToUpnpavObject(cdsObject object, fi
 	}
 
 	if fileInfo.IsDir() {
+		children, err := cds.readContainer(cdsObject, host)
+		if err != nil {
+			return nil, err
+		}
+
 		obj.Class = "object.container.storageFolder"
 		obj.Title = fileInfo.Name()
-		ret = upnpav.Container{Object: obj}
-		return
+		return upnpav.Container{
+			Object:     obj,
+			ChildCount: len(children),
+		}, nil
 	}
 
 	if !fileInfo.Mode().IsRegular() {

--- a/cmd/serve/dlna/dlna_test.go
+++ b/cmd/serve/dlna/dlna_test.go
@@ -3,6 +3,7 @@ package dlna
 import (
 	"context"
 	"fmt"
+	"html"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -118,6 +119,9 @@ func TestContentDirectoryBrowseMetadata(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
-	require.Contains(t, string(body), "&lt;container ")
-	require.NotContains(t, string(body), "&lt;item ")
+	// expect a <container> element
+	require.Contains(t, string(body), html.EscapeString("<container "))
+	require.NotContains(t, string(body), html.EscapeString("<item "))
+	// with a non-zero childCount
+	require.Contains(t, string(body), html.EscapeString(`childCount="1"`))
 }


### PR DESCRIPTION
Further fixes for #3253.  The ContentDirectory spec actually says the childCount attribute is optional, so maybe we could just leave it out, but I can't test this one myself & it looks like other implementations (minidlna & emby) choose to fill in.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
