### PR TITLE
cmd/serve/ftp: replace deprecated os.SEEK_SET with io.SeekStart

### DIFF
--- a/cmd/serve/ftp/ftp.go
+++ b/cmd/serve/ftp/ftp.go
@@ -442,7 +442,7 @@ func (d *Driver) GetFile(path string, offset int64) (size int64, fr io.ReadClose
 	if err != nil {
 		return 0, nil, err
 	}
-	_, err = handle.Seek(offset, os.SEEK_SET)
+	_, err = handle.Seek(offset, io.SeekStart)
 	if err != nil {
 		return 0, nil, err
 	}


### PR DESCRIPTION
`os.SEEK_SET` is deprecated, and replaced with `io.SeekStart`.