### PR TITLE
s3: add Scaleway provider - fixes #4338

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -1675,6 +1675,7 @@ Scaleway provides an S3 interface which can be configured for use with rclone li
 ```
 [scaleway]
 type = s3
+provider = Scaleway
 env_auth = false
 endpoint = s3.nl-ams.scw.cloud
 access_key_id = SCWXXXXXXXXXXXXXX
@@ -1682,7 +1683,6 @@ secret_access_key = 1111111-2222-3333-44444-55555555555555
 region = nl-ams
 location_constraint =
 acl = private
-force_path_style = false
 server_side_encryption =
 storage_class =
 ```


### PR DESCRIPTION
#### What is the purpose of this change?
This PR adds Scaleway to the list of know S3 compatible providers, allowing quick selection of region/endpoint and enforcing required settings for ForcePathStyle and MaxUploadParts.

#### Was the change discussed in an issue or in the forum before?
Suggested in #4159 and formalized in #4338 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
