### PR TITLE
doc: fix links in generated documentation

### DIFF
--- a/bin/make_manual.py
+++ b/bin/make_manual.py
@@ -110,7 +110,7 @@ def read_doc(doc):
     # Remove icons
     contents = re.sub(r'<i class="fa.*?</i>\s*', "", contents)
     # Make [...](/links/) absolute
-    contents = re.sub(r'\((\/.*?\/)\)', r"(https://rclone.org\1)", contents)
+    contents = re.sub(r'\]\((\/.*?\/(#.*)?)\)', r"](https://rclone.org\1)", contents)
     # Interpret provider shortcode
     # {{< provider name="Amazon S3" home="https://aws.amazon.com/s3/" config="/s3/" >}}
     contents = re.sub(r'\{\{<\s+provider.*?name="(.*?)".*?>\}\}', r"\1", contents)

--- a/docs/content/changelog.md
+++ b/docs/content/changelog.md
@@ -9,8 +9,8 @@ date: "2020-02-01"
 ## v1.51.0 - 2020-02-01
 
 * New backends
-    * [Memory](/memory) (Nick Craig-Wood)
-    * [Sugarsync](/sugarsync) (Nick Craig-Wood)
+    * [Memory](/memory/) (Nick Craig-Wood)
+    * [Sugarsync](/sugarsync/) (Nick Craig-Wood)
 * New Features
     * Adjust all backends to have `--backend-encoding` parameter (Nick Craig-Wood)
         * this enables the encoding for special characters to be adjusted or disabled
@@ -165,9 +165,9 @@ date: "2020-02-01"
 ## v1.50.0 - 2019-10-26
 
 * New backends
-    * [Citrix Sharefile](/sharefile) (Nick Craig-Wood)
-    * [Chunker](/chunker) - an overlay backend to split files into smaller parts (Ivan Andreev)
-    * [Mail.ru Cloud](/mailru) (Ivan Andreev)
+    * [Citrix Sharefile](/sharefile/) (Nick Craig-Wood)
+    * [Chunker](/chunker/) - an overlay backend to split files into smaller parts (Ivan Andreev)
+    * [Mail.ru Cloud](/mailru/) (Ivan Andreev)
 * New Features
     * encodings (Fabian Möller & Nick Craig-Wood)
         * All backends now use file name encoding to ensure any file name can be written to any backend.
@@ -320,7 +320,7 @@ date: "2020-02-01"
 
 * New backends
     * [1fichier](/fichier/) (Laura Hausmann)
-    * [Google Photos](/googlephotos) (Nick Craig-Wood)
+    * [Google Photos](/googlephotos/) (Nick Craig-Wood)
     * [Putio](/putio/) (Cenk Alti)
     * [premiumize.me](/premiumizeme/) (Nick Craig-Wood)
 * New Features


### PR DESCRIPTION
#### What is the purpose of this change?

Generated documentation has invalid links.
To see such errors, you can use the command `grep -E -o -e '\(/[^)]+\)' rclone.1 | sort | uniq`:
```
(/amazonclouddrive/#status)
(/bugs/#limitations)
(/chunker)
(/commands/rclone_mount/#attribute-caching)
(/commands/rclone_mount/#file-buffering)
(/docs/#backup-dir-dir)
(/docs/#configure)
(/docs/#fast-list)
(/docs/#max-backlog-n)
(/docs/#no-traverse)
(/googlephotos)
(/local/#filenames)
(/mailru)
(/memory)
(/overview/#encoding)
(/overview/#features)
(/overview/#invalid-utf8)
(/overview/#optional-features)
(/overview/#restricted-characters)
(/overview/#restricted-filenames)
(/rc)
(/s3/#digitalocean-spaces)
(/sharefile)
(/sugarsync)
```

These links are not converted from relative style into absolute.
And this problem affects not only [`rclone.1`](https://github.com/rclone/rclone/blob/7586a345ff3c87d29a08b44909f9be5579172938/rclone.1#L483) but [`MANUAL.html`](https://github.com/rclone/rclone/blob/7586a345ff3c87d29a08b44909f9be5579172938/MANUAL.html#L229) and [`MANUAL.md`](https://github.com/rclone/rclone/blame/master/MANUAL.md#L314) too.

I am not sure about changes in `changelog.md` as I see it's generated by `bin/make_changelog.py` but I cannot find the code that generates links in the list of new backends.

#### Was the change discussed in an issue or in the forum before?

No, changes weren't discussed before.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
