### PR TITLE
Add flag --base64 to command hashsum

### DIFF
--- a/cmd/hashsum/hashsum.go
+++ b/cmd/hashsum/hashsum.go
@@ -7,13 +7,20 @@ import (
 	"os"
 
 	"github.com/rclone/rclone/cmd"
+	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/spf13/cobra"
 )
 
+var (
+	outputBase64 = false
+)
+
 func init() {
 	cmd.Root.AddCommand(commandDefinition)
+	cmdFlags := commandDefinition.Flags()
+	flags.BoolVarP(cmdFlags, &outputBase64, "base64", "", outputBase64, "Output base64 encoded hashsum")
 }
 
 var commandDefinition = &cobra.Command{
@@ -55,6 +62,9 @@ Then
 		}
 		fsrc := cmd.NewFsSrc(args[1:])
 		cmd.Run(false, false, command, func() error {
+			if outputBase64 {
+				return operations.HashListerBase64(context.Background(), ht, fsrc, os.Stdout)
+			}
 			return operations.HashLister(context.Background(), ht, fsrc, os.Stdout)
 		})
 		return nil

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -225,6 +225,43 @@ func TestHashSums(t *testing.T) {
 		!strings.Contains(res, "                                          potato2\n") {
 		t.Errorf("potato2 missing: %q", res)
 	}
+
+	// QuickXorHash Sum
+
+	buf.Reset()
+	var ht hash.Type
+	err = ht.Set("QuickXorHash")
+	require.NoError(t, err)
+	err = operations.HashLister(context.Background(), ht, r.Fremote, &buf)
+	require.NoError(t, err)
+	res = buf.String()
+	if !strings.Contains(res, "2d00000000000000000000000100000000000000  empty space\n") &&
+		!strings.Contains(res, "                             UNSUPPORTED  empty space\n") &&
+		!strings.Contains(res, "                                          empty space\n") {
+		t.Errorf("empty space missing: %q", res)
+	}
+	if !strings.Contains(res, "4001dad296b6b4a52d6d694b67dad296b6b4a52d  potato2\n") &&
+		!strings.Contains(res, "                             UNSUPPORTED  potato2\n") &&
+		!strings.Contains(res, "                                          potato2\n") {
+		t.Errorf("potato2 missing: %q", res)
+	}
+
+	// QuickXorHash Sum with Base64 Encoded
+
+	buf.Reset()
+	err = operations.HashListerBase64(context.Background(), ht, r.Fremote, &buf)
+	require.NoError(t, err)
+	res = buf.String()
+	if !strings.Contains(res, "LQAAAAAAAAAAAAAAAQAAAAAAAAA=  empty space\n") &&
+		!strings.Contains(res, "                 UNSUPPORTED  empty space\n") &&
+		!strings.Contains(res, "                              empty space\n") {
+		t.Errorf("empty space missing: %q", res)
+	}
+	if !strings.Contains(res, "QAHa0pa2tKUtbWlLZ9rSlra0pS0=  potato2\n") &&
+		!strings.Contains(res, "                 UNSUPPORTED  potato2\n") &&
+		!strings.Contains(res, "                              potato2\n") {
+		t.Errorf("potato2 missing: %q", res)
+	}
 }
 
 func TestSuffixName(t *testing.T) {


### PR DESCRIPTION
#3663 
this flag used to output QuickXorHash in the same format with MS Graph
Api 

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
