### PR TITLE
fs: Add support for max transfer cutoff mode #2672

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -710,6 +710,20 @@ When the limit is reached all transfers will stop immediately.
 
 Rclone will exit with exit code 8 if the transfer limit is reached.
 
+### --max-transfer-(hard,soft,cautious) ###
+
+This modifies the behavior of `--max-transfer`
+Defaults to `--max-transfer-hard`.
+
+Specifiying `--max-transfer-hard` will stop transferring immediately
+when Rclone reaches the limit.
+
+Specifiying `--max-transfer-soft` will stop starting new transfers
+when Rclone reaches the limit.
+
+Specifiying `--max-transfer-cautious` will try to prevent Rclone
+from reaching the limit.
+
 ### --modify-window=TIME ###
 
 When checking whether a file has been modified, this is the maximum

--- a/fs/accounting/accounting.go
+++ b/fs/accounting/accounting.go
@@ -61,7 +61,10 @@ func newAccountSizeName(stats *StatsInfo, in io.ReadCloser, size int64, name str
 		exit:   make(chan struct{}),
 		avg:    0,
 		lpTime: time.Now(),
-		max:    int64(fs.Config.MaxTransfer),
+		max:    -1,
+	}
+	if fs.Config.MaxTransferMode != fs.MaxTransferModeSoft {
+		acc.max = int64((fs.Config.MaxTransfer))
 	}
 	go acc.averageLoop()
 	stats.inProgress.set(acc.name, acc)

