### PR TITLE
backend/s3: fix ExpiryWindow value

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -961,7 +961,7 @@ func s3Connection(opt *Options) (*s3.S3, *session.Session, error) {
 			Client: ec2metadata.New(session.New(), &aws.Config{
 				HTTPClient: lowTimeoutClient,
 			}),
-			ExpiryWindow: 3,
+			ExpiryWindow: 3 * time.Minute,
 		},
 	}
 	cred := credentials.NewChainCredentials(providers)


### PR DESCRIPTION
#### What is the purpose of this change?

`ExpiryWindow` accepts time.Duration but it was set to value 3.
This changes it to 3 * time.Minute since default is 5 min.

I haven't seen some drastic bug from this but the value seems odd enough to change it.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
