### PR TITLE
Sftp: Ssh add key pem to config 2

### DIFF
--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -107,10 +107,20 @@ The SFTP remote supports three authentication methods:
 Key files should be PEM-encoded private key files. For instance `/home/$USER/.ssh/id_rsa`.
 Only unencrypted OpenSSH or PEM encrypted files are supported.
 
-If you don't specify `pass` or `key_file` then rclone will attempt to contact an ssh-agent.
+The key file can be specified in either an external file (key_file) or contained within the 
+rclone config file (key_pem).  If using key_pem in the config file, the entry should be on a
+single line with new line ('\n' or '\r\n') separating lines.  i.e. 
+
+key_pem = -----BEGIN RSA PRIVATE KEY-----\nMaMbaIXtE\n0gAMbMbaSsd\nMbaass\n-----END RSA PRIVATE KEY-----
+
+This will generate it correctly for key_pem for use in the config:  
+
+    awk '{printf "%s\\n", $0}' < ~/.ssh/id_rsa
+
+If you don't specify `pass`, `key_file`, or `key_pem` then rclone will attempt to contact an ssh-agent.
 
 You can also specify `key_use_agent` to force the usage of an ssh-agent. In this case
-`key_file` can also be specified to force the usage of a specific key in the ssh-agent.
+`key_file` or `key_pem` can also be specified to force the usage of a specific key in the ssh-agent.
 
 Using an ssh-agent is the only way to load encrypted OpenSSH keys at the moment.
 


### PR DESCRIPTION
This was closed by mistake:

https://github.com/rclone/rclone/pull/4238

 I'd like to be able to store the key in the config (or environment variable) with the rest of the parameters rather than carrying it around in an external file to deploy along with the rclone config.

So i'd allow for a config parameter to store the actual key rather than only read a file system file. This would also enable tools that abstract the filesystem from the app running rclone to work correctly here (RCX for android for example).

command:
--sftp-key-pem (actual key)

config:
key_pem = (actual key)

I was thinking since the config file doesn't allow multi-line that I would force a sane delimiter (\r\n and \n).


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
