### PR TITLE
Update filtering.md

### DIFF
--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -305,6 +305,10 @@ This reads a list of file names from the file passed in and **only**
 these files are transferred.  The **filtering rules are ignored**
 completely if you use this option.
 
+`--files-from` expects a list of files as it's input. [rclone lsf](/commands/rclone_lsf/)
+has a compatible format that can be used to export file lists from
+remotes.
+
 Rclone will traverse the file system if you use `--files-from`,
 effectively using the files in `--files-from` as a set of filters.
 Rclone will not error if any of the files are missing.


### PR DESCRIPTION
added:
--files-from expects a list of files as it's input. rclone lsf has 
a compatible format that can be used to export file lists from remotes.
https://rclone.org/commands/rclone_lsf/

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
clarify --files-from feature
-->

#### Was the change discussed in an issue or in the forum before?

<!--
You asked me Nick ;)
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
