### PR TITLE
serve sftp: add support for multiple host keys

### DIFF
--- a/cmd/serve/sftp/sftp.go
+++ b/cmd/serve/sftp/sftp.go
@@ -19,12 +19,12 @@ import (
 
 // Options contains options for the http Server
 type Options struct {
-	ListenAddr     string // Port to listen on
-	Key            string // Path to private host key
-	AuthorizedKeys string // Path to authorized keys file
-	User           string // single username
-	Pass           string // password for user
-	NoAuth         bool   // allow no authentication on connections
+	ListenAddr     string   // Port to listen on
+	HostKeys       []string // Paths to private host keys
+	AuthorizedKeys string   // Path to authorized keys file
+	User           string   // single username
+	Pass           string   // password for user
+	NoAuth         bool     // allow no authentication on connections
 }
 
 // DefaultOpt is the default values used for Options
@@ -40,7 +40,7 @@ var Opt = DefaultOpt
 func AddFlags(flagSet *pflag.FlagSet, Opt *Options) {
 	rc.AddOption("sftp", &Opt)
 	flags.StringVarP(flagSet, &Opt.ListenAddr, "addr", "", Opt.ListenAddr, "IPaddress:Port or :Port to bind server to.")
-	flags.StringVarP(flagSet, &Opt.Key, "key", "", Opt.Key, "SSH private host key file (leave blank to auto generate)")
+	flags.StringArrayVarP(flagSet, &Opt.HostKeys, "key", "", Opt.HostKeys, "SSH private host key file (Can be multi-valued, leave blank to auto generate)")
 	flags.StringVarP(flagSet, &Opt.AuthorizedKeys, "authorized-keys", "", Opt.AuthorizedKeys, "Authorized keys file")
 	flags.StringVarP(flagSet, &Opt.User, "user", "", Opt.User, "User name for authentication.")
 	flags.StringVarP(flagSet, &Opt.Pass, "pass", "", Opt.Pass, "Password for authentication.")


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
<!--
Describe the changes here
-->
It is often useful to provide different host key algorithms for client compatibility reasons.
For example, `Ed25519` is still not supported everywhere, incompatible clients should be able to fall back on `ECDSA` or `RSA`.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
