### PR TITLE
vfs: Change modtime of file before upload to current

### DIFF
--- a/vfs/file.go
+++ b/vfs/file.go
@@ -356,7 +356,7 @@ func (f *File) ModTime() (modTime time.Time) {
 		return pendingModTime
 	}
 	if o == nil {
-		return d.ModTime()
+		return time.Now()
 	}
 	return o.ModTime(context.TODO())
 }


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Previously files before they get uploaded will inherit the directory modtime.  This changes that to use the current time instead.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/times-on-files-initially-set-incorrect-on-mount/16923/3

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
