### PR TITLE
fs: Add configurable matching criteria for --track-renames

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1142,6 +1142,15 @@ Note also that `--track-renames` is incompatible with
 `--delete-before` and will select `--delete-after` instead of
 `--delete-during`.
 
+### --track-using-modtime
+
+This option changes the matching criteria for `--track-renames` to match
+by modification time instead of matching by file hash. This also means
+that it enables `--track-renames` support for encrypted destinations.
+The source and destination file modification time must be within one
+millisecond to match.
+
+
 ### --delete-(before,during,after) ###
 
 This option allows you to specify when files on your destination are

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1142,14 +1142,13 @@ Note also that `--track-renames` is incompatible with
 `--delete-before` and will select `--delete-after` instead of
 `--delete-during`.
 
-### --track-using-modtime
+### --track-renames-strategy (hash,modtime) ###
 
 This option changes the matching criteria for `--track-renames` to match
-by modification time instead of matching by file hash. This also means
+by any combination of modtime, hash, size. Matchig by size is always enabled
+no matter what option is selected here. This also means
 that it enables `--track-renames` support for encrypted destinations.
-The source and destination file modification time must be within one
-millisecond to match.
-
+If nothing is specified, the default option is matching by hashes.
 
 ### --delete-(before,during,after) ###
 

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -128,6 +128,7 @@ These flags are available for every command.
       --tpslimit float                       Limit HTTP transactions per second to this.
       --tpslimit-burst int                   Max burst of transactions for --tpslimit. (default 1)
       --track-renames                        When synchronizing, track file renames and do a server side move if possible
+      --track-using-modtime                  When tracking renames, use file modification time instead of file hashes to match
       --transfers int                        Number of file transfers to run in parallel. (default 4)
   -u, --update                               Skip files that are newer on the destination.
       --use-cookies                          Enable session cookiejar.

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -128,7 +128,7 @@ These flags are available for every command.
       --tpslimit float                       Limit HTTP transactions per second to this.
       --tpslimit-burst int                   Max burst of transactions for --tpslimit. (default 1)
       --track-renames                        When synchronizing, track file renames and do a server side move if possible
-      --track-using-modtime                  When tracking renames, use file modification time instead of file hashes to match
+      --track-renames-strategy                  When tracking renames, use multiple strategies of hash, modtime
       --transfers int                        Number of file transfers to run in parallel. (default 4)
   -u, --update                               Skip files that are newer on the destination.
       --use-cookies                          Enable session cookiejar.

--- a/fs/config.go
+++ b/fs/config.go
@@ -60,6 +60,7 @@ type ConfigInfo struct {
 	DeleteMode             DeleteMode
 	MaxDelete              int64
 	TrackRenames           bool // Track file renames.
+	TrackUsingModTime      bool // Use mod time for renames instead of hashes
 	LowLevelRetries        int
 	UpdateOlder            bool // Skip files that are newer on the destination
 	NoGzip                 bool // Disable compression

--- a/fs/config.go
+++ b/fs/config.go
@@ -59,8 +59,8 @@ type ConfigInfo struct {
 	InsecureSkipVerify     bool // Skip server certificate verification
 	DeleteMode             DeleteMode
 	MaxDelete              int64
-	TrackRenames           bool // Track file renames.
-	TrackUsingModTime      bool // Use mod time for renames instead of hashes
+	TrackRenames           bool   // Track file renames.
+	TrackRenamesStrategy   string // Comma separated list of stratgies used to track renames
 	LowLevelRetries        int
 	UpdateOlder            bool // Skip files that are newer on the destination
 	NoGzip                 bool // Disable compression
@@ -145,6 +145,8 @@ func NewConfig() *ConfigInfo {
 	//	c.StatsOneLineDateFormat = "2006/01/02 15:04:05 - "
 	c.MultiThreadCutoff = SizeSuffix(250 * 1024 * 1024)
 	c.MultiThreadStreams = 4
+
+	c.TrackRenamesStrategy = "hash"
 
 	return c
 }

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -61,6 +61,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &deleteAfter, "delete-after", "", false, "When synchronizing, delete files on destination after transferring (default)")
 	flags.Int64VarP(flagSet, &fs.Config.MaxDelete, "max-delete", "", -1, "When synchronizing, limit the number of deletes")
 	flags.BoolVarP(flagSet, &fs.Config.TrackRenames, "track-renames", "", fs.Config.TrackRenames, "When synchronizing, track file renames and do a server side move if possible")
+	flags.BoolVarP(flagSet, &fs.Config.TrackUsingModTime, "track-using-modtime", "", fs.Config.TrackUsingModTime, "When tracking renames, use the modtime for comparison instead of the file hash")
 	flags.IntVarP(flagSet, &fs.Config.LowLevelRetries, "low-level-retries", "", fs.Config.LowLevelRetries, "Number of low level retries to do.")
 	flags.BoolVarP(flagSet, &fs.Config.UpdateOlder, "update", "u", fs.Config.UpdateOlder, "Skip files that are newer on the destination.")
 	flags.BoolVarP(flagSet, &fs.Config.UseServerModTime, "use-server-modtime", "", fs.Config.UseServerModTime, "Use server modified time instead of object metadata")

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -61,7 +61,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &deleteAfter, "delete-after", "", false, "When synchronizing, delete files on destination after transferring (default)")
 	flags.Int64VarP(flagSet, &fs.Config.MaxDelete, "max-delete", "", -1, "When synchronizing, limit the number of deletes")
 	flags.BoolVarP(flagSet, &fs.Config.TrackRenames, "track-renames", "", fs.Config.TrackRenames, "When synchronizing, track file renames and do a server side move if possible")
