### PR TITLE
fs: improve log output when no changes are made - fixes #3454

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -640,7 +640,7 @@ func DeleteFilesWithBackupDir(ctx context.Context, toBeDeleted fs.ObjectsChan, b
 			}
 		}()
 	}
-	fs.Infof(nil, "Waiting for deletions to finish")
+	fs.Debugf(nil, "Waiting for deletions to finish")
 	wg.Wait()
 	if errorCount > 0 {
 		err := errors.Errorf("failed to delete %d files", errorCount)
@@ -872,7 +872,7 @@ func CheckFn(ctx context.Context, fdst, fsrc fs.Fs, check checkFn, oneway bool) 
 		Dir:      "",
 		Callback: c,
 	}
-	fs.Infof(fdst, "Waiting for checks to finish")
+	fs.Debugf(fdst, "Waiting for checks to finish")
 	err := m.Run()
 
 	if c.dstFilesMissing > 0 {

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -345,7 +345,7 @@ func (s *syncCopyMove) startCheckers() {
 // This stops the background checkers
 func (s *syncCopyMove) stopCheckers() {
 	s.toBeChecked.Close()
-	fs.Infof(s.fdst, "Waiting for checks to finish")
+	fs.Debugf(s.fdst, "Waiting for checks to finish")
 	s.checkerWg.Wait()
 }
 
@@ -360,7 +360,7 @@ func (s *syncCopyMove) startTransfers() {
 // This stops the background transfers
 func (s *syncCopyMove) stopTransfers() {
 	s.toBeUploaded.Close()
-	fs.Infof(s.fdst, "Waiting for transfers to finish")
+	fs.Debugf(s.fdst, "Waiting for transfers to finish")
 	s.transfersWg.Wait()
 }
 
@@ -381,7 +381,7 @@ func (s *syncCopyMove) stopRenamers() {
 		return
 	}
 	s.toBeRenamed.Close()
-	fs.Infof(s.fdst, "Waiting for renames to finish")
+	fs.Debugf(s.fdst, "Waiting for renames to finish")
 	s.renamerWg.Wait()
 }
 
@@ -755,6 +755,10 @@ func (s *syncCopyMove) run() error {
 
 	// Read the error out of the context if there is one
 	s.processError(s.ctx.Err())
+
+	if accounting.Stats(s.ctx).GetTransfers() == 0 {
+		fs.Infof(nil, "There was nothing to transfer")
+	}
 
 	// cancel the context to free resources
 	s.cancel()


### PR DESCRIPTION
#### What is the purpose of this change?

The purpose of this change is to improve the log output for when no changes are made. This is accomplished by the following changes:

- changing a few log messages to debug level
- adding an info log message for when 0 bytes were transferred

Here is an example output:
```shell
~/go/src/rclone $ ./rclone -vv sync ~/src_folder/ ~/dst_folder/
2020/02/09 13:38:02 DEBUG : rclone: Version "v1.51.0-DEV" starting with parameters ["./rclone" "-vv" "sync" "/Users/tim/src_f
older/" "/Users/tim/dst_folder/"]                                                                                           
2020/02/09 13:38:02 NOTICE: Config file "/Users/tim/.config/rclone/rclone.conf" not found - using defaults
2020/02/09 13:38:02 DEBUG : Local file system at /Users/tim/dst_folder/: Waiting for checks to finish
2020/02/09 13:38:02 DEBUG : hi.txt: Size and modification time the same (differ by 0s, within tolerance 1ns)
2020/02/09 13:38:02 DEBUG : hi.txt: Unchanged skipping
2020/02/09 13:38:02 DEBUG : Local file system at /Users/tim/dst_folder/: Waiting for transfers to finish
2020/02/09 13:38:02 DEBUG : Waiting for deletions to finish
2020/02/09 13:38:02 INFO  : There was nothing to transfer
2020/02/09 13:38:02 INFO  : 
Transferred:             0 / 0 Bytes, -, 0 Bytes/s, ETA -
Checks:                 1 / 1, 100%
Elapsed time:         0.0s

2020/02/09 13:38:02 DEBUG : 4 go routines active
2020/02/09 13:38:02 DEBUG : rclone: Version "v1.51.0-DEV" finishing with parameters ["./rclone" "-vv" "sync" "/Users/tim/src_
folder/" "/Users/tim/dst_folder/"]                                                                                                                                                                                     
```

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/3454

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
