### PR TITLE
rc: adding mount command

### DIFF
--- a/cmd/cmount/mount.go
+++ b/cmd/cmount/mount.go
@@ -39,6 +39,9 @@ func init() {
 		name = "mount"
 	}
 	mountlib.NewMountCommand(name, false, Mount)
+	// Add mount to rc
+	mountlib.AddRc("cmount", mount)
+
 }
 
 // mountOptions configures the options from the command line flags

--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -23,6 +23,8 @@ import (
 
 func init() {
 	mountlib.NewMountCommand("mount", false, Mount)
+	// Add mount to rc
+	mountlib.AddRc("mount", mount)
 }
 
 // mountOptions configures the options from the command line flags

--- a/cmd/mount2/mount.go
+++ b/cmd/mount2/mount.go
@@ -24,6 +24,10 @@ import (
 
 func init() {
 	mountlib.NewMountCommand("mount2", true, Mount)
+
+	// Add mount to rc
+	mountlib.AddRc("mount2", mount)
+
 }
 
 // mountOptions configures the options from the command line flags

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -39,6 +39,13 @@ var (
 	AsyncRead          = true        // do async reads by default
 )
 
+type (
+	// UnmountFn is called to unmount the file system
+	UnmountFn func() error
+	// MountFn is called to mount the file system
+	MountFn func(f fs.Fs, mountpoint string) (*vfs.VFS, <-chan error, func() error, error)
+)
+
 // Global constants
 const (
 	MaxLeafSize = 4095 // don't pass file names longer than this

--- a/cmd/mountlib/rc.go
+++ b/cmd/mountlib/rc.go
@@ -3,6 +3,7 @@ package mountlib
 import (
 	"context"
 	"log"
+	"sort"
 
 	"github.com/pkg/errors"
 	"github.com/rclone/rclone/fs"
@@ -16,6 +17,18 @@ var (
 	unmountFns map[string]UnmountFn
 )
 
+// AddRc adds mount and unmount functionality to rc
+func AddRc(mountUtilName string, mountFunction MountFn) {
+	if mountFns == nil {
+		mountFns = make(map[string]MountFn)
+	}
+	if unmountFns == nil {
+		unmountFns = make(map[string]UnmountFn)
+	}
+	// rcMount allows the mount command to be run from rc
+	mountFns[mountUtilName] = mountFunction
+}
+
 func init() {
 	rc.Add(rc.Call{
 		Path:         "mount/mount",
@@ -25,21 +38,60 @@ func init() {
 		Help: `rclone allows Linux, FreeBSD, macOS and Windows to mount any of
 Rclone's cloud storage systems as a file system with FUSE.
 
-If no mountOption is provided, the priority is given as follows: 1. mount 2.cmount 3.mount2
+If no mountType is provided, the priority is given as follows: 1. mount 2.cmount 3.mount2
 
 This takes the following parameters
 
 - fs - a remote path to be mounted (required)
 - mountPoint: valid path on the local machine (required)
-- mountOption: One of the values (mount, cmount, mount2) specifies the mount implementation to use
+- mountType: One of the values (mount, cmount, mount2) specifies the mount implementation to use
 
 Eg
 
     rclone rc mount/mount fs=mydrive: mountPoint=/home/<user>/mountPoint
-    rclone rc mount/mount fs=mydrive: mountPoint=/home/<user>/mountPoint mountOption=mount
+    rclone rc mount/mount fs=mydrive: mountPoint=/home/<user>/mountPoint mountType=mount
 `,
 	})
+}
 
+// rcMount allows the mount command to be run from rc
+func mountRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
+	mountPoint, err := in.GetString("mountPoint")
+	if err != nil {
+		return nil, err
+	}
+
+	mountType, err := in.GetString("mountType")
+
+	if err != nil || mountType == "" {
+		if mountFns["mount"] != nil {
+			mountType = "mount"
+		} else if mountFns["cmount"] != nil {
+			mountType = "cmount"
+		} else if mountFns["mount2"] != nil {
+			mountType = "mount2"
+		}
+	}
+
+	// Get Fs.fs to be mounted from fs parameter in the params
+	fdst, err := rc.GetFs(in)
+	if err != nil {
+		return nil, err
+	}
+
+	if mountFns[mountType] != nil {
+		_, _, unmountFns[mountPoint], err = mountFns[mountType](fdst, mountPoint)
+		if err != nil {
+			log.Printf("mount FAILED: %v", err)
+			return nil, err
+		}
+		fs.Debugf(nil, "Mount for %s created at %s using %s", fdst.String(), mountPoint, mountType)
+		return nil, nil
+	}
+	return nil, errors.New("Mount Option specified is not registered, or is invalid")
+}
+
+func init() {
 	rc.Add(rc.Call{
 		Path:         "mount/unmount",
 		AuthRequired: true,
@@ -59,19 +111,6 @@ Eg
     rclone rc mount/unmount mountPoint=/home/<user>/mountPoint
 `,
 	})
-
-}
-
-// AddRc adds mount and unmount functionality to rc
-func AddRc(mountUtilName string, mountFunction MountFn) {
-	if mountFns == nil {
-		mountFns = make(map[string]MountFn)
-	}
-	if unmountFns == nil {
-		unmountFns = make(map[string]UnmountFn)
-	}
-	// rcMount allows the mount command to be run from rc
-	mountFns[mountUtilName] = mountFunction
 }
 
 // rcMount allows the umount command to be run from rc
@@ -94,39 +133,36 @@ func unMountRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
 	return nil, nil
 }
 
-// rcMount allows the mount command to be run from rc
-func mountRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
-	mountPoint, err := in.GetString("mountPoint")
-	if err != nil {
-		return nil, err
-	}
+func init() {
+	rc.Add(rc.Call{
+		Path:         "mount/types",
+		AuthRequired: true,
+		Fn:           mountTypesRc,
+		Title:        "Show all possible mount types",
+		Help: `This shows all possible mount types and returns them as a list.
 
-	mountOption, err := in.GetString("mountOption")
+This takes no parameters and returns
 
-	if err != nil || mountOption == "" {
-		if mountFns["mount"] != nil {
-			mountOption = "mount"
-		} else if mountFns["cmount"] != nil {
-			mountOption = "cmount"
-		} else if mountFns["mount2"] != nil {
-			mountOption = "mount2"
-		}
-	}
+- mountTypes: list of mount types
 
-	// Get Fs.fs to be mounted from fs parameter in the params
-	fdst, err := rc.GetFs(in)
-	if err != nil {
-		return nil, err
-	}
+The mount types are strings like "mount", "mount2", "cmount" and can
+be passed to mount/mount as the mountType parameter.
 
-	if mountFns[mountOption] != nil {
-		_, _, unmountFns[mountPoint], err = mountFns[mountOption](fdst, mountPoint)
-		if err != nil {
-			log.Printf("mount FAILED: %v", err)
-			return nil, err
-		}
-		fs.Debugf(nil, "Mount for %s created at %s using %s", fdst.String(), mountPoint, mountOption)
-		return nil, nil
+Eg
+
+    rclone rc mount/types
+`,
+	})
+}
+
+// mountTypesRc returns a list of available mount types.
+func mountTypesRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
+	var mountTypes = []string{}
+	for mountType := range mountFns {
+		mountTypes = append(mountTypes, mountType)
 	}
-	return nil, errors.New("Mount Option specified is not registered, or is invalid")
+	sort.Strings(mountTypes)
+	return rc.Params{
+		"mountTypes": mountTypes,
+	}, nil
 }

--- a/cmd/mountlib/rc.go
+++ b/cmd/mountlib/rc.go
@@ -1,0 +1,132 @@
+package mountlib
+
+import (
+	"context"
+	"log"
+
+	"github.com/pkg/errors"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/rc"
+)
+
+var (
+	// Mount functions available
+	mountFns map[string]MountFn
+	// Map of mounted path => unmount function
+	unmountFns map[string]UnmountFn
+)
+
+func init() {
+	rc.Add(rc.Call{
+		Path:         "mount/mount",
+		AuthRequired: true,
+		Fn:           mountRc,
+		Title:        "Create a new mount point",
+		Help: `rclone allows Linux, FreeBSD, macOS and Windows to mount any of
+Rclone's cloud storage systems as a file system with FUSE.
+
+If no mountOption is provided, the priority is given as follows: 1. mount 2.cmount 3.mount2
+
+This takes the following parameters
+
+- fs - a remote path to be mounted (required)
+- mountPoint: valid path on the local machine (required)
+- mountOption: One of the values (mount, cmount, mount2) specifies the mount implementation to use
+
+Eg
+
+    rclone rc mount/mount fs=mydrive: mountPoint=/home/<user>/mountPoint
+    rclone rc mount/mount fs=mydrive: mountPoint=/home/<user>/mountPoint mountOption=mount
+`,
+	})
+
+	rc.Add(rc.Call{
+		Path:         "mount/unmount",
+		AuthRequired: true,
+		Fn:           unMountRc,
+		Title:        "Unmount all active mounts",
+		Help: `
+rclone allows Linux, FreeBSD, macOS and Windows to
+mount any of Rclone's cloud storage systems as a file system with
+FUSE.
+
+This takes the following parameters
+
+- mountPoint: valid path on the local machine where the mount was created (required)
+
+Eg
+
+    rclone rc mount/unmount mountPoint=/home/<user>/mountPoint
+`,
+	})
+
+}
+
+// AddRc adds mount and unmount functionality to rc
+func AddRc(mountUtilName string, mountFunction MountFn) {
+	if mountFns == nil {
+		mountFns = make(map[string]MountFn)
+	}
+	if unmountFns == nil {
+		unmountFns = make(map[string]UnmountFn)
+	}
+	// rcMount allows the mount command to be run from rc
+	mountFns[mountUtilName] = mountFunction
+}
+
+// rcMount allows the umount command to be run from rc
+func unMountRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
+	mountPoint, err := in.GetString("mountPoint")
+	if err != nil {
+		return nil, err
+	}
+
+	if unmountFns != nil && unmountFns[mountPoint] != nil {
+		err := unmountFns[mountPoint]()
+		if err != nil {
+			return nil, err
+		}
+		unmountFns[mountPoint] = nil
+	} else {
+		return nil, errors.New("mount not found")
+	}
+
+	return nil, nil
+}
+
+// rcMount allows the mount command to be run from rc
+func mountRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
+	mountPoint, err := in.GetString("mountPoint")
+	if err != nil {
+		return nil, err
+	}
+
+	mountOption, err := in.GetString("mountOption")
+
+	if err != nil || mountOption == "" {
+		if mountFns["mount"] != nil {
+			mountOption = "mount"
+		} else if mountFns["cmount"] != nil {
+			mountOption = "cmount"
+		} else if mountFns["mount2"] != nil {
+			mountOption = "mount2"
+		}
+	}
+
+	// Get Fs.fs to be mounted from fs parameter in the params
+	fdst, err := rc.GetFs(in)
+	if err != nil {
+		return nil, err
+	}
+
+	if mountFns[mountOption] != nil {
+		_, _, unmountFns[mountPoint], err = mountFns[mountOption](fdst, mountPoint)
+		if err != nil {
+			log.Printf("mount FAILED: %v", err)
+			return nil, err
+		}
+		fs.Debugf(nil, "Mount for %s created at %s using %s", fdst.String(), mountPoint, mountOption)
+		return nil, nil
+	}
+	return nil, errors.New("Mount Option specified is not registered, or is invalid")
+}

--- a/cmd/mountlib/rc_test.go
+++ b/cmd/mountlib/rc_test.go
@@ -1,0 +1,97 @@
+package mountlib_test
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	_ "github.com/rclone/rclone/backend/local"
+	_ "github.com/rclone/rclone/cmd/cmount"
+	_ "github.com/rclone/rclone/cmd/mount"
+	_ "github.com/rclone/rclone/cmd/mount2"
+	"github.com/rclone/rclone/fs/rc"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRc(t *testing.T) {
+	ctx := context.Background()
+	mount := rc.Calls.Get("mount/mount")
+	assert.NotNil(t, mount)
+	unmount := rc.Calls.Get("mount/unmount")
+	assert.NotNil(t, unmount)
+	getMountTypes := rc.Calls.Get("mount/types")
+	assert.NotNil(t, getMountTypes)
+
+	localDir, err := ioutil.TempDir("", "rclone-mountlib-localDir")
+	require.NoError(t, err)
+	defer func() { _ = os.RemoveAll(localDir) }()
+	err = ioutil.WriteFile(filepath.Join(localDir, "file.txt"), []byte("hello"), 0666)
+	require.NoError(t, err)
+
+	mountPoint, err := ioutil.TempDir("", "rclone-mountlib-mountPoint")
+	require.NoError(t, err)
+	if runtime.GOOS == "windows" {
+		// Windows requires the mount point not to exist
+		require.NoError(t, os.RemoveAll(mountPoint))
+	} else {
+		defer func() { _ = os.RemoveAll(mountPoint) }()
+	}
+
+	out, err := getMountTypes.Fn(ctx, nil)
+	require.NoError(t, err)
+	var mountTypes []string
+
+	err = out.GetStruct("mountTypes", &mountTypes)
+	require.NoError(t, err)
+	t.Logf("Mount types %v", mountTypes)
+
+	t.Run("Errors", func(t *testing.T) {
+		_, err := mount.Fn(ctx, rc.Params{})
+		assert.Error(t, err)
+
+		_, err = mount.Fn(ctx, rc.Params{"fs": "/tmp"})
+		assert.Error(t, err)
+
+		_, err = mount.Fn(ctx, rc.Params{"mountPoint": "/tmp"})
+		assert.Error(t, err)
+	})
+
+	t.Run("Mount", func(t *testing.T) {
+		if len(mountTypes) == 0 {
+			t.Skip("Can't mount")
+		}
+		in := rc.Params{
+			"fs":         localDir,
+			"mountPoint": mountPoint,
+		}
+
+		// check file.txt is not there
+		filePath := filepath.Join(mountPoint, "file.txt")
+		_, err := os.Stat(filePath)
+		require.Error(t, err)
+		require.True(t, os.IsNotExist(err))
+
+		// mount
+		_, err = mount.Fn(ctx, in)
+		require.NoError(t, err)
+
+		// check file.txt is there now
+		fi, err := os.Stat(filePath)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), fi.Size())
+
+		// FIXME the OS somtimes appears to be using the mount
+		// immediately after it appears so wait a moment
+		time.Sleep(100 * time.Millisecond)
+
+		t.Run("Unmount", func(t *testing.T) {
+			_, err := unmount.Fn(ctx, in)
+			require.NoError(t, err)
+		})
+	})
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Adding mount support for remote control.
I need suggestions about the directory structure, and the change is being implemented correctly.
This is just an initial implementation. 

I see that every independent module like `fs` has a separate `rc.go` file. But the files in `cmd` don't have it. Instead inside their init function, they have an `AddCommand()` call. How should the `mount` endpoint addition for `rc` look like?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
