### PR TITLE
filter: prevent mix opts when filesfrom is present - fixes #3599

### DIFF
--- a/fs/filter/filter.go
+++ b/fs/filter/filter.go
@@ -191,7 +191,12 @@ func NewFilter(opt *Opt) (f *Filter, err error) {
 			return nil, err
 		}
 	}
+
+	inActive := f.InActive()
 	for _, rule := range f.Opt.FilesFrom {
+		if !inActive {
+			return nil, fmt.Errorf("The usage of --files-from overrides all other filters, it should be used alone")
+		}
 		f.initAddFile() // init to show --files-from set even if no files within
 		err := forEachLine(rule, func(line string) error {
 			return f.AddFile(line)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

I would like to address the issue #3599 where one should forbid mixing --files-from opt with other one

#### Was the change discussed in an issue or in the forum before?

Here's the link to the discussion: https://forum.rclone.org/t/why-do-we-ignore-other-filtering-rules-when-using-the-files-from-flag/12065/5

#### Checklist

- [ x ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ x ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ x ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x ] I'm done, this Pull Request is ready for review :-)
