### PR TITLE
build: fix import path and upload failures for forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -104,7 +104,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
         with:
-          path: ./src/github.com/${{ github.repository }}
+          # Checkout into a fixed path to avoid import path problems on go < 1.11
+          path: ./src/github.com/rclone/rclone
 
       - name: Install Go
         uses: actions/setup-go@v1
@@ -201,7 +202,8 @@ jobs:
         env:
           RCLONE_CONFIG_PASS: ${{ secrets.RCLONE_CONFIG_PASS }}
         # working-directory: '$(modulePath)'
-        if: matrix.deploy && github.head_ref == ''
+        # Deploy binaries if enabled in config && not a PR && not a fork
+        if: matrix.deploy && github.head_ref == '' && github.repository == 'rclone/rclone'
 
   xgo:
     timeout-minutes: 60
@@ -213,7 +215,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
         with:
-          path: ./src/github.com/${{ github.repository }}
+          # Checkout into a fixed path to avoid import path problems on go < 1.11
+          path: ./src/github.com/rclone/rclone
 
       - name: Set environment variables
         shell: bash
@@ -247,4 +250,5 @@ jobs:
           make circleci_upload
         env:
           RCLONE_CONFIG_PASS: ${{ secrets.RCLONE_CONFIG_PASS }}
-        if: github.head_ref == ''
+        # Upload artifacts if not a PR && not a fork
+        if: github.head_ref == '' && github.repository == 'rclone/rclone'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,13 +82,9 @@ You patch will get reviewed and you might get asked to fix some stuff.
 If so, then make the changes in the same branch, squash the commits,
 rebase it to master then push it to GitHub with `--force`.
 
-## Enabling CI for your fork ##
+## CI for your fork ##
 
-The CI config files for rclone have taken care of forks of the project, so you can enable CI for your fork repo easily.
-
-rclone currently uses [Travis CI](https://travis-ci.org/), [AppVeyor](https://ci.appveyor.com/), and
-[Circle CI](https://circleci.com/) to build the project. To enable them for your fork, simply go into their
-websites, find your fork of rclone, and enable building there.
+rclone currently uses [GitHub Actions](https://github.com/rclone/rclone/actions) to build and test the project, which should be automatically available for your fork too from the `Actions` tab in your repository.
 
 ## Testing ##
 


### PR DESCRIPTION
Before the fixes in this PR, GitHub Actions builds will fail in forks of rclone because of:
- Import path problems ([Example](https://github.com/Cnly/rclone/runs/372322900#step:9:1)), and
- impossible attempts to upload built binaries ([Example](https://github.com/Cnly/rclone/runs/372323002#step:6:1))

This PR fixes the problems by specifying a fixed path when cloning the source code and ensuring the build is not in a fork before trying to upload artifacts. A better solution for the import path problem may be to set `GO111MODULE=on`, but we still have go 1.10 in our build matrix, which doesn't support Go modules, hence the current solution.

GitHub Actions builds after these fixes can be seen in [my fork](https://github.com/Cnly/rclone/commit/10a04d11f1115154ef9d4e4e92c1128086cc2cb6/checks?check_suite_id=382968074) and [this repo](https://github.com/rclone/rclone/commit/10a04d11f1115154ef9d4e4e92c1128086cc2cb6/checks?check_suite_id=382973661).

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
