### PR TITLE
backend/googlephotos: Add start_year for google photos options

### DIFF
--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -134,13 +134,12 @@ rclone mount needs to know the size of files in advance of reading
 them, so setting this flag when using rclone mount is recommended if
 you want to read the media.`,
 			Advanced: true,
+		}, {
+			Name:     "start_year",
+			Default:  2000,
+			Help:     `Year limits the photos to be downloaded to those which are uploaded after the given year`,
+			Advanced: true,
 		},
-			{
-				Name:     "start_year",
-				Default:  2000,
-				Help:     `Year limits the photos to be downloaded to those which are uploaded after the given year`,
-				Advanced: true,
-			},
 		},
 	})
 }

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -139,8 +139,7 @@ you want to read the media.`,
 			Default:  2000,
 			Help:     `Year limits the photos to be downloaded to those which are uploaded after the given year`,
 			Advanced: true,
-		},
-		},
+		}},
 	})
 }
 

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -138,7 +138,7 @@ you want to read the media.`,
 			{
 				Name:     "start_year",
 				Default:  2000,
-				Help:     `Year limits the photos to be downloaded  to those which are uploaded before the given time`,
+				Help:     `Year limits the photos to be downloaded to those which are uploaded after the given year`,
 				Advanced: true,
 			},
 		},

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -134,14 +134,22 @@ rclone mount needs to know the size of files in advance of reading
 them, so setting this flag when using rclone mount is recommended if
 you want to read the media.`,
 			Advanced: true,
-		}},
+		},
+			{
+				Name:     "start_year",
+				Default:  2000,
+				Help:     `Year limits the photos to be downloaded  to those which are uploaded before the given time`,
+				Advanced: true,
+			},
+		},
 	})
 }
 
 // Options defines the configuration for this backend
 type Options struct {
-	ReadOnly bool `config:"read_only"`
-	ReadSize bool `config:"read_size"`
+	ReadOnly  bool `config:"read_only"`
+	ReadSize  bool `config:"read_size"`
+	StartYear int  `config:"start_year"`
 }
 
 // Fs represents a remote storage server
@@ -200,6 +208,11 @@ func (f *Fs) Features() *fs.Features {
 // dirTime returns the time to set a directory to
 func (f *Fs) dirTime() time.Time {
 	return f.startTime
+}
+
+// startYear returns the start year
+func (f *Fs) startYear() int {
+	return f.opt.StartYear
 }
 
 // retryErrorCodes is a slice of error codes that we will retry

--- a/backend/googlephotos/pattern.go
+++ b/backend/googlephotos/pattern.go
@@ -23,6 +23,7 @@ type lister interface {
 	listAlbums(ctx context.Context, shared bool) (all *albums, err error)
 	listUploads(ctx context.Context, dir string) (entries fs.DirEntries, err error)
 	dirTime() time.Time
+	startYear() int
 }
 
 // dirPattern describes a single directory pattern
@@ -222,11 +223,10 @@ func (ds dirPatterns) match(root string, itemPath string, isFile bool) (match []
 	return nil, "", nil
 }
 
-// Return the years from 2000 to today
-// FIXME make configurable?
+// Return the years from startYear to today
 func years(ctx context.Context, f lister, prefix string, match []string) (entries fs.DirEntries, err error) {
 	currentYear := f.dirTime().Year()
-	for year := 2000; year <= currentYear; year++ {
+	for year := f.startYear(); year <= currentYear; year++ {
 		entries = append(entries, fs.NewDir(prefix+fmt.Sprint(year), f.dirTime()))
 	}
 	return entries, nil

--- a/backend/googlephotos/pattern_test.go
+++ b/backend/googlephotos/pattern_test.go
@@ -59,6 +59,11 @@ func (f *testLister) dirTime() time.Time {
 	return startTime
 }
 
+// mock startYear for testing
+func (f *testLister) startYear() int {
+	return 2000
+}
+
 func TestPatternMatch(t *testing.T) {
 	for testNumber, test := range []struct {
 		// input


### PR DESCRIPTION
#### What is the purpose of this change?
Make the start year configurable instead of hard coding it to `2000`

#### Was the change discussed in an issue or in the forum before?
Discussion: https://github.com/rclone/rclone/issues/3630

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
