### PR TITLE
koofr: set rclone-specific user agent for Koofr backend.

### DIFF
--- a/backend/koofr/koofr.go
+++ b/backend/koofr/koofr.go
@@ -263,6 +263,7 @@ func NewFs(name, root string, m configmap.Mapper) (ff fs.Fs, err error) {
 	basicAuth := fmt.Sprintf("Basic %s",
 		base64.StdEncoding.EncodeToString([]byte(opt.User+":"+pass)))
 	client.HTTPClient.Headers.Set("Authorization", basicAuth)
+	client.SetUserAgent(fs.Config.UserAgent)
 	mounts, err := client.Mounts()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Merely setting a rclone specific user agent, so that we can discriminate between clients on server side.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
