### PR TITLE
install.sh: Install to /usr/local/bin

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -146,6 +146,10 @@ cd $unzip_dir/*
 
 case $OS in
   'linux')
+    rclonepath="$(command -v rclone)"
+    if [ -x "$rclonepath" ] && ! [ "$rclonepath" = '/usr/local/bin' ]; then
+        echo "WARNING: Existing rclone installation found in PATH: $rclonepath"
+    fi
     #binary
     cp rclone /usr/local/bin/rclone.new
     chmod 755 /usr/local/bin/rclone.new
@@ -161,6 +165,10 @@ case $OS in
     fi
     ;;
   'freebsd'|'openbsd'|'netbsd')
+    rclonepath="$(command -v rclone)"
+    if [ -x "$rclonepath" ] && ! [ "$rclonepath" = '/usr/local/bin' ]; then
+        echo "WARNING: Existing rclone installation found in PATH: $rclonepath"
+    fi
     #bin
     cp rclone /usr/local/bin/rclone.new
     chown root:wheel /usr/local/bin/rclone.new
@@ -171,6 +179,10 @@ case $OS in
     makewhatis
     ;;
   'osx')
+    rclonepath="$(command -v rclone)"
+    if [ -x "$rclonepath" ] && ! [ "$rclonepath" = '/usr/local/bin' ]; then
+        echo "WARNING: Existing rclone installation found in PATH: $rclonepath"
+    fi
     #binary
     mkdir -p /usr/local/bin
     cp rclone /usr/local/bin/rclone.new

--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -147,7 +147,7 @@ cd $unzip_dir/*
 case $OS in
   'linux')
     rclonepath="$(command -v rclone)"
-    if [ -x "$rclonepath" ] && ! [ "$rclonepath" = '/usr/local/bin' ]; then
+    if [ -x "$rclonepath" ] && ! [ "$rclonepath" = '/usr/local/bin/rclone' ]; then
         echo "WARNING: Existing rclone installation found in PATH: $rclonepath"
     fi
     #binary
@@ -166,7 +166,7 @@ case $OS in
     ;;
   'freebsd'|'openbsd'|'netbsd')
     rclonepath="$(command -v rclone)"
-    if [ -x "$rclonepath" ] && ! [ "$rclonepath" = '/usr/local/bin' ]; then
+    if [ -x "$rclonepath" ] && ! [ "$rclonepath" = '/usr/local/bin/rclone' ]; then
         echo "WARNING: Existing rclone installation found in PATH: $rclonepath"
     fi
     #bin
@@ -180,7 +180,7 @@ case $OS in
     ;;
   'osx')
     rclonepath="$(command -v rclone)"
-    if [ -x "$rclonepath" ] && ! [ "$rclonepath" = '/usr/local/bin' ]; then
+    if [ -x "$rclonepath" ] && ! [ "$rclonepath" = '/usr/local/bin/rclone' ]; then
         echo "WARNING: Existing rclone installation found in PATH: $rclonepath"
     fi
     #binary

--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -147,10 +147,10 @@ cd $unzip_dir/*
 case $OS in
   'linux')
     #binary
-    cp rclone /usr/bin/rclone.new
-    chmod 755 /usr/bin/rclone.new
-    chown root:root /usr/bin/rclone.new
-    mv /usr/bin/rclone.new /usr/bin/rclone
+    cp rclone /usr/local/bin/rclone.new
+    chmod 755 /usr/local/bin/rclone.new
+    chown root:root /usr/local/bin/rclone.new
+    mv /usr/local/bin/rclone.new /usr/local/bin/rclone
     #manuals
     if ! [ -x "$(command -v mandb)" ]; then
         echo 'mandb not found. The rclone man docs will not be installed.'
@@ -162,9 +162,9 @@ case $OS in
     ;;
   'freebsd'|'openbsd'|'netbsd')
     #bin
-    cp rclone /usr/bin/rclone.new
-    chown root:wheel /usr/bin/rclone.new
-    mv /usr/bin/rclone.new /usr/bin/rclone
+    cp rclone /usr/local/bin/rclone.new
+    chown root:wheel /usr/local/bin/rclone.new
+    mv /usr/local/bin/rclone.new /usr/local/bin/rclone
     #man
     mkdir -p /usr/local/man/man1
     cp rclone.1 /usr/local/man/man1/


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This PR changes the install script to use `/usr/local/bin` instead of `/usr/bin`. You should never install to `/usr/bin` directly, it should be reserved for the package manager. Installing to `/usr/bin` will also mess up a possible existing installation in there.

#### Was the change discussed in an issue or in the forum before?

No, but this is a pretty standard thing.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
