### PR TITLE
Moving from dockercloud to GitHub action + multi-arch support

### DIFF
--- a/.github/workflows/build_publish_docker_image.yml
+++ b/.github/workflows/build_publish_docker_image.yml
@@ -1,0 +1,23 @@
+name: Build and publish develop image
+
+on:
+    push:
+      branches:
+        - master
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        name: Build image job
+        steps:
+            - name: Checkout master
+              uses: actions/checkout@master
+            - name: Build and publish image
+              uses: ilteoood/docker_buildx@master
+              with:
+                tag: beta
+                imageName: rclone/rclone
+                platform: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7
+                publish: true
+                dockerHubUser: ${{ secrets.DOCKER_HUB_USER }}
+                dockerHubPassword: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/build_publish_docker_image.yml
+++ b/.github/workflows/build_publish_docker_image.yml
@@ -1,4 +1,4 @@
-name: Build and publish develop image
+name: Docker beta build
 
 on:
     push:
@@ -11,13 +11,15 @@ jobs:
         name: Build image job
         steps:
             - name: Checkout master
-              uses: actions/checkout@master
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
             - name: Build and publish image
-              uses: ilteoood/docker_buildx@master
+              uses: ilteoood/docker_buildx@439099796bfc03dd9cedeb72a0c7cb92be5cc92c
               with:
                 tag: beta
                 imageName: rclone/rclone
-                platform: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7
+                platform: linux/amd64,linux/386,linux/arm64,linux/arm/v7
                 publish: true
                 dockerHubUser: ${{ secrets.DOCKER_HUB_USER }}
                 dockerHubPassword: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/build_publish_release_docker_image.yml
+++ b/.github/workflows/build_publish_release_docker_image.yml
@@ -1,0 +1,30 @@
+name: Build and publish release image
+on:
+  release:
+    types: [published]
+
+jobs:
+    build:
+        runs-on: ubuntu-latest
+        name: Build image job
+        steps:
+            - name: Checkout master
+              uses: actions/checkout@master
+            - name: Get actual patch version
+              id: actual_patch_version
+              run: echo ::set-output name=ACTUAL_PATCH_VERSION::$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/v//g')
+            - name: Get actual minor version
+              id: actual_minor_version
+              run: echo ::set-output name=ACTUAL_MINOR_VERSION::$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/v//g' | cut -d "." -f 1,2)
+            - name: Get actual major version
+              id: actual_major_version
+              run: echo ::set-output name=ACTUAL_MAJOR_VERSION::$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/v//g' | cut -d "." -f 1)
+            - name: Build and publish image
+              uses: ilteoood/docker_buildx@master
+              with:
+                tag: latest,${{ steps.actual_patch_version.outputs.ACTUAL_PATCH_VERSION }},${{ steps.actual_minor_version.outputs.ACTUAL_MINOR_VERSION }},${{ steps.actual_major_version.outputs.ACTUAL_MAJOR_VERSION }}
+                imageName: rclone/rclone
+                platform: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7
+                publish: true
+                dockerHubUser: ${{ secrets.DOCKER_HUB_USER }}
+                dockerHubPassword: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/.github/workflows/build_publish_release_docker_image.yml
+++ b/.github/workflows/build_publish_release_docker_image.yml
@@ -1,4 +1,5 @@
-name: Build and publish release image
+name: Docker release build
+
 on:
   release:
     types: [published]
@@ -9,7 +10,9 @@ jobs:
         name: Build image job
         steps:
             - name: Checkout master
-              uses: actions/checkout@master
+              uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
             - name: Get actual patch version
               id: actual_patch_version
               run: echo ::set-output name=ACTUAL_PATCH_VERSION::$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/v//g')
@@ -20,11 +23,11 @@ jobs:
               id: actual_major_version
               run: echo ::set-output name=ACTUAL_MAJOR_VERSION::$(echo $GITHUB_REF | cut -d / -f 3 | sed 's/v//g' | cut -d "." -f 1)
             - name: Build and publish image
-              uses: ilteoood/docker_buildx@master
+              uses: ilteoood/docker_buildx@@439099796bfc03dd9cedeb72a0c7cb92be5cc92c
               with:
                 tag: latest,${{ steps.actual_patch_version.outputs.ACTUAL_PATCH_VERSION }},${{ steps.actual_minor_version.outputs.ACTUAL_MINOR_VERSION }},${{ steps.actual_major_version.outputs.ACTUAL_MAJOR_VERSION }}
                 imageName: rclone/rclone
