### PR TITLE
Cache - Add Support for Server Side Copy When Using Temp Upload

### DIFF
--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -520,9 +520,6 @@ func NewFs(name, rootPath string, m configmap.Mapper) (fs.Fs, error) {
 	// override only those features that use a temp fs and it doesn't support them
 	//f.features.ChangeNotify = f.ChangeNotify
 	if f.opt.TempWritePath != "" {
-		if f.tempFs.Features().Copy == nil {
-			f.features.Copy = nil
-		}
 		if f.tempFs.Features().Move == nil {
 			f.features.Move = nil
 		}
@@ -1531,6 +1528,9 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 	do := f.Fs.Features().Copy
 	if do == nil {
 		fs.Errorf(src, "source remote (%v) doesn't support Copy", src.Fs())
+		return nil, fs.ErrorCantCopy
+	}
+	if f.opt.TempWritePath != "" && src.Fs() == f.tempFs {
 		return nil, fs.ErrorCantCopy
 	}
 	// the source must be a cached object or we abort

--- a/cmd/backend/backend.go
+++ b/cmd/backend/backend.go
@@ -59,7 +59,7 @@ Note to run these commands on a running backend then see
 [backend/command](/rc/#backend/command) in the rc docs.
 `,
 	RunE: func(command *cobra.Command, args []string) error {
-		cmd.CheckArgs(2, 1E6, command, args)
+		cmd.CheckArgs(2, 1e6, command, args)
 		name, remote := args[0], args[1]
 		cmd.Run(false, false, command, func() error {
 			// show help if remote is a backend name


### PR DESCRIPTION
#### What is the purpose of this change?

This change adds support for server side copying to the cache backend (when wrapping a backend that supports it) when the `tmp_upload_path` option is specified. Previously, this configuration would result in the following behaviour from e.g. `mv`:

```text
user@HOSTNAME:/data/data# mv a.txt b.txt
mv: cannot move 'a.txt' to 'b.txt': Input/output error
```

rclone itself would emit a message similar to the following:

```text
ERROR : data/a.txt: Dir.Rename error: Fs "Encrypted drive 'data:'" can't rename files (no server side Move or Copy)
```

This was caused by the `cache` backend "masking out" Copy support from the wrapped backend due to the `local` backend not supporting it.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/3206

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
