### PR TITLE
rc: add config/upload

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -1419,6 +1419,7 @@ func Dump() error {
 	if err != nil {
 		return errors.Wrap(err, "failed to write config dump")
 	}
+	fmt.Println()
 	return nil
 }
 


### PR DESCRIPTION
Adds an `config/upload` call to rc.
The call has two parameters: 
 - _content_: Content of the config file
 - _nosave_: Don't write updated config to file (optional)

Caveat: _nosave_ is not effective on subsequent calls to `config/update,delete,…` which could cause secret information to "leak" to disk.

Solves #3437