### PR TITLE
chunker: reduce length of temporary suffix

### DIFF
--- a/backend/chunker/chunker_internal_test.go
+++ b/backend/chunker/chunker_internal_test.go
@@ -64,35 +64,40 @@ func testChunkNameFormat(t *testing.T, f *Fs) {
 		assert.Error(t, err)
 	}
 
-	assertMakeName := func(wantChunkName, mainName string, chunkNo int, ctrlType string, xactNo int64) {
-		gotChunkName := f.makeChunkName(mainName, chunkNo, ctrlType, xactNo)
-		assert.Equal(t, wantChunkName, gotChunkName)
+	assertMakeName := func(wantChunkName, mainName string, chunkNo int, ctrlType, xactID string) {
+		gotChunkName := ""
+		assert.NotPanics(t, func() {
+			gotChunkName = f.makeChunkName(mainName, chunkNo, ctrlType, xactID)
+		}, "makeChunkName(%q,%d,%q,%q) must not panic", mainName, chunkNo, ctrlType, xactID)
+		if gotChunkName != "" {
+			assert.Equal(t, wantChunkName, gotChunkName)
+		}
 	}
 
-	assertMakeNamePanics := func(mainName string, chunkNo int, ctrlType string, xactNo int64) {
+	assertMakeNamePanics := func(mainName string, chunkNo int, ctrlType, xactID string) {
 		assert.Panics(t, func() {
-			_ = f.makeChunkName(mainName, chunkNo, ctrlType, xactNo)
-		}, "makeChunkName(%q,%d,%q,%d) should panic", mainName, chunkNo, ctrlType, xactNo)
+			_ = f.makeChunkName(mainName, chunkNo, ctrlType, xactID)
+		}, "makeChunkName(%q,%d,%q,%q) should panic", mainName, chunkNo, ctrlType, xactID)
 	}
 
