### PR TITLE
accounting: reset bytes read during copy retry - fixes #4178

### DIFF
--- a/fs/accounting/accounting.go
+++ b/fs/accounting/accounting.go
@@ -138,6 +138,8 @@ func (acc *Account) UpdateReader(in io.ReadCloser) {
 	acc.close = in
 	acc.origIn = in
 	acc.closed = false
+	acc.lpBytes = 0
+	acc.bytes = int64(0)
 	if withBuf {
 		acc.WithBuffer()
 	}


### PR DESCRIPTION
During a copy/sync command, if an operation fails due to a network
issue and is retried, the underlying io.Reader is re-initialised,
but the stats for bytes already read are not reset, leading to incorrect
stats. THis was fixed by resetting the bytes read when an Account is
re-initialized.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

During a copy/sync command, if an operation fails due to a network issue and is retried, the underlying io.Reader is re-initialised, but the stats for bytes already read are not reset, leading to incorrect stats. This was fixed by resetting the bytes read when an Account is
re-initialized.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/4178

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
