### PR TITLE
s3: add `max_upload_parts` support

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -774,6 +774,20 @@ larger files then you will need to increase chunk_size.`,
 			Default:  minChunkSize,
 			Advanced: true,
 		}, {
+			Name: "max_upload_parts",
+			Help: `Maximum amount of parts being used.
+
+This option defined maximum amount of multipart chunks to upload files.
+
+This can be useful if service does support less amount of parts than AWS S3 specification.
+Maximum to be 10,000 chunks.
+
+Rclone will automatically increase the chunk size when uploading a
+large file of known size to stay below that limit chunks limit.
+`,
+			Default:  maxUploadParts,
+			Advanced: true,
+		}, {
 			Name: "copy_cutoff",
 			Help: `Cutoff for switching to multipart copy
 
@@ -931,6 +945,7 @@ type Options struct {
 	UploadCutoff          fs.SizeSuffix        `config:"upload_cutoff"`
 	CopyCutoff            fs.SizeSuffix        `config:"copy_cutoff"`
 	ChunkSize             fs.SizeSuffix        `config:"chunk_size"`
+	MaxUploadParts        int64                `config:"max_upload_parts"`
 	DisableChecksum       bool                 `config:"disable_checksum"`
 	SessionToken          string               `config:"session_token"`
 	UploadConcurrency     int                  `config:"upload_concurrency"`
@@ -2197,6 +2212,13 @@ func (o *Object) uploadMultipart(ctx context.Context, req *s3.PutObjectInput, si
 	}
 	tokens := pacer.NewTokenDispenser(concurrency)
 
+	uploadParts := f.opt.MaxUploadParts
+	if uploadParts < 1 {
+		uploadParts = 1
+	} else if uploadParts > maxUploadParts {
+		uploadParts = maxUploadParts
+	}
+
 	// calculate size of parts
 	partSize := int(f.opt.ChunkSize)
 
@@ -2206,13 +2228,13 @@ func (o *Object) uploadMultipart(ctx context.Context, req *s3.PutObjectInput, si
 	if size == -1 {
 		warnStreamUpload.Do(func() {
 			fs.Logf(f, "Streaming uploads using chunk size %v will have maximum file size of %v",
-				f.opt.ChunkSize, fs.SizeSuffix(partSize*maxUploadParts))
+				f.opt.ChunkSize, fs.SizeSuffix(int64(partSize)*uploadParts))
 		})
 	} else {
 		// Adjust partSize until the number of parts is small enough.
-		if size/int64(partSize) >= maxUploadParts {
+		if size/int64(partSize) >= uploadParts {
 			// Calculate partition size rounded up to the nearest MB
-			partSize = int((((size / maxUploadParts) >> 20) + 1) << 20)
+			partSize = int((((size / uploadParts) >> 20) + 1) << 20)
 		}
 	}
 

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -775,15 +775,16 @@ larger files then you will need to increase chunk_size.`,
 			Advanced: true,
 		}, {
 			Name: "max_upload_parts",
-			Help: `Maximum amount of parts being used.
+			Help: `Maximum number of parts in a multipart upload.
 
-This option defined maximum amount of multipart chunks to upload files.
+This option defines the maximum number of multipart chunks to use
+when doing a multipart upload.
 
-This can be useful if service does support less amount of parts than AWS S3 specification.
-Maximum to be 10,000 chunks.
+This can be useful if a service does not support the AWS S3
+specification of 10,000 chunks.
 
 Rclone will automatically increase the chunk size when uploading a
-large file of known size to stay below that limit chunks limit.
+large file of a known size to stay below this number of chunks limit.
 `,
 			Default:  maxUploadParts,
 			Advanced: true,


### PR DESCRIPTION
#### What is the purpose of this change?

This allows to configure a maximum amount of chunks used to upload file.

- Support Scaleway which has a limit of 1k chunks currently
- Reduce a cost on S3 when each request costs some money at the expense of memory used

#### Was the change discussed in an issue or in the forum before?

Nope

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
