### PR TITLE
backend/tardigrade: Set UserAgent to rclone

### DIFF
--- a/backend/tardigrade/fs.go
+++ b/backend/tardigrade/fs.go
@@ -269,7 +269,9 @@ func (f *Fs) connect(ctx context.Context) (project *uplink.Project, err error) {
 	fs.Debugf(f, "connecting...")
 	defer fs.Debugf(f, "connected: %+v", err)
 
-	cfg := uplink.Config{}
+	cfg := uplink.Config{
+		UserAgent: "rclone",
+	}
 
 	project, err = cfg.OpenProject(ctx, f.access)
 	if err != nil {


### PR DESCRIPTION
#### What is the purpose of this change?

This provides two things:

* It gives Storj insight into which uplink clients are using the
  network.
* It facilitate rclone participating in the Tardigrade Open Source
  Partner Program https://tardigrade.io/partner/

#### Was the change discussed in an issue or in the forum before?

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
