### PR TITLE
Add --file flag to cat command

### DIFF
--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -20,6 +20,7 @@ var (
 	offset  = int64(0)
 	count   = int64(-1)
 	discard = false
+        file    = false
 )
 
 func init() {
@@ -30,6 +31,7 @@ func init() {
 	flags.Int64VarP(cmdFlags, &offset, "offset", "", offset, "Start printing at offset N (or from end if -ve).")
 	flags.Int64VarP(cmdFlags, &count, "count", "", count, "Only print N characters.")
 	flags.BoolVarP(cmdFlags, &discard, "discard", "", discard, "Discard the output instead of printing.")
+	flags.BoolVarP(cmdFlags, &file, "file", "", file, "Expect path to file. Error if directory is passed.")
 }
 
 var commandDefinition = &cobra.Command{
@@ -71,11 +73,12 @@ Note that if offset is negative it will count from the end, so
 			count = -1
 		}
 		cmd.CheckArgs(1, 1, command, args)
-		fsrc := cmd.NewFsSrc(args)
+		fsrc := cmd.NewFsSrcForceFile(args)
 		var w io.Writer = os.Stdout
 		if discard {
 			w = ioutil.Discard
 		}
+
 		cmd.Run(false, false, command, func() error {
 			return operations.Cat(context.Background(), fsrc, w, offset, count)
 		})

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -130,6 +130,14 @@ func NewFsSrc(args []string) fs.Fs {
 	return fsrc
 }
 
+func NewFsSrcForceFile(args []string) fs.Fs {
+	fsrc, fileName := newFsFileAddFilter(args[0])
+        if fileName == "" {
+                log.Fatal("Must provide path to file when --file is specified")
+        }
+	return fsrc
+}
+
 // newFsDir creates an Fs from a name
 //
 // This must point to a directory


### PR DESCRIPTION
#### What is the purpose of this change?

cat accepts either a file or directory. However, in some cases it
is not desirable to cat a directory, and an error should be
return if the user provides a directory path. This commit adds
a --file flag to the cat command to accomplish that.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/4311

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
