### PR TITLE
copy/sync: fix bug on copying empty dirs

### DIFF
--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -879,11 +879,15 @@ func (s *syncCopyMove) Match(ctx context.Context, dst, src fs.DirEntry) (recurse
 		// Do the same thing to the entire contents of the directory
 		_, ok := dst.(fs.Directory)
 		if ok {
-			// Record the src directory for deletion
-			s.srcEmptyDirsMu.Lock()
-			s.srcParentDirCheck(src)
-			s.srcEmptyDirs[src.Remote()] = src
-			s.srcEmptyDirsMu.Unlock()
+			// Only record matched (src & dst) empty dirs when performing move
+			if s.DoMove {
+				// Record the src directory for deletion
+				s.srcEmptyDirsMu.Lock()
+				s.srcParentDirCheck(src)
+				s.srcEmptyDirs[src.Remote()] = src
+				s.srcEmptyDirsMu.Unlock()
+			}
+
 			return true
 		}
 		// FIXME src is dir, dst is file


### PR DESCRIPTION
Sync/copy now only creates empty directories when they don't exist on the remote (--create-empty-src-dirs flag) - fixes #2800

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

sync/copy now only create empty source directories on dst when they do not exist.

#### Was the change discussed in an issue or in the forum before?

Yes, this is issue #2800

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
