### PR TITLE
rclone supporting 21Vianet version of OneDrive

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -329,7 +329,7 @@ listing, set this option.`,
 
 // Options defines the configuration for this backend
 type Options struct {
-	Is21Vianet         bool          `config:"is_21vianet_version"`
+	Is21Vianet         bool                 `config:"is_21vianet_version"`
 	ChunkSize          fs.SizeSuffix        `config:"chunk_size"`
 	DriveID            string               `config:"drive_id"`
 	DriveType          string               `config:"drive_type"`

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -244,7 +244,7 @@ func init() {
 			Name: config.ConfigClientSecret,
 			Help: "Microsoft App Client Secret\nLeave blank normally.",
 		}, {
-			Name: "is_21vianet_version",
+			Name:    "is_21vianet_version",
 			Default: false,
 			Help:    "OneDrive operated by 21Vianet (世纪互联).",
 		}, {

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -244,7 +244,7 @@ func init() {
 			Name: config.ConfigClientSecret,
 			Help: "Microsoft App Client Secret\nLeave blank normally.",
 		}, {
-			Name:    "is_21vianet_version",
+			Name: "is_21vianet_version",
 			Default: false,
 			Help:    "OneDrive operated by 21Vianet (世纪互联).",
 		}, {

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -589,7 +589,6 @@ func NewFs(name, root string, m configmap.Mapper) (fs.Fs, error) {
 		rootURL = graphAPIEndpoint21V + "/v1.0" + "/me/drive"
 		oauthConfig.Endpoint = *oauthEndpointV21
 	}
-	
 	root = parsePath(root)
 	oAuthClient, ts, err := oauthutil.NewClient(name, m, oauthConfig)
 	if err != nil {

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -238,15 +238,15 @@ func init() {
 			config.SaveConfig()
 		},
 		Options: []fs.Option{{
-			Name:    "is_21vianet_version",
-			Default: false,
-			Help:    "OneDrive operated by 21Vianet (世纪互联).必须输入ClientID&ClientSecret",
- 		}, {
 			Name: config.ConfigClientID,
 			Help: "Microsoft App Client Id\nLeave blank normally.",
 		}, {
 			Name: config.ConfigClientSecret,
 			Help: "Microsoft App Client Secret\nLeave blank normally.",
+		}, {
+			Name:    "is_21vianet_version",
+			Default: false,
+			Help:    "OneDrive operated by 21Vianet (世纪互联).",
 		}, {
 			Name: "chunk_size",
 			Help: `Chunk size to upload files with - must be multiple of 320k (327,680 bytes).


### PR DESCRIPTION
This is come from "https://gist.github.com/ShadeShady/81b6fecca82c289e8e5ae0637918e7e6"
By this ,we can use onedrive for chinese ,which is go by 21Vianet.
Thanks to this boy for give us a chance to use rclone for chinese onedrive.
In chinese:
这个版本来自于：https://gist.github.com/ShadeShady/81b6fecca82c289e8e5ae0637918e7e6
通过这个改变、我们能够使用onedrive中国版，是由世纪互联运营的。
谢谢这位大佬给世纪互联onedrive的用户一个使用rclone的机会。

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
