### PR TITLE
crypt: correctly handle trailing dot

### DIFF
--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path"
 	"strings"
 	"time"
 
@@ -143,6 +144,10 @@ func NewFs(name, rpath string, m configmap.Mapper) (fs.Fs, error) {
 	wInfo, wName, wPath, wConfig, err := fs.ConfigFs(remote)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse remote %q to wrap", remote)
+	}
+	// Make sure to remove trailing . reffering to the current dir
+	if path.Base(rpath) == "." {
+		rpath = strings.TrimSuffix(rpath, ".")
 	}
 	// Look for a file first
 	remotePath := fspath.JoinRootPath(wPath, cipher.EncryptFileName(rpath))


### PR DESCRIPTION
Currently running something like `rclone copy test/. crypt:test/.` causes the crypt remote to interpret the trailing `.` as a directory as directory name. This is incorrect and causes all kinds of problems. Add a simple check to remove trailing dots from paths on the crypt remote.