### PR TITLE
ftp: allow disabling EPSV mode

### DIFF
--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -65,6 +65,11 @@ func init() {
 				Help:     "Do not verify the TLS certificate of the server",
 				Default:  false,
 				Advanced: true,
+			}, {
+				Name:     "disable_epsv",
+				Help:     "Disable using EPSV even if server advertises support",
+				Default:  false,
+				Advanced: true,
 			},
 		},
 	})
@@ -79,6 +84,7 @@ type Options struct {
 	TLS               bool   `config:"tls"`
 	Concurrency       int    `config:"concurrency"`
 	SkipVerifyTLSCert bool   `config:"no_check_certificate"`
+	DisableEPSV       bool   `config:"disable_epsv"`
 }
 
 // Fs represents a remote FTP server
@@ -143,6 +149,9 @@ func (f *Fs) ftpConnection() (*ftp.ServerConn, error) {
 			InsecureSkipVerify: f.opt.SkipVerifyTLSCert,
 		}
 		ftpConfig = append(ftpConfig, ftp.DialWithTLS(tlsConfig))
+	}
+	if f.opt.DisableEPSV {
+		ftpConfig = append(ftpConfig, ftp.DialWithDisabledEPSV(true))
 	}
 	c, err := ftp.Dial(f.dialAddr, ftpConfig...)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Some misconfigured FTP servers advertise support for EPSV mode (the modern-day
equivalent of PASV), whereas in reality this doesn't always work (due to a
buggy firewall/gateway between the FTP server and the client, or a buggy server
implementation).

This option will tell the underlying FTP module to never use EPSV mode even if
the server claims to support it.

#### Was the change discussed in an issue or in the forum before?

Not that I've seen, it's probably quite a rare occurrence.
#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
