### PR TITLE
docs: update onedrive/sharepoint docs on some known issues

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -225,9 +225,9 @@ func init() {
 			Help: "Microsoft App Client Secret\nLeave blank normally.",
 		}, {
 			Name: "chunk_size",
-			Help: `Chunk size to upload files with - must be multiple of 320k.
+			Help: `Chunk size to upload files with - must be multiple of 320k (327,680 bytes).
 
-Above this size files will be chunked - must be multiple of 320k. Note
+Above this size files will be chunked - must be multiple of 320k (327,680 bytes). Note
 that the chunks will be buffered into memory.`,
 			Default:  defaultChunkSize,
 			Advanced: true,

--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -354,10 +354,10 @@ mainly affect Office files (.docx, .xlsx, etc.). As a workaround, you may use
 the `--backup-dir <BACKUP_DIR>` command line argument so rclone moves the
 files to be replaced/deleted into a given backup directory (instead of directly
 replacing/deleting them). For example, to instruct rclone to move the files into
-the directory `rclone-backup-dir`, you may use:
+the directory `rclone-backup-dir` on backend `mysharepoint`, you may use:
 
 ```
---backup-dir rclone-backup-dir
+--backup-dir mysharepoint:rclone-backup-dir
 ```
 
 #### access\_denied (AADSTS65005) ####

--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -133,7 +133,7 @@ Client ID and Key by following the steps below:
 Now the application is complete. Run `rclone config` to create or edit a OneDrive remote.
 Supply the app ID and password as Client ID and Secret, respectively. rclone will walk you through the remaining steps.
 
-### Modified time and hashes ###
+### Modification time and hashes ###
 
 OneDrive allows modification times to be set on objects accurate to 1
 second.  These will be used to detect whether objects need syncing or
@@ -145,7 +145,7 @@ Sharepoint Server support
 
 For all types of OneDrive you can use the `--checksum` flag.
 
-#### Restricted filename characters
+### Restricted filename characters ###
 
 In addition to the [default restricted characters set](/overview/#restricted-characters)
 the following characters are also replaced:
@@ -220,9 +220,9 @@ Here are the advanced options specific to onedrive (Microsoft OneDrive).
 
 #### --onedrive-chunk-size
 
-Chunk size to upload files with - must be multiple of 320k.
+Chunk size to upload files with - must be multiple of 320k (327,680 bytes).
 
-Above this size files will be chunked - must be multiple of 320k. Note
+Above this size files will be chunked - must be multiple of 320k (327,680 bytes). Note
 that the chunks will be buffered into memory.
 
 - Config:      chunk_size
@@ -267,6 +267,8 @@ listing, set this option.
 
 ### Limitations ###
 
+#### Naming ####
+
 Note that OneDrive is case insensitive so you can't have a
 file called "Hello.doc" and one called "hello.doc".
 
@@ -276,16 +278,22 @@ platforms they are common.  Rclone will map these names to and from an
 identical looking unicode equivalent.  For example if a file has a `?`
 in it will be mapped to `？` instead.
 
+#### File sizes ####
+
 The largest allowed file sizes are 15GB for OneDrive for Business and 35GB for OneDrive Personal (Updated 4 Jan 2019).
 
+#### Path length ####
+
 The entire path, including the file name, must contain fewer than 400 characters for OneDrive, OneDrive for Business and SharePoint Online. If you are encrypting file and folder names with rclone, you may want to pay attention to this limitation because the encrypted names are typically longer than the original ones.
+
+#### Number of files ####
 
 OneDrive seems to be OK with at least 50,000 files in a folder, but at
 100,000 rclone will get errors listing the directory like `couldn’t
 list files: UnknownError:`.  See
 [#2707](https://github.com/rclone/rclone/issues/2707) for more info.
 
-An official document about the limitations for different types of OneDrive can be found [here](https://support.office.com/en-us/article/invalid-file-names-and-file-types-in-onedrive-onedrive-for-business-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa). 
+An official document about the limitations for different types of OneDrive can be found [here](https://support.office.com/en-us/article/invalid-file-names-and-file-types-in-onedrive-onedrive-for-business-and-sharepoint-64883a5d-228e-48f5-b3d2-eb39e07630fa).
 
 ### Versioning issue ###
 
@@ -324,6 +332,36 @@ Note: This will disable the creation of new file versions, but will not remove a
 
 ### Troubleshooting ###
 
+#### Unexpected file size/hash differences on Sharepoint ####
+
+It is a
+[known](https://github.com/OneDrive/onedrive-api-docs/issues/935#issuecomment-441741631)
+issue that Sharepoint (not OneDrive or OneDrive for Business) silently modifies
+uploaded files, mainly Office files (.docx, .xlsx, etc.), causing file size and
+hash checks to fail. To use rclone with such affected files on Sharepoint, you
+may disable these checks with the following command line arguments:
+
+```
+--ignore-checksum --ignore-size
+```
+
+#### Replacing/deleting existing files on Sharepoint gets "item not found" ####
+
+It is a [known](https://github.com/OneDrive/onedrive-api-docs/issues/1068) issue
+that Sharepoint (not OneDrive or OneDrive for Business) may return "item not
+found" errors when users try to replace or delete uploaded files; this seems to
+mainly affect Office files (.docx, .xlsx, etc.). As a workaround, you may use
+the `--backup-dir <BACKUP_DIR>` command line argument so rclone moves the
+files to be replaced/deleted into a given backup directory (instead of directly
+replacing/deleting them). For example, to instruct rclone to move the files into
+the directory `rclone-backup-dir`, you may use:
+
+```
+--backup-dir rclone-backup-dir
+```
+
+#### access\_denied (AADSTS65005) ####
+
 ```
 Error: access_denied
 Code: AADSTS65005
@@ -334,6 +372,7 @@ This means that rclone can't use the OneDrive for Business API with your account
 
 However, there are other ways to interact with your OneDrive account. Have a look at the webdav backend: https://rclone.org/webdav/#sharepoint
 
+#### invalid\_grant (AADSTS50076) ####
 
 ```
 Error: invalid_grant

--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -246,7 +246,7 @@ pass = encryptedpassword
 #### Required Flags for SharePoint ####
 As SharePoint does some special things with uploaded documents, you won't be able to use the documents size or the documents hash to compare if a file has been changed since the upload / which file is newer.
 
-For all Rclone calls copying files from/to SharePoint or OneDrive (like copy, sync, etc.), you should append these flags to ensure Rclone uses the "Last Modified" datetime property to compare your documents:
+For Rclone calls copying files (especially Office files such as .docx, .xlsx, etc.) from/to SharePoint (like copy, sync, etc.), you should append these flags to ensure Rclone uses the "Last Modified" datetime property to compare your documents:
 
 ```
 --ignore-size --ignore-checksum --update


### PR DESCRIPTION
#### What is the purpose of this change?

This PR adds the workarounds for these long-standing, frequently-asked-about issues:

- [SharePoint: Replacing existing Office files returns itemNotFound: The resource could not be found. · Issue #3212](https://github.com/rclone/rclone/issues/3212)
- [onedrive (SharePoint): file integrity check fails because SharePoint modifies specific files · Issue #2599](https://github.com/rclone/rclone/issues/2599)

...and a hint on the unit of chunk size corresponding to #3512.

The Sharepoint section in `docs/content/webdav.md` is also updated for accuracy.

Lastly, this PR applies some minor format adjustments to the docs for clarity.