### PR TITLE
Try to deal with new 1fichier rate limiting

### DIFF
--- a/backend/fichier/api.go
+++ b/backend/fichier/api.go
@@ -17,6 +17,7 @@ import (
 // retryErrorCodes is a slice of error codes that we will retry
 var retryErrorCodes = []int{
 	429, // Too Many Requests.
+	403, // Forbidden (may happen when request limit is exceeded)
 	500, // Internal Server Error
 	502, // Bad Gateway
 	503, // Service Unavailable

--- a/backend/fichier/fichier.go
+++ b/backend/fichier/fichier.go
@@ -23,11 +23,12 @@ import (
 )
 
 const (
-	rootID        = "0"
-	apiBaseURL    = "https://api.1fichier.com/v1"
-	minSleep      = 334 * time.Millisecond // 3 API calls per second is recommended
-	maxSleep      = 5 * time.Second
-	decayConstant = 2 // bigger for slower decay, exponential
+	rootID         = "0"
+	apiBaseURL     = "https://api.1fichier.com/v1"
+	minSleep       = 400 * time.Millisecond // api is extremely rate limited now
+	maxSleep       = 5 * time.Second
+	decayConstant  = 2 // bigger for slower decay, exponential
+	attackConstant = 0 // start with max sleep
 )
 
 func init() {
@@ -185,7 +186,7 @@ func NewFs(name string, root string, config configmap.Mapper) (fs.Fs, error) {
 		name:       name,
 		root:       root,
 		opt:        *opt,
-		pacer:      fs.NewPacer(pacer.NewDefault(pacer.MinSleep(minSleep), pacer.MaxSleep(maxSleep), pacer.DecayConstant(decayConstant))),
+		pacer:      fs.NewPacer(pacer.NewDefault(pacer.MinSleep(minSleep), pacer.MaxSleep(maxSleep), pacer.DecayConstant(decayConstant), pacer.AttackConstant(attackConstant))),
 		baseClient: &http.Client{},
 	}
 


### PR DESCRIPTION
1fichier recently changed there rate-limiting to a level that makes it almost unusable. Additionally they changed the HTTP error when rate limited from 429 to 403. Together this causes rclone's in integration tests to fail and makes any sync with 1fichier basicly impossible. The api documentation doesn't reflect the changes yet so this is a best-guess effort to work around it.

It looks like you can make barely 2 requests per second with the actual rate possibly being different for different operations. For this reason, I added a custom pacer for 1fichier though neither usage nor settings a final yet. Sadly the changes make 1fichier almost unusable for more than a handful of files and folders. The integrations tests alone take almost 1 hour to complete now.