### PR TITLE
crypt: support timestamped filenames from --b2-versions

### DIFF
--- a/backend/b2/api/types.go
+++ b/backend/b2/api/types.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -64,6 +65,16 @@ func (t *Timestamp) UnmarshalJSON(data []byte) error {
 }
 
 const versionFormat = "-v2006-01-02-150405.000"
+
+var /* const */ versionRegexp = regexp.MustCompile("-v\\d{4}-\\d{2}-\\d{2}-\\d{6}-\\d{3}")
+
+// HasVersion returns true if it looks like the passed filename has a timestamp on it.
+//
+// Note that the passed filename's timestamp may still be invalid even if this
+// function returns true.
+func HasVersion(remote string) bool {
+	return versionRegexp.MatchString(remote)
+}
 
 // AddVersion adds the timestamp as a version string into the filename passed in.
 func (t Timestamp) AddVersion(remote string) string {

--- a/backend/b2/api/types_test.go
+++ b/backend/b2/api/types_test.go
@@ -36,6 +36,24 @@ func TestTimestampUnmarshalJSON(t *testing.T) {
 	assert.Equal(t, (time.Time)(t1), (time.Time)(tActual))
 }
 
+func TestTimestampHasVersion(t *testing.T) {
+	for _, test := range []struct {
+		in       string
+		expected bool
+	}{
+		{"potato.txt", false},
+		{"potato", false},
+		{"", false},
+		{"potato-v1970-01-01-010101-123.txt", true},
+		{"potato-v2001-02-03-040506-123", true},
+		{"-v2001-02-03-040506-123", true},
+		{"-v9999-99-99-999999-999", true},
+	} {
+		actual := api.HasVersion(test.in)
+		assert.Equal(t, test.expected, actual, test.in)
+	}
+}
+
 func TestTimestampAddVersion(t *testing.T) {
 	for _, test := range []struct {
 		t        api.Timestamp

--- a/docs/content/b2.md
+++ b/docs/content/b2.md
@@ -167,11 +167,6 @@ the file instead of hiding it.
 Old versions of files, where available, are visible using the 
 `--b2-versions` flag.
 
-**NB** Note that `--b2-versions` does not work with crypt at the
-moment [#1627](https://github.com/rclone/rclone/issues/1627). Using
-[--backup-dir](/docs/#backup-dir-dir) with rclone is the recommended
-way of working around this.
-
 If you wish to remove all the old versions then you can use the
 `rclone cleanup remote:bucket` command which will delete all the old
 versions of files, leaving the current ones intact.  You can also


### PR DESCRIPTION
Relies on identifying the version string that backend/b2 adds to the
filename. There are pathological cases where an obfuscated filename
could end in what looks like a version string purely by chance. In such
a case, this code will incorrectly leave that portion of the filename
obfuscated. There's not really a clean fix for that, other than keeping
track of versions out-of-band instead of in the filename string.

Fixes #1627

#### What is the purpose of this change?

Background: Backblaze B2 supports multiple versions of a given filename. rclone supports this behind `--b2-versions` for read-only access, by appending a timestamp suffix to all but the most recent version of a file. The crypt backend supports encrypted or obfuscated filenames, but fails to decrypt them when a timestamp suffix has been added.

This change updates the crypt backend to identify when a file has a version string added to it. If it does, the version string will be stripped off before decrypting the filename, and added back to the decrypted name. This allows `--b2-versions` to be used with crypt remotes backed by B2.

#### Was the change discussed in an issue or in the forum before?

This issue was discussed in #1627, where a fix broadly similar to this was suggested.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- *Note:* I have added unit tests, but I'm not sure what the best way is to add integration tests for a crypt remote backed by b2. I imagine we want to add some that cover this use case.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)