--- a/fs/accounting/accounting_test.go
+++ b/fs/accounting/accounting_test.go
@@ -197,9 +197,12 @@ func TestAccountAccounter(t *testing.T) {
 
 func TestAccountMaxTransfer(t *testing.T) {
 	old := fs.Config.MaxTransfer
+	oldMode := fs.Config.MaxTransferMode
+
 	fs.Config.MaxTransfer = 15
 	defer func() {
 		fs.Config.MaxTransfer = old
+		fs.Config.MaxTransferMode = oldMode
 	}()
 
 	in := ioutil.NopCloser(bytes.NewBuffer(make([]byte, 100)))
@@ -218,6 +221,20 @@ func TestAccountMaxTransfer(t *testing.T) {
 	assert.Equal(t, 0, n)
 	assert.Equal(t, ErrorMaxTransferLimitReached, err)
 	assert.True(t, fserrors.IsFatalError(err))
+
+	fs.Config.MaxTransferMode = fs.MaxTransferModeSoft
+	stats = NewStats()
+	acc = newAccountSizeName(stats, in, 1, "test")
+
+	n, err = acc.Read(b)
+	assert.Equal(t, 10, n)
+	assert.NoError(t, err)
+	n, err = acc.Read(b)
+	assert.Equal(t, 10, n)
+	assert.NoError(t, err)
+	n, err = acc.Read(b)
+	assert.Equal(t, 10, n)
+	assert.NoError(t, err)
 }
 
 func TestShortenName(t *testing.T) {

--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -375,6 +375,22 @@ func (s *StatsInfo) GetBytes() int64 {
 	return s.bytes
 }
 
+// GetBytes returns the number of bytes transferred and allocated so far
+func (s *StatsInfo) GetBytesWithPending() int64 {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	pending := int64(0)
+	for _, tr := range s.startedTransfers {
+		if tr.acc != nil {
+			bytes, size := tr.acc.progress()
+			if bytes < size {
+				pending += size - bytes
+			}
+		}
+	}
+	return s.bytes + pending
+}
+
 // Errors updates the stats for errors
 func (s *StatsInfo) Errors(errors int64) {
 	s.mu.Lock()

--- a/fs/config.go
+++ b/fs/config.go
@@ -89,6 +89,7 @@ type ConfigInfo struct {
 	AskPassword            bool
 	UseServerModTime       bool
 	MaxTransfer            SizeSuffix
+	MaxTransferMode        MaxTransferMode
 	MaxBacklog             int
 	MaxStatsGroups         int
 	StatsOneLine           bool

--- a/fs/maxtransfermode.go
+++ b/fs/maxtransfermode.go
@@ -1,0 +1,12 @@
+package fs
+
+// MaxTransferMode describes the possible delete modes in the config
+type MaxTransferMode byte
+
+// MaxTransferMode constants
+const (
+	MaxTransferModeHard MaxTransferMode = iota
+	MaxTransferModeSoft
+	MaxTransferModeCautious
+	MaxTransferModeDefault = MaxTransferModeHard
+)

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/accounting"
 	"github.com/rclone/rclone/fs/filter"
+	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/fshttp"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
@@ -1371,4 +1372,59 @@ func TestGetFsInfo(t *testing.T) {
 	}
 	assert.Equal(t, f.Hashes(), hashSet)
 	assert.Equal(t, f.Features().Enabled(), info.Features)
+}
+
+func TestCopyFileMaxTransfer(t *testing.T) {
+	r := fstest.NewRun(t)
+	defer r.Finalise()
+	old := fs.Config.MaxTransfer
+	oldMode := fs.Config.MaxTransferMode
+
+	defer func() {
+		fs.Config.MaxTransfer = old
+		fs.Config.MaxTransferMode = oldMode
+		accounting.Stats(context.Background()).ResetCounters()
+	}()
+
+	file1 := r.WriteFile("file1", "file1 contents", t1)
+	file2 := r.WriteFile("file2", "file2 contents...........", t2)
+
+	rfile1 := file1
+	rfile1.Path = "sub/file1"
+	rfile2 := file2
+	rfile2.Path = "sub/file2"
+
+	fs.Config.MaxTransfer = 15
+	fs.Config.MaxTransferMode = fs.MaxTransferModeHard
+	accounting.Stats(context.Background()).ResetCounters()
+
+	err := operations.CopyFile(context.Background(), r.Fremote, r.Flocal, rfile1.Path, file1.Path)
+	require.NoError(t, err)
+	fstest.CheckItems(t, r.Flocal, file1, file2)
+	fstest.CheckItems(t, r.Fremote, rfile1)
+
+	accounting.Stats(context.Background()).ResetCounters()
+
+	err = operations.CopyFile(context.Background(), r.Fremote, r.Flocal, rfile2.Path, file2.Path)
+	fstest.CheckItems(t, r.Flocal, file1, file2)
+	fstest.CheckItems(t, r.Fremote, rfile1)
+	assert.Equal(t, accounting.ErrorMaxTransferLimitReached, err)
+	assert.True(t, fserrors.IsFatalError(err))
+
+	fs.Config.MaxTransferMode = fs.MaxTransferModeCautious
+	accounting.Stats(context.Background()).ResetCounters()
+
+	err = operations.CopyFile(context.Background(), r.Fremote, r.Flocal, rfile2.Path, file2.Path)
+	fstest.CheckItems(t, r.Flocal, file1, file2)
+	fstest.CheckItems(t, r.Fremote, rfile1)
+	assert.Equal(t, accounting.ErrorMaxTransferLimitReached, err)
+	assert.True(t, fserrors.IsFatalError(err))
+
+	fs.Config.MaxTransferMode = fs.MaxTransferModeSoft
+	accounting.Stats(context.Background()).ResetCounters()
+
+	err = operations.CopyFile(context.Background(), r.Fremote, r.Flocal, rfile2.Path, file2.Path)
+	require.NoError(t, err)
+	fstest.CheckItems(t, r.Flocal, file1, file2)
+	fstest.CheckItems(t, r.Fremote, rfile1, rfile2)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Implement max transfer cut off mode.
Added new flags `--max-transfer-(hard,soft,cautious)`

Defaults to `--max-transfer-hard`.

Specifiying `--max-transfer-hard` will stop transferring immediately
when Rclone reaches the limit.

Specifiying `--max-transfer-soft` will stop starting new transfers
when Rclone reaches the limit.

Specifiying `--max-transfer-cautious` will try to prevent Rclone
from reaching the limit.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

The feature is requested in #2672 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