-	flags.StringVarP(flagSet, &fs.Config.TrackRenamesStrategy, "track-renames-strategy", "", fs.Config.TrackRenamesStrategy, "When tracking renames, use the modtime for comparison instead of the file hash")
+	flags.StringVarP(flagSet, &fs.Config.TrackRenamesStrategy, "track-renames-strategy", "", fs.Config.TrackRenamesStrategy, "Strategies to use when synchronizing using track-renames hash|modtime")
 	flags.IntVarP(flagSet, &fs.Config.LowLevelRetries, "low-level-retries", "", fs.Config.LowLevelRetries, "Number of low level retries to do.")
 	flags.BoolVarP(flagSet, &fs.Config.UpdateOlder, "update", "u", fs.Config.UpdateOlder, "Skip files that are newer on the destination.")
 	flags.BoolVarP(flagSet, &fs.Config.UseServerModTime, "use-server-modtime", "", fs.Config.UseServerModTime, "Use server modified time instead of object metadata")

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -61,7 +61,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &deleteAfter, "delete-after", "", false, "When synchronizing, delete files on destination after transferring (default)")
 	flags.Int64VarP(flagSet, &fs.Config.MaxDelete, "max-delete", "", -1, "When synchronizing, limit the number of deletes")
 	flags.BoolVarP(flagSet, &fs.Config.TrackRenames, "track-renames", "", fs.Config.TrackRenames, "When synchronizing, track file renames and do a server side move if possible")
-	flags.BoolVarP(flagSet, &fs.Config.TrackUsingModTime, "track-using-modtime", "", fs.Config.TrackUsingModTime, "When tracking renames, use the modtime for comparison instead of the file hash")
+	flags.StringVarP(flagSet, &fs.Config.TrackRenamesStrategy, "track-renames-strategy", "", fs.Config.TrackRenamesStrategy, "When tracking renames, use the modtime for comparison instead of the file hash")
 	flags.IntVarP(flagSet, &fs.Config.LowLevelRetries, "low-level-retries", "", fs.Config.LowLevelRetries, "Number of low level retries to do.")
 	flags.BoolVarP(flagSet, &fs.Config.UpdateOlder, "update", "u", fs.Config.UpdateOlder, "Skip files that are newer on the destination.")
 	flags.BoolVarP(flagSet, &fs.Config.UseServerModTime, "use-server-modtime", "", fs.Config.UseServerModTime, "Use server modified time instead of object metadata")

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -676,7 +676,7 @@ func (s *syncCopyMove) tryRename(src fs.Object) bool {
 	}
 
 	//Verify that modtime is within 1ms margin
-	if s.trackUsingModTime && dst.ModTime(s.ctx).Sub(dst.ModTime(s.ctx)).Milliseconds() > 1 {
+	if s.trackUsingModTime && dst.ModTime(s.ctx).Sub(dst.ModTime(s.ctx)).Nanoseconds() > 1000000 {
 		return false
 	}
 

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -682,11 +682,6 @@ func (s *syncCopyMove) tryRename(src fs.Object) bool {
 		return false
 	}
 
-	//Verify that modtime is within 1ms margin
-	if isUsingRenameStrategy("modtime", s.trackRenamesStrategy) && src.ModTime(s.ctx).Sub(dst.ModTime(s.ctx)) > fs.GetModifyWindow(src.Fs(), dst.Fs()) {
-		return false
-	}
-
 	// Find dst object we are about to overwrite if it exists
 	dstOverwritten, _ := s.fdst.NewObject(s.ctx, src.Remote())
 

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -594,7 +594,7 @@ func (s *syncCopyMove) renameID(obj fs.Object, renameStrategy []string, precisio
 
 	if isUsingRenameStrategy("modtime", renameStrategy) {
 		modTime := obj.ModTime(s.ctx).Unix() / precision.Nanoseconds() / 2
-		renameID += fmt.Sprintf(",%s", modTime)
+		renameID += fmt.Sprintf(",%d", modTime)
 	}
 
 	return renameID

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1127,7 +1127,7 @@ func TestSyncWithTrackRenames(t *testing.T) {
 	}
 }
 
-func TestSyncWithTrackRenamesUsingModtime(t *testing.T) {
+func TestSyncWithTrackRenamesStrategyModtime(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1132,10 +1132,10 @@ func TestSyncWithTrackRenamesUsingModtime(t *testing.T) {
 	defer r.Finalise()
 
 	fs.Config.TrackRenames = true
-	fs.Config.TrackUsingModTime = true
+	fs.Config.TrackRenamesStrategy = "hash,modtime"
 	defer func() {
 		fs.Config.TrackRenames = false
-		fs.Config.TrackUsingModTime = false
+		fs.Config.TrackRenamesStrategy = "hash"
 	}()
 
 	haveHash := r.Fremote.Hashes().Overlap(r.Flocal.Hashes()).GetOne() != hash.None


### PR DESCRIPTION
This commit adds the --track-using-modtime flag which makes
rclone match renames using the file modification time instead
of file hashes. This enables support for tracking renames in
encrypted remotes. For two files to match, their modification
times must be within 1 millisecond of each other to account
for remote modification time inaccuracies.

Fixes #3696
Fixes #2721

#### What is the purpose of this change?
This commit adds the `--track-using-modtime` flag which makes
rclone match renames using file modification time. It makes
`--track-renames` work with encrypted destinations.

#### Was the change discussed in an issue or in the forum before?
It was discussed [here](https://forum.rclone.org/t/can-not-use-track-renames-when-syncing-to-and-from-crypt-remotes/11063).

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
