### PR TITLE
docs/install: explain how to workaround macOS Gatekeeper requiring notarization

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -56,7 +56,14 @@ Run `rclone config` to setup. See [rclone config docs](/docs/) for more details.
 
     rclone config
 
-## macOS installation from precompiled binary ##
+## macOS installation with brew ##
+
+    brew install rclone
+
+## macOS installation from precompiled binary, using curl ##
+
+To avoid problems with macOS gatekeeper enforcing the binary to be signed and
+notarized it is enough to download with `curl`.
 
 Download the latest version of rclone.
 
@@ -80,6 +87,19 @@ Remove the leftover files.
 Run `rclone config` to setup. See [rclone config docs](/docs/) for more details.
 
     rclone config
+
+## macOS installation from precompiled binary, using a web browser ##
+
+When downloading a binary with a web browser, the browser will set the macOS
+gatekeeper quarantine attribute. Starting from Catalina, when attempting to run
+`rclone`, a pop-up will appear saying:
+
+    “rclone” cannot be opened because the developer cannot be verified.
+    macOS cannot verify that this app is free from malware.
+
+The simplest fix is to run
+
+    xattr -d com.apple.quarantine rclone
 
 ## Install with docker ##
 


### PR DESCRIPTION
#### What is the purpose of this change?

Explain how to workaround the problems due to macOS Gatekeeper requiring an executable to be notarized.

With reference to @ncw requests in #3689:

> I think what we should do now put a note into the install doc to the effect that macOS Catalina can't run rclone binaries by default and specify the xattr workaround provided it works OK.

Done. I also mentioned the `xattr` workaround, although I am not even sure it makes sense to mention, since it is needed only when downloading the package with a web browser. Please have a look at the details in the PR.

> Maybe another section on brew install rclone. I don't know who packages rclone for brew so I'm a bit nervous recommending it there, but it seems bang up to date.

I added a new section, and actually put it as the first macOS section given the simplicity. Let me know if you want me to change.

> Perhaps adding the xattr fix to install.sh would be OK too?

I tested with `install.sh` and the workaround is not needed: `rclone` works fine. It turns out that it is really the web browser that sets the quarantine attribute :-D (More details at https://news.ycombinator.com/item?id=21179970)

> Can a macOS Catalina user test the xattr -d com.apple.quarantine fix to see if it actually works

I tested downloading the package and the `xattr` workaround works.

To summarize:

1. `install.sh` works out of the box.
2. `brew install rclone` works out of the box.
3. if downloading with a web browser, the `xattr` workaround works.

#### Was the change discussed in an issue or in the forum before?

Fixes #3689

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
