### PR TITLE
install.sh: create ~/.config/rclone directory

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -187,6 +187,8 @@ esac
 
 #update version variable post install
 version=`rclone --version 2>>errors | head -n 1`
+#create the directory for the default configuration folder
+mkdir $HOME/.config/rclone -p
 
 printf "\n${version} has successfully installed."
 printf '\nNow run "rclone config" for setup. Check https://rclone.org/docs/ for more details.\n\n'


### PR DESCRIPTION
This allows people with their config already made to copy their config to the new server(s), without having to create the directories.
It's irritating to get the error 50th time or so that the directory doesn't exist.

#### Was the change discussed in an issue or in the forum before?
No.
#### Checklist
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
