### PR TITLE
POC: thoughts into code for readaead

### DIFF
--- a/backend/local/readahead_linux.go
+++ b/backend/local/readahead_linux.go
@@ -1,0 +1,32 @@
+// +build linux
+
+package local
+
+import (
+	"syscall"
+
+	"github.com/rclone/rclone/fs"
+)
+
+/*
+const (
+	readaheadAmount = 50 * 1024 * 1024
+	reread    = 25 * 1024 * 1024
+	doReahead = true
+)
+*/
+
+func readahead(file *localOpenFile) {
+	readaheadAmount := file.o.fs.opt.ReadaheadAmount
+	if readaheadAmount != 0 {
+		readaheadMinBuf := file.o.fs.opt.ReadaheadMinBuf
+		if file.readAheadTill == 0 || (file.readAheadTill-file.readTill) < readaheadMinBuf {
+			r0, _, errno := syscall.Syscall(syscall.SYS_READAHEAD, file.fd.Fd(), file.readAheadTill, readaheadAmount)
+			if r0 != 0 {
+				fs.Logf(file.o, "failed to execute sys_readahead: %v", errno)
+			} else {
+				file.readAheadTill += readaheadAmount
+			}
+		}
+	}
+}

--- a/backend/local/readahead_other.go
+++ b/backend/local/readahead_other.go
@@ -1,0 +1,5 @@
+// +build !linux
+
+package local
+
+func readahead(_ *localOpenFile) {}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

this is right now just a POC, not even tested yet, but the idea is to try and do better on readahead when reading many large files that we are copying/moving to a remote to try to do more optimal disk io, i.e. less thrashing

<!--
Describe the changes here
-->

in local backend, enable using linux's sys_readahead to instruct io scheduer to read large blocks of data into memory at specific intervals.

#### Was the change discussed in an issue or in the forum before?

yes: https://forum.rclone.org/t/rclone-and-linux-readahead/14132/

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
