### PR TITLE
dropbox: Add copyright detector info in limitations section

### DIFF
--- a/docs/content/dropbox.md
+++ b/docs/content/dropbox.md
@@ -198,6 +198,12 @@ of this document](https://www.dropbox.com/en/help/145).  Rclone will
 issue an error message `File name disallowed - not uploading` if it
 attempts to upload one of those file names, but the sync won't fail.
 
+Some errors may occur ff you try to sync copyright-protected files
+due that Dropbox has its own [copyright detector](https://techcrunch.com/2014/03/30/how-dropbox-knows-when-youre-sharing-copyrighted-stuff-without-actually-looking-at-your-stuff/) that
+prevents this files to be synced. This will return the error `ERROR :
+/path/to/your/file: Failed to copy: failed to open source object:
+path/restricted_content/.`
+
 If you have more than 10,000 files in a directory then `rclone purge
 dropbox:dir` will return the error `Failed to purge: There are too
 many files involved in this operation`.  As a work-around do an

--- a/docs/content/dropbox.md
+++ b/docs/content/dropbox.md
@@ -198,9 +198,9 @@ of this document](https://www.dropbox.com/en/help/145).  Rclone will
 issue an error message `File name disallowed - not uploading` if it
 attempts to upload one of those file names, but the sync won't fail.
 
-Some errors may occur ff you try to sync copyright-protected files
-due that Dropbox has its own [copyright detector](https://techcrunch.com/2014/03/30/how-dropbox-knows-when-youre-sharing-copyrighted-stuff-without-actually-looking-at-your-stuff/) that
-prevents this files to be synced. This will return the error `ERROR :
+Some errors may occur if you try to sync copyright-protected files
+because Dropbox has its own [copyright detector](https://techcrunch.com/2014/03/30/how-dropbox-knows-when-youre-sharing-copyrighted-stuff-without-actually-looking-at-your-stuff/) that
+prevents this sort of file being downloaded. This will return the error `ERROR :
 /path/to/your/file: Failed to copy: failed to open source object:
 path/restricted_content/.`
 


### PR DESCRIPTION
Proposed by the original repo owner in this comment: https://github.com/rclone/rclone/issues/2301#issuecomment-388291079

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Give rclone users more info about an error that occurs while you are trying to sync Dropbox files protected by copiright.

#### Was the change discussed in an issue or in the forum before?

Yep, the original repo owner suggested it [here](https://github.com/rclone/rclone/issues/2301#issuecomment-388291079)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
