### PR TITLE
fs/accounting: add a call to delete status groups

### DIFF
--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -634,20 +634,6 @@ func (s *StatsInfo) RemoveTransfer(transfer *Transfer) {
 	s.mu.Unlock()
 }
 
-// PruneAllTransfers removes all finished transfers.
-func (s *StatsInfo) PruneAllTransfers() {
-	s.mu.Lock()
-	for i := 0; i < len(s.startedTransfers); i++ {
-		tr := s.startedTransfers[i]
-		if tr.IsDone() {
-			s.removeTransfer(tr, i)
-			// i'th element is removed, recover iterator to not skip next element.
-			i--
-		}
-	}
-	s.mu.Unlock()
-}
-
 // PruneTransfers makes sure there aren't too many old transfers by removing
 // single finished transfer.
 func (s *StatsInfo) PruneTransfers() {

--- a/fs/accounting/stats_groups_test.go
+++ b/fs/accounting/stats_groups_test.go
@@ -1,0 +1,104 @@
+package accounting
+
+import (
+	"fmt"
+	"runtime"
+	"testing"
+)
+
+func TestStatsGroupOperations(t *testing.T) {
+
+	t.Run("empty group returns nil", func(t *testing.T) {
+		t.Parallel()
+		sg := newStatsGroups()
+		sg.get("invalid-group")
+	})
+
+	t.Run("set assigns stats to group", func(t *testing.T) {
+		t.Parallel()
+		stats := NewStats()
+		sg := newStatsGroups()
+		sg.set("test", stats)
+		sg.set("test1", stats)
+		if len(sg.m) != len(sg.names()) || len(sg.m) != 2 {
+			t.Fatalf("Expected two stats got %d, %d", len(sg.m), len(sg.order))
+		}
+	})
+
+	t.Run("get returns correct group", func(t *testing.T) {
+		t.Parallel()
+		stats := NewStats()
+		sg := newStatsGroups()
+		sg.set("test", stats)
+		sg.set("test1", stats)
+		got := sg.get("test")
+		if got != stats {
+			t.Fatal("get returns incorrect stats")
+		}
+	})
+
+	t.Run("sum returns correct values", func(t *testing.T) {
+		t.Parallel()
+		stats1 := NewStats()
+		stats1.bytes = 5
+		stats1.errors = 5
+		stats2 := NewStats()
+		sg := newStatsGroups()
+		sg.set("test1", stats1)
+		sg.set("test2", stats2)
+		sum := sg.sum()
+		if sum.bytes != stats1.bytes+stats2.bytes {
+			t.Fatalf("sum() => bytes %d, expected %d", sum.bytes, stats1.bytes+stats2.bytes)
+		}
+		if sum.errors != stats1.errors+stats2.errors {
+			t.Fatalf("sum() => errors %d, expected %d", sum.errors, stats1.errors+stats2.errors)
+		}
+	})
+
+	t.Run("delete removes stats", func(t *testing.T) {
+		t.Parallel()
+		stats := NewStats()
+		sg := newStatsGroups()
+		sg.set("test", stats)
+		sg.set("test1", stats)
+		sg.delete("test1")
+		if sg.get("test1") != nil {
+			t.Fatal("stats not deleted")
+		}
+		if len(sg.m) != len(sg.names()) || len(sg.m) != 1 {
+			t.Fatalf("Expected two stats got %d, %d", len(sg.m), len(sg.order))
+		}
+	})
+
+	t.Run("memory is reclaimed", func(t *testing.T) {
+		var (
+			count      = 1000
+			start, end runtime.MemStats
+			sg         = newStatsGroups()
+		)
+
+		runtime.GC()
+		runtime.ReadMemStats(&start)
+
+		for i := 0; i < count; i++ {
+			sg.set(fmt.Sprintf("test-%d", i), NewStats())
+		}
+
+		for i := 0; i < count; i++ {
+			sg.delete(fmt.Sprintf("test-%d", i))
+		}
+
+		runtime.GC()
+		runtime.ReadMemStats(&end)
+
+		t.Log(fmt.Sprintf("%+v\n%+v", start, end))
+		diff := percentDiff(start.HeapObjects, end.HeapObjects)
+		if diff > 1 || diff < 0 {
+			t.Errorf("HeapObjects = %d, expected %d", end.HeapObjects, start.HeapObjects)
+		}
+	})
+}
+
+func percentDiff(start, end uint64) uint64 {
+	return (start - end) * 100 / start
+}

--- a/fs/accounting/stats_test.go
+++ b/fs/accounting/stats_test.go
@@ -431,25 +431,3 @@ func TestPruneTransfers(t *testing.T) {
 		})
 	}
 }
-
-func TestPruneAllTransfers(t *testing.T) {
-	const transfers = 10
-
-	s := NewStats()
-	for i := int64(1); i <= int64(transfers); i++ {
-		s.AddTransfer(&Transfer{
-			startedAt:   time.Unix(i, 0),
-			completedAt: time.Unix(i+1, 0),
-		})
-	}
-
-	s.mu.Lock()
-	assert.Equal(t, transfers, len(s.startedTransfers))
-	s.mu.Unlock()
-
-	s.PruneAllTransfers()
-
-	s.mu.Lock()
-	assert.Empty(t, s.startedTransfers)
-	s.mu.Unlock()
-}


### PR DESCRIPTION
#### What is the purpose of this change?

This change is adding an option to delete stats on demand to avoid piling them up. Reset is not enough when you want to avoid hitting the max configured value.

Also did some cleanup to the touched files and added test.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
