### PR TITLE
cmd: add --error-on-no-transfer option

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -66,6 +66,7 @@ const (
 	exitCodeNoRetryError
 	exitCodeFatalError
 	exitCodeTransferExceeded
+	exitCodeNoFilesTransferred
 )
 
 // ShowVersion prints the version to stdout
@@ -312,6 +313,7 @@ func Run(Retry bool, showStats bool, cmd *cobra.Command, f func() error) {
 		}
 	}
 	resolveExitCode(cmdErr)
+
 }
 
 // CheckArgs checks there are enough arguments and prints a message if not
@@ -430,6 +432,11 @@ func initConfig() {
 func resolveExitCode(err error) {
 	atexit.Run()
 	if err == nil {
+		if fs.Config.ErrorOnNoTransfer {
+			if accounting.GlobalStats().GetTransfers() == 0 {
+				os.Exit(exitCodeNoFilesTransferred)
+			}
+		}
 		os.Exit(exitCodeSuccess)
 	}
 

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -553,6 +553,18 @@ the time to send the request header.
 
 The default is `1s`.  Set to 0 to disable.
 
+### --error-on-no-transfer ###
+
+By default, rclone will exit with return code 0 if there were no errors.
+
+This option allows rclone to return exit code 9 if no files were transferred
+between the source and destination. This allows using rclone in scripts, and
+triggering follow-on actions if data was copied, or skipping if not.
+
+NB: Enabling this option turns a usually non-fatal error into a potentially
+fatal one - please check and adjust your scripts accordingly!
+
+
 ### --ignore-case-sync ###
 
 Using this option will cause rclone to ignore the case of the files 
@@ -1622,6 +1634,7 @@ it will log a high priority message if the retry was successful.
   * `6` - Less serious errors (like 461 errors from dropbox) (NoRetry errors)
   * `7` - Fatal error (one that more retries won't fix, like account suspended) (Fatal errors)
   * `8` - Transfer exceeded - limit set by --max-transfer reached
+  * `9` - Operation successful, but no files transferred
 
 Environment Variables
 ---------------------

--- a/fs/config.go
+++ b/fs/config.go
@@ -100,6 +100,7 @@ type ConfigInfo struct {
 	StatsOneLine           bool
 	StatsOneLineDate       bool   // If we want a date prefix at all
 	StatsOneLineDateFormat string // If we want to customize the prefix
+	ErrorOnNoTransfer      bool   // Set appropriate exit code if no files transferred
 	Progress               bool
 	Cookie                 bool
 	UseMmap                bool

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -101,6 +101,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &fs.Config.StatsOneLine, "stats-one-line", "", fs.Config.StatsOneLine, "Make the stats fit on one line.")
 	flags.BoolVarP(flagSet, &fs.Config.StatsOneLineDate, "stats-one-line-date", "", fs.Config.StatsOneLineDate, "Enables --stats-one-line and add current date/time prefix.")
 	flags.StringVarP(flagSet, &fs.Config.StatsOneLineDateFormat, "stats-one-line-date-format", "", fs.Config.StatsOneLineDateFormat, "Enables --stats-one-line-date and uses custom formatted date. Enclose date string in double quotes (\"). See https://golang.org/pkg/time/#Time.Format")
+	flags.BoolVarP(flagSet, &fs.Config.ErrorOnNoTransfer, "error-on-no-transfer", "", fs.Config.ErrorOnNoTransfer, "Sets exit code 9 if no files are transferred, useful in scripts")
 	flags.BoolVarP(flagSet, &fs.Config.Progress, "progress", "P", fs.Config.Progress, "Show progress during transfer.")
 	flags.BoolVarP(flagSet, &fs.Config.Cookie, "use-cookies", "", fs.Config.Cookie, "Enable session cookiejar.")
 	flags.BoolVarP(flagSet, &fs.Config.UseMmap, "use-mmap", "", fs.Config.UseMmap, "Use mmap allocator (see docs).")


### PR DESCRIPTION
#### What is the purpose of this change?

This allows rclone to exit with a non-zero return code if no files are
transferred. This is useful when calling rclone as part of a workflow/script
pipeline as it allows the end user to stop processing if no files have been
transferred.

NB: Enabling this option will return in rclone exiting non-zero if there are no
transfers. Depending on how you're currently using rclone in your scripts,
this may break existing setups!

##### Example usage:
```
rclone --error-on-no-transfer copy remote:/myfiles s3:my-s3-bucket/files/from/me
RC=$?
if [ $RC -eq 0 ]; then
  echo "I'm going to process some files now"
elif [ $RC -eq 9 ]; then
  echo "There's nothing to do, goodbye"
  exit 0
else
  echo "Something went wrong in the transfer"
  exit 1
fi
```

#### Was the change discussed in an issue or in the forum before?

No, but it probably should be... I've sort of stolen the `--stats-*` namespace for the command option as it seemed the most logical place to put it. I've also added a new exit code (the next sequential/available one in the list of current codes) to reflect "all good, but no files transferred".

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
