### PR TITLE
mount: replace use of WriteAt with Write for files opened with O_APPEND

### DIFF
--- a/cmd/cmount/fs.go
+++ b/cmd/cmount/fs.go
@@ -366,7 +366,12 @@ func (fsys *FS) Write(path string, buff []byte, ofst int64, fh uint64) (n int) {
 	if errc != 0 {
 		return errc
 	}
-	n, err := handle.WriteAt(buff, ofst)
+	var err error
+	if fsys.VFS.Opt.CacheMode < vfs.CacheModeWrites || handle.Node().Mode()&os.ModeAppend == 0 {
+		n, err = handle.WriteAt(buff, ofst)
+	} else {
+		n, err = handle.Write(buff)
+	}
 	if err != nil {
 		return translateError(err)
 	}

--- a/cmd/mountlib/mounttest/file.go
+++ b/cmd/mountlib/mounttest/file.go
@@ -34,6 +34,11 @@ func osCreate(name string) (*os.File, error) {
 	return os.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
 }
 
+// os.Create with append
+func osAppend(name string) (*os.File, error) {
+	return os.OpenFile(name, os.O_WRONLY|os.O_APPEND, 0666)
+}
+
 // TestFileModTimeWithOpenWriters tests mod time on open files
 func TestFileModTimeWithOpenWriters(t *testing.T) {
 	run.skipIfNoFUSE(t)

--- a/cmd/mountlib/mounttest/fs.go
+++ b/cmd/mountlib/mounttest/fs.go
@@ -78,6 +78,7 @@ func RunTests(t *testing.T, fn MountFn) {
 			t.Run("TestWriteFileDoubleClose", TestWriteFileDoubleClose)
 			t.Run("TestWriteFileFsync", TestWriteFileFsync)
 			t.Run("TestWriteFileDup", TestWriteFileDup)
+			t.Run("TestWriteFileAppend", TestWriteFileAppend)
 		})
 		log.Printf("Finished test run with cache mode %v (ok=%v)", cacheMode, ok)
 		if !ok {


### PR DESCRIPTION
os.File.WriteAt returns an error if a file was opened with O_APPEND. Replacing it with os.File.Seek and os.File.Write for cache modes >= writes will ensure that writes will always work if a file is opened with O_APPEND.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Writing to a file opened with O_APPEND on a mounted remote (with caching >= writes) returns an error because os.File.WriteAt does not allow writing to files opened with O_APPEND.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
