### PR TITLE
serve sftp: Add support for public key with auth proxy - fixes #3572

### DIFF
--- a/cmd/serve/ftp/ftp.go
+++ b/cmd/serve/ftp/ftp.go
@@ -246,7 +246,7 @@ var connServeFunction = []byte("(*Conn).Serve(")
 func (s *server) CheckPasswd(user, pass string) (ok bool, err error) {
 	var VFS *vfs.VFS
 	if s.proxy != nil {
-		VFS, _, err = s.proxy.Call(user, pass)
+		VFS, _, err = s.proxy.Call(user, pass, false)
 		if err != nil {
 			fs.Infof(nil, "proxy login failed: %v", err)
 			return false, nil

--- a/cmd/serve/proxy/proxy_test.go
+++ b/cmd/serve/proxy/proxy_test.go
@@ -3,6 +3,7 @@ package proxy
 import (
 	"crypto/rand"
 	"crypto/rsa"
+	"crypto/sha256"
 	"encoding/base64"
 	"log"
 	"strings"
@@ -13,7 +14,6 @@ import (
 	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/ssh"
 )
 
@@ -85,8 +85,7 @@ func TestRun(t *testing.T) {
 		require.True(t, ok)
 
 		// check hash is correct in entry
-		err = bcrypt.CompareHashAndPassword(entry.pwHash, passwordBytes)
-		require.NoError(t, err)
+		assert.Equal(t, entry.pwHash, sha256.Sum256(passwordBytes))
 		require.NotNil(t, entry.vfs)
 		f := entry.vfs.Fs()
 		require.NotNil(t, f)

--- a/cmd/serve/proxy/proxy_test.go
+++ b/cmd/serve/proxy/proxy_test.go
@@ -1,6 +1,10 @@
 package proxy
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/base64"
+	"log"
 	"strings"
 	"testing"
 
@@ -10,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/crypto/bcrypt"
+	"golang.org/x/crypto/ssh"
 )
 
 func TestRun(t *testing.T) {
@@ -68,13 +73,13 @@ func TestRun(t *testing.T) {
 	const testUser = "testUser"
 	const testPass = "testPass"
 
-	t.Run("call", func(t *testing.T) {
+	t.Run("call w/Password", func(t *testing.T) {
 		// check cache empty
 		assert.Equal(t, 0, p.vfsCache.Entries())
 		defer p.vfsCache.Clear()
 
 		passwordBytes := []byte(testPass)
-		value, err := p.call(testUser, testPass, passwordBytes)
+		value, err := p.call(testUser, testPass, false)
 		require.NoError(t, err)
 		entry, ok := value.(cacheEntry)
 		require.True(t, ok)
@@ -95,12 +100,12 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, value, cacheValue)
 	})
 
-	t.Run("Call", func(t *testing.T) {
+	t.Run("Call w/Password", func(t *testing.T) {
 		// check cache empty
 		assert.Equal(t, 0, p.vfsCache.Entries())
 		defer p.vfsCache.Clear()
 
-		vfs, vfsKey, err := p.Call(testUser, testPass)
+		vfs, vfsKey, err := p.Call(testUser, testPass, false)
 		require.NoError(t, err)
 		require.NotNil(t, vfs)
 		assert.Equal(t, "proxy-"+testUser, vfs.Fs().Name())
@@ -121,7 +126,7 @@ func TestRun(t *testing.T) {
 		})
 
 		// now try again from the cache
-		vfs, vfsKey, err = p.Call(testUser, testPass)
+		vfs, vfsKey, err = p.Call(testUser, testPass, false)
 		require.NoError(t, err)
 		require.NotNil(t, vfs)
 		assert.Equal(t, "proxy-"+testUser, vfs.Fs().Name())
@@ -131,7 +136,7 @@ func TestRun(t *testing.T) {
 		assert.Equal(t, 1, p.vfsCache.Entries())
 
 		// now try again from the cache but with wrong password
-		vfs, vfsKey, err = p.Call(testUser, testPass+"wrong")
+		vfs, vfsKey, err = p.Call(testUser, testPass+"wrong", false)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "incorrect password")
 		require.Nil(t, vfs)
@@ -142,4 +147,89 @@ func TestRun(t *testing.T) {
 
 	})
 
+	privateKey, privateKeyErr := rsa.GenerateKey(rand.Reader, 2048)
+	if privateKeyErr != nil {
+		log.Fatal("error generating test private key " + privateKeyErr.Error())
+	}
+	publicKey, publicKeyError := ssh.NewPublicKey(&privateKey.PublicKey)
+	if privateKeyErr != nil {
+		log.Fatal("error generating test public key " + publicKeyError.Error())
+	}
+
+	publicKeyString := base64.StdEncoding.EncodeToString(publicKey.Marshal())
+
+	t.Run("Call w/PublicKey", func(t *testing.T) {
+		// check cache empty
+		assert.Equal(t, 0, p.vfsCache.Entries())
+		defer p.vfsCache.Clear()
+
+		value, err := p.call(testUser, publicKeyString, true)
+		require.NoError(t, err)
+		entry, ok := value.(cacheEntry)
+		require.True(t, ok)
+
+		// check publicKey is correct in entry
+		require.NoError(t, err)
+		require.NotNil(t, entry.vfs)
+		f := entry.vfs.Fs()
+		require.NotNil(t, f)
+		assert.Equal(t, "proxy-"+testUser, f.Name())
+		assert.True(t, strings.HasPrefix(f.String(), "Local file system"))
+
+		// check it is in the cache
+		assert.Equal(t, 1, p.vfsCache.Entries())
+		cacheValue, ok := p.vfsCache.GetMaybe(testUser)
+		assert.True(t, ok)
+		assert.Equal(t, value, cacheValue)
+	})
+
+	t.Run("call w/PublicKey", func(t *testing.T) {
+		// check cache empty
+		assert.Equal(t, 0, p.vfsCache.Entries())
+		defer p.vfsCache.Clear()
+
+		vfs, vfsKey, err := p.Call(
+			testUser,
+			publicKeyString,
+			true,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, vfs)
+		assert.Equal(t, "proxy-"+testUser, vfs.Fs().Name())
+		assert.Equal(t, testUser, vfsKey)
+
+		// check it is in the cache
+		assert.Equal(t, 1, p.vfsCache.Entries())
+		cacheValue, ok := p.vfsCache.GetMaybe(testUser)
+		assert.True(t, ok)
+		cacheEntry, ok := cacheValue.(cacheEntry)
+		assert.True(t, ok)
+		assert.Equal(t, vfs, cacheEntry.vfs)
+
+		// Test Get works while we have something in the cache
+		t.Run("Get", func(t *testing.T) {
+			assert.Equal(t, vfs, p.Get(testUser))
+			assert.Nil(t, p.Get("unknown"))
+		})
+
+		// now try again from the cache
+		vfs, vfsKey, err = p.Call(testUser, publicKeyString, true)
+		require.NoError(t, err)
+		require.NotNil(t, vfs)
+		assert.Equal(t, "proxy-"+testUser, vfs.Fs().Name())
+		assert.Equal(t, testUser, vfsKey)
+
+		// check cache is at the same level
+		assert.Equal(t, 1, p.vfsCache.Entries())
+
+		// now try again from the cache but with wrong public key
+		vfs, vfsKey, err = p.Call(testUser, publicKeyString+"wrong", true)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "incorrect public key")
+		require.Nil(t, vfs)
+		require.Equal(t, "", vfsKey)
+
+		// check cache is at the same level
+		assert.Equal(t, 1, p.vfsCache.Entries())
+	})
 }

--- a/cmd/serve/sftp/sftp_test.go
+++ b/cmd/serve/sftp/sftp_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/obscure"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -45,7 +45,7 @@ func TestSftp(t *testing.T) {
 		opt.Pass = testPass
 
 		w := newServer(f, &opt)
-		assert.NoError(t, w.serve())
+		require.NoError(t, w.serve())
 
 		// Read the host and port we started on
 		addr := w.Addr()

--- a/cmd/serve/webdav/webdav.go
+++ b/cmd/serve/webdav/webdav.go
@@ -159,7 +159,7 @@ func (w *WebDAV) getVFS(ctx context.Context) (VFS *vfs.VFS, err error) {
 
 // auth does proxy authorization
 func (w *WebDAV) auth(user, pass string) (value interface{}, err error) {
-	VFS, _, err := w.proxy.Call(user, pass)
+	VFS, _, err := w.proxy.Call(user, pass, false)
 	if err != nil {
 		return nil, err
 	}

--- a/docs/content/commands/rclone_serve_sftp.md
+++ b/docs/content/commands/rclone_serve_sftp.md
@@ -22,9 +22,9 @@ The server will log errors.  Use -v to see access logs.
 --bwlimit will be respected for file transfers.  Use --stats to
 control the stats printing.
 
-You must provide some means of authentication, either with --user/--pass,
-an authorized keys file (specify location with --authorized-keys - the
-default is the same as ssh) or set the --no-auth flag for no
+You must provide some means of authentication, either with `--user`/`--pass`,
+an authorized keys file (specify location with `--authorized-keys` - the
+default is the same as ssh), an `--auth-proxy`, or set the --no-auth flag for no
 authentication when logging in.
 
 Note that this also implements a small number of shell commands so
@@ -183,11 +183,13 @@ rclone will use that program to generate backends on the fly which
 then are used to authenticate incoming requests.  This uses a simple
 JSON based protocl with input on STDIN and output on STDOUT.
 
+> **PLEASE NOTE:** `--auth-proxy` and `--authorized-keys` cannot be used together, if `--auth-proxy` is set the authorized keys option will be ignored.
+
 There is an example program
 [bin/test_proxy.py](https://github.com/rclone/rclone/blob/master/test_proxy.py)
 in the rclone source code.
 
-The program's job is to take a `user` and `pass` on the input and turn
+The program's job is to take a `user` and `pass` or `public_key` on the input and turn
 those into the config for a backend on STDOUT in JSON format.  This
 config will have any default parameters for the backend added, but it
 won't use configuration from environment variables or command line
@@ -200,7 +202,7 @@ This config generated must have this extra parameter
 And it may have this parameter
 - `_obscure` - comma separated strings for parameters to obscure
 
-For example the program might take this on STDIN
+If password authentication was used by the client, input to the proxy process (on STDIN) would look similar to this:
 
 ```
 {
@@ -209,7 +211,16 @@ For example the program might take this on STDIN
 }
 ```
 
-And return this on STDOUT
+If public-key authentication was used by the client, input to the proxy process (on STDIN) would look similar to this:
+
+```
+{
+    "user": "me",
+    "public_key": "AAAAB3NzaC1yc2EAAAADAQABAAABAQDuwESFdAe14hVS6omeyX7edc+4BlQz1s6tWT5VxBu1YlR9w39BUAom4qDKuH+uqLMDIaS5F7D6lNwOuPylvyV/LgMFsgJV4QZ52Kws7mNgdsCEDTvfLz5Pt9Qtp6Gnah3kA0cmbXcfQFaO50Ojnz/W1ozg2z5evKmGtyYMtywTXvH/KVh5WjhbpQ/ERgu+1pbgwWkpWNBM8TCO8D85PSpxtkdpEdkaiGtKA6U+6ZOtdCqd88EasyMEBWLVSx9bvqMVsD8plYstXOm5CCptGWWqckZBIqp0YBP6atw/ANRESD3cIJ4dOO+qlWkLR5npAZZTx2Qqh+hVw6qqTFB+JQdf"
+}
+```
+
+And as an example return this on STDOUT
 
 ```
 {
@@ -223,7 +234,7 @@ And return this on STDOUT
 ```
 
 This would mean that an SFTP backend would be created on the fly for
-the `user` and `pass` returned in the output to the host given.  Note
+the `user` and `pass`/`public_key` returned in the output to the host given.  Note
 that since `_obscure` is set to `pass`, rclone will obscure the `pass`
 parameter before creating the backend (which is required for sftp
 backends).
@@ -235,8 +246,8 @@ in the output and the user to `user`. For security you'd probably want
 to restrict the `host` to a limited list.
 
 Note that an internal cache is keyed on `user` so only use that for
-configuration, don't use `pass`.  This also means that if a user's
-password is changed the cache will need to expire (which takes 5 mins)
+configuration, don't use `pass` or `public_key`.  This also means that if a user's
+password or public-key is changed the cache will need to expire (which takes 5 mins)
 before it takes effect.
 
 This can be used to build general purpose proxies to any kind of


### PR DESCRIPTION
#### What is the purpose of this change?

Add support for #3572 (public key auth with auth proxy)

#### Was the change discussed in an issue or in the forum before?

#3572

This is a slight modification of the discussion on the ticket, I made it match the behavior of user/pass when the proxy is involved. Instead of spitting back public keys that are acceptable, the proxy returns a backend config and a zero if the public key is acceptable. I did it this way for two reasons #1 consistency of behavior and #2 I want to be able to log specifics of an auth request and while I definitely don't send user passwords on to logging, I see real value in having the successful or failed public key to help a user debug a connectivity issue.

Let me know if you have any concerns or if I've goofed this up somehow, Thanks!

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
