### PR TITLE
rc: Add operations/uploadfile to upload a file through rc using multipart/form-data

### DIFF
--- a/fs/operations/rc.go
+++ b/fs/operations/rc.go
@@ -138,10 +138,11 @@ func rcMoveOrCopyFile(ctx context.Context, in rc.Params, cp bool) (out rc.Params
 
 func init() {
 	for _, op := range []struct {
-		name     string
-		title    string
-		help     string
-		noRemote bool
+		name         string
+		title        string
+		help         string
+		noRemote     bool
+		needsRequest bool
 	}{
 		{name: "mkdir", title: "Make a destination directory or container"},
 		{name: "rmdir", title: "Remove an empty directory or container"},
@@ -160,6 +161,7 @@ func init() {
 		rc.Add(rc.Call{
 			Path:         "operations/" + op.name,
 			AuthRequired: true,
+			NeedsRequest: op.needsRequest,
 			Fn: func(ctx context.Context, in rc.Params) (rc.Params, error) {
 				return rcSingleCommand(ctx, in, op.name, op.noRemote)
 			},

--- a/fs/rc/params.go
+++ b/fs/rc/params.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"net/http"
 	"strconv"
 	"time"
 
@@ -88,6 +89,23 @@ func (p Params) Get(key string) (interface{}, error) {
 		return nil, ErrParamNotFound(key)
 	}
 	return value, nil
+}
+
+// GetHTTPRequest gets a http.Request parameter associated with the request with the key "HttpRequest"
+//
+// If the parameter isn't found then error will be of type
+// ErrParamNotFound and the returned value will be nil.
+func (p Params) GetHTTPRequest() (*http.Request, error) {
+	key := "_request"
+	value, err := p.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	request, ok := value.(*http.Request)
+	if !ok {
+		return nil, ErrParamInvalid{errors.Errorf("expecting http.request value for key %q (was %T)", key, value)}
+	}
+	return request, nil
 }
 
 // GetString gets a string parameter from the input

--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -248,7 +248,6 @@ func (s *Server) handlePost(w http.ResponseWriter, r *http.Request, path string)
 			return
 		}
 	}
-
 	// Find the call
 	call := rc.Calls.Get(path)
 	if call == nil {
@@ -260,6 +259,10 @@ func (s *Server) handlePost(w http.ResponseWriter, r *http.Request, path string)
 	if !s.opt.NoAuth && call.AuthRequired && !s.UsingAuth() {
 		writeError(path, in, w, errors.Errorf("authentication must be set up on the rc server to use %q or the --rc-no-auth flag must be in use", path), http.StatusForbidden)
 		return
+	}
+	if call.NeedsRequest {
+		// Add the request to RC
+		in["_request"] = r
 	}
 
 	// Check to see if it is async or not

--- a/fs/rc/registry.go
+++ b/fs/rc/registry.go
@@ -22,6 +22,7 @@ type Call struct {
 	Title        string // help for the function
 	AuthRequired bool   // if set then this call requires authorisation to be set
 	Help         string // multi-line markdown formatted help
+	NeedsRequest bool   // if set then this call will be passed the original request object as _request
 }
 
 // Registry holds the list of all the registered remote control functions


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Add functionality to upload a file to a remote using the rc. 
This will allow a file to be uploaded directly through the web GUI.
May close #3412
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
No
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
