### PR TITLE
march: added flag to allow Unicode filenames to remain unique

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -908,6 +908,20 @@ changed and won't need copying then you shouldn't use `--no-traverse`.
 
 See [rclone copy](/commands/rclone_copy/) for an example of how to use it.
 
+### --no-unicode-normalization ###
+
+Don't normalize unicode characters in filenames during the sync routine.
+
+Sometimes, an operating system will store filenames containing unicode
+parts in their decomposed form (particularly macOS). Some cloud storage
+systems will then recompose the unicode, resulting in duplicate files if
+the data is ever copied back to a local filesystem.
+
+Using this flag will disable that functionality, treating each unicode
+character as unique. For example, by default é and é will be normalized
+into the same character. With `--no-unicode-normalization` they will be
+treated as unique characters.
+
 ### --no-update-modtime ###
 
 When using this flag, rclone won't update modification times of remote

--- a/fs/config.go
+++ b/fs/config.go
@@ -70,6 +70,7 @@ type ConfigInfo struct {
 	IgnoreCaseSync         bool
 	NoTraverse             bool
 	NoCheckDest            bool
+	NoUnicodeNormalization bool
 	NoUpdateModTime        bool
 	DataRateUnit           string
 	CompareDest            string

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -75,6 +75,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &fs.Config.IgnoreCaseSync, "ignore-case-sync", "", fs.Config.IgnoreCaseSync, "Ignore case when synchronizing")
 	flags.BoolVarP(flagSet, &fs.Config.NoTraverse, "no-traverse", "", fs.Config.NoTraverse, "Don't traverse destination file system on copy.")
 	flags.BoolVarP(flagSet, &fs.Config.NoCheckDest, "no-check-dest", "", fs.Config.NoCheckDest, "Don't check the destination, copy regardless.")
+	flags.BoolVarP(flagSet, &fs.Config.NoUnicodeNormalization, "no-unicode-normalization", "", fs.Config.NoUnicodeNormalization, "Don't normalize unicode characters in filenames.")
 	flags.BoolVarP(flagSet, &fs.Config.NoUpdateModTime, "no-update-modtime", "", fs.Config.NoUpdateModTime, "Don't update destination mod-time if files identical.")
 	flags.StringVarP(flagSet, &fs.Config.CompareDest, "compare-dest", "", fs.Config.CompareDest, "Include additional server-side path during comparison.")
 	flags.StringVarP(flagSet, &fs.Config.CopyDest, "copy-dest", "", fs.Config.CopyDest, "Implies --compare-dest but also copies files from path into destination.")

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -22,15 +22,16 @@ import (
 // calling Callback for each match
 type March struct {
 	// parameters
-	Ctx           context.Context // context for background goroutines
-	Fdst          fs.Fs           // source Fs
-	Fsrc          fs.Fs           // dest Fs
-	Dir           string          // directory
-	NoTraverse    bool            // don't traverse the destination
-	SrcIncludeAll bool            // don't include all files in the src
-	DstIncludeAll bool            // don't include all files in the destination
-	Callback      Marcher         // object to call with results
-	NoCheckDest   bool            // transfer all objects regardless without checking dst
+	Ctx                    context.Context // context for background goroutines
+	Fdst                   fs.Fs           // source Fs
+	Fsrc                   fs.Fs           // dest Fs
+	Dir                    string          // directory
+	NoTraverse             bool            // don't traverse the destination
+	SrcIncludeAll          bool            // don't include all files in the src
+	DstIncludeAll          bool            // don't include all files in the destination
+	Callback               Marcher         // object to call with results
+	NoCheckDest            bool            // transfer all objects regardless without checking dst
+	NoUnicodeNormalization bool            // don't normalize unicode characters in filenames
 	// internal state
 	srcListDir listDirFn // function to call to list a directory in the src
 	dstListDir listDirFn // function to call to list a directory in the dst
@@ -55,7 +56,9 @@ func (m *March) init() {
 	}
 	// Now create the matching transform
 	// ..normalise the UTF8 first
-	m.transforms = append(m.transforms, norm.NFC.String)
+	if !m.NoUnicodeNormalization {
+		m.transforms = append(m.transforms, norm.NFC.String)
+	}
 	// ..if destination is caseInsensitive then make it lower case
 	// case Insensitive | src | dst | lower case compare |
 	//                  | No  | No  | No                 |

--- a/fs/march/march_test.go
+++ b/fs/march/march_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rclone/rclone/fstest/mockobject"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/text/unicode/norm"
 )
 
 // Some times used in the tests
@@ -313,6 +314,8 @@ func TestMatchListings(t *testing.T) {
 		b    = mockobject.Object("b")
 		c    = mockobject.Object("c")
 		d    = mockobject.Object("d")
+		uE1  = mockobject.Object("é") // one of the unicode E characters
+		uE2  = mockobject.Object("é")  // a different unicode E character
 		dirA = mockdir.New("A")
 		dirb = mockdir.New("b")
 	)
@@ -418,6 +421,28 @@ func TestMatchListings(t *testing.T) {
 				{A, A},
 			},
 			transforms: []matchTransformFn{strings.ToLower},
+		},
+		{
+			what: "Unicode near-duplicate that becomes duplicate with normalization",
+			input: fs.DirEntries{
+				uE1, uE1,
+				uE2, uE2,
+			},
+			matches: []matchPair{
+				{uE1, uE1},
+			},
+			transforms: []matchTransformFn{norm.NFC.String},
+		},
+		{
+			what: "Unicode near-duplicate with no normalization",
+			input: fs.DirEntries{
+				uE1, uE1,
+				uE2, uE2,
+			},
+			matches: []matchPair{
+				{uE1, uE1},
+				{uE2, uE2},
+			},
 		},
 		{
 			what: "File and directory are not duplicates - srcOnly",


### PR DESCRIPTION
#### What is the purpose of this change?

To add the flag discussed in issue #4228 which was born out of a conversation about a suspected bug on the forum.

https://forum.rclone.org/t/unique-unicode-characters-lead-to-duplicate-object-found/16314 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
