### PR TITLE
Error: errInvalidCharacters: 'and space .' -> 'and space.' Remove a space between the word, space, and period.

### DIFF
--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	errInvalidCharacters = errors.New("config name contains invalid characters - may only contain 0-9, A-Z ,a-z ,_ , - and space ")
+	errInvalidCharacters = errors.New("config name contains invalid characters - may only contain 0-9, A-Z ,a-z ,_ , - and space")
 	errCantBeEmpty       = errors.New("can't use empty string as a path")
 
 	// urlMatcher is a pattern to match an rclone URL


### PR DESCRIPTION
#### What is the purpose of this change?
```
q) Quit config
e/n/d/r/c/s/q> n
name> !)"=)¤
Can't use "!)\"=)¤" as config name contains invalid characters - may only contain 0-9, A-Z ,a-z ,_ , - and space .
```
Notice: `and space .`?
Change it to `and space.`.

There isn't anything using this error, what places something else than a dot at the end (if there was, you'd end up with 'and spacesomething other.').

#### Was the change discussed in an issue or in the forum before?
No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~I have added tests for all changes in this PR if appropriate.~
- [x] This _is_ the documentation.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] AKA Did you take 50% of the time of this commit for v4 of the commit message.
- [x] I'm done, this Pull Request is ready for review :-)
