### PR TITLE
cmd: added --rmdirs flag to delete command - fixes #4055

### DIFF
--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -50,12 +50,14 @@ delete all files bigger than 100MBytes.
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(true, false, command, func() error {
-			err := operations.Delete(context.Background(), fsrc)
-			if err == nil && rmdirs {
+			if err := operations.Delete(context.Background(), fsrc); err != nil {
+				return err
+			}
+			if rmdirs {
 				fdst := cmd.NewFsDir(args)
 				return operations.Rmdirs(context.Background(), fdst, "", true)
 			}
-			return err
+			return nil
 		})
 	},
 }


### PR DESCRIPTION
If you supply `--rmdirs` flag with delete command, it will remove all empty directories along with it leaving the root intact.


#### What is the purpose of this change?

Implementing remove folders with rclone delete #4055

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/4055

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
