### PR TITLE
Adding group parameter in status return

### DIFF
--- a/fs/accounting/accounting.go
+++ b/fs/accounting/accounting.go
@@ -378,6 +378,7 @@ func (acc *Account) RemoteStats() (out rc.Params) {
 		percentageDone = int(100 * float64(a) / float64(b))
 	}
 	out["percentage"] = percentageDone
+	out["group"] = acc.stats.group
 
 	return out
 }

--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -40,6 +40,7 @@ type StatsInfo struct {
 	startedTransfers  []*Transfer   // currently active transfers
 	oldTimeRanges     timeRanges    // a merged list of time ranges for the transfers
 	oldDuration       time.Duration // duration of transfers we have culled
+	group             string
 }
 
 // NewStats creates an initialised StatsInfo

--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -245,6 +245,7 @@ func GlobalStats() *StatsInfo {
 // NewStatsGroup creates new stats under named group.
 func NewStatsGroup(group string) *StatsInfo {
 	stats := NewStats()
+	stats.group = group
 	groups.set(group, stats)
 	return stats
 }

--- a/fs/accounting/transfer.go
+++ b/fs/accounting/transfer.go
@@ -18,6 +18,7 @@ type TransferSnapshot struct {
 	StartedAt   time.Time `json:"started_at"`
 	CompletedAt time.Time `json:"completed_at,omitempty"`
 	Error       error     `json:"-"`
+	Group       string    `json:"group"`
 }
 
 // MarshalJSON implements json.Marshaler interface.
@@ -26,6 +27,7 @@ func (as TransferSnapshot) MarshalJSON() ([]byte, error) {
 	if as.Error != nil {
 		err = as.Error.Error()
 	}
+
 	type Alias TransferSnapshot
 	return json.Marshal(&struct {
 		Error string `json:"error"`
@@ -176,5 +178,6 @@ func (tr *Transfer) Snapshot() TransferSnapshot {
 		StartedAt:   tr.startedAt,
 		CompletedAt: tr.completedAt,
 		Error:       tr.err,
+		Group:       tr.stats.group,
 	}
 }


### PR DESCRIPTION
The group parameter gives a id to uniquely identify a job and allow operations to be performed on it.
This will allow the job to be stopped using the rclone web ui.