### PR TITLE
config: SetValueAndSave ignore error if config section does not exist

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -575,7 +575,7 @@ func SetValueAndSave(name, key, value string) (err error) {
 	_, err = reloadedConfigFile.GetSection(name)
 	if err != nil {
 		// Section doesn't exist yet so ignore reload
-		return err
+		return nil
 	}
 	// Update the config file with the reloaded version
 	configFile = reloadedConfigFile


### PR DESCRIPTION
While working on the jotta fix i noticed these erros:
```
2019/11/08 22:39:58 ERROR : Failed saving config "client_id" = "o7cd6o7fa1v34jha6ir9tq67ev" in section "jtest" of the config file: section 'jtest' not found
2019/11/08 22:39:58 ERROR : Failed saving config "client_secret" = "MOukZqTJb-Y_N_VTc7QoUQsgkgOmyaBbdDyUi3YFy4tmHd5FqoM84Fv_" in section "jtest" of the config file: section 'jtest' not found
```
This is caused by the config reload in SetValueAndSafe. While I'm not entirely sure while there is even a need to reload the config in SetValueAndSafe I'm pretty sure this error should be ignored and the comment suggests so too.