### PR TITLE
vfs: --vfs-used-is-size uses `rclone size` to give used space (full recursive listing)

### DIFF
--- a/vfs/help.go
+++ b/vfs/help.go
@@ -259,4 +259,17 @@ The flag controls whether "fixup" is performed to satisfy the target.
 If the flag is not provided on the command line, then its default value depends
 on the operating system where rclone runs: "true" on Windows and macOS, "false"
 otherwise. If the flag is provided without a value, then it is "true".
+
+### Alternate report of used bytes
+
+Some backends, most notably S3, do not report the amount of bytes used.
+If you need this information to be available when running !df! on the
+filesystem, then pass the flag !--vfs-used-is-size! to rclone.
+With this flag set, instead of relying on the backend to report this
+information, rclone will scan the whole remote similar to !rclone size!
+and compute the total used space itself.
+
+_WARNING._ Contrary to !rclone size!, this flag ignores filters so that the
+result is accurate. However, this is very inefficient and may cost lots of API
+calls resulting in extra charges. Use it as a last resort and only with caching.
 `, "!", "`")

--- a/vfs/vfscommon/options.go
+++ b/vfs/vfscommon/options.go
@@ -32,6 +32,7 @@ type Options struct {
 	ReadWait          time.Duration // time to wait for in-sequence read
 	WriteBack         time.Duration // time to wait before writing back dirty files
 	ReadAhead         fs.SizeSuffix // bytes to read ahead in cache mode "full"
+	UsedIsSize        bool          // if true, use the `rclone size` algorithm for Used size
 }
 
 // DefaultOpt is the default values uses for Opt
@@ -58,4 +59,5 @@ var DefaultOpt = Options{
 	ReadWait:          20 * time.Millisecond,
 	WriteBack:         5 * time.Second,
 	ReadAhead:         0 * fs.MebiByte,
+	UsedIsSize:        false,
 }

--- a/vfs/vfsflags/vfsflags.go
+++ b/vfs/vfsflags/vfsflags.go
@@ -37,5 +37,6 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.DurationVarP(flagSet, &Opt.ReadWait, "vfs-read-wait", "", Opt.ReadWait, "Time to wait for in-sequence read before seeking.")
 	flags.DurationVarP(flagSet, &Opt.WriteBack, "vfs-write-back", "", Opt.WriteBack, "Time to writeback files after last use when using cache.")
 	flags.FVarP(flagSet, &Opt.ReadAhead, "vfs-read-ahead", "", "Extra read ahead over --buffer-size when using cache-mode full.")
+	flags.BoolVarP(flagSet, &Opt.UsedIsSize, "vfs-used-is-size", "", Opt.UsedIsSize, "Use the `rclone size` algorithm for Used size.")
 	platformFlags(flagSet)
 }


### PR DESCRIPTION
#### What is the purpose of this change?

I needed a report on Used space for S3 remotes, whereas none is given as it is now.
Implementation relies on pre-existing code for `rclone size`, i.e. the `Count` operation, which ultimately relies on the `walk.ListR(…)` function.
I chose to follow the trail down to `ListR` instead of using `Count`, because:

* Although the software architecture of rclone is not very clear to me at this stage, for some reason I did not feel comfortable having `vfs.go` rely on `operations.go`;
* `Count` also counts the number of objects, which is useless to me;
* `Count` does not have any guarantee regarding parallelism for its function, and thus uses costly atomic integers, whereas `ListR` explicitly guarantees, that “fn will not be called concurrently whereas the directory listing will proceed concurrently”;
* `Count` does not allow me to override filters or force infinite recursion.

Thus the same algorithm as `rclone size` is used, but at a low level and without filtering.

#### Was the change discussed in an issue or in the forum before?

No, but it was here: https://github.com/rclone/rclone/pull/4022

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
