### PR TITLE
config: reject remote names starting with a dash. (#4261)

### DIFF
--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -19,6 +19,7 @@ const (
 var (
 	errInvalidCharacters = errors.New("config name contains invalid characters - may only contain 0-9, A-Z ,a-z ,_ , - and space ")
 	errCantBeEmpty       = errors.New("can't use empty string as a path")
+	errCantStartWithDash = errors.New("config name starts with -")
 
 	// urlMatcher is a pattern to match an rclone URL
 	// note that this matches invalid remoteNames
@@ -35,6 +36,10 @@ var (
 func CheckConfigName(configName string) error {
 	if !configNameMatcher.MatchString(configName) {
 		return errInvalidCharacters
+	}
+	// Reject configName, if it starts with -, complicates usage. (#4261)
+	if strings.HasPrefix(configName, "-") {
+		return errCantStartWithDash
 	}
 	return nil
 }

--- a/fs/fspath/path_test.go
+++ b/fs/fspath/path_test.go
@@ -23,6 +23,9 @@ func TestCheckConfigName(t *testing.T) {
 		{"rem\\ote", errInvalidCharacters},
 		{"[remote", errInvalidCharacters},
 		{"*", errInvalidCharacters},
+		{"-remote", errCantStartWithDash},
+		{"r-emote-", nil},
+		{"_rem_ote_", nil},
 	} {
 		got := CheckConfigName(test.in)
 		assert.Equal(t, test.want, got, test.in)


### PR DESCRIPTION
I have briefly looked at go (and familiarized myself with it) before, this is the first actually useful piece of code I have written with go. In total, it took 3 hours for this tiny piece of code. A bit of remind go, a casual (hackathon mode: <5m) 30-40m in this tiny piece, more time than I'd like in getting the environment ready (mainly [cloning to the wrong location the wrong way](https://github.com/rclone/rclone/issues/4261#issuecomment-644315664)), 10m to install go (the recommended way is to get a tar and never update, what I don't agree to, returned to my package manager and also added it to my script of run-this-after-reinstall), ~45 in general adding to documentation.  :tada: 

#### What is the purpose of this change?

Disallow naming or renaming remotes beginning with a dash ( - ), as while operating normally, you can't have flags after the remote and must use `--` between the flags and the remote(s), what might confuse people, whose first-in-life remote (assuming little cli experience) usage might get confusing, frustrating; possibly leading to opting for an rclone alternative.

Already named remotes are unaffected. Hardcore i-want-to-name-my-remotes-starting-with-dashes-and-give-me-less-flexibility users can still (re)name the remotes by editing the config file manually.

#### Was the change discussed in an issue or in the forum before?

Closes #4261 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)