### PR TITLE
vfs: make `df` output more consistent on a rclone mount.

### DIFF
--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -506,6 +506,15 @@ func (vfs *VFS) Statfs() (total, used, free int64) {
 		if u.Used != nil {
 			used = *u.Used
 		}
+		if total < 0 && free >= 0 && used >= 0 {
+			total = free + used
+		}
+		if free < 0 && total >= 0 && used >= 0 {
+			free = total - used
+		}
+		if used < 0 && total >= 0 && free >= 0 {
+			used = total - free
+		}
 	}
 	return
 }


### PR DESCRIPTION
#### What is the purpose of this change?

I wish, that running Linux `df` on a mount is as accurate as possible, considering the data reported by the remote.

#### Was the change discussed in an issue or in the forum before?

Yes: https://github.com/rclone/rclone/issues/3997#issuecomment-591664003

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
