### PR TITLE
--password-command doc Powershell Wiki link

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -987,6 +987,8 @@ Eg
 
 See the [Configuration Encryption](#configuration-encryption) for more info.
 
+See a [Windows Powershell example on the Wiki.](https://github.com/rclone/rclone/wiki/Windows-Powershell-use-rclone-password-command-for-Config-file-password)
+
 ### -P, --progress ###
 
 This flag makes rclone update the stats in a static block in the


### PR DESCRIPTION
add Windows Powershell example wiki link to  --password-command doc

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

In the --password-command documentation, add a link to the Windows Powershell Wiki article 


#### Was the change discussed in an issue or in the forum before?

Nick suggested I do this in a reply 

https://forum.rclone.org/t/how-to-use-rclone-password-command-with-windows-powershell-for-config-password/15950

Note: It appears from the diff that a trailing blank was added to line 925 ("`size` - order by the size of the files "). I have no idea how that happened (I'm using the GitHub web interface to make this change). 

Worse, I don't know how to remove the trailing blank with the GitHub web interface - sorry..

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x ] I'm done, this Pull Request is ready for review :-)
