### PR TITLE
swift: fix deletion of static large object

### DIFF
--- a/backend/swift/swift.go
+++ b/backend/swift/swift.go
@@ -959,7 +959,7 @@ func (o *Object) isStaticLargeObject() (bool, error) {
 	return o.hasHeader("X-Static-Large-Object")
 }
 
-func (o *Object) isLargeObject() ( result bool, err error) {
+func (o *Object) isLargeObject() (result bool, err error) {
 	result, err = o.hasHeader("X-Static-Large-Object")
 	if result {
 		return
@@ -1351,12 +1351,12 @@ func (o *Object) Remove(ctx context.Context) (err error) {
 	container, containerPath := o.split()
 
 	//check object is large object
-	isLargeObject, err := o.isLargeObject();
+	isLargeObject, err := o.isLargeObject()
 	if err != nil {
 		return err
 	}
 	//check container has enabled version to reserve segment when delete
-	isInContainerVersioning := false;
+	isInContainerVersioning := false
 	if isLargeObject {
 		isInContainerVersioning, err = o.isInContainerVersioning(container)
 		if err != nil {
@@ -1371,7 +1371,7 @@ func (o *Object) Remove(ctx context.Context) (err error) {
 	var segmentObjects []swift.Object
 
 	if isStaticLargeObject {
-		segmentContainer, segmentObjects, err = o.fs.c.LargeObjectGetSegments(container, containerPath);
+		segmentContainer, segmentObjects, err = o.fs.c.LargeObjectGetSegments(container, containerPath)
 		if err != nil {
 			return err
 		}
@@ -1410,7 +1410,7 @@ func (o *Object) Remove(ctx context.Context) (err error) {
 		}
 		_, err := o.fs.c.BulkDelete(segmentContainer, segmentNames)
 		if err != nil {
-			return err;
+			return err
 		}
 	}
 

--- a/backend/swift/swift.go
+++ b/backend/swift/swift.go
@@ -959,6 +959,18 @@ func (o *Object) isStaticLargeObject() (bool, error) {
 	return o.hasHeader("X-Static-Large-Object")
 }
 
+func (o *Object) isLargeObject() ( result bool, err error) {
+	result, err = o.hasHeader("X-Static-Large-Object")
+	if result {
+		return
+	}
+	result, err = o.hasHeader("X-Object-Manifest")
+	if result {
+		return
+	}
+	return false, nil
+}
+
 func (o *Object) isInContainerVersioning(container string) (bool, error) {
 	_, headers, err := o.fs.c.Container(container)
 	if err != nil {
@@ -1338,6 +1350,32 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 func (o *Object) Remove(ctx context.Context) (err error) {
 	container, containerPath := o.split()
 
+	//check object is large object
+	isLargeObject, err := o.isLargeObject();
+	if err != nil {
+		return err
+	}
+	//check container has enabled version to reserve segment when delete
+	isInContainerVersioning := false;
+	if isLargeObject {
+		isInContainerVersioning, err = o.isInContainerVersioning(container)
+		if err != nil {
+			return err
+		}
+	}
+	isStaticLargeObject, err := o.isStaticLargeObject()
+	if err != nil {
+		return err
+	}
+	var segmentContainer string
+	var segmentObjects []swift.Object
+
+	if isStaticLargeObject {
+		segmentContainer, segmentObjects, err = o.fs.c.LargeObjectGetSegments(container, containerPath);
+		if err != nil {
+			return err
+		}
+	}
 	// Remove file/manifest first
 	err = o.fs.pacer.Call(func() (bool, error) {
 		err = o.fs.c.ObjectDelete(container, containerPath)
@@ -1346,23 +1384,36 @@ func (o *Object) Remove(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+
+	if !isLargeObject || isInContainerVersioning {
+		return nil
+	}
+
 	isDynamicLargeObject, err := o.isDynamicLargeObject()
 	if err != nil {
 		return err
 	}
 	// ...then segments if required
+	//delete segment for dynamic large object
 	if isDynamicLargeObject {
-		isInContainerVersioning, err := o.isInContainerVersioning(container)
-		if err != nil {
-			return err
-		}
-		if !isInContainerVersioning {
-			err = o.removeSegments("")
-			if err != nil {
-				return err
+		return o.removeSegments("")
+	}
+
+	//delete segment for static large object
+	if isStaticLargeObject && len(segmentContainer) > 0 && segmentObjects != nil && len(segmentObjects) > 0 {
+		var segmentNames []string
+		for _, segmentObject := range segmentObjects {
+			if len(segmentObject.Name) == 0 {
+				continue
 			}
+			segmentNames = append(segmentNames, segmentObject.Name)
+		}
+		_, err := o.fs.c.BulkDelete(segmentContainer, segmentNames)
+		if err != nil {
+			return err;
 		}
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Add code to delete object what in openstack swift backend. In case object is static large object, the code missing delete segments.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
