### PR TITLE
Docker container fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,11 @@ RUN ./rclone version
 # Begin final image
 FROM alpine:latest
 
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates fuse
 
-WORKDIR /root/
+COPY --from=builder /go/src/github.com/rclone/rclone/rclone /usr/local/bin/
 
-COPY --from=builder /go/src/github.com/rclone/rclone/rclone .
+ENTRYPOINT [ "rclone" ]
 
-ENTRYPOINT [ "./rclone" ]
+WORKDIR /data
+ENV XDG_CONFIG_HOME=/config

--- a/docs/content/authors.md
+++ b/docs/content/authors.md
@@ -288,3 +288,4 @@ Contributors
   * Ivan Andreev <ivandeex@gmail.com>
   * David Baumgold <david@davidbaumgold.com>
   * Lars Lehtonen <lars.lehtonen@gmail.com>
+  * Matei David <matei.david@gmail.com>

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -102,13 +102,54 @@ rclone v1.49.1
 - go version: go1.12.9
 ```
 
-You will probably want to mount rclone's config file directory or file
-from the host, or configure rclone with environment variables.
+There are a few command line options to consider when starting an rclone Docker container
+from the rclone image.
 
-Eg to share your local config with the container
+- You need to mount the host rclone config dir at `/config` into the Docker container.
+  Due to the way in which rclone updates tokens inside its config file, you need to
+  mount a host config dir, not just a host config file.
+
+- You need to mount a host data dir at `/data` into the Docker container.
+
+- By default, the rclone binary inside a Docker container runs with UID=0 (root).
+  As a result, all files created in a run will have UID=0. If your config and data files
+  reside on the host with a non-root UID:GID, you need to pass these on the container
+  start command line.
+
+- It is possible to use `rclone mount` inside a userspace Docker container, and expose
+  the resulting fuse mount to the host. The exact `docker run` options to do that might
+  vary slightly between hosts. See, e.g. the discussion in this
+  [thread](https://github.com/moby/moby/issues/9448).
+
+  You also need to mount the host `/etc/passwd` and `/etc/group` for fuse to work inside
+  the container.
+
+Here are some commands tested on an Ubuntu 18.04.3 host:
 
 ```
-docker run  -v ~/.config/rclone:/root/.config/rclone rclone/rclone:latest listremotes
+# config on host at ~/.config/rclone/rclone.conf
+# data on host at ~/data
+
+# make sure the config is ok by listing the remotes
+docker run --rm \
+    --volume ~/.config/rclone:/config/rclone \
+    --volume ~/data:/data:shared \
+    --user $(id -u):$(id -g) \
+    rclone/rclone \
+    listremotes
+
+# perform mount inside Docker container, expose result to host
+mkdir -p ~/data/mount
+docker run --rm \
+    --volume ~/.config/rclone:/config/rclone \
+    --volume ~/data:/data:shared \
+    --user $(id -u):$(id -g) \
+    --volume /etc/passwd:/etc/passwd:ro --volume /etc/group:/etc/group:ro \
+    --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined \
+    rclone/rclone \
+    mount dropbox:Photos /data/mount &
+ls ~/data/mount
+kill %1
 ```
 
 ## Install from source ##


### PR DESCRIPTION
#### What is the purpose of this change?

Specifically:
- enable Docker container userspace operation
- enable Docker userspace mount exposed to the host
- add more Docker image usage documentation

The changes affect only the Docker image. I haven't noticed any CI/CD pipeline checking the Docker image. (Perhaps that should be a task in itself.)

#### Was the change discussed in an issue or in the forum before?

Yes: https://forum.rclone.org/t/run-docker-container-in-userspace/11734/7

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)

