### PR TITLE
Add DSCP support (alternate/duplicate of #4266)

### DIFF
--- a/fs/config.go
+++ b/fs/config.go
@@ -116,6 +116,7 @@ type ConfigInfo struct {
 	UploadHeaders          []*HTTPOption
 	DownloadHeaders        []*HTTPOption
 	Headers                []*HTTPOption
+	DSCP                   uint8
 }
 
 // NewConfig creates a new config with everything set to the default

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -120,6 +120,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.StringArrayVarP(flagSet, &uploadHeaders, "header-upload", "", nil, "Set HTTP header for upload transactions")
 	flags.StringArrayVarP(flagSet, &downloadHeaders, "header-download", "", nil, "Set HTTP header for download transactions")
 	flags.StringArrayVarP(flagSet, &headers, "header", "", nil, "Set HTTP header for all transactions")
+	flags.Uint8VarP(flagSet, &fs.Config.DSCP, "dscp", "", fs.Config.DSCP, "Value for the DSCP field in transmitted packets.")
 }
 
 // ParseHeaders converts the strings passed in via the header flags into HTTPOptions

--- a/fs/config/flags/flags.go
+++ b/fs/config/flags/flags.go
@@ -106,6 +106,14 @@ func Uint32VarP(flags *pflag.FlagSet, p *uint32, name, shorthand string, value u
 	setDefaultFromEnv(flags, name)
 }
 
+// Uint8VarP defines a flag which can be overridden by an environment variable
+//
+// It is a thin wrapper around pflag.Uint8VarP
+func Uint8VarP(flags *pflag.FlagSet, p *uint8, name, shorthand string, value uint8, usage string) {
+	flags.Uint8VarP(p, name, shorthand, value, usage)
+	setDefaultFromEnv(flags, name)
+}
+
 // Float64P defines a flag which can be overridden by an environment variable
 //
 // It is a thin wrapper around pflag.Float64P


### PR DESCRIPTION
#### What is the purpose of this change?

Enables the user to manually specify a DSCP (TOS) value for the IP packets sent by rclone. This makes it far easier to (de)prioritize rclone upload traffic appropriately via QoS systems.

Previously, doing this sort of thing potentially involved much more hassle.

In my case (a Google Drive user), I was using FireQoS on my firewall/router box to do packet prioritization. And the only good way I could come up with to somewhat-reliably identify which packets on the LAN were from background bulk rclone upload traffic was to write a Bash-and-Python contraption that would do DNS queries of `www.googleapis.com` every 5 minutes; store the IP addresses in a rudimentary database along with each address's date-and-time-last-seen; and then also every 5 minutes, update the `iptables` rules on the machine via FireQoS by doing a really horrible scripting thing where I'd basically just dump like ~100 individual match rules in there for each one of the IP addresses in my database that were known to probably be associated with Google Drive. (Yes, I really did that. Yes, I was ashamed of what I had done. But also, yes, it *did* essentially work. 😝)

With the ability to just set the DSCP value on the packets directly via `rclone.conf`, I can now use a much simpler (and more exact) matching mechanism on the router box that merely reads the DSCP value and prioritizes accordingly. (With a single `iptables` match rule, rather than a hundred or so.)

And I believe some hardware also will just automatically Do The Right Thing based on the DSCP values they see. (I think all of my networking hardware is too cheap for that level of fanciness though.)

#### Was the change discussed in an issue or in the forum before?

#755, #4266.

#### Why on earth am I submitting a pull request for this now, when a much better one was already submitted just two weeks ago?

Yeah, funny story. So, I originally worked on this patch back around December 2018 (judging by file datestamps). But I'm very much a C++ person, with effectively zero experience with Go at all; and after trying a few things with the available libraries, I couldn't *quite* get it all to work properly, so I shelved it and eventually ended up writing the previously-described DNS-based monstrosity instead.

Then, today, I decided I'd come back to this dumb thing and make it work once and for all. And I actually *was* able to get a patch working this time, albeit a somewhat rough one; but it definitely *does* work, on Linux, for IPv4. (The patch hasn't been tested on anything else.)

Next I set about searching the issues and PR's on this repository so I could find the right issue numbers to reference in preparation to submit a cleaned-up PR... and that's when I discovered that @Max-Sum had already submitted a much nicer PR (#4266) for this exact feature just two weeks ago. 🤦 D'oh! Should have checked that *before*, not after.

In any case, I figured it would be worthwhile to throw the code I have up here anyway, just in case there's anything to be gained from looking at a slightly different approach to the same problem. For what it's worth, I think #4266 is what you should go forward with; my patch is a bit of a "hey it actually works!" situation, and some aspects of it aren't ideal (e.g. relying on the `setsockopt` syscall, which isn't particularly existent on Windows). But again, maybe something in here will be useful to incorporate over there.

I'm not sure if the fact that I used the `Dialer.Control` callback interface in my implementation is a good thing or not. Maybe it's better because the setting will be applied slightly earlier in the connection process? But then I don't know how easy it'd be to use the higher-level `SetTOS`/`SetTrafficClass` functions from within there. So I dunno.

One thing I think both #4266 and my own PR could have maybe done better, is to allow specifying *either* a raw DSCP value *or* one of the pre-defined RFC 4594 style named values (CS0, AF11, EF, etc). Personally I'd probably leave out the RFC 1349 style named values (low-delay, throughput, reliability, etc).

(It inevitably gets hairy, because over the decades there have been approximately a thousand different, conflicting, mutually-exclusive RFC's and de-facto "standards" for that one stupid damned byte in the IP header. Using just the 6-bit DSCP portion of the TOS byte and using the RFC 4594 style values seems to have emerged as the most agreed-upon approach these days, so I'd probably just stick to that.)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)

(Yeah, I didn't exactly get around to all the make-it-spiffy type stuff, for reasons described above. 😜)