### PR TITLE
docs: fix in-page anchor navigation positioning

### DIFF
--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -43,7 +43,11 @@ h3:hover .header-link,
 h4:hover .header-link,
 h5:hover .header-link,
 h6:hover .header-link {
-  opacity: 1;
+  	opacity: 1;
+}
+h2, h3, h4, h5, h6 {
+	padding-top: 55px;
+	margin-top: -44px;
 }
 
 /* Fix spacing between menu items */


### PR DESCRIPTION
#### What is the purpose of this change?

Fix the problem where clicking on in-page anchor results in heading hidden behind the fixed navigation bar.

**Before**
![Kapture2019-12-22at3 50 22 out 20191222-085648](https://user-images.githubusercontent.com/5880908/71319655-1f1a2b80-246f-11ea-8723-115489e2a385.gif)

**After**
![Kapture2019-12-22at3 48 48 out 20191222-085427](https://user-images.githubusercontent.com/5880908/71319637-e9754280-246e-11ea-8fdc-c9e6c0f013aa.gif)

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- _N/A_ I have added tests for all changes in this PR if appropriate.
- _N/A_ I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
