### PR TITLE
backend/local: add disable_checksum option

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2040,7 +2040,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	// read the md5sum if available for non multpart and if
 	// disable checksum isn't present.
 	var md5sum string
-	if !multipart || !o.fs.opt.DisableChecksum {
+	if !multipart && !o.fs.opt.DisableChecksum {
 		hash, err := src.Hash(ctx, hash.MD5)
 		if err == nil && matchMd5.MatchString(hash) {
 			hashBytes, err := hex.DecodeString(hash)


### PR DESCRIPTION
Rclone will calculate checksums on read for all objects in local
backend. This is a problem in performance critical environments or for
large files.

We are introducing `disable_checksum option for the local backend to
disable hashing for file reads.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
