### PR TITLE
fix #4047: use the provided size parameter to allocate new memory pool

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1917,7 +1917,7 @@ func (f *Fs) getMemoryPool(size int64) *pool.Pool {
 	if !ok {
 		f.pools[size] = pool.New(
 			time.Duration(f.opt.MemoryPoolFlushTime),
-			int(f.opt.ChunkSize),
+			int(size),
 			f.opt.UploadConcurrency*fs.Config.Transfers,
 			f.opt.MemoryPoolUseMmap,
 		)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix the memory pool allocator in the s3 backend to use the provided size argument. Otherwise, when the requested pool is larger than the configured size, a panic occurs when attempting to use the buffer.

#### Was the change discussed in an issue or in the forum before?

see #4047 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
