### PR TITLE
Fixes #2127 Ensures config directory is owned by the user and hence w…

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -188,7 +188,9 @@ esac
 #update version variable post install
 version=`rclone --version 2>>errors | head -n 1`
 #create the directory for the default configuration folder
-mkdir $HOME/.config/rclone -p
+# Make sure we don't create a root owned .config/rclone directory #2127
+mkdir -p $HOME/.config/rclone
+chown -R $USER:$USER $HOME/.config/rclone
 
 printf "\n${version} has successfully installed."
 printf '\nNow run "rclone config" for setup. Check https://rclone.org/docs/ for more details.\n\n'


### PR DESCRIPTION
#### What is the purpose of this change?

Ensures the config directory is owned by the user and hence writable. Currently `rclone config` fails at writing configs at the end of process.

#### Was the change discussed in an issue or in the forum before?

Yes. #2127 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
