### PR TITLE
mailru: skip extra http request if data fits in hash

### DIFF
--- a/backend/mailru/mailru.go
+++ b/backend/mailru/mailru.go
@@ -217,11 +217,11 @@ var retryErrorCodes = []int{
 // deserve to be retried. It returns the err as a convenience.
 // Retries password authorization (once) in a special case of access denied.
 func shouldRetry(res *http.Response, err error, f *Fs, opts *rest.Opts) (bool, error) {
-	if res.StatusCode == 403 && f.opt.Password != "" && !f.passFailed {
+	if res != nil && res.StatusCode == 403 && f.opt.Password != "" && !f.passFailed {
 		reAuthErr := f.reAuthorize(opts, err)
 		return reAuthErr == nil, err // return an original error
 	}
-	if f.quirks.retry400 && res.StatusCode == 400 {
+	if res != nil && res.StatusCode == 400 && f.quirks.retry400 {
 		return true, err
 	}
 	return fserrors.ShouldRetry(err) || fserrors.ShouldRetryHTTP(res, retryErrorCodes), err


### PR DESCRIPTION
#### What is the purpose of this change?

When a file to upload is 40 bytes or more, it can be put directly in the hash field of Mailru metadata. Currently backend performs unneeded actions for small files: requests or calculates checksum and tries put by hash.
This patch optimizes that out. It also fixes a very rare nil point dereference panic.
It does not require new documentation or tests, just run the integration suite.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
