### PR TITLE
make error quotaLimitReached (onedrive) and teamDriveFileLimitExceeded (google drive) to be fatal

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -616,6 +616,9 @@ func (f *Fs) shouldRetry(err error) (bool, error) {
 					return false, fserrors.FatalError(err)
 				}
 				return true, err
+			} else if f.opt.StopOnUploadLimit && reason == "teamDriveFileLimitExceeded" {
+				fs.Errorf(f, "Received team drive file limit error: %v", err)
+				return false, fserrors.FatalError(err)
 			}
 		}
 	}

--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -225,7 +225,11 @@ func shouldRetry(err error) (bool, error) {
 		return false, err
 	}
 	baseErrString := errors.Cause(err).Error()
-	// handle any official Retry-After header from Dropbox's SDK first
+	// First check for Insufficient Space
+	if strings.Contains(baseErrString, "insufficient_space") {
+		return false, fserrors.FatalError(err)
+	}
+	// Then handle any official Retry-After header from Dropbox's SDK
 	switch e := err.(type) {
 	case auth.RateLimitAPIError:
 		if e.RateLimitError.RetryAfter > 0 {

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -436,6 +436,8 @@ func shouldRetry(resp *http.Response, err error) (bool, error) {
 					fs.Debugf(nil, "Too many requests. Trying again in %d seconds.", retryAfter)
 				}
 			}
+		case 507: // Insufficient Storage
+			return false, fserrors.FatalError(err)
 		}
 	}
 	return retry || fserrors.ShouldRetry(err) || fserrors.ShouldRetryHTTP(resp, retryErrorCodes), err


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

# 1st commit

Stop sync when OneDrive has no storage left. OneDrive returns HTTP response code `507` and error code `quotaLimitReached` when that happens.

#### Was the change discussed in an issue or in the forum before?

Yes. Fixes #4089

```
harry@ubuntu16:/mnt/c/Users/HARRY/rclone$ ./rclone copy "/mnt/c/Users/HARRY/1GbTestFile.bin" onedrive1:
2020/03/25 18:19:19 ERROR : 1GbTestFile.bin: Failed to copy: quotaLimitReached: Quota limit reached
2020/03/25 18:19:19 ERROR : Fatal error received - not attempting retries
2020/03/25 18:19:19 Failed to copy: quotaLimitReached: Quota limit reached
```

# 2nd commit

Stop sync when Team Drive has reached its maximum files limit and flag `--drive-stop-on-upload-limit` set to **true**.

#### Was the change discussed in an issue or in the forum before?

Yes. Fixes #3979

# 3rd commit

Stop sync when Dropbox has no storage/space left.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