-                platform: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x,linux/386,linux/arm/v7
+                platform: linux/amd64,linux/386,linux/arm64,linux/arm/v7
                 publish: true
                 dockerHubUser: ${{ secrets.DOCKER_HUB_USER }}
                 dockerHubPassword: ${{ secrets.DOCKER_HUB_PASSWORD }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM golang AS builder
 COPY . /go/src/github.com/rclone/rclone/
 WORKDIR /go/src/github.com/rclone/rclone/
 
-RUN make quicktest
 RUN \
   CGO_ENABLED=0 \
   make

--- a/go.mod
+++ b/go.mod
@@ -70,4 +70,4 @@ require (
 	storj.io/uplink v1.0.6
 )
 
-go 1.13
+go 1.14

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,29 +1,42 @@
 # bazil.org/fuse v0.0.0-20200117225306-7b5117fecadc
+## explicit
 bazil.org/fuse
 bazil.org/fuse/fs
 bazil.org/fuse/fuseutil
 # cloud.google.com/go v0.53.0
+## explicit
 cloud.google.com/go/compute/metadata
 # github.com/Azure/azure-pipeline-go v0.2.2
+## explicit
 github.com/Azure/azure-pipeline-go/pipeline
 # github.com/Azure/azure-storage-blob-go v0.8.0
+## explicit
 github.com/Azure/azure-storage-blob-go/azblob
+# github.com/Azure/go-autorest/autorest/adal v0.6.0
+## explicit
 # github.com/Unknwon/goconfig v0.0.0-20191126170842-860a72fb44fd
+## explicit
 github.com/Unknwon/goconfig
 # github.com/a8m/tree v0.0.0-20181222104329-6a0b80129de4
+## explicit
 github.com/a8m/tree
 # github.com/aalpar/deheap v0.0.0-20191229192855-f837f7a9ba26
+## explicit
 github.com/aalpar/deheap
 # github.com/abbot/go-http-auth v0.4.0
+## explicit
 github.com/abbot/go-http-auth
 # github.com/anacrolix/dms v1.1.0
+## explicit
 github.com/anacrolix/dms/dlna
 github.com/anacrolix/dms/soap
 github.com/anacrolix/dms/ssdp
 github.com/anacrolix/dms/upnp
 # github.com/atotto/clipboard v0.1.2
+## explicit
 github.com/atotto/clipboard
 # github.com/aws/aws-sdk-go v1.29.9
+## explicit
 github.com/aws/aws-sdk-go/aws
 github.com/aws/aws-sdk-go/aws/arn
 github.com/aws/aws-sdk-go/aws/awserr
@@ -69,6 +82,7 @@ github.com/aws/aws-sdk-go/service/sts/stsiface
 # github.com/beorn7/perks v1.0.1
 github.com/beorn7/perks/quantile
 # github.com/billziss-gh/cgofuse v1.2.0
+## explicit
 github.com/billziss-gh/cgofuse/fuse
 # github.com/btcsuite/btcutil v1.0.1
 github.com/btcsuite/btcutil/base58
@@ -77,14 +91,17 @@ github.com/calebcase/tmpfile
 # github.com/cespare/xxhash/v2 v2.1.1
 github.com/cespare/xxhash/v2
 # github.com/coreos/go-semver v0.3.0
+## explicit
 github.com/coreos/go-semver/semver
 # github.com/cpuguy83/go-md2man/v2 v2.0.0
 github.com/cpuguy83/go-md2man/v2/md2man
 # github.com/davecgh/go-spew v1.1.1
 github.com/davecgh/go-spew/spew
 # github.com/djherbis/times v1.2.0
+## explicit
 github.com/djherbis/times
 # github.com/dropbox/dropbox-sdk-go-unofficial v5.6.0+incompatible
+## explicit
 github.com/dropbox/dropbox-sdk-go-unofficial/dropbox
 github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/async
 github.com/dropbox/dropbox-sdk-go-unofficial/dropbox/auth
@@ -109,10 +126,14 @@ github.com/golang/protobuf/ptypes/any
 github.com/golang/protobuf/ptypes/duration
 github.com/golang/protobuf/ptypes/timestamp
 # github.com/google/go-querystring v1.0.0
+## explicit
 github.com/google/go-querystring/query
 # github.com/googleapis/gax-go/v2 v2.0.5
 github.com/googleapis/gax-go/v2
+# github.com/gopherjs/gopherjs v0.0.0-20190812055157-5d271430af9f
+## explicit
 # github.com/hanwen/go-fuse/v2 v2.0.3-0.20191108143333-152e6ac32d54
+## explicit
 github.com/hanwen/go-fuse/v2/fs
 github.com/hanwen/go-fuse/v2/fuse
 github.com/hanwen/go-fuse/v2/internal
@@ -121,44 +142,64 @@ github.com/hanwen/go-fuse/v2/splice
 # github.com/inconshreveable/mousetrap v1.0.0
 github.com/inconshreveable/mousetrap
 # github.com/jlaffaye/ftp v0.0.0-20191218041957-e1b8fdd0dcc3
+## explicit
 github.com/jlaffaye/ftp
 # github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af
 github.com/jmespath/go-jmespath
 # github.com/jzelinskie/whirlpool v0.0.0-20170603002051-c19460b8caa6
+## explicit
 github.com/jzelinskie/whirlpool
 # github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
+## explicit
 github.com/kardianos/osext
 # github.com/konsorten/go-windows-terminal-sequences v1.0.2
+## explicit
 github.com/konsorten/go-windows-terminal-sequences
 # github.com/koofr/go-httpclient v0.0.0-20190818202018-e0dc8fd921dc
+## explicit
 github.com/koofr/go-httpclient
 # github.com/koofr/go-koofrclient v0.0.0-20190724113126-8e5366da203a
+## explicit
 github.com/koofr/go-koofrclient
 # github.com/kr/fs v0.1.0
 github.com/kr/fs
 # github.com/mattn/go-colorable v0.1.4
+## explicit
 github.com/mattn/go-colorable
 # github.com/mattn/go-ieproxy v0.0.0-20200203040449-2dbc853185d9
+## explicit
 github.com/mattn/go-ieproxy
 # github.com/mattn/go-isatty v0.0.12
+## explicit
 github.com/mattn/go-isatty
 # github.com/mattn/go-runewidth v0.0.8
+## explicit
 github.com/mattn/go-runewidth
 # github.com/matttproud/golang_protobuf_extensions v1.0.1
 github.com/matttproud/golang_protobuf_extensions/pbutil
 # github.com/minio/sha256-simd v0.0.0-20190328051042-05b4dd3047e5
 github.com/minio/sha256-simd
 # github.com/mitchellh/go-homedir v1.1.0
+## explicit
 github.com/mitchellh/go-homedir
 # github.com/ncw/go-acd v0.0.0-20171120105400-887eb06ab6a2
+## explicit
 github.com/ncw/go-acd
 # github.com/ncw/swift v1.0.50
+## explicit
 github.com/ncw/swift
 # github.com/nsf/termbox-go v0.0.0-20200204031403-4d2b513ad8be
+## explicit
 github.com/nsf/termbox-go
 # github.com/okzk/sdnotify v0.0.0-20180710141335-d9becc38acbd
+## explicit
 github.com/okzk/sdnotify
+# github.com/onsi/ginkgo v1.9.0
+## explicit
+# github.com/onsi/gomega v1.6.0
+## explicit
 # github.com/patrickmn/go-cache v2.1.0+incompatible
+## explicit
 github.com/patrickmn/go-cache
 # github.com/pengsrc/go-shared v0.2.1-0.20190131101655-1999055a4a14
 github.com/pengsrc/go-shared/buffer
@@ -167,12 +208,15 @@ github.com/pengsrc/go-shared/convert
 github.com/pengsrc/go-shared/log
 github.com/pengsrc/go-shared/reopen
 # github.com/pkg/errors v0.9.1
+## explicit
 github.com/pkg/errors
 # github.com/pkg/sftp v1.11.0
+## explicit
 github.com/pkg/sftp
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib
 # github.com/prometheus/client_golang v1.4.1
+## explicit
 github.com/prometheus/client_golang/prometheus
 github.com/prometheus/client_golang/prometheus/internal
 github.com/prometheus/client_golang/prometheus/promhttp
@@ -187,41 +231,57 @@ github.com/prometheus/procfs
 github.com/prometheus/procfs/internal/fs
 github.com/prometheus/procfs/internal/util
 # github.com/putdotio/go-putio/putio v0.0.0-20200123120452-16d982cac2b8
+## explicit
 github.com/putdotio/go-putio/putio
 # github.com/rfjakob/eme v0.0.0-20171028163933-2222dbd4ba46
+## explicit
 github.com/rfjakob/eme
 # github.com/russross/blackfriday/v2 v2.0.1
 github.com/russross/blackfriday/v2
 # github.com/sevlyar/go-daemon v0.1.5
+## explicit
 github.com/sevlyar/go-daemon
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
 # github.com/sirupsen/logrus v1.4.2
+## explicit
 github.com/sirupsen/logrus
 # github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
+## explicit
 github.com/skratchdot/open-golang/open
+# github.com/smartystreets/assertions v1.0.1
+## explicit
+# github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337
+## explicit
 # github.com/spacemonkeygo/errors v0.0.0-20171212215202-9064522e9fd1
 github.com/spacemonkeygo/errors
 # github.com/spacemonkeygo/monkit/v3 v3.0.7-0.20200515175308-072401d8c752
 github.com/spacemonkeygo/monkit/v3
 github.com/spacemonkeygo/monkit/v3/monotime
 # github.com/spf13/cobra v1.0.0
+## explicit
 github.com/spf13/cobra
 github.com/spf13/cobra/doc
 # github.com/spf13/pflag v1.0.5
+## explicit
 github.com/spf13/pflag
 # github.com/stretchr/testify v1.5.1
+## explicit
 github.com/stretchr/testify/assert
 github.com/stretchr/testify/require
 # github.com/t3rm1n4l/go-mega v0.0.0-20200117211730-79a813bb328d
+## explicit
 github.com/t3rm1n4l/go-mega
 # github.com/vivint/infectious v0.0.0-20190108171102-2455b059135b
 github.com/vivint/infectious
 # github.com/xanzy/ssh-agent v0.2.1
+## explicit
 github.com/xanzy/ssh-agent
 # github.com/youmark/pkcs8 v0.0.0-20191102193632-94c173a94d60
+## explicit
 github.com/youmark/pkcs8
 # github.com/yunify/qingstor-sdk-go/v3 v3.2.0
+## explicit
 github.com/yunify/qingstor-sdk-go/v3
 github.com/yunify/qingstor-sdk-go/v3/config
 github.com/yunify/qingstor-sdk-go/v3/logger
@@ -236,6 +296,7 @@ github.com/yunify/qingstor-sdk-go/v3/utils
 # github.com/zeebo/errs v1.2.2
 github.com/zeebo/errs
 # go.etcd.io/bbolt v1.3.3
+## explicit
 go.etcd.io/bbolt
 # go.opencensus.io v0.22.3
 go.opencensus.io
@@ -266,8 +327,10 @@ go.uber.org/zap/internal/color
 go.uber.org/zap/internal/exit
 go.uber.org/zap/zapcore
 # goftp.io/server v0.3.2
+## explicit
 goftp.io/server
 # golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d
+## explicit
 golang.org/x/crypto/argon2
 golang.org/x/crypto/bcrypt
 golang.org/x/crypto/blake2b
@@ -287,6 +350,7 @@ golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/terminal
 # golang.org/x/net v0.0.0-20200222125558-5a598a2470a0
+## explicit
 golang.org/x/net/bpf
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp
@@ -307,27 +371,33 @@ golang.org/x/net/webdav
 golang.org/x/net/webdav/internal/xml
 golang.org/x/net/websocket
 # golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
+## explicit
 golang.org/x/oauth2
 golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
 # golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e
+## explicit
 golang.org/x/sync/errgroup
 golang.org/x/sync/semaphore
 # golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae
+## explicit
 golang.org/x/sys/cpu
 golang.org/x/sys/unix
 golang.org/x/sys/windows
 golang.org/x/sys/windows/registry
 # golang.org/x/text v0.3.2
+## explicit
 golang.org/x/text/secure/bidirule
 golang.org/x/text/transform
 golang.org/x/text/unicode/bidi
 golang.org/x/text/unicode/norm
 # golang.org/x/time v0.0.0-20191024005414-555d28b269f0
+## explicit
 golang.org/x/time/rate
 # google.golang.org/api v0.21.1-0.20200411000818-c8cf5cff125e
+## explicit
 google.golang.org/api/drive/v2
 google.golang.org/api/drive/v3
 google.golang.org/api/googleapi
@@ -353,6 +423,7 @@ google.golang.org/appengine/internal/remote_api
 google.golang.org/appengine/internal/urlfetch
 google.golang.org/appengine/urlfetch
 # google.golang.org/genproto v0.0.0-20200225123651-fc8f55426688
+## explicit
 google.golang.org/genproto/googleapis/rpc/status
 # google.golang.org/grpc v1.27.1
 google.golang.org/grpc
@@ -392,6 +463,7 @@ google.golang.org/grpc/stats
 google.golang.org/grpc/status
 google.golang.org/grpc/tap
 # gopkg.in/yaml.v2 v2.2.8
+## explicit
 gopkg.in/yaml.v2
 # storj.io/common v0.0.0-20200519171747-3ff8acf78c46
 storj.io/common/encryption
@@ -433,6 +505,7 @@ storj.io/drpc/drpcsignal
 storj.io/drpc/drpcstream
 storj.io/drpc/drpcwire
 # storj.io/uplink v1.0.6
+## explicit
 storj.io/uplink
 storj.io/uplink/internal/expose
 storj.io/uplink/internal/telemetryclient


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

With this PR I would like to move the CI for docker images from dockercloud to GitHub Actions.
Also, I would like to add support for multi-arch images in order to support not only amd64 but also arm, x86... architectures

#### Was the change discussed in an issue or in the forum before?

I don't know

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
