### PR TITLE
Implement option to view the Jottacloud trash

### DIFF
--- a/backend/jottacloud/api/types.go
+++ b/backend/jottacloud/api/types.go
@@ -164,6 +164,12 @@ type CustomerInfo struct {
 	IOSHash           string      `json:"ios_hash"`
 }
 
+// TrashResponse is returned when emptying the Trash
+type TrashResponse struct {
+	Folders int64 `json:"folders"`
+	Files   int64 `json:"files"`
+}
+
 // XML structures returned by the old API
 
 // Flag is a hacky type for checking if an attribute is present

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -1064,6 +1064,22 @@ func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	return usage, nil
 }
 
+// CleanUp empties the trash
+func (f *Fs) CleanUp(ctx context.Context) error {
+	opts := rest.Opts{
+		Method: "POST",
+		Path:   "files/v1/purge_trash",
+	}
+
+	var info api.TrashResponse
+	_, err := f.apiSrv.CallJSON(ctx, &opts, nil, &info)
+	if err != nil {
+		return errors.Wrap(err, "couldn't empty trash")
+	}
+
+	return nil
+}
+
 // Hashes returns the supported hash sets.
 func (f *Fs) Hashes() hash.Set {
 	return hash.Set(hash.MD5)
@@ -1370,6 +1386,7 @@ var (
 	_ fs.ListRer      = (*Fs)(nil)
 	_ fs.PublicLinker = (*Fs)(nil)
 	_ fs.Abouter      = (*Fs)(nil)
+	_ fs.CleanUpper   = (*Fs)(nil)
 	_ fs.Object       = (*Object)(nil)
 	_ fs.MimeTyper    = (*Object)(nil)
 )

--- a/docs/content/jottacloud.md
+++ b/docs/content/jottacloud.md
@@ -174,6 +174,16 @@ Files bigger than this will be cached on disk to calculate the MD5 if required.
 - Type:        SizeSuffix
 - Default:     10M
 
+#### --jottacloud-trashed-only
+
+Only show files that are in the trash.
+This will show trashed files in their original directory structure.
+
+- Config:      trashed_only
+- Env Var:     RCLONE_JOTTACLOUD_TRASHED_ONLY
+- Type:        bool
+- Default:     false
+
 #### --jottacloud-hard-delete
 
 Delete files permanently rather than putting them into the trash.


### PR DESCRIPTION
As discussed in the forum I added a --jottacloud-trash-only flag that shows Trashed files in their original location. Normal operations should actually work on trashed files as long as the flag is included in the command.
I've also quickly added the cleanup command.