### PR TITLE
dlna: cds: don't specify childCount at all when unknown

### DIFF
--- a/cmd/serve/dlna/cds.go
+++ b/cmd/serve/dlna/cds.go
@@ -16,8 +16,8 @@ import (
 
 	"github.com/anacrolix/dms/dlna"
 	"github.com/anacrolix/dms/upnp"
-	"github.com/anacrolix/dms/upnpav"
 	"github.com/pkg/errors"
+	"github.com/rclone/rclone/cmd/serve/dlna/upnpav"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/vfs"
 )
@@ -77,16 +77,10 @@ func (cds *contentDirectoryService) cdsObjectToUpnpavObject(cdsObject object, fi
 	}
 
 	if fileInfo.IsDir() {
-		children, err := cds.readContainer(cdsObject, host)
-		if err != nil {
-			return nil, err
-		}
-
 		obj.Class = "object.container.storageFolder"
 		obj.Title = fileInfo.Name()
 		return upnpav.Container{
-			Object:     obj,
-			ChildCount: len(children),
+			Object: obj,
 		}, nil
 	}
 

--- a/cmd/serve/dlna/dlna_test.go
+++ b/cmd/serve/dlna/dlna_test.go
@@ -122,8 +122,8 @@ func TestContentDirectoryBrowseMetadata(t *testing.T) {
 	// expect a <container> element
 	require.Contains(t, string(body), html.EscapeString("<container "))
 	require.NotContains(t, string(body), html.EscapeString("<item "))
-	// with a non-zero childCount
-	require.Regexp(t, " childCount=&#34;[1-9]", string(body))
+	// if there is a childCount, it better not be zero
+	require.NotContains(t, string(body), html.EscapeString(" childCount=\"0\""))
 }
 
 // Check that the X_MS_MediaReceiverRegistrar is faked out properly.

--- a/cmd/serve/dlna/upnpav/upnpav.go
+++ b/cmd/serve/dlna/upnpav/upnpav.go
@@ -1,0 +1,63 @@
+package upnpav
+
+import (
+	"encoding/xml"
+	"time"
+)
+
+const (
+	// NoSuchObjectErrorCode : The specified ObjectID is invalid.
+	NoSuchObjectErrorCode = 701
+)
+
+// Resource description
+type Resource struct {
+	XMLName      xml.Name `xml:"res"`
+	ProtocolInfo string   `xml:"protocolInfo,attr"`
+	URL          string   `xml:",chardata"`
+	Size         uint64   `xml:"size,attr,omitempty"`
+	Bitrate      uint     `xml:"bitrate,attr,omitempty"`
+	Duration     string   `xml:"duration,attr,omitempty"`
+	Resolution   string   `xml:"resolution,attr,omitempty"`
+}
+
+// Container description
+type Container struct {
+	Object
+	XMLName    xml.Name `xml:"container"`
+	ChildCount *int     `xml:"childCount,attr"`
+}
+
+// Item description
+type Item struct {
+	Object
+	XMLName  xml.Name `xml:"item"`
+	Res      []Resource
+	InnerXML string `xml:",innerxml"`
+}
+
+// Object description
+type Object struct {
+	ID          string    `xml:"id,attr"`
+	ParentID    string    `xml:"parentID,attr"`
+	Restricted  int       `xml:"restricted,attr"` // indicates whether the object is modifiable
+	Class       string    `xml:"upnp:class"`
+	Icon        string    `xml:"upnp:icon,omitempty"`
+	Title       string    `xml:"dc:title"`
+	Date        Timestamp `xml:"dc:date"`
+	Artist      string    `xml:"upnp:artist,omitempty"`
+	Album       string    `xml:"upnp:album,omitempty"`
+	Genre       string    `xml:"upnp:genre,omitempty"`
+	AlbumArtURI string    `xml:"upnp:albumArtURI,omitempty"`
+	Searchable  int       `xml:"searchable,attr"`
+}
+
+// Timestamp wraps time.Time for formatting purposes
+type Timestamp struct {
+	time.Time
+}
+
+// MarshalXML formats the Timestamp per DIDL-Lite spec
+func (t Timestamp) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	return e.EncodeElement(t.Format("2006-01-02"), start)
+}


### PR DESCRIPTION
Basically, solving #3541 with a different approach - bringing in
the upstream upnpav module, and changing ChildCount from int to a
*int to avoid childCount="0" in the XML output when that value is
simply unknown.

Current approach is leading to some recursion issues and according
to the DLNA spec it shouldn't be necessary, anyway.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

Discussed in #3588 , @jorams reported an issue where the entire remote is being scanned in order to get the childCount metadata.

Alternative approach: could also just add a flag to ensure there's no recursion, but the CDS stuff is already quite messy, so this seems like a better idea and better handles the "top level directory with subdirectories for each media item" use case anyway.

It's possible some clients may have an adverse reaction to the change, but I think it's worth putting it out there, since it is spec compliant.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
