### PR TITLE
accounting: allow MaxCompletedTransfers to be configurable

### DIFF
--- a/docs/content/rc.md
+++ b/docs/content/rc.md
@@ -521,8 +521,8 @@ The value for "eta" is null if an eta cannot be determined.
 
 ### core/stats-reset: Reset stats. {#core/stats-reset}
 
-This clears counters and errors for all stats or specific stats group if group
-is provided.
+This clears counters, errors and finished transfers for all stats or specific
+stats group if group is provided.
 
 Parameters
 

--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -13,8 +13,8 @@ import (
 	"github.com/rclone/rclone/fs/rc"
 )
 
-// Maximum number of completed transfers in startedTransfers list
-const maxCompletedTransfers = 100
+// MaxCompletedTransfers specifies maximum number of completed transfers in startedTransfers list
+var MaxCompletedTransfers = 100
 
 // StatsInfo accounts all transfers
 type StatsInfo struct {
@@ -624,11 +624,15 @@ func (s *StatsInfo) RemoveTransfer(transfer *Transfer) {
 	s.mu.Unlock()
 }
 
-// PruneTransfers makes sure there aren't too many old transfers
+// PruneTransfers makes sure there aren't too many old transfers by removing
+// single finished transfer.
 func (s *StatsInfo) PruneTransfers() {
+	if MaxCompletedTransfers < 0 {
+		return
+	}
 	s.mu.Lock()
 	// remove a transfer from the start if we are over quota
-	if len(s.startedTransfers) > maxCompletedTransfers+fs.Config.Transfers {
+	if len(s.startedTransfers) > MaxCompletedTransfers+fs.Config.Transfers {
 		for i, tr := range s.startedTransfers {
 			if tr.IsDone() {
 				s.removeTransfer(tr, i)

--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -624,6 +624,20 @@ func (s *StatsInfo) RemoveTransfer(transfer *Transfer) {
 	s.mu.Unlock()
 }
 
+// PruneAllTransfers removes all finished transfers.
+func (s *StatsInfo) PruneAllTransfers() {
+	s.mu.Lock()
+	for i := 0; i < len(s.startedTransfers); i++ {
+		tr := s.startedTransfers[i]
+		if tr.IsDone() {
+			s.removeTransfer(tr, i)
+			// i'th element is removed, recover iterator to not skip next element.
+			i--
+		}
+	}
+	s.mu.Unlock()
+}
+
 // PruneTransfers makes sure there aren't too many old transfers by removing
 // single finished transfer.
 func (s *StatsInfo) PruneTransfers() {

--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -59,8 +59,10 @@ func resetStats(ctx context.Context, in rc.Params) (rc.Params, error) {
 	}
 
 	if group != "" {
-		groups.get(group).ResetCounters()
-		groups.get(group).ResetErrors()
+		stats := groups.get(group)
+		stats.ResetCounters()
+		stats.ResetErrors()
+		stats.PruneAllTransfers()
 	} else {
 		groups.clear()
 	}
@@ -190,8 +192,8 @@ Returns the following values:
 		Fn:    resetStats,
 		Title: "Reset stats.",
 		Help: `
-This clears counters and errors for all stats or specific stats group if group
-is provided.
+This clears counters, errors and finished transfers for all stats or specific 
+stats group if group is provided.
 
 Parameters
 
@@ -333,6 +335,7 @@ func (sg *statsGroups) clear() {
 	for _, stats := range sg.m {
 		stats.ResetErrors()
 		stats.ResetCounters()
+		stats.PruneAllTransfers()
 	}
 
 	sg.m = make(map[string]*StatsInfo)

--- a/fs/accounting/stats_test.go
+++ b/fs/accounting/stats_test.go
@@ -431,3 +431,25 @@ func TestPruneTransfers(t *testing.T) {
 		})
 	}
 }
+
+func TestPruneAllTransfers(t *testing.T) {
+	const transfers = 10
+
+	s := NewStats()
+	for i := int64(1); i <= int64(transfers); i++ {
+		s.AddTransfer(&Transfer{
+			startedAt:   time.Unix(i, 0),
+			completedAt: time.Unix(i+1, 0),
+		})
+	}
+
+	s.mu.Lock()
+	assert.Equal(t, transfers, len(s.startedTransfers))
+	s.mu.Unlock()
+
+	s.PruneAllTransfers()
+
+	s.mu.Lock()
+	assert.Empty(t, s.startedTransfers)
+	s.mu.Unlock()
+}


### PR DESCRIPTION
#### What is the purpose of this change?
Two changes in single PR since they depend on each other.

1.
rclone library users might be intrested in changing default value to other, or even disabling it. With current version it's impossible which leads to races when number of uploaded objects exceeds default limit.

Fixes #3732

2.
In order to reduce memory usage `stats-reset` also clears finished transfers.
 
Fixes #3734 
#### Was the change discussed in an issue or in the forum before?
No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
