### PR TITLE
Remove "iat" from box jwt claims and fix error handling

### DIFF
--- a/backend/box/box.go
+++ b/backend/box/box.go
@@ -185,7 +185,6 @@ func getClaims(boxConfig *api.ConfigJSON, boxSubType string) (claims *jws.ClaimS
 		Iss: boxConfig.BoxAppSettings.ClientID,
 		Sub: boxConfig.EnterpriseID,
 		Aud: tokenURL,
-		Iat: time.Now().Unix(),
 		Exp: time.Now().Add(time.Second * 45).Unix(),
 		PrivateClaims: map[string]interface{}{
 			"box_sub_type": boxSubType,


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

When using box jwt auth from a server that has an incorrect timestamp. It can result in the following error:
`Current date/time MUST be after or equal to the not-before date\/time listed in the 'nbf' or 'iat' claim`

The `iat` claim doesn't actually have to be set on the request for box to accept it, and so it makes sense to remove it.

When I first hit this issue I wasn't receiving any error messages from rclone, so I've fixed that up too.
#### Was the change discussed in an issue or in the forum before?

Nope

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
