### PR TITLE
s3: fix signature v2_auth headers

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1925,6 +1925,10 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 			return errors.Wrap(err, "s3 upload: sign request")
 		}
 
+		if o.fs.opt.V2Auth && headers == nil {
+			headers = putObj.HTTPRequest.Header
+		}
+
 		// Set request to nil if empty so as not to make chunked encoding
 		if size == 0 {
 			in = nil


### PR DESCRIPTION
When used with `v2_auth = true`, `PresignRequest` doesn't return
signed headers, so remote dest authentication would be fail.
This commit copying back `HTTPRequest.Header` to `headers`.

Tested with RiakCS v2.1.0.

Signed-off-by: Anthony Rusdi <33247310+antrusd@users.noreply.github.com>