### PR TITLE
docs: fix spacing error under `-P` in `docs.md`

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -926,7 +926,7 @@ with the `--stats` flag.
 This can be used with the `--stats-one-line` flag for a simpler
 display.
 
-Note: On Windows until[this bug](https://github.com/Azure/go-ansiterm/issues/26)
+Note: On Windows until [this bug](https://github.com/Azure/go-ansiterm/issues/26)
 is fixed all non-ASCII characters will be replaced with `.` when
 `--progress` is in use.
 


### PR DESCRIPTION
#### What is the purpose of this change?

Fix spacing error under `-P --progress` in `docs.md`

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
