### PR TITLE
s3: do not resize buf on put to memBuf

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2305,7 +2305,7 @@ func (o *Object) uploadMultipart(ctx context.Context, req *s3.PutObjectInput, si
 			})
 
 			// return the memory and token
-			memPool.Put(buf[:partSize])
+			memPool.Put(buf)
 			tokens.Put()
 
 			if err != nil {


### PR DESCRIPTION
#### What is the purpose of this change?

Resizing is not needed as it is handled by Pool implementation.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
