### PR TITLE
fs: expand stats output for json log

### DIFF
--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -377,7 +377,7 @@ func (s *StatsInfo) Transferred() []TransferSnapshot {
 func (s *StatsInfo) Log() {
 	if fs.Config.UseJSONLog {
 		out, _ := s.RemoteStats()
-		fs.LogLevelPrintf(fs.Config.StatsLogLevel, nil, "%T\n", map[string]interface{}(out))
+		fs.LogLevelPrintf(fs.Config.StatsLogLevel, nil, "%v%v\n", s, fs.LogValue("stats", out))
 	} else {
 		fs.LogLevelPrintf(fs.Config.StatsLogLevel, nil, "%v\n", s)
 	}

--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -375,7 +375,13 @@ func (s *StatsInfo) Transferred() []TransferSnapshot {
 
 // Log outputs the StatsInfo to the log
 func (s *StatsInfo) Log() {
-	fs.LogLevelPrintf(fs.Config.StatsLogLevel, nil, "%v\n", s)
+	if fs.Config.UseJSONLog {
+		out, _ := s.RemoteStats()
+		fs.LogLevelPrintf(fs.Config.StatsLogLevel, nil, "%T\n", map[string]interface{}(out))
+	} else {
+		fs.LogLevelPrintf(fs.Config.StatsLogLevel, nil, "%v\n", s)
+	}
+
 }
 
 // Bytes updates the stats for bytes bytes

--- a/fs/log.go
+++ b/fs/log.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"fmt"
 	"log"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -85,6 +86,10 @@ func LogPrintf(level LogLevel, o interface{}, text string, args ...interface{}) 
 				"object":     fmt.Sprintf("%+v", o),
 				"objectType": fmt.Sprintf("%T", o),
 			}
+		}
+		if strings.HasPrefix(out, "map[") {
+			fields["json"] = args[0]
+			out = ""
 		}
 		switch level {
 		case LogLevelDebug:


### PR DESCRIPTION

#### What is the purpose of this change?

Output actual json representation when using json logs.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/pull/3373#issuecomment-523395333
https://github.com/rclone/rclone/pull/3903#issuecomment-578971245

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
