### PR TITLE
log: change cache invalidation to an info level

### DIFF
--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -113,7 +113,7 @@ func (d *Dir) forgetDirPath(relativePath string) {
 	if dir := d.cachedDir(relativePath); dir != nil {
 		dir.walk(func(dir *Dir) {
 			// this is called with the mutex held
-			fs.Debugf(dir.path, "forgetting directory cache")
+			fs.Infof(dir.path, "forgetting directory cache")
 			dir.read = time.Time{}
 			dir.items = make(map[string]Node)
 		})
@@ -134,7 +134,7 @@ func (d *Dir) invalidateDir(absPath string) {
 	if dir, ok := node.(*Dir); ok {
 		dir.mu.Lock()
 		if !dir.read.IsZero() {
-			fs.Debugf(dir.path, "invalidating directory cache")
+			fs.Infof(dir.path, "invalidating directory cache")
 			dir.read = time.Time{}
 		}
 		dir.mu.Unlock()


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This is useful for users of plex_autoscan and plex_rcs.
log-level debug can create a very large log file, very quickly, 1G in less than an hour.

#### Was the change discussed in an issue or in the forum before?

No, but not needed IMO.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
