### PR TITLE
fs: add header-download and header-upload flags

### DIFF
--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -1816,6 +1816,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		Method:  "POST",
 		RootURL: upload.UploadURL,
 		Body:    in,
+		Options: options,
 		ExtraHeaders: map[string]string{
 			"Authorization":  upload.AuthorizationToken,
 			"X-Bz-File-Name": urlEncode(o.fs.opt.Enc.FromStandardPath(bucketPath)),

--- a/backend/box/box.go
+++ b/backend/box/box.go
@@ -1191,7 +1191,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 // upload does a single non-multipart upload
 //
 // This is recommended for less than 50 MB of content
-func (o *Object) upload(ctx context.Context, in io.Reader, leaf, directoryID string, modTime time.Time) (err error) {
+func (o *Object) upload(ctx context.Context, in io.Reader, leaf, directoryID string, modTime time.Time, options ...fs.OpenOption) (err error) {
 	upload := api.UploadFile{
 		Name:              o.fs.opt.Enc.FromStandardName(leaf),
 		ContentModifiedAt: api.Time(modTime),
@@ -1210,6 +1210,7 @@ func (o *Object) upload(ctx context.Context, in io.Reader, leaf, directoryID str
 		MultipartContentName:  "contents",
 		MultipartFileName:     upload.Name,
 		RootURL:               uploadURL,
+		Options:               options,
 	}
 	// If object has an ID then it is existing so create a new version
 	if o.id != "" {
@@ -1251,7 +1252,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 
 	// Upload with simple or multipart
 	if size <= int64(o.fs.opt.UploadCutoff) {
-		err = o.upload(ctx, in, leaf, directoryID, modTime)
+		err = o.upload(ctx, in, leaf, directoryID, modTime, options...)
 	} else {
 		err = o.uploadMultipart(ctx, in, leaf, directoryID, size, modTime)
 	}

--- a/backend/box/box.go
+++ b/backend/box/box.go
@@ -1254,7 +1254,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	if size <= int64(o.fs.opt.UploadCutoff) {
 		err = o.upload(ctx, in, leaf, directoryID, modTime, options...)
 	} else {
-		err = o.uploadMultipart(ctx, in, leaf, directoryID, size, modTime)
+		err = o.uploadMultipart(ctx, in, leaf, directoryID, size, modTime, options...)
 	}
 	return err
 }

--- a/backend/fichier/api.go
+++ b/backend/fichier/api.go
@@ -320,7 +320,7 @@ func (f *Fs) getUploadNode(ctx context.Context) (response *GetUploadNodeResponse
 	return response, err
 }
 
-func (f *Fs) uploadFile(ctx context.Context, in io.Reader, size int64, fileName, folderID, uploadID, node string) (response *http.Response, err error) {
+func (f *Fs) uploadFile(ctx context.Context, in io.Reader, size int64, fileName, folderID, uploadID, node string, options ...fs.OpenOption) (response *http.Response, err error) {
 	// fs.Debugf(f, "Uploading File `%s`", fileName)
 
 	fileName = f.opt.Enc.FromStandardName(fileName)
@@ -338,6 +338,7 @@ func (f *Fs) uploadFile(ctx context.Context, in io.Reader, size int64, fileName,
 		NoResponse:           true,
 		Body:                 in,
 		ContentLength:        &size,
+		Options:              options,
 		MultipartContentName: "file[]",
 		MultipartFileName:    fileName,
 		MultipartParams: map[string][]string{

--- a/backend/fichier/fichier.go
+++ b/backend/fichier/fichier.go
@@ -338,7 +338,7 @@ func (f *Fs) putUnchecked(ctx context.Context, in io.Reader, remote string, size
 		return nil, err
 	}
 
-	_, err = f.uploadFile(ctx, in, size, leaf, directoryID, nodeResponse.ID, nodeResponse.URL)
+	_, err = f.uploadFile(ctx, in, size, leaf, directoryID, nodeResponse.ID, nodeResponse.URL, options...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -954,8 +954,9 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 
 	// Upload the media item in exchange for an UploadToken
 	opts := rest.Opts{
-		Method: "POST",
-		Path:   "/uploads",
+		Method:  "POST",
+		Path:    "/uploads",
+		Options: options,
 		ExtraHeaders: map[string]string{
 			"X-Goog-Upload-File-Name": fileName,
 			"X-Goog-Upload-Protocol":  "raw",

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -1290,6 +1290,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	opts := rest.Opts{
 		Method:       "POST",
 		Path:         "files/v1/allocate",
+		Options:      options,
 		ExtraHeaders: make(map[string]string),
 	}
 	fileDate := api.Time(src.ModTime(ctx)).APIString()

--- a/backend/opendrive/opendrive.go
+++ b/backend/opendrive/opendrive.go
@@ -687,8 +687,9 @@ func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options .
 				Name:      leaf,
 			}
 			opts := rest.Opts{
-				Method: "POST",
-				Path:   "/upload/create_file.json",
+				Method:  "POST",
+				Options: options,
+				Path:    "/upload/create_file.json",
 			}
 			resp, err = o.fs.srv.CallJSON(ctx, &opts, &createFileData, &response)
 			return o.fs.shouldRetry(resp, err)
@@ -970,8 +971,9 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		openUploadData := openUpload{SessionID: o.fs.session.SessionID, FileID: o.id, Size: size}
 		// fs.Debugf(nil, "PreOpen: %#v", openUploadData)
 		opts := rest.Opts{
-			Method: "POST",
-			Path:   "/upload/open_file_upload.json",
+			Method:  "POST",
+			Options: options,
+			Path:    "/upload/open_file_upload.json",
 		}
 		resp, err := o.fs.srv.CallJSON(ctx, &opts, &openUploadData, &openResponse)
 		return o.fs.shouldRetry(resp, err)

--- a/backend/pcloud/pcloud.go
+++ b/backend/pcloud/pcloud.go
@@ -1080,6 +1080,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		ContentLength:    &size,
 		Parameters:       url.Values{},
 		TransferEncoding: []string{"identity"}, // pcloud doesn't like chunked encoding
+		Options:          options,
 	}
 	leaf = o.fs.opt.Enc.FromStandardName(leaf)
 	opts.Parameters.Set("filename", leaf)

--- a/backend/premiumizeme/premiumizeme.go
+++ b/backend/premiumizeme/premiumizeme.go
@@ -517,7 +517,7 @@ func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options .
 		return existingObj, existingObj.Update(ctx, in, src, options...)
 	case fs.ErrorObjectNotFound:
 		// Not found so create it
-		return f.PutUnchecked(ctx, in, src)
+		return f.PutUnchecked(ctx, in, src, options...)
 	default:
 		return nil, err
 	}
@@ -1002,6 +1002,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		Method:     "POST",
 		Path:       "/folder/uploadinfo",
 		Parameters: o.fs.baseParams(),
+		Options:    options,
 		MultipartParams: url.Values{
 			"id": {directoryID},
 		},

--- a/backend/sharefile/sharefile.go
+++ b/backend/sharefile/sharefile.go
@@ -1429,8 +1429,9 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	var resp *http.Response
 	var info api.UploadSpecification
 	opts := rest.Opts{
-		Method: "POST",
-		Path:   "/Items(" + directoryID + ")/Upload2",
+		Method:  "POST",
+		Path:    "/Items(" + directoryID + ")/Upload2",
+		Options: options,
 	}
 	err = o.fs.pacer.Call(func() (bool, error) {
 		resp, err = o.fs.srv.CallJSON(ctx, &opts, &req, &info)

--- a/backend/sugarsync/sugarsync.go
+++ b/backend/sugarsync/sugarsync.go
@@ -733,7 +733,7 @@ func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options .
 		return existingObj, existingObj.Update(ctx, in, src, options...)
 	case fs.ErrorObjectNotFound:
 		// Not found so create it
-		return f.PutUnchecked(ctx, in, src)
+		return f.PutUnchecked(ctx, in, src, options...)
 	default:
 		return nil, err
 	}
@@ -1320,6 +1320,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		RootURL:    o.id,
 		Path:       "/data",
 		NoResponse: true,
+		Options:    options,
 		Body:       in,
 	}
 	if size >= 0 {

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -1135,6 +1135,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		NoResponse:    true,
 		ContentLength: &size, // FIXME this isn't necessary with owncloud - See https://github.com/nextcloud/nextcloud-snap/issues/365
 		ContentType:   fs.MimeType(ctx, src),
+		Options:       options,
 	}
 	if o.fs.useOCMtime || o.fs.hasMD5 || o.fs.hasSHA1 {
 		opts.ExtraHeaders = map[string]string{}

--- a/backend/yandex/yandex.go
+++ b/backend/yandex/yandex.go
@@ -1065,7 +1065,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	return resp.Body, err
 }
 
-func (o *Object) upload(ctx context.Context, in io.Reader, overwrite bool, mimeType string) (err error) {
+func (o *Object) upload(ctx context.Context, in io.Reader, overwrite bool, mimeType string, options ...fs.OpenOption) (err error) {
 	// prepare upload
 	var resp *http.Response
 	var ur api.AsyncInfo
@@ -1073,6 +1073,7 @@ func (o *Object) upload(ctx context.Context, in io.Reader, overwrite bool, mimeT
 		Method:     "GET",
 		Path:       "/resources/upload",
 		Parameters: url.Values{},
+		Options:    options,
 	}
 
 	opts.Parameters.Set("path", o.fs.opt.Enc.FromStandardPath(o.filePath()))
@@ -1121,7 +1122,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	}
 
 	//upload file
-	err = o.upload(ctx, in1, true, fs.MimeType(ctx, src))
+	err = o.upload(ctx, in1, true, fs.MimeType(ctx, src), options...)
 	if err != nil {
 		return err
 	}

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -564,6 +564,29 @@ triggering follow-on actions if data was copied, or skipping if not.
 NB: Enabling this option turns a usually non-fatal error into a potentially
 fatal one - please check and adjust your scripts accordingly!
 
+### --header-download ###
+
+Add an HTTP header for all download transactions. The flag can be repeated to
+add multiple headers.
+
+```
+rclone sync s3:test/src ~/dst --header-download "X-Amz-Meta-Test: Foo" --header-download "X-Amz-Meta-Test2: Bar"
+```
+
+See the Github issue [here](https://github.com/rclone/rclone/issues/59) for
+currently supported backends.
+
+### --header-upload ###
+
+Add an HTTP header for all upload transactions. The flag can be repeated to add
+multiple headers.
+
+```
+rclone sync ~/src s3:test/dst --header-upload "Content-Disposition: attachment; filename='cool.html'" --header-upload "X-Amz-Meta-Test: FooBar"
+```
+
+See the Github issue [here](https://github.com/rclone/rclone/issues/59) for
+currently supported backends.
 
 ### --ignore-case-sync ###
 

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -48,6 +48,8 @@ These flags are available for every command.
       --files-from stringArray               Read list of source-file names from file (use - to read from stdin).
   -f, --filter stringArray                   Add a file-filtering rule
       --filter-from stringArray              Read filtering patterns from a file (use - to read from stdin).
+      --header-download stringArray          Add HTTP header for download transactions
+      --header-upload stringArray            Add HTTP header for upload transactions
       --ignore-case                          Ignore case in filters (case insensitive)
       --ignore-case-sync                     Ignore case when synchronizing
       --ignore-checksum                      Skip post copy check of checksums.

--- a/fs/config.go
+++ b/fs/config.go
@@ -111,6 +111,8 @@ type ConfigInfo struct {
 	MultiThreadStreams     int
 	MultiThreadSet         bool   // whether MultiThreadStreams was set (set in fs/config/configflags)
 	OrderBy                string // instructions on how to order the transfer
+	UploadHeaders          []*HTTPOption
+	DownloadHeaders        []*HTTPOption
 }
 
 // NewConfig creates a new config with everything set to the default

--- a/fs/operations/multithread.go
+++ b/fs/operations/multithread.go
@@ -71,7 +71,7 @@ func (mc *multiThreadCopyState) copyStream(ctx context.Context, stream int) (err
 
 	fs.Debugf(mc.src, "multi-thread copy: stream %d/%d (%d-%d) size %v starting", stream+1, mc.streams, start, end, fs.SizeSuffix(end-start))
 
-	rc, err := NewReOpen(ctx, mc.src, nil, &fs.RangeOption{Start: start, End: end - 1}, fs.Config.LowLevelRetries)
+	rc, err := NewReOpen(ctx, mc.src, fs.Config.LowLevelRetries, &fs.RangeOption{Start: start, End: end - 1})
 	if err != nil {
 		return errors.Wrap(err, "multpart copy: failed to open source")
 	}

--- a/fs/operations/reopen.go
+++ b/fs/operations/reopen.go
@@ -12,17 +12,16 @@ import (
 
 // ReOpen is a wrapper for an object reader which reopens the stream on error
 type ReOpen struct {
-	ctx         context.Context
-	mu          sync.Mutex       // mutex to protect the below
-	src         fs.Object        // object to open
-	hashOption  *fs.HashesOption // option to pass to initial open
-	rangeOption *fs.RangeOption  // option to pass to initial open
-	rc          io.ReadCloser    // underlying stream
-	read        int64            // number of bytes read from this stream
-	maxTries    int              // maximum number of retries
-	tries       int              // number of retries we've had so far in this stream
-	err         error            // if this is set then Read/Close calls will return it
-	opened      bool             // if set then rc is valid and needs closing
+	ctx      context.Context
+	mu       sync.Mutex      // mutex to protect the below
+	src      fs.Object       // object to open
+	options  []fs.OpenOption // option to pass to initial open
+	rc       io.ReadCloser   // underlying stream
+	read     int64           // number of bytes read from this stream
+	maxTries int             // maximum number of retries
+	tries    int             // number of retries we've had so far in this stream
+	err      error           // if this is set then Read/Close calls will return it
+	opened   bool            // if set then rc is valid and needs closing
 }
 
 var (
@@ -36,13 +35,12 @@ var (
 //
 // If rangeOption is set then this will applied when reading from the
 // start, and updated on retries.
-func NewReOpen(ctx context.Context, src fs.Object, hashOption *fs.HashesOption, rangeOption *fs.RangeOption, maxTries int) (rc io.ReadCloser, err error) {
+func NewReOpen(ctx context.Context, src fs.Object, maxTries int, options ...fs.OpenOption) (rc io.ReadCloser, err error) {
 	h := &ReOpen{
-		ctx:         ctx,
-		src:         src,
-		hashOption:  hashOption,
-		rangeOption: rangeOption,
-		maxTries:    maxTries,
+		ctx:      ctx,
+		src:      src,
+		maxTries: maxTries,
+		options:  options,
 	}
 	h.mu.Lock()
 	defer h.mu.Unlock()
@@ -57,20 +55,35 @@ func NewReOpen(ctx context.Context, src fs.Object, hashOption *fs.HashesOption, 
 //
 // we don't retry here as the Open() call will itself have low level retries
 func (h *ReOpen) open() error {
-	var optsArray [2]fs.OpenOption
-	var opts = optsArray[:0]
-	if h.read == 0 {
-		if h.rangeOption != nil {
-			opts = append(opts, h.rangeOption)
+	opts := []fs.OpenOption{}
+	var hashOption *fs.HashesOption
+	var rangeOption *fs.RangeOption
+	for _, option := range h.options {
+		switch option.(type) {
+		case *fs.HashesOption:
+			hashOption = option.(*fs.HashesOption)
+		case *fs.RangeOption:
+			rangeOption = option.(*fs.RangeOption)
+		case *fs.HTTPOption:
+			opts = append(opts, option)
+		default:
+			if option.Mandatory() {
+				fs.Logf(h.src, "Unsupported mandatory option: %v", option)
+			}
 		}
-		if h.hashOption != nil {
+	}
+	if h.read == 0 {
+		if rangeOption != nil {
+			opts = append(opts, rangeOption)
+		}
+		if hashOption != nil {
 			// put hashOption on if reading from the start, ditch otherwise
-			opts = append(opts, h.hashOption)
+			opts = append(opts, hashOption)
 		}
 	} else {
-		if h.rangeOption != nil {
+		if rangeOption != nil {
 			// range to the read point
-			opts = append(opts, &fs.RangeOption{Start: h.rangeOption.Start + h.read, End: h.rangeOption.End})
+			opts = append(opts, &fs.RangeOption{Start: rangeOption.Start + h.read, End: rangeOption.End})
 		} else {
 			// seek to the read point
 			opts = append(opts, &fs.SeekOption{Offset: h.read})

--- a/fs/operations/reopen_test.go
+++ b/fs/operations/reopen_test.go
@@ -74,7 +74,7 @@ func TestReOpen(t *testing.T) {
 					breaks: breaks,
 				}
 				hashOption := &fs.HashesOption{Hashes: hash.NewHashSet(hash.MD5)}
-				return NewReOpen(context.Background(), src, hashOption, rangeOption, maxRetries)
+				return NewReOpen(context.Background(), src, maxRetries, hashOption, rangeOption)
 			}
 
 			t.Run("Basics", func(t *testing.T) {


### PR DESCRIPTION
#### What is the purpose of this change?

The goal is to add two repeatable flags as follows

--header-upload "Header: String"
--header-download "Header: String"

Headers added with the --header-upload flag will get added to all Put/Update calls.
Headers added with the --header-download flag will get added to all Open calls.

In this PR I would like to lay the groundwork for these flags and complete an implementation for at least one of the backends. My immediate need is for s3/minio so I am focusing on that.

I have been following the implementation steps laid out [here](https://github.com/rclone/rclone/issues/59#issuecomment-504379064).

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/59

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
