### PR TITLE
Prune qingstor

### DIFF
--- a/backend/qingstor/qingstor.go
+++ b/backend/qingstor/qingstor.go
@@ -392,7 +392,7 @@ func (f *Fs) Root() string {
 // String converts this Fs to a string
 func (f *Fs) String() string {
 	if f.rootBucket == "" {
-		return fmt.Sprintf("QingStor root")
+		return "QingStor root"
 	}
 	if f.rootDirectory == "" {
 		return fmt.Sprintf("QingStor bucket %s", f.rootBucket)

--- a/backend/qingstor/upload.go
+++ b/backend/qingstor/upload.go
@@ -297,21 +297,6 @@ func (mu *multiUploader) send(c chunk) error {
 	return err
 }
 
-// list list the ObjectParts of an multipart upload
-func (mu *multiUploader) list() error {
-	bucketInit, _ := mu.bucketInit()
-
-	req := qs.ListMultipartInput{
-		UploadID: mu.uploadID,
-	}
-	fs.Debugf(mu, "Reading multi-part details")
-	rsp, err := bucketInit.ListMultipart(mu.cfg.key, &req)
-	if err == nil {
-		mu.objectParts = rsp.ObjectParts
-	}
-	return err
-}
-
 // complete complete an multipart upload
 func (mu *multiUploader) complete() error {
 	var err error


### PR DESCRIPTION
I linted this with `staticcheck`.

This prunes the unused `list()` function and satisfies the linter by removing a noop `fmt.Sprintf()`.