### PR TITLE
vfs: Unused Variables

### DIFF
--- a/vfs/cache_test.go
+++ b/vfs/cache_test.go
@@ -333,7 +333,7 @@ func TestCacheOpenMkdir(t *testing.T) {
 	assert.Equal(t, []string(nil), itemAsString(c))
 
 	// test directory does not exist
-	fi, err = os.Stat(filepath.Dir(p))
+	_, err = os.Stat(filepath.Dir(p))
 	require.True(t, os.IsNotExist(err))
 }
 

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -238,7 +238,7 @@ func TestDirStat(t *testing.T) {
 	assert.Equal(t, int64(14), node.Size())
 	assert.Equal(t, "file1", node.Name())
 
-	node, err = dir.Stat("not found")
+	_, err = dir.Stat("not found")
 	assert.Equal(t, ENOENT, err)
 }
 

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -405,7 +405,7 @@ func TestDirRemove(t *testing.T) {
 	require.NoError(t, err)
 
 	// check directory is not there
-	node, err = vfs.Stat("dir")
+	_, err = vfs.Stat("dir")
 	assert.Equal(t, ENOENT, err)
 
 	// check the vfs

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -293,7 +293,7 @@ func TestDirOpen(t *testing.T) {
 	assert.True(t, ok)
 	require.NoError(t, fd.Close())
 
-	fd, err = dir.Open(os.O_WRONLY)
+	_, err = dir.Open(os.O_WRONLY)
 	assert.Equal(t, EPERM, err)
 }
 

--- a/vfs/file_test.go
+++ b/vfs/file_test.go
@@ -238,7 +238,7 @@ func TestFileOpen(t *testing.T) {
 	_, ok = fd.(*WriteFileHandle)
 	assert.True(t, ok)
 
-	fd, err = file.Open(3)
+	_, err = file.Open(3)
 	assert.Equal(t, EPERM, err)
 }
 

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -152,16 +152,16 @@ func TestVFSStat(t *testing.T) {
 	assert.True(t, node.IsFile())
 	assert.Equal(t, "file2", node.Name())
 
-	node, err = vfs.Stat("not found")
+	_, err = vfs.Stat("not found")
 	assert.Equal(t, os.ErrNotExist, err)
 
-	node, err = vfs.Stat("dir/not found")
+	_, err = vfs.Stat("dir/not found")
 	assert.Equal(t, os.ErrNotExist, err)
 
-	node, err = vfs.Stat("not found/not found")
+	_, err = vfs.Stat("not found/not found")
 	assert.Equal(t, os.ErrNotExist, err)
 
-	node, err = vfs.Stat("file1/under a file")
+	_, err = vfs.Stat("file1/under a file")
 	assert.Equal(t, os.ErrNotExist, err)
 }
 


### PR DESCRIPTION
Linted with `staticcheck`.

This explicitly assigns unused variables to `_` in the `vfs` package.