### PR TITLE
doc: Clarify 'key' option for host key on serve sftp

### DIFF
--- a/cmd/serve/sftp/sftp.go
+++ b/cmd/serve/sftp/sftp.go
@@ -20,7 +20,7 @@ import (
 // Options contains options for the http Server
 type Options struct {
 	ListenAddr     string // Port to listen on
-	Key            string // Path to private key
+	Key            string // Path to private host key
 	AuthorizedKeys string // Path to authorized keys file
 	User           string // single username
 	Pass           string // password for user
@@ -40,7 +40,7 @@ var Opt = DefaultOpt
 func AddFlags(flagSet *pflag.FlagSet, Opt *Options) {
 	rc.AddOption("sftp", &Opt)
 	flags.StringVarP(flagSet, &Opt.ListenAddr, "addr", "", Opt.ListenAddr, "IPaddress:Port or :Port to bind server to.")
-	flags.StringVarP(flagSet, &Opt.Key, "key", "", Opt.Key, "SSH private key file (leave blank to auto generate)")
+	flags.StringVarP(flagSet, &Opt.Key, "key", "", Opt.Key, "SSH private host key file (leave blank to auto generate)")
 	flags.StringVarP(flagSet, &Opt.AuthorizedKeys, "authorized-keys", "", Opt.AuthorizedKeys, "Authorized keys file")
 	flags.StringVarP(flagSet, &Opt.User, "user", "", Opt.User, "User name for authentication.")
 	flags.StringVarP(flagSet, &Opt.Pass, "pass", "", Opt.Pass, "Password for authentication.")


### PR DESCRIPTION

#### What is the purpose of this change?

The option --key would set the sftp host key. It could be mistaken for some default-user-key. Instead, explicitly call it 'host key' to avoid confusion.

#### Was the change discussed in an issue or in the forum before?

No related issue, spontaneous suggestion after personal confusion.

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
