### PR TITLE
Dead! drive: optimize performace for --max-age or --min-age

### DIFF
--- a/fs/sync/contextkeys/contextkeys.go
+++ b/fs/sync/contextkeys/contextkeys.go
@@ -1,0 +1,10 @@
+// Package contextkeys reveals contextkeys used by fs/sync
+package contextkeys
+
+type syncCopyMoveContextKey int
+
+// import SyncCoveMoveSrcNameKey and SyncCopyMoveDstNameKey
+const (
+	SyncCopyMoveSrcNameKey syncCopyMoveContextKey = iota
+	SyncCopyMoveDstNameKey
+)

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -16,6 +16,7 @@ import (
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/march"
 	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fs/sync/contextkeys"
 )
 
 type syncCopyMove struct {
@@ -90,6 +91,9 @@ func newSyncCopyMove(ctx context.Context, fdst, fsrc fs.Fs, deleteMode fs.Delete
 		toBeRenamed:        newPipe(accounting.Stats(ctx).SetRenameQueue, fs.Config.MaxBacklog),
 		trackRenamesCh:     make(chan fs.Object, fs.Config.Checkers),
 	}
+	// Record names of src/dst so that the backend may know it is called during a syncCopyMove.
+	ctx = context.WithValue(ctx, contextkeys.SyncCopyMoveSrcNameKey, fsrc.Name())
+	ctx = context.WithValue(ctx, contextkeys.SyncCopyMoveDstNameKey, fdst.Name())
 	s.ctx, s.cancel = context.WithCancel(ctx)
 	if s.noTraverse && s.deleteMode != fs.DeleteModeOff {
 		fs.Errorf(nil, "Ignoring --no-traverse with sync")


### PR DESCRIPTION
The Google Drive API allows to place a clause like "modifiedTime > '2012-06-04T12:00:00'" in the query param, so the filterflags --max-age and --min-age can be applied directly at the directory listing phase rather than in a filter. This is extremely helpful when we want to do an incremental backup of a remote drive with a large number of files but the number of recently changed file is small.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