-	assertParseName := func(fileName, wantMainName string, wantChunkNo int, wantCtrlType string, wantXactNo int64) {
-		gotMainName, gotChunkNo, gotCtrlType, gotXactNo := f.parseChunkName(fileName)
+	assertParseName := func(fileName, wantMainName string, wantChunkNo int, wantCtrlType, wantXactID string) {
+		gotMainName, gotChunkNo, gotCtrlType, gotXactID := f.parseChunkName(fileName)
 		assert.Equal(t, wantMainName, gotMainName)
 		assert.Equal(t, wantChunkNo, gotChunkNo)
 		assert.Equal(t, wantCtrlType, gotCtrlType)
-		assert.Equal(t, wantXactNo, gotXactNo)
+		assert.Equal(t, wantXactID, gotXactID)
 	}
 
 	const newFormatSupported = false // support for patterns not starting with base name (*)
 
 	// valid formats
-	assertFormat(`*.rclone_chunk.###`, `%s.rclone_chunk.%03d`, `%s.rclone_chunk._%s`, `^(.+?)\.rclone_chunk\.(?:([0-9]{3,})|_([a-z]{3,9}))(?:\.\.tmp_([0-9]{10,19}))?$`)
-	assertFormat(`*.rclone_chunk.#`, `%s.rclone_chunk.%d`, `%s.rclone_chunk._%s`, `^(.+?)\.rclone_chunk\.(?:([0-9]+)|_([a-z]{3,9}))(?:\.\.tmp_([0-9]{10,19}))?$`)
-	assertFormat(`*_chunk_#####`, `%s_chunk_%05d`, `%s_chunk__%s`, `^(.+?)_chunk_(?:([0-9]{5,})|_([a-z]{3,9}))(?:\.\.tmp_([0-9]{10,19}))?$`)
-	assertFormat(`*-chunk-#`, `%s-chunk-%d`, `%s-chunk-_%s`, `^(.+?)-chunk-(?:([0-9]+)|_([a-z]{3,9}))(?:\.\.tmp_([0-9]{10,19}))?$`)
-	assertFormat(`*-chunk-#-%^$()[]{}.+-!?:\`, `%s-chunk-%d-%%^$()[]{}.+-!?:\`, `%s-chunk-_%s-%%^$()[]{}.+-!?:\`, `^(.+?)-chunk-(?:([0-9]+)|_([a-z]{3,9}))-%\^\$\(\)\[\]\{\}\.\+-!\?:\\(?:\.\.tmp_([0-9]{10,19}))?$`)
+	assertFormat(`*.rclone_chunk.###`, `%s.rclone_chunk.%03d`, `%s.rclone_chunk._%s`, `^(.+?)\.rclone_chunk\.(?:([0-9]{3,})|_([a-z][a-z0-9]{2,6}))(?:_([0-9a-z]{4,9})|\.\.tmp_([0-9]{10,13}))?$`)
+	assertFormat(`*.rclone_chunk.#`, `%s.rclone_chunk.%d`, `%s.rclone_chunk._%s`, `^(.+?)\.rclone_chunk\.(?:([0-9]+)|_([a-z][a-z0-9]{2,6}))(?:_([0-9a-z]{4,9})|\.\.tmp_([0-9]{10,13}))?$`)
+	assertFormat(`*_chunk_#####`, `%s_chunk_%05d`, `%s_chunk__%s`, `^(.+?)_chunk_(?:([0-9]{5,})|_([a-z][a-z0-9]{2,6}))(?:_([0-9a-z]{4,9})|\.\.tmp_([0-9]{10,13}))?$`)
+	assertFormat(`*-chunk-#`, `%s-chunk-%d`, `%s-chunk-_%s`, `^(.+?)-chunk-(?:([0-9]+)|_([a-z][a-z0-9]{2,6}))(?:_([0-9a-z]{4,9})|\.\.tmp_([0-9]{10,13}))?$`)
+	assertFormat(`*-chunk-#-%^$()[]{}.+-!?:\`, `%s-chunk-%d-%%^$()[]{}.+-!?:\`, `%s-chunk-_%s-%%^$()[]{}.+-!?:\`, `^(.+?)-chunk-(?:([0-9]+)|_([a-z][a-z0-9]{2,6}))-%\^\$\(\)\[\]\{\}\.\+-!\?:\\(?:_([0-9a-z]{4,9})|\.\.tmp_([0-9]{10,13}))?$`)
 	if newFormatSupported {
-		assertFormat(`_*-chunk-##,`, `_%s-chunk-%02d,`, `_%s-chunk-_%s,`, `^_(.+?)-chunk-(?:([0-9]{2,})|_([a-z]{3,9})),(?:\.\.tmp_([0-9]{10,19}))?$`)
+		assertFormat(`_*-chunk-##,`, `_%s-chunk-%02d,`, `_%s-chunk-_%s,`, `^_(.+?)-chunk-(?:([0-9]{2,})|_([a-z][a-z0-9]{2,6})),(?:_([0-9a-z]{4,9})|\.\.tmp_([0-9]{10,13}))?$`)
 	}
 
 	// invalid formats
@@ -111,142 +116,223 @@ func testChunkNameFormat(t *testing.T, f *Fs) {
 
 	// quick tests
 	if newFormatSupported {
-		assertFormat(`part_*_#`, `part_%s_%d`, `part_%s__%s`, `^part_(.+?)_(?:([0-9]+)|_([a-z]{3,9}))(?:\.\.tmp_([0-9]{10,19}))?$`)
+		assertFormat(`part_*_#`, `part_%s_%d`, `part_%s__%s`, `^part_(.+?)_(?:([0-9]+)|_([a-z][a-z0-9]{2,6}))(?:_([0-9][0-9a-z]{3,8})\.\.tmp_([0-9]{10,13}))?$`)
 		f.opt.StartFrom = 1
 
-		assertMakeName(`part_fish_1`, "fish", 0, "", -1)
-		assertParseName(`part_fish_43`, "fish", 42, "", -1)
-		assertMakeName(`part_fish_3..tmp_0000000004`, "fish", 2, "", 4)
-		assertParseName(`part_fish_4..tmp_0000000005`, "fish", 3, "", 5)
-		assertMakeName(`part_fish__locks`, "fish", -2, "locks", -3)
-		assertParseName(`part_fish__locks`, "fish", -1, "locks", -1)
-		assertMakeName(`part_fish__blockinfo..tmp_1234567890123456789`, "fish", -3, "blockinfo", 1234567890123456789)
-		assertParseName(`part_fish__blockinfo..tmp_1234567890123456789`, "fish", -1, "blockinfo", 1234567890123456789)
+		assertMakeName(`part_fish_1`, "fish", 0, "", "")
+		assertParseName(`part_fish_43`, "fish", 42, "", "")
+		assertMakeName(`part_fish__locks`, "fish", -2, "locks", "")
+		assertParseName(`part_fish__locks`, "fish", -1, "locks", "")
+		assertMakeName(`part_fish__x2y`, "fish", -2, "x2y", "")
+		assertParseName(`part_fish__x2y`, "fish", -1, "x2y", "")
+		assertMakeName(`part_fish_3_0004`, "fish", 2, "", "4")
+		assertParseName(`part_fish_4_0005`, "fish", 3, "", "0005")
+		assertMakeName(`part_fish__blkinfo_jj5fvo3wr`, "fish", -3, "blkinfo", "jj5fvo3wr")
+		assertParseName(`part_fish__blkinfo_zz9fvo3wr`, "fish", -1, "blkinfo", "zz9fvo3wr")
+
+		// old-style temporary suffix (parse only)
+		assertParseName(`part_fish_4..tmp_0000000011`, "fish", 3, "", "000b")
+		assertParseName(`part_fish__blkinfo_jj5fvo3wr`, "fish", -1, "blkinfo", "jj5fvo3wr")
 	}
 
 	// prepare format for long tests
-	assertFormat(`*.chunk.###`, `%s.chunk.%03d`, `%s.chunk._%s`, `^(.+?)\.chunk\.(?:([0-9]{3,})|_([a-z]{3,9}))(?:\.\.tmp_([0-9]{10,19}))?$`)
+	assertFormat(`*.chunk.###`, `%s.chunk.%03d`, `%s.chunk._%s`, `^(.+?)\.chunk\.(?:([0-9]{3,})|_([a-z][a-z0-9]{2,6}))(?:_([0-9a-z]{4,9})|\.\.tmp_([0-9]{10,13}))?$`)
 	f.opt.StartFrom = 2
 
 	// valid data chunks
-	assertMakeName(`fish.chunk.003`, "fish", 1, "", -1)
-	assertMakeName(`fish.chunk.011..tmp_0000054321`, "fish", 9, "", 54321)
-	assertMakeName(`fish.chunk.011..tmp_1234567890`, "fish", 9, "", 1234567890)
-	assertMakeName(`fish.chunk.1916..tmp_123456789012345`, "fish", 1914, "", 123456789012345)
+	assertMakeName(`fish.chunk.003`, "fish", 1, "", "")
+	assertParseName(`fish.chunk.003`, "fish", 1, "", "")
+	assertMakeName(`fish.chunk.021`, "fish", 19, "", "")
+	assertParseName(`fish.chunk.021`, "fish", 19, "", "")
 
-	assertParseName(`fish.chunk.003`, "fish", 1, "", -1)
-	assertParseName(`fish.chunk.004..tmp_0000000021`, "fish", 2, "", 21)
-	assertParseName(`fish.chunk.021`, "fish", 19, "", -1)
-	assertParseName(`fish.chunk.323..tmp_1234567890123456789`, "fish", 321, "", 1234567890123456789)
+	// valid temporary data chunks
+	assertMakeName(`fish.chunk.011_4321`, "fish", 9, "", "4321")
+	assertParseName(`fish.chunk.011_4321`, "fish", 9, "", "4321")
+	assertMakeName(`fish.chunk.011_00bc`, "fish", 9, "", "00bc")
+	assertParseName(`fish.chunk.011_00bc`, "fish", 9, "", "00bc")
+	assertMakeName(`fish.chunk.1916_5jjfvo3wr`, "fish", 1914, "", "5jjfvo3wr")
+	assertParseName(`fish.chunk.1916_5jjfvo3wr`, "fish", 1914, "", "5jjfvo3wr")
+	assertMakeName(`fish.chunk.1917_zz9fvo3wr`, "fish", 1915, "", "zz9fvo3wr")
+	assertParseName(`fish.chunk.1917_zz9fvo3wr`, "fish", 1915, "", "zz9fvo3wr")
+
+	// valid temporary data chunks (old temporary suffix, only parse)
+	assertParseName(`fish.chunk.004..tmp_0000000047`, "fish", 2, "", "001b")
+	assertParseName(`fish.chunk.323..tmp_9994567890123`, "fish", 321, "", "3jjfvo3wr")
 
 	// parsing invalid data chunk names
-	assertParseName(`fish.chunk.3`, "", -1, "", -1)
-	assertParseName(`fish.chunk.001`, "", -1, "", -1)
-	assertParseName(`fish.chunk.21`, "", -1, "", -1)
-	assertParseName(`fish.chunk.-21`, "", -1, "", -1)
+	assertParseName(`fish.chunk.3`, "", -1, "", "")
+	assertParseName(`fish.chunk.001`, "", -1, "", "")
+	assertParseName(`fish.chunk.21`, "", -1, "", "")
+	assertParseName(`fish.chunk.-21`, "", -1, "", "")
 
-	assertParseName(`fish.chunk.004.tmp_0000000021`, "", -1, "", -1)
-	assertParseName(`fish.chunk.003..tmp_123456789`, "", -1, "", -1)
-	assertParseName(`fish.chunk.003..tmp_012345678901234567890123456789`, "", -1, "", -1)
-	assertParseName(`fish.chunk.003..tmp_-1`, "", -1, "", -1)
+	assertParseName(`fish.chunk.004abcd`, "", -1, "", "")        // missing underscore delimiter
+	assertParseName(`fish.chunk.004__1234`, "", -1, "", "")      // extra underscore delimiter
+	assertParseName(`fish.chunk.004_123`, "", -1, "", "")        // too short temporary suffix
+	assertParseName(`fish.chunk.004_1234567890`, "", -1, "", "") // too long temporary suffix
+	assertParseName(`fish.chunk.004_-1234`, "", -1, "", "")      // temporary suffix must be positive
+	assertParseName(`fish.chunk.004_123E`, "", -1, "", "")       // uppercase not allowed
+	assertParseName(`fish.chunk.004_12.3`, "", -1, "", "")       // punctuation not allowed
+
+	// parsing invalid data chunk names (old temporary suffix)
+	assertParseName(`fish.chunk.004.tmp_0000000021`, "", -1, "", "")
+	assertParseName(`fish.chunk.003..tmp_123456789`, "", -1, "", "")
+	assertParseName(`fish.chunk.003..tmp_012345678901234567890123456789`, "", -1, "", "")
+	assertParseName(`fish.chunk.323..tmp_12345678901234`, "", -1, "", "")
+	assertParseName(`fish.chunk.003..tmp_-1`, "", -1, "", "")
 
 	// valid control chunks
-	assertMakeName(`fish.chunk._info`, "fish", -1, "info", -1)
-	assertMakeName(`fish.chunk._locks`, "fish", -2, "locks", -1)
-	assertMakeName(`fish.chunk._blockinfo`, "fish", -3, "blockinfo", -1)
+	assertMakeName(`fish.chunk._info`, "fish", -1, "info", "")
+	assertMakeName(`fish.chunk._locks`, "fish", -2, "locks", "")
+	assertMakeName(`fish.chunk._blkinfo`, "fish", -3, "blkinfo", "")
+	assertMakeName(`fish.chunk._x2y`, "fish", -4, "x2y", "")
 
-	assertParseName(`fish.chunk._info`, "fish", -1, "info", -1)
-	assertParseName(`fish.chunk._locks`, "fish", -1, "locks", -1)
-	assertParseName(`fish.chunk._blockinfo`, "fish", -1, "blockinfo", -1)
+	assertParseName(`fish.chunk._info`, "fish", -1, "info", "")
+	assertParseName(`fish.chunk._locks`, "fish", -1, "locks", "")
+	assertParseName(`fish.chunk._blkinfo`, "fish", -1, "blkinfo", "")
+	assertParseName(`fish.chunk._x2y`, "fish", -1, "x2y", "")
 
 	// valid temporary control chunks
-	assertMakeName(`fish.chunk._info..tmp_0000000021`, "fish", -1, "info", 21)
-	assertMakeName(`fish.chunk._locks..tmp_0000054321`, "fish", -2, "locks", 54321)
-	assertMakeName(`fish.chunk._uploads..tmp_0000000000`, "fish", -3, "uploads", 0)
-	assertMakeName(`fish.chunk._blockinfo..tmp_1234567890123456789`, "fish", -4, "blockinfo", 1234567890123456789)
+	assertMakeName(`fish.chunk._info_0001`, "fish", -1, "info", "1")
+	assertMakeName(`fish.chunk._locks_4321`, "fish", -2, "locks", "4321")
+	assertMakeName(`fish.chunk._uploads_abcd`, "fish", -3, "uploads", "abcd")
+	assertMakeName(`fish.chunk._blkinfo_xyzabcdef`, "fish", -4, "blkinfo", "xyzabcdef")
+	assertMakeName(`fish.chunk._x2y_1aaa`, "fish", -5, "x2y", "1aaa")
 
-	assertParseName(`fish.chunk._info..tmp_0000000021`, "fish", -1, "info", 21)
-	assertParseName(`fish.chunk._locks..tmp_0000054321`, "fish", -1, "locks", 54321)
-	assertParseName(`fish.chunk._uploads..tmp_0000000000`, "fish", -1, "uploads", 0)
-	assertParseName(`fish.chunk._blockinfo..tmp_1234567890123456789`, "fish", -1, "blockinfo", 1234567890123456789)
+	assertParseName(`fish.chunk._info_0001`, "fish", -1, "info", "0001")
+	assertParseName(`fish.chunk._locks_4321`, "fish", -1, "locks", "4321")
+	assertParseName(`fish.chunk._uploads_9abc`, "fish", -1, "uploads", "9abc")
+	assertParseName(`fish.chunk._blkinfo_xyzabcdef`, "fish", -1, "blkinfo", "xyzabcdef")
+	assertParseName(`fish.chunk._x2y_1aaa`, "fish", -1, "x2y", "1aaa")
+
+	// valid temporary control chunks (old temporary suffix, parse only)
+	assertParseName(`fish.chunk._info..tmp_0000000047`, "fish", -1, "info", "001b")
+	assertParseName(`fish.chunk._locks..tmp_0000054321`, "fish", -1, "locks", "15wx")
+	assertParseName(`fish.chunk._uploads..tmp_0000000000`, "fish", -1, "uploads", "0000")
+	assertParseName(`fish.chunk._blkinfo..tmp_9994567890123`, "fish", -1, "blkinfo", "3jjfvo3wr")
+	assertParseName(`fish.chunk._x2y..tmp_0000000000`, "fish", -1, "x2y", "0000")
 
 	// parsing invalid control chunk names
-	assertParseName(`fish.chunk.info`, "", -1, "", -1)
-	assertParseName(`fish.chunk.locks`, "", -1, "", -1)
-	assertParseName(`fish.chunk.uploads`, "", -1, "", -1)
-	assertParseName(`fish.chunk.blockinfo`, "", -1, "", -1)
+	assertParseName(`fish.chunk.metadata`, "", -1, "", "") // must be prepended by underscore
+	assertParseName(`fish.chunk.info`, "", -1, "", "")
+	assertParseName(`fish.chunk.locks`, "", -1, "", "")
+	assertParseName(`fish.chunk.uploads`, "", -1, "", "")
 
-	assertParseName(`fish.chunk._os`, "", -1, "", -1)
-	assertParseName(`fish.chunk._futuredata`, "", -1, "", -1)
-	assertParseName(`fish.chunk._me_ta`, "", -1, "", -1)
-	assertParseName(`fish.chunk._in-fo`, "", -1, "", -1)
-	assertParseName(`fish.chunk._.bin`, "", -1, "", -1)
+	assertParseName(`fish.chunk._os`, "", -1, "", "")        // too short
+	assertParseName(`fish.chunk._metadata`, "", -1, "", "")  // too long
+	assertParseName(`fish.chunk._blockinfo`, "", -1, "", "") // way too long
+	assertParseName(`fish.chunk._4me`, "", -1, "", "")       // cannot start with digit
+	assertParseName(`fish.chunk._567`, "", -1, "", "")       // cannot be all digits
+	assertParseName(`fish.chunk._me_ta`, "", -1, "", "")     // punctuation not allowed
+	assertParseName(`fish.chunk._in-fo`, "", -1, "", "")
+	assertParseName(`fish.chunk._.bin`, "", -1, "", "")
+	assertParseName(`fish.chunk._.2xy`, "", -1, "", "")
 
-	assertParseName(`fish.chunk._locks..tmp_123456789`, "", -1, "", -1)
-	assertParseName(`fish.chunk._meta..tmp_-1`, "", -1, "", -1)
-	assertParseName(`fish.chunk._blockinfo..tmp_012345678901234567890123456789`, "", -1, "", -1)
+	// parsing invalid temporary control chunks
+	assertParseName(`fish.chunk._blkinfo1234`, "", -1, "", "")     // missing underscore delimiter
+	assertParseName(`fish.chunk._info__1234`, "", -1, "", "")      // extra underscore delimiter
+	assertParseName(`fish.chunk._info_123`, "", -1, "", "")        // too short temporary suffix
+	assertParseName(`fish.chunk._info_1234567890`, "", -1, "", "") // too long temporary suffix
+	assertParseName(`fish.chunk._info_-1234`, "", -1, "", "")      // temporary suffix must be positive
+	assertParseName(`fish.chunk._info_123E`, "", -1, "", "")       // uppercase not allowed
+	assertParseName(`fish.chunk._info_12.3`, "", -1, "", "")       // punctuation not allowed
+
+	assertParseName(`fish.chunk._locks..tmp_123456789`, "", -1, "", "")
+	assertParseName(`fish.chunk._meta..tmp_-1`, "", -1, "", "")
+	assertParseName(`fish.chunk._blockinfo..tmp_012345678901234567890123456789`, "", -1, "", "")
 
 	// short control chunk names: 3 letters ok, 1-2 letters not allowed
-	assertMakeName(`fish.chunk._ext`, "fish", -1, "ext", -1)
-	assertMakeName(`fish.chunk._ext..tmp_0000000021`, "fish", -1, "ext", 21)
-	assertParseName(`fish.chunk._int`, "fish", -1, "int", -1)
-	assertParseName(`fish.chunk._int..tmp_0000000021`, "fish", -1, "int", 21)
-	assertMakeNamePanics("fish", -1, "in", -1)
-	assertMakeNamePanics("fish", -1, "up", 4)
-	assertMakeNamePanics("fish", -1, "x", -1)
-	assertMakeNamePanics("fish", -1, "c", 4)
+	assertMakeName(`fish.chunk._ext`, "fish", -1, "ext", "")
+	assertParseName(`fish.chunk._int`, "fish", -1, "int", "")
+
+	assertMakeNamePanics("fish", -1, "in", "")
+	assertMakeNamePanics("fish", -1, "up", "4")
+	assertMakeNamePanics("fish", -1, "x", "")
+	assertMakeNamePanics("fish", -1, "c", "1z")
+
+	assertMakeName(`fish.chunk._ext_0000`, "fish", -1, "ext", "0")
+	assertMakeName(`fish.chunk._ext_0026`, "fish", -1, "ext", "26")
+	assertMakeName(`fish.chunk._int_0abc`, "fish", -1, "int", "abc")
+	assertMakeName(`fish.chunk._int_9xyz`, "fish", -1, "int", "9xyz")
+	assertMakeName(`fish.chunk._out_jj5fvo3wr`, "fish", -1, "out", "jj5fvo3wr")
+	assertMakeName(`fish.chunk._out_jj5fvo3wr`, "fish", -1, "out", "jj5fvo3wr")
+
+	assertParseName(`fish.chunk._ext_0000`, "fish", -1, "ext", "0000")
+	assertParseName(`fish.chunk._ext_0026`, "fish", -1, "ext", "0026")
+	assertParseName(`fish.chunk._int_0abc`, "fish", -1, "int", "0abc")
+	assertParseName(`fish.chunk._int_9xyz`, "fish", -1, "int", "9xyz")
+	assertParseName(`fish.chunk._out_jj5fvo3wr`, "fish", -1, "out", "jj5fvo3wr")
+	assertParseName(`fish.chunk._out_jj5fvo3wr`, "fish", -1, "out", "jj5fvo3wr")
 
 	// base file name can sometimes look like a valid chunk name
-	assertParseName(`fish.chunk.003.chunk.004`, "fish.chunk.003", 2, "", -1)
-	assertParseName(`fish.chunk.003.chunk.005..tmp_0000000021`, "fish.chunk.003", 3, "", 21)
-	assertParseName(`fish.chunk.003.chunk._info`, "fish.chunk.003", -1, "info", -1)
-	assertParseName(`fish.chunk.003.chunk._blockinfo..tmp_1234567890123456789`, "fish.chunk.003", -1, "blockinfo", 1234567890123456789)
-	assertParseName(`fish.chunk.003.chunk._Meta`, "", -1, "", -1)
-	assertParseName(`fish.chunk.003.chunk._x..tmp_0000054321`, "", -1, "", -1)
+	assertParseName(`fish.chunk.003.chunk.004`, "fish.chunk.003", 2, "", "")
+	assertParseName(`fish.chunk.003.chunk._info`, "fish.chunk.003", -1, "info", "")
+	assertParseName(`fish.chunk.003.chunk._Meta`, "", -1, "", "")
 
-	assertParseName(`fish.chunk.004..tmp_0000000021.chunk.004`, "fish.chunk.004..tmp_0000000021", 2, "", -1)
-	assertParseName(`fish.chunk.004..tmp_0000000021.chunk.005..tmp_0000000021`, "fish.chunk.004..tmp_0000000021", 3, "", 21)
-	assertParseName(`fish.chunk.004..tmp_0000000021.chunk._info`, "fish.chunk.004..tmp_0000000021", -1, "info", -1)
-	assertParseName(`fish.chunk.004..tmp_0000000021.chunk._blockinfo..tmp_1234567890123456789`, "fish.chunk.004..tmp_0000000021", -1, "blockinfo", 1234567890123456789)
-	assertParseName(`fish.chunk.004..tmp_0000000021.chunk._Meta`, "", -1, "", -1)
-	assertParseName(`fish.chunk.004..tmp_0000000021.chunk._x..tmp_0000054321`, "", -1, "", -1)
+	assertParseName(`fish.chunk._info.chunk.004`, "fish.chunk._info", 2, "", "")
+	assertParseName(`fish.chunk._info.chunk._info`, "fish.chunk._info", -1, "info", "")
+	assertParseName(`fish.chunk._info.chunk._info.chunk._Meta`, "", -1, "", "")
 
-	assertParseName(`fish.chunk._info.chunk.004`, "fish.chunk._info", 2, "", -1)
-	assertParseName(`fish.chunk._info.chunk.005..tmp_0000000021`, "fish.chunk._info", 3, "", 21)
-	assertParseName(`fish.chunk._info.chunk._info`, "fish.chunk._info", -1, "info", -1)
-	assertParseName(`fish.chunk._info.chunk._blockinfo..tmp_1234567890123456789`, "fish.chunk._info", -1, "blockinfo", 1234567890123456789)
-	assertParseName(`fish.chunk._info.chunk._info.chunk._Meta`, "", -1, "", -1)
-	assertParseName(`fish.chunk._info.chunk._info.chunk._x..tmp_0000054321`, "", -1, "", -1)
+	// base file name looking like a valid chunk name (old temporary suffix)
+	assertParseName(`fish.chunk.003.chunk.005..tmp_0000000022`, "fish.chunk.003", 3, "", "000m")
+	assertParseName(`fish.chunk.003.chunk._x..tmp_0000054321`, "", -1, "", "")
+	assertParseName(`fish.chunk._info.chunk.005..tmp_0000000023`, "fish.chunk._info", 3, "", "000n")
+	assertParseName(`fish.chunk._info.chunk._info.chunk._x..tmp_0000054321`, "", -1, "", "")
 
-	assertParseName(`fish.chunk._blockinfo..tmp_1234567890123456789.chunk.004`, "fish.chunk._blockinfo..tmp_1234567890123456789", 2, "", -1)
-	assertParseName(`fish.chunk._blockinfo..tmp_1234567890123456789.chunk.005..tmp_0000000021`, "fish.chunk._blockinfo..tmp_1234567890123456789", 3, "", 21)
-	assertParseName(`fish.chunk._blockinfo..tmp_1234567890123456789.chunk._info`, "fish.chunk._blockinfo..tmp_1234567890123456789", -1, "info", -1)
-	assertParseName(`fish.chunk._blockinfo..tmp_1234567890123456789.chunk._blockinfo..tmp_1234567890123456789`, "fish.chunk._blockinfo..tmp_1234567890123456789", -1, "blockinfo", 1234567890123456789)
-	assertParseName(`fish.chunk._blockinfo..tmp_1234567890123456789.chunk._info.chunk._Meta`, "", -1, "", -1)
-	assertParseName(`fish.chunk._blockinfo..tmp_1234567890123456789.chunk._info.chunk._x..tmp_0000054321`, "", -1, "", -1)
+	assertParseName(`fish.chunk.003.chunk._blkinfo..tmp_9994567890123`, "fish.chunk.003", -1, "blkinfo", "3jjfvo3wr")
+	assertParseName(`fish.chunk._info.chunk._blkinfo..tmp_9994567890123`, "fish.chunk._info", -1, "blkinfo", "3jjfvo3wr")
+
+	assertParseName(`fish.chunk.004..tmp_0000000021.chunk.004`, "fish.chunk.004..tmp_0000000021", 2, "", "")
+	assertParseName(`fish.chunk.004..tmp_0000000021.chunk.005..tmp_0000000025`, "fish.chunk.004..tmp_0000000021", 3, "", "000p")
+	assertParseName(`fish.chunk.004..tmp_0000000021.chunk._info`, "fish.chunk.004..tmp_0000000021", -1, "info", "")
+	assertParseName(`fish.chunk.004..tmp_0000000021.chunk._blkinfo..tmp_9994567890123`, "fish.chunk.004..tmp_0000000021", -1, "blkinfo", "3jjfvo3wr")
+	assertParseName(`fish.chunk.004..tmp_0000000021.chunk._Meta`, "", -1, "", "")
+	assertParseName(`fish.chunk.004..tmp_0000000021.chunk._x..tmp_0000054321`, "", -1, "", "")
+
+	assertParseName(`fish.chunk._blkinfo..tmp_9994567890123.chunk.004`, "fish.chunk._blkinfo..tmp_9994567890123", 2, "", "")
+	assertParseName(`fish.chunk._blkinfo..tmp_9994567890123.chunk.005..tmp_0000000026`, "fish.chunk._blkinfo..tmp_9994567890123", 3, "", "000q")
+	assertParseName(`fish.chunk._blkinfo..tmp_9994567890123.chunk._info`, "fish.chunk._blkinfo..tmp_9994567890123", -1, "info", "")
+	assertParseName(`fish.chunk._blkinfo..tmp_9994567890123.chunk._blkinfo..tmp_9994567890123`, "fish.chunk._blkinfo..tmp_9994567890123", -1, "blkinfo", "3jjfvo3wr")
+	assertParseName(`fish.chunk._blkinfo..tmp_9994567890123.chunk._info.chunk._Meta`, "", -1, "", "")
+	assertParseName(`fish.chunk._blkinfo..tmp_9994567890123.chunk._info.chunk._x..tmp_0000054321`, "", -1, "", "")
+
+	assertParseName(`fish.chunk._blkinfo..tmp_1234567890123456789.chunk.004`, "fish.chunk._blkinfo..tmp_1234567890123456789", 2, "", "")
+	assertParseName(`fish.chunk._blkinfo..tmp_1234567890123456789.chunk.005..tmp_0000000022`, "fish.chunk._blkinfo..tmp_1234567890123456789", 3, "", "000m")
+	assertParseName(`fish.chunk._blkinfo..tmp_1234567890123456789.chunk._info`, "fish.chunk._blkinfo..tmp_1234567890123456789", -1, "info", "")
+	assertParseName(`fish.chunk._blkinfo..tmp_1234567890123456789.chunk._blkinfo..tmp_9994567890123`, "fish.chunk._blkinfo..tmp_1234567890123456789", -1, "blkinfo", "3jjfvo3wr")
+	assertParseName(`fish.chunk._blkinfo..tmp_1234567890123456789.chunk._info.chunk._Meta`, "", -1, "", "")
+	assertParseName(`fish.chunk._blkinfo..tmp_1234567890123456789.chunk._info.chunk._x..tmp_0000054321`, "", -1, "", "")
 
 	// attempts to make invalid chunk names
-	assertMakeNamePanics("fish", -1, "", -1)           // neither data nor control
-	assertMakeNamePanics("fish", 0, "info", -1)        // both data and control
-	assertMakeNamePanics("fish", -1, "futuredata", -1) // control type too long
-	assertMakeNamePanics("fish", -1, "123", -1)        // digits not allowed
-	assertMakeNamePanics("fish", -1, "Meta", -1)       // only lower case letters allowed
-	assertMakeNamePanics("fish", -1, "in-fo", -1)      // punctuation not allowed
-	assertMakeNamePanics("fish", -1, "_info", -1)
-	assertMakeNamePanics("fish", -1, "info_", -1)
-	assertMakeNamePanics("fish", -2, ".bind", -3)
-	assertMakeNamePanics("fish", -2, "bind.", -3)
+	assertMakeNamePanics("fish", -1, "", "")          // neither data nor control
+	assertMakeNamePanics("fish", 0, "info", "")       // both data and control
+	assertMakeNamePanics("fish", -1, "metadata", "")  // control type too long
+	assertMakeNamePanics("fish", -1, "blockinfo", "") // control type way too long
+	assertMakeNamePanics("fish", -1, "2xy", "")       // first digit not allowed
+	assertMakeNamePanics("fish", -1, "123", "")       // all digits not allowed
+	assertMakeNamePanics("fish", -1, "Meta", "")      // only lower case letters allowed
+	assertMakeNamePanics("fish", -1, "in-fo", "")     // punctuation not allowed
+	assertMakeNamePanics("fish", -1, "_info", "")
+	assertMakeNamePanics("fish", -1, "info_", "")
+	assertMakeNamePanics("fish", -2, ".bind", "")
+	assertMakeNamePanics("fish", -2, "bind.", "")
 
-	assertMakeNamePanics("fish", -1, "", 1)            // neither data nor control
-	assertMakeNamePanics("fish", 0, "info", 12)        // both data and control
-	assertMakeNamePanics("fish", -1, "futuredata", 45) // control type too long
-	assertMakeNamePanics("fish", -1, "123", 123)       // digits not allowed
-	assertMakeNamePanics("fish", -1, "Meta", 456)      // only lower case letters allowed
-	assertMakeNamePanics("fish", -1, "in-fo", 321)     // punctuation not allowed
-	assertMakeNamePanics("fish", -1, "_info", 15678)
-	assertMakeNamePanics("fish", -1, "info_", 999)
-	assertMakeNamePanics("fish", -2, ".bind", 0)
-	assertMakeNamePanics("fish", -2, "bind.", 0)
+	assertMakeNamePanics("fish", -1, "", "1")          // neither data nor control
+	assertMakeNamePanics("fish", 0, "info", "23")      // both data and control
+	assertMakeNamePanics("fish", -1, "metadata", "45") // control type too long
+	assertMakeNamePanics("fish", -1, "blockinfo", "7") // control type way too long
+	assertMakeNamePanics("fish", -1, "2xy", "abc")     // first digit not allowed
+	assertMakeNamePanics("fish", -1, "123", "def")     // all digits not allowed
+	assertMakeNamePanics("fish", -1, "Meta", "mnk")    // only lower case letters allowed
+	assertMakeNamePanics("fish", -1, "in-fo", "xyz")   // punctuation not allowed
+	assertMakeNamePanics("fish", -1, "_info", "5678")
+	assertMakeNamePanics("fish", -1, "info_", "999")
+	assertMakeNamePanics("fish", -2, ".bind", "0")
+	assertMakeNamePanics("fish", -2, "bind.", "0")
+
+	assertMakeNamePanics("fish", 0, "", "1234567890") // temporary suffix too long
+	assertMakeNamePanics("fish", 0, "", "123F4")      // uppercase not allowed
+	assertMakeNamePanics("fish", 0, "", "123.")       // punctuation not allowed
+	assertMakeNamePanics("fish", 0, "", "_123")
 }
 
 func testSmallFileInternals(t *testing.T, f *Fs) {
@@ -383,7 +469,7 @@ func testPreventCorruption(t *testing.T, f *Fs) {
 	billyObj := newFile("billy")
 
 	billyChunkName := func(chunkNo int) string {
-		return f.makeChunkName(billyObj.Remote(), chunkNo, "", -1)
+		return f.makeChunkName(billyObj.Remote(), chunkNo, "", "")
 	}
 
 	err := f.Mkdir(ctx, billyChunkName(1))
@@ -433,7 +519,7 @@ func testPreventCorruption(t *testing.T, f *Fs) {
 
 	// recreate billy in case it was anyhow corrupted
 	willyObj := newFile("willy")
-	willyChunkName := f.makeChunkName(willyObj.Remote(), 1, "", -1)
+	willyChunkName := f.makeChunkName(willyObj.Remote(), 1, "", "")
 	f.opt.FailHard = false
 	willyChunk, err := f.NewObject(ctx, willyChunkName)
 	f.opt.FailHard = true
@@ -484,7 +570,7 @@ func testChunkNumberOverflow(t *testing.T, f *Fs) {
 
 	f.opt.FailHard = false
 	file, fileName := newFile(f, "wreaker")
-	wreak, _ := newFile(f.base, f.makeChunkName("wreaker", wreakNumber, "", -1))
+	wreak, _ := newFile(f.base, f.makeChunkName("wreaker", wreakNumber, "", ""))
 
 	f.opt.FailHard = false
 	fstest.CheckListingWithRoot(t, f, dir, nil, nil, f.Precision())
@@ -532,7 +618,7 @@ func testMetadataInput(t *testing.T, f *Fs) {
 		filename := path.Join(dir, name)
 		require.True(t, len(contents) > 2 && len(contents) < minChunkForTest, description+" test data is correct")
 
-		part := putFile(f.base, f.makeChunkName(filename, 0, "", -1), "oops", "", true)
+		part := putFile(f.base, f.makeChunkName(filename, 0, "", ""), "oops", "", true)
 		_ = putFile(f, filename, contents, "upload "+description, false)
 
 		obj, err := f.NewObject(ctx, filename)

--- a/docs/content/chunker.md
+++ b/docs/content/chunker.md
@@ -130,10 +130,10 @@ error message in such cases.
 
 #### Chunk names
 
-The default chunk name format is `*.rclone-chunk.###`, hence by default
-chunk names are `BIG_FILE_NAME.rclone-chunk.001`,
-`BIG_FILE_NAME.rclone-chunk.002` etc. You can configure a different name
-format using the `--chunker-name-format` option. The format uses asterisk
+The default chunk name format is `*.rclone_chunk.###`, hence by default
+chunk names are `BIG_FILE_NAME.rclone_chunk.001`,
+`BIG_FILE_NAME.rclone_chunk.002` etc. You can configure another name format
+using the `name_format` configuration file option. The format uses asterisk
 `*` as a placeholder for the base file name and one or more consecutive
 hash characters `#` as a placeholder for sequential chunk number.
 There must be one and only one asterisk. The number of consecutive hash
@@ -211,6 +211,9 @@ file hashing, configure chunker with `md5all` or `sha1all`. These two modes
 guarantee given hash for all files. If wrapped remote doesn't support it,
 chunker will then add metadata to all files, even small. However, this can
 double the amount of small files in storage and incur additional service charges.
+You can even use chunker to force md5/sha1 support in any other remote
+at expence of sidecar meta objects by setting eg. `chunk_type=sha1all`
+to force hashsums and `chunk_size=1P` to effectively disable chunking.
 
 Normally, when a file is copied to chunker controlled remote, chunker
 will ask the file source for compatible file hash and revert to on-the-fly
@@ -273,6 +276,14 @@ Chunker requires wrapped remote to support server side `move` (or `copy` +
 `delete`) operations, otherwise it will explicitly refuse to start.
 This is because it internally renames temporary chunk files to their final
 names when an operation completes successfully.
+
+Chunker encodes chunk number in file name, so with default `name_format`
+setting it adds 17 characters. Also chunker adds 7 characters of temporary
+suffix during operations. Many file systems limit base file name without path
+by 255 characters. Using rclone's crypt remote as a base file system limits
+file name by 143 characters. Thus, maximum name length is 231 for most files
+and 119 for chunker-over-crypt. A user in need can change name format to
+eg. `*.rcc##` and save 10 characters (provided at most 99 chunks per file).
 
 Note that a move implemented using the copy-and-delete method may incur
 double charging with some cloud storage providers.


### PR DESCRIPTION
#### What is the purpose of this change?

This patch reduces string length of temporary transaction identifiers from 10 to 6 characters while keeping them sufficiently random. This helps to reduce file name overhead from 34 to 24 characters (with default settings).

#### Was the change discussed in an issue or in the forum before?

Discussed in the issue https://github.com/rclone/rclone/issues/3705 and in https://forum.rclone.org/t/filename-too-long/12753/34

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
