### PR TITLE
fs config: bind Stdin to password command

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -282,6 +282,7 @@ func loadConfigFile() (*goconfig.ConfigFile, error) {
 
 			cmd.Stdout = &stdout
 			cmd.Stderr = &stderr
+			cmd.Stdin = os.Stdin
 
 			if err := cmd.Run(); err != nil {
 				// One does not always get the stderr returned in the wrapped error.


### PR DESCRIPTION
Bind rclone standard input to password command's standard input. This
allows to provide password from a pipe and collect it using `cat`.

The typical use case is when rclone is on a remote server with an
encrypted configuration. This solved the environment variable
issue (#3368), the password storage on remote host and a potential
issue with command logging on remote host when password command
is `echo secret`.

Now the following chain is allowed:

    echo 'secret' | ssh host.example.com \
       sudo -u rclone \
       rclone --config /path/to/rclone.conf \
       --password-command 'cat' ls remote:

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Allow password-command to read password from rclone standard input and use `cat`.

A typical usage can be:

    echo 'secret' | ssh host.example.com \
       sudo -u rclone \
       rclone --config /path/to/rclone.conf \
       --password-command 'cat' ls remote:

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/3368

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
