### PR TITLE
Add support of checksum check on crypted remote

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -348,6 +348,13 @@ type ObjectInfo interface {
 	Storable() bool
 }
 
+// HashUnWrapper is an optional interface for ObjectInfo
+type HashUnWrapper interface {
+	// UnWrapHash returns the selected checksum of the source underlying file and its wrapped version
+	// If no checksum is available for a layer it returns "" for this specific layer only
+	UnWrapHash(ctx context.Context, ty hash.Type) (srcHash string, wrappedHash string, err error)
+}
+
 // DirEntry provides read only information about the common subset of
 // a Dir or Object.  These are returned from directory listings - type
 // assert them into the correct type.


### PR DESCRIPTION
#### What is the purpose of this change?
This allow users to store the MD5 of the un-encrypted file content as a metadata on a azure blob storage, so we are still able to use the `--checksum` parameter for any command.

When a remote is encrypted, checksums is usually just ignored by all commands and the only way to check the diff between source and remote is to use the `cryptcheck`. This command will try to read some metadata at the beginning of the remote file, decrypt them, and then validate the hash. 

This however is not a suitable solution when a remote is (kind of) write-only. For instance if you configure your backups to use the [archive tier](https://docs.microsoft.com/en-us/azure/storage/blobs/storage-blob-storage-tiers#archive-access-tier) on a azure blob backend, you need re-hydrate your data before reading it ... which usually takes few hours!

#### Why ?
My own use-case is to backup my personal photos library:

* I obviously want to encrypt all my photos locally before sending them to azure; 
* As photos are [`--immutable`](https://rclone.org/docs/#immutable), the cheap archive tier fits perfectly;
* I would like to run a "full backup" once from time to time with checksum validation to make sure that the data does not get corrupted for any reason (which happened to me last winter due to a failing disk on my local server 😭).


#### Was the change discussed in an issue or in the forum before?
Not yet ... that's why I opened this PR as a draft only

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
