### PR TITLE
docs: unmystify how crypt stores encryption password in config

### DIFF
--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -101,10 +101,15 @@ y/e/d> y
 obscured so it isn't immediately obvious what it is.  It is in no way
 secure unless you use config file encryption.
 
-A long passphrase is recommended, or you can use a random one.  Note
-that if you reconfigure rclone with the same passwords/passphrases
-elsewhere it will be compatible - all the secrets used are derived
-from those two passwords/passphrases.
+A long passphrase is recommended, or you can use a random one.
+
+The obscured password is created by using AES-CTR with a static key, with
+the salt stored verbatim at the beginning of the obscured password. This
+static key is shared by between all versions of rclone.
+
+If you reconfigure rclone with the same passwords/passphrases
+elsewhere it will be compatible, but the obscured version will be different
+due to the different salt.
 
 Note that rclone does not encrypt
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Without explaining exactly how this is generated, it can be confusing
and worrying to not know how the password that encrypts your data is
stored.

This also brings peace of mind to the user that even though
the same password is obscured differently each time, all the data to
get back to the original password remains. Explaining how it works
is much better than the reader of the documentation having to trust
a blackboxy/magical mechanism.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)