### PR TITLE
Google console doesn't list 'other' anymore

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -1101,7 +1101,7 @@ of "External" above, but this has not been tested/documented so far).
 6.  Click on the "+ CREATE CREDENTIALS" button at the top of the screen,
 then select "OAuth client ID".
 
-7. Choose an application type of "other", and click "Create". (the
+7. Choose an application type of "Desktop app", and click "Create". (the
 default name is fine)
 
 8. It will show you a client ID and client secret.  Use these values


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
The option of 'other' seems to be gone from the https://console.developers.google.com/apis/credentials/oauthclient
page.
It only lists these now:

Web application
Android
Chrome app
iOS
TVs and Limited Input devices
Desktop app
Universal Windows Platform (UWP)

![Screenshot_20200518_222739](https://user-images.githubusercontent.com/1010226/82257787-fa13e100-9958-11ea-8b44-44651abb57aa.png)
<!--
Describe the changes here
-->
I just changed those couple words


<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ x] I have added tests for all changes in this PR if appropriate.
- [ x] I have added documentation for the changes if appropriate.
- [ x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)
