### PR TITLE
Fix custom timezone in rclone docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN ./rclone version
 # Begin final image
 FROM alpine:latest
 
-RUN apk --no-cache add ca-certificates fuse && \
+RUN apk --no-cache add ca-certificates fuse tzdata && \
   echo "user_allow_other" >> /etc/fuse.conf
 
 COPY --from=builder /go/src/github.com/rclone/rclone/rclone /usr/local/bin/


### PR DESCRIPTION
#### What is the purpose of this change?

Added the tzdata package to the dockerfile to fix custom timezone

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/rclone-in-docker-uses-tz-as-utc-not-as-provided/17173