### PR TITLE
Added starred files only support for Google Drive backend #3928

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -679,13 +679,8 @@ func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directorie
 			q = fmt.Sprintf("(mimeType='%s' or %s)", driveFolderType, q)
 		}
 		query = append(query, q)
-
-		s := "starred=" + strconv.FormatBool(f.opt.StarredOnly)
-		if f.opt.StarredOnly {
-			s = fmt.Sprintf("(mimeType='%s' or %s)", driveFolderType, s)
-		}
-		query = append(query, s)
 	}
+
 	// Search with sharedWithMe will always return things listed in "Shared With Me" (without any parents)
 	// We must not filter with parent when we try list "ROOT" with drive-shared-with-me
 	// If we need to list file inside those shared folders, we must search it without sharedWithMe
@@ -697,8 +692,13 @@ func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directorie
 		if parentsQuery.Len() > 1 {
 			_, _ = parentsQuery.WriteString(" or ")
 		}
-		if f.opt.SharedWithMe && dirID == f.rootFolderID {
-			_, _ = parentsQuery.WriteString("sharedWithMe=true")
+		if dirID == f.rootFolderID {
+			if f.opt.SharedWithMe {
+				_, _ = parentsQuery.WriteString("sharedWithMe=true")
+			}
+			if f.opt.StarredOnly {
+				_, _ = parentsQuery.WriteString("starred=true")
+			}
 		} else {
 			_, _ = fmt.Fprintf(parentsQuery, "'%s' in parents", dirID)
 		}

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -283,6 +283,12 @@ commands (copy, sync, etc), and with all other commands too.`,
 			Help:     "Only show files that are in the trash.\nThis will show trashed files in their original directory structure.",
 			Advanced: true,
 		}, {
+		}, {
+			Name:     "starred_only",
+			Default:  false,
+			Help:     "Only show files that are starred.",
+			Advanced: true,
+		}, {
 			Name:     "formats",
 			Default:  "",
 			Help:     "Deprecated: see export_formats",
@@ -504,6 +510,7 @@ type Options struct {
 	SkipChecksumGphotos       bool                 `config:"skip_checksum_gphotos"`
 	SharedWithMe              bool                 `config:"shared_with_me"`
 	TrashedOnly               bool                 `config:"trashed_only"`
+	StarredOnly               bool                 `config:"starred_only"`
 	Extensions                string               `config:"formats"`
 	ExportExtensions          string               `config:"export_formats"`
 	ImportExtensions          string               `config:"import_formats"`
@@ -672,6 +679,12 @@ func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directorie
 			q = fmt.Sprintf("(mimeType='%s' or %s)", driveFolderType, q)
 		}
 		query = append(query, q)
+
+		s := "starred=" + strconv.FormatBool(f.opt.StarredOnly)
+		if f.opt.StarredOnly {
+			s = fmt.Sprintf("(mimeType='%s' or %s)", driveFolderType, s)
+		}
+		query = append(query, s)
 	}
 	// Search with sharedWithMe will always return things listed in "Shared With Me" (without any parents)
 	// We must not filter with parent when we try list "ROOT" with drive-shared-with-me


### PR DESCRIPTION
What is the purpose of this change?
Allowing start files only to display on the Google drive backend.

Was the change discussed in an issue or in the forum before?
Not that I know of....now referenced by #3928 

