### PR TITLE
allow specification of config password dynamically - fixes #3694

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -880,6 +880,14 @@ Rclone will do its best to transfer the best file it has so in
 practice this should not cause a problem.  Think of `--order-by` as
 being more of a best efforts flag rather than a perfect ordering.
 
+### --password-command=STRING ###
+
+This flag supplies a program which should supply the config password
+when run. This is an alternative to rclone prompting for the password
+or setting the `RCLONE_CONFIG_PASS` variable.
+
+See the [Configuration Encryption](#configuration-encryption) for more info.
+
 ### -P, --progress ###
 
 This flag makes rclone update the stats in a static block in the
@@ -1361,13 +1369,13 @@ which will retrieve the password and print on standard output.  This
 script should have a fully specified path name and not rely on any
 environment variables.  The script is supplied either via
 `--password-command="..."` command line argument or via the
-`RCLONE_CONFIG_PASS_COMMAND` environment variable.
+`RCLONE_PASSWORD_COMMAND` environment variable.
 
 One useful example of this is using the `passwordstore` application
 to retrieve the password:
 
 ```
-export RCLONE_CONFIG_PASS_COMMAND="pass rclone/config"
+export RCLONE_PASSWORD_COMMAND="pass rclone/config"
 ```
 
 If the `passwordstore` password manager holds the password for the
@@ -1381,11 +1389,11 @@ script method of supplying the password enhances the security of
 the config password considerably.
 
 If you are running rclone inside a script, unless you are using the
-`RCLONE_CONFIG_PASS_COMMAND` method, you might want to disable 
+`--password-command` method, you might want to disable 
 password prompts. To do that, pass the parameter 
 `--ask-password=false` to rclone. This will make rclone fail instead
 of asking for a password if `RCLONE_CONFIG_PASS` doesn't contain
-a valid password, and `RCLONE_CONFIG_PASS_COMMAND` has not been supplied.
+a valid password, and `--password-command` has not been supplied.
 
 
 Developer options

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1285,7 +1285,7 @@ your cloud services. This means that you should keep your
 
 If you are in an environment where that isn't possible, you can
 add a password to your configuration. This means that you will
-have to enter the password every time you start rclone.
+have to supply the password every time you start rclone.
 
 To add a password to your rclone configuration, execute `rclone config`.
 
@@ -1322,9 +1322,9 @@ c/u/q>
 ```
 
 Your configuration is now encrypted, and every time you start rclone
-you will now be asked for the password. In the same menu, you can
-change the password or completely remove encryption from your
-configuration.
+you will have to supply the password. See below for details.
+In the same menu, you can change the password or completely remove
+encryption from your configuration.
 
 There is no way to recover the configuration if you lose your password.
 
@@ -1356,11 +1356,36 @@ Then source the file when you want to use it.  From the shell you
 would do `source set-rclone-password`.  It will then ask you for the
 password and set it in the environment variable.
 
-If you are running rclone inside a script, you might want to disable 
+An alternate means of supplying the password is to provide a script
+which will retrieve the password and print on standard output.  This
+script should have a fully specified path name and not rely on any
+environment variables.  The script is supplied either via
+`--password-command="..."` command line argument or via the
+`RCLONE_CONFIG_PASS_COMMAND` environment variable.
+
+One useful example of this is using the `passwordstore` application
+to retrieve the password:
+
+```
+export RCLONE_CONFIG_PASS_COMMAND="pass rclone/config"
+```
+
+If the `passwordstore` password manager holds the password for the
+rclone configuration, using the script method means the password
+is primarily protected by the `passwordstore` system, and is never
+embedded in the clear in scripts, nor available for examination
+using the standard commands available.  It is quite possible with
+long running rclone sessions for copies of passwords to be innocently
+captured in log files or terminal scroll buffers, etc.  Using the
+script method of supplying the password enhances the security of
+the config password considerably.
+
+If you are running rclone inside a script, unless you are using the
+`RCLONE_CONFIG_PASS_COMMAND` method, you might want to disable 
 password prompts. To do that, pass the parameter 
 `--ask-password=false` to rclone. This will make rclone fail instead
 of asking for a password if `RCLONE_CONFIG_PASS` doesn't contain
-a valid password.
+a valid password, and `RCLONE_CONFIG_PASS_COMMAND` has not been supplied.
 
 
 Developer options

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -880,11 +880,23 @@ Rclone will do its best to transfer the best file it has so in
 practice this should not cause a problem.  Think of `--order-by` as
 being more of a best efforts flag rather than a perfect ordering.
 
-### --password-command=STRING ###
+### --password-command SpaceSepList ###
 
 This flag supplies a program which should supply the config password
 when run. This is an alternative to rclone prompting for the password
 or setting the `RCLONE_CONFIG_PASS` variable.
+
+The argument to this should be a command with a space separated list
+of arguments. If one of the arguments has a space in then enclose it
+in `"`, if you want a literal `"` in an argument then enclose the
+argument in `"` and double the `"`. See [CSV encoding](https://godoc.org/encoding/csv)
+for more info.
+
+Eg
+
+    --password-command echo hello
+    --password-command echo "hello with space"
+    --password-command echo "hello with ""quotes"" and space"
 
 See the [Configuration Encryption](#configuration-encryption) for more info.
 

--- a/fs/config.go
+++ b/fs/config.go
@@ -89,7 +89,7 @@ type ConfigInfo struct {
 	StreamingUploadCutoff  SizeSuffix
 	StatsFileNameLength    int
 	AskPassword            bool
-	PasswordCommand        string
+	PasswordCommand        SpaceSepList
 	UseServerModTime       bool
 	MaxTransfer            SizeSuffix
 	MaxBacklog             int

--- a/fs/config.go
+++ b/fs/config.go
@@ -89,6 +89,7 @@ type ConfigInfo struct {
 	StreamingUploadCutoff  SizeSuffix
 	StatsFileNameLength    int
 	AskPassword            bool
+	PasswordCommand        string
 	UseServerModTime       bool
 	MaxTransfer            SizeSuffix
 	MaxBacklog             int

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -275,10 +275,6 @@ func loadConfigFile() (*goconfig.ConfigFile, error) {
 
 	if len(configKey) == 0 {
 		pwc := fs.Config.PasswordCommand
-
-		if pwc == "" {
-			pwc = os.Getenv("RCLONE_CONFIG_PASS_COMMAND")
-		}
 		if pwc != "" {
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
@@ -291,7 +287,7 @@ func loadConfigFile() (*goconfig.ConfigFile, error) {
 
 			if err := cmd.Run(); err != nil {
 				// One does not always get the stderr returned in the wrapped error.
-				fs.Errorf(nil, "Using RCLONE_CONFIG_PASS_COMMAND returned: %v", err)
+				fs.Errorf(nil, "Using --password-command returned: %v", err)
 				if ers := strings.TrimSpace(stderr.String()); ers != "" {
 					fs.Errorf(nil, "--password-command stderr: %s", ers)
 				}
@@ -357,7 +353,7 @@ func loadConfigFile() (*goconfig.ConfigFile, error) {
 		} else {
 			if len(configKey) == 0 {
 				if usingPasswordCommand {
-					return nil, errors.New("using password command derived password, unable to decrypt configuration")
+					return nil, errors.New("using --password-command derived password, unable to decrypt configuration")
 				}
 				if !fs.Config.AskPassword {
 					return nil, errors.New("unable to decrypt configuration and not allowed to ask for password - set RCLONE_CONFIG_PASS to your configuration password")

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -274,13 +274,11 @@ func loadConfigFile() (*goconfig.ConfigFile, error) {
 	}
 
 	if len(configKey) == 0 {
-		pwc := fs.Config.PasswordCommand
-		if pwc != "" {
+		if len(fs.Config.PasswordCommand) != 0 {
 			var stdout bytes.Buffer
 			var stderr bytes.Buffer
 
-			args := strings.Fields(pwc)
-			cmd := exec.Command(args[0], args[1:]...)
+			cmd := exec.Command(fs.Config.PasswordCommand[0], fs.Config.PasswordCommand[1:]...)
 
 			cmd.Stdout = &stdout
 			cmd.Stderr = &stderr

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -14,6 +14,7 @@ import (
 	"log"
 	mathrand "math/rand"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"runtime"
@@ -239,15 +240,7 @@ var errorConfigFileNotFound = errors.New("config file not found")
 // loadConfigFile will load a config file, and
 // automatically decrypt it.
 func loadConfigFile() (*goconfig.ConfigFile, error) {
-	envpw := os.Getenv("RCLONE_CONFIG_PASS")
-	if len(configKey) == 0 && envpw != "" {
-		err := setConfigPassword(envpw)
-		if err != nil {
-			fs.Errorf(nil, "Using RCLONE_CONFIG_PASS returned: %v", err)
-		} else {
-			fs.Debugf(nil, "Using RCLONE_CONFIG_PASS password.")
-		}
-	}
+	var usingPasswordCommand bool
 
 	b, err := ioutil.ReadFile(ConfigPath)
 	if err != nil {
@@ -280,6 +273,59 @@ func loadConfigFile() (*goconfig.ConfigFile, error) {
 		return goconfig.LoadFromReader(bytes.NewBuffer(b))
 	}
 
+	if len(configKey) == 0 {
+		pwc := fs.Config.PasswordCommand
+
+		if pwc == "" {
+			pwc = os.Getenv("RCLONE_CONFIG_PASS_COMMAND")
+		}
+		if pwc != "" {
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+
+			args := strings.Fields(pwc)
+			cmd := exec.Command(args[0], args[1:]...)
+
+			cmd.Stdout = &stdout
+			cmd.Stderr = &stderr
+
+			if err := cmd.Run(); err != nil {
+				// One does not always get the stderr returned in the wrapped error.
+				fs.Errorf(nil, "Using RCLONE_CONFIG_PASS_COMMAND returned: %v", err)
+				if ers := strings.TrimSpace(stderr.String()); ers != "" {
+					fs.Errorf(nil, "--password-command stderr: %s", ers)
+				}
+				return nil, errors.Wrap(err, "password command failed")
+			}
+			if pass := strings.Trim(stdout.String(), "\r\n"); pass != "" {
+				err := setConfigPassword(pass)
+				if err != nil {
+					return nil, errors.Wrap(err, "incorrect password")
+				}
+			} else {
+				return nil, errors.New("password-command returned empty string")
+			}
+
+			if len(configKey) == 0 {
+				return nil, errors.New("unable to decrypt configuration: incorrect password")
+			}
+			usingPasswordCommand = true
+		} else {
+			usingPasswordCommand = false
+
+			envpw := os.Getenv("RCLONE_CONFIG_PASS")
+
+			if envpw != "" {
+				err := setConfigPassword(envpw)
+				if err != nil {
+					fs.Errorf(nil, "Using RCLONE_CONFIG_PASS returned: %v", err)
+				} else {
+					fs.Debugf(nil, "Using RCLONE_CONFIG_PASS password.")
+				}
+			}
+		}
+	}
+
 	// Encrypted content is base64 encoded.
 	dec := base64.NewDecoder(base64.StdEncoding, r)
 	box, err := ioutil.ReadAll(dec)
@@ -310,6 +356,9 @@ func loadConfigFile() (*goconfig.ConfigFile, error) {
 			fs.Debugf(nil, "using _RCLONE_CONFIG_KEY_FILE for configKey")
 		} else {
 			if len(configKey) == 0 {
+				if usingPasswordCommand {
+					return nil, errors.New("using password command derived password, unable to decrypt configuration")
+				}
 				if !fs.Config.AskPassword {
 					return nil, errors.New("unable to decrypt configuration and not allowed to ask for password - set RCLONE_CONFIG_PASS to your configuration password")
 				}

--- a/fs/config/config_test.go
+++ b/fs/config/config_test.go
@@ -270,6 +270,84 @@ func TestConfigLoadEncrypted(t *testing.T) {
 	assert.Equal(t, expect, keys)
 }
 
+func expectConfigValid(t *testing.T) {
+	var err error
+
+	configKey = nil // reset password
+
+	c, err := loadConfigFile()
+	require.NoError(t, err)
+
+	// Not sure why there is no "RCLONE_ENCRYPT_V0" here...
+	sections := c.GetSectionList()
+	var expect = []string{"nounc", "unc"}
+	assert.Equal(t, expect, sections)
+
+	keys := c.GetKeyList("nounc")
+	expect = []string{"type", "nounc"}
+	assert.Equal(t, expect, keys)
+}
+
+func expectConfigInvalid(t *testing.T) {
+	var err error
+
+	configKey = nil // reset password
+
+	_, err = loadConfigFile()
+	require.Error(t, err)
+}
+
+func TestConfigLoadEncryptedWithValidPassCommand(t *testing.T) {
+	oldConfigPath := ConfigPath
+	oldConfig := fs.Config
+	ConfigPath = "./testdata/encrypted.conf"
+	defer func() {
+		ConfigPath = oldConfigPath
+		configKey = nil // reset password
+		fs.Config = oldConfig
+	}()
+
+	// using fs.Config.PasswordCommand, correct password
+	fs.Config.PasswordCommand = "echo asdf"
+	expectConfigValid(t)
+
+	var err error
+
+	// using "RCLONE_CONFIG_PASS_COMMAND"
+
+	err = os.Setenv("RCLONE_CONFIG_PASS_COMMAND", "echo asdf")
+	require.NoError(t, err)
+	expectConfigValid(t)
+
+	err = os.Unsetenv("RCLONE_CONFIG_PASS_COMMAND")
+	require.NoError(t, err)
+}
+
+func TestConfigLoadEncryptedWithInvalidPassCommand(t *testing.T) {
+	oldConfigPath := ConfigPath
+	oldConfig := fs.Config
+	ConfigPath = "./testdata/encrypted.conf"
+	defer func() {
+		ConfigPath = oldConfigPath
+		configKey = nil // reset password
+		fs.Config = oldConfig
+	}()
+
+	// using fs.Config.PasswordCommand, incorrect password
+	fs.Config.PasswordCommand = "echo asdf-blurfl"
+	expectConfigInvalid(t)
+	fs.Config.PasswordCommand = ""
+
+	var err error
+
+	err = os.Setenv("RCLONE_CONFIG_PASS_COMMAND", "echo asdf-blurfl")
+	require.NoError(t, err)
+	expectConfigInvalid(t)
+
+	err = os.Unsetenv("RCLONE_CONFIG_PASS_COMMAND")
+	require.NoError(t, err)
+}
+
 func TestConfigLoadEncryptedFailures(t *testing.T) {
 	var err error
 

--- a/fs/config/config_test.go
+++ b/fs/config/config_test.go
@@ -275,12 +275,12 @@ func TestConfigLoadEncryptedWithValidPassCommand(t *testing.T) {
 	oldConfig := fs.Config
 	ConfigPath = "./testdata/encrypted.conf"
 	// using fs.Config.PasswordCommand, correct password
-	fs.Config.PasswordCommand = "echo asdf"
+	fs.Config.PasswordCommand = fs.SpaceSepList{"echo", "asdf"}
 	defer func() {
 		ConfigPath = oldConfigPath
 		configKey = nil // reset password
 		fs.Config = oldConfig
-		fs.Config.PasswordCommand = ""
+		fs.Config.PasswordCommand = nil
 	}()
 
 	configKey = nil // reset password
@@ -302,12 +302,12 @@ func TestConfigLoadEncryptedWithInvalidPassCommand(t *testing.T) {
 	oldConfig := fs.Config
 	ConfigPath = "./testdata/encrypted.conf"
 	// using fs.Config.PasswordCommand, incorrect password
-	fs.Config.PasswordCommand = "echo asdf-blurfl"
+	fs.Config.PasswordCommand = fs.SpaceSepList{"echo", "asdf-blurfl"}
 	defer func() {
 		ConfigPath = oldConfigPath
 		configKey = nil // reset password
 		fs.Config = oldConfig
-		fs.Config.PasswordCommand = ""
+		fs.Config.PasswordCommand = nil
 	}()
 
 	configKey = nil // reset password

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -55,7 +55,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &dumpBodies, "dump-bodies", "", false, "Dump HTTP headers and bodies - may contain sensitive info")
 	flags.BoolVarP(flagSet, &fs.Config.InsecureSkipVerify, "no-check-certificate", "", fs.Config.InsecureSkipVerify, "Do not verify the server SSL certificate. Insecure.")
 	flags.BoolVarP(flagSet, &fs.Config.AskPassword, "ask-password", "", fs.Config.AskPassword, "Allow prompt for password for encrypted configuration.")
-	flags.StringVarP(flagSet, &fs.Config.PasswordCommand, "password-command", "", fs.Config.PasswordCommand, "Command for supplying password for encrypted configuration.")
+	flags.FVarP(flagSet, &fs.Config.PasswordCommand, "password-command", "", "Command for supplying password for encrypted configuration.")
 	flags.BoolVarP(flagSet, &deleteBefore, "delete-before", "", false, "When synchronizing, delete files on destination before transferring")
 	flags.BoolVarP(flagSet, &deleteDuring, "delete-during", "", false, "When synchronizing, delete files during transfer")
 	flags.BoolVarP(flagSet, &deleteAfter, "delete-after", "", false, "When synchronizing, delete files on destination after transferring (default)")

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -55,6 +55,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &dumpBodies, "dump-bodies", "", false, "Dump HTTP headers and bodies - may contain sensitive info")
 	flags.BoolVarP(flagSet, &fs.Config.InsecureSkipVerify, "no-check-certificate", "", fs.Config.InsecureSkipVerify, "Do not verify the server SSL certificate. Insecure.")
 	flags.BoolVarP(flagSet, &fs.Config.AskPassword, "ask-password", "", fs.Config.AskPassword, "Allow prompt for password for encrypted configuration.")
+	flags.StringVarP(flagSet, &fs.Config.PasswordCommand, "password-command", "", fs.Config.PasswordCommand, "Command for supplying password for encrypted configuration.")
 	flags.BoolVarP(flagSet, &deleteBefore, "delete-before", "", false, "When synchronizing, delete files on destination before transferring")
 	flags.BoolVarP(flagSet, &deleteDuring, "delete-during", "", false, "When synchronizing, delete files during transfer")
 	flags.BoolVarP(flagSet, &deleteAfter, "delete-after", "", false, "When synchronizing, delete files on destination after transferring (default)")


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Allow specification of config password dynamically.

When the config is encrypted, the password to decrypt can be supplied by passing a command string, rather than a static password.
The command string is executed when required (once per rclone invocation) yielding the password via a pipe.  The command writes to stdout, which has been arranged so as to be a pipe.
I am assuming reasonable OS here.  No idea if WinDoze will support this.  If not, don't use it.
-->

#### Was the change discussed in an issue or in the forum before?

<!--
https://github.com/rclone/rclone/issues/3694#issue-516455556
-->

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ x] I have added tests for all changes in this PR if appropriate.
- [x ] I have added documentation for the changes if appropriate.
- [x ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x ] I'm done, this Pull Request is ready for review :-)

よろしくお願いします。