### PR TITLE
finish chunker meta-format before release

### DIFF
--- a/backend/chunker/chunker_test.go
+++ b/backend/chunker/chunker_test.go
@@ -28,10 +28,14 @@ var (
 // dynamic chunker overlay wrapping a local temporary directory.
 func TestIntegration(t *testing.T) {
 	opt := fstests.Opt{
-		RemoteName:                   *fstest.RemoteName,
-		NilObject:                    (*chunker.Object)(nil),
-		SkipBadWindowsCharacters:     !*UseBadChars,
-		UnimplementableObjectMethods: []string{"MimeType"},
+		RemoteName:               *fstest.RemoteName,
+		NilObject:                (*chunker.Object)(nil),
+		SkipBadWindowsCharacters: !*UseBadChars,
+		UnimplementableObjectMethods: []string{
+			"MimeType",
+			"GetTier",
+			"SetTier",
+		},
 		UnimplementableFsMethods: []string{
 			"PublicLink",
 			"OpenWriterAt",

--- a/fstest/test_all/config.yaml
+++ b/fstest/test_all/config.yaml
@@ -34,18 +34,11 @@ backends:
    remote:   "TestChunkerNometaLocal:"
    fastlist: true
  - backend:  "chunker"
-   remote:   "TestChunkerCompatLocal:"
-   fastlist: true
- - backend:  "chunker"
    remote:   "TestChunkerChunk3bLocal:"
    fastlist: true
    maxfile:  6k
  - backend:  "chunker"
    remote:   "TestChunkerChunk3bNometaLocal:"
-   fastlist: true
-   maxfile:  6k
- - backend:  "chunker"
-   remote:   "TestChunkerChunk3bCompatLocal:"
    fastlist: true
    maxfile:  6k
  - backend:  "chunker"
@@ -66,30 +59,26 @@ backends:
  - backend:  "chunker"
    remote:   "TestChunkerS3:"
    fastlist: true
-   ignore:
-     - TestIntegration/FsMkdir/FsPutFiles/SetTier
  - backend:  "chunker"
    remote:   "TestChunkerChunk50bS3:"
    fastlist: true
    maxfile:  1k
-   ignore:
-     - TestIntegration/FsMkdir/FsPutFiles/SetTier
- #- backend:  "chunker"
- #  remote:   "TestChunkerChunk50bMD5HashS3:"
- #  fastlist: true
- #  maxfile:  1k
- #- backend:  "chunker"
- #  remote:   "TestChunkerChunk50bMD5QuickS3:"
- #  fastlist: true
- #  maxfile:  1k
- #- backend:  "chunker"
- #  remote:   "TestChunkerChunk50bSHA1HashS3:"
- #  fastlist: true
- #  maxfile:  1k
- #- backend:  "chunker"
- #  remote:   "TestChunkerChunk50bSHA1QuickS3:"
- #  fastlist: true
- #  maxfile:  1k
+ - backend:  "chunker"
+   remote:   "TestChunkerChunk50bMD5HashS3:"
+   fastlist: true
+   maxfile:  1k
+ - backend:  "chunker"
+   remote:   "TestChunkerChunk50bSHA1HashS3:"
+   fastlist: true
+   maxfile:  1k
+ - backend:  "chunker"
+   remote:   "TestChunkerChunk50bMD5QuickS3:"
+   fastlist: true
+   maxfile:  1k
+ - backend:  "chunker"
+   remote:   "TestChunkerChunk50bSHA1QuickS3:"
+   fastlist: true
+   maxfile:  1k
  ## end chunker
  - backend:  "drive"
    remote:   "TestDrive:"


### PR DESCRIPTION
#### What is the purpose of this change?

- remove GetTier and SetTier
- remove wdmrcompat metaformat
- remove fastopen strategy
- make hash_type option non-advanced
- adverise hash support when possible
- add metadata field "ver", run strict checks
- describe internal behavior in comments
- improve documentation

note:
wdmrcompat used to write file name in the metadata, so maximum metadata size was 1K
removing this format allows to cap size by 200 bytes now.

#### Was the change discussed in an issue or in the forum before?

see https://github.com/rclone/rclone/pull/3503#issuecomment-534300870

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
