### PR TITLE
rc: Add mount to list only if mount point was successfully created

### DIFF
--- a/cmd/mountlib/rc.go
+++ b/cmd/mountlib/rc.go
@@ -93,16 +93,18 @@ func mountRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
 	if mountFns[mountType] != nil {
 		_, _, unmountFn, err := mountFns[mountType](fdst, mountPoint)
 
+		if err != nil {
+			log.Printf("mount FAILED: %v", err)
+			return nil, err
+		}
+		// Add mount to list if mount point was successfully created
 		liveMounts[mountPoint] = MountInfo{
 			unmountFn:  unmountFn,
 			MountedOn:  time.Now(),
 			Fs:         fdst.Name(),
 			MountPoint: mountPoint,
 		}
-		if err != nil {
-			log.Printf("mount FAILED: %v", err)
-			return nil, err
-		}
+
 		fs.Debugf(nil, "Mount for %s created at %s using %s", fdst.String(), mountPoint, mountType)
 		return nil, nil
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Currently, the mount is saved even if an error, occurs, which should not happen. This PR fixes that by returning the error and not saving the mount.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
