### PR TITLE
config: do not open browser on headless on google

### DIFF
--- a/cmd/authorize/authorize.go
+++ b/cmd/authorize/authorize.go
@@ -3,11 +3,18 @@ package authorize
 import (
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/config"
+	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/spf13/cobra"
+)
+
+var (
+	noAutoBrowser bool
 )
 
 func init() {
 	cmd.Root.AddCommand(commandDefinition)
+	cmdFlags := commandDefinition.Flags()
+	flags.BoolVarP(cmdFlags, &noAutoBrowser, "auth-no-open-browser", "", false, "Do not automatically open auth link in default browser")
 }
 
 var commandDefinition = &cobra.Command{
@@ -16,9 +23,12 @@ var commandDefinition = &cobra.Command{
 	Long: `
 Remote authorization. Used to authorize a remote or headless
 rclone from a machine with a browser - use as instructed by
-rclone config.`,
+rclone config.
+
+Use the --auth-no-open-browser to prevent rclone to open auth
+link in default browser automatically.`,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(1, 3, command, args)
-		config.Authorize(args)
+		config.Authorize(args, noAutoBrowser)
 	},
 }

--- a/docs/content/commands/rclone_authorize.md
+++ b/docs/content/commands/rclone_authorize.md
@@ -22,7 +22,8 @@ rclone authorize [flags]
 ### Options
 
 ```
-  -h, --help   help for authorize
+  --auth-no-open-browser   Do not automatically open auth link in default browser
+  -h, --help               help for authorize
 ```
 
 See the [global flags page](/flags/) for global options not listed here.

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -62,6 +62,9 @@ const (
 
 	// ConfigAuthorize indicates that we just want "rclone authorize"
 	ConfigAuthorize = "config_authorize"
+
+	// ConfigAuthNoBrowser indicates that we do not want to open browser
+	ConfigAuthNoBrowser = "config_auth_no_browser"
 )
 
 // Global
@@ -1299,7 +1302,7 @@ func SetPassword() {
 //
 //   rclone authorize "fs name"
 //   rclone authorize "fs name" "client id" "client secret"
-func Authorize(args []string) {
+func Authorize(args []string, noAutoBrowser bool) {
 	defer suppressConfirm()()
 	switch len(args) {
 	case 1, 3:
@@ -1319,10 +1322,15 @@ func Authorize(args []string) {
 
 	// Indicate that we are running rclone authorize
 	getConfigData().SetValue(name, ConfigAuthorize, "true")
+	if noAutoBrowser {
+		getConfigData().SetValue(name, ConfigAuthNoBrowser, "true")
+	}
+
 	if len(args) == 3 {
 		getConfigData().SetValue(name, ConfigClientID, args[1])
 		getConfigData().SetValue(name, ConfigClientSecret, args[2])
 	}
+
 	m := fs.ConfigMap(f, name)
 	f.Config(name, m)
 }

--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -386,6 +386,8 @@ func doConfig(id, name string, m configmap.Mapper, oauthConfig *oauth2.Config, o
 	oauthConfig, changed := overrideCredentials(name, m, oauthConfig)
 	authorizeOnlyValue, ok := m.Get(config.ConfigAuthorize)
 	authorizeOnly := ok && authorizeOnlyValue != "" // set if being run by "rclone authorize"
+	authorizeNoAutoBrowserValue, ok := m.Get(config.ConfigAuthNoBrowser)
+	authorizeNoAutoBrowser := ok && authorizeNoAutoBrowserValue != ""
 
 	// See if already have a token
 	tokenString, ok := m.Get("token")
@@ -470,9 +472,13 @@ func doConfig(id, name string, m configmap.Mapper, oauthConfig *oauth2.Config, o
 		authURL = "http://" + bindAddress + "/auth?state=" + state
 	}
 
-	// Open the URL for the user to visit
-	_ = open.Start(authURL)
-	fmt.Printf("If your browser doesn't open automatically go to the following link: %s\n", authURL)
+	if !authorizeNoAutoBrowser && oauthConfig.RedirectURL != TitleBarRedirectURL {
+		// Open the URL for the user to visit
+		_ = open.Start(authURL)
+		fmt.Printf("If your browser doesn't open automatically go to the following link: %s\n", authURL)
+	} else {
+		fmt.Printf("Please go to the following link: %s\n", authURL)
+	}
 	fmt.Printf("Log in and authorize rclone for access\n")
 
 	// Read the code via the webserver or manually


### PR DESCRIPTION
On google fs (drive, google photos, and google cloud storage), if
headless is selected, do not open browser.

This also supplies a new option "auth-no-open-browser" for authorize
if the user does not want it.

This should fix #3323.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

No browser popup if headless and using drive

#### Was the change discussed in an issue or in the forum before?

#3323

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
