### PR TITLE
s3: Use regional s3 us-east-1 endpoint

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -40,6 +40,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
@@ -1204,7 +1205,9 @@ func s3Connection(opt *Options) (*s3.S3, *session.Session, error) {
 		WithCredentials(cred).
 		WithHTTPClient(fshttp.NewClient(fs.Config)).
 		WithS3ForcePathStyle(opt.ForcePathStyle).
-		WithS3UseAccelerate(opt.UseAccelerateEndpoint)
+		WithS3UseAccelerate(opt.UseAccelerateEndpoint).
+		WithS3UsEast1RegionalEndpoint(endpoints.RegionalS3UsEast1Endpoint)
+
 	if opt.Region != "" {
 		awsConfig.WithRegion(opt.Region)
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

Use the regional s3 endpoint for us-east-1

#### Was the change discussed in an issue or in the forum before?

No. Came across this yesterday. When having an s3 endpoint set up with the following config:
```
[s3]
type = s3
provider = AWS
env_auth = true
region = us-east-1
acl = bucket-owner-full-control
```
Running `rclone -vv lsjson s3://{bucket_in_another_region}/whatever` gives the following:

```
ERROR : : error listing: AuthorizationHeaderMalformed: The authorization header is malformed; the region 'us-east-1' is wrong; expecting 'eu-west-1'
	status code: 400, request id: {ID}, host id: {ID}
```

This isn't caught by the [retry](https://github.com/rclone/rclone/blob/master/backend/s3/s3.go#L1089) because it's a 400, not a 301

The reason why it's a 400 is because rclone is going to `s3.amazonaws.com` rather than `s3.us-east-1.amazonaws.com`. 

When changing the rclone config to have another region, eg `us-west-1`, rclone correctly goes to `s3.us-west-1.amazonaws.com`, receives a 301, updates the bucket region and retries successfully.

After some digging I found `aws-sdk-go` have added this `WithS3UsEast1RegionalEndpoint` to specify which endpoint to use when using us-east-1, and it fixes the issue. Unsure if it'll cause any issues elsewhere though. I'd assume not because we rclone must have been using `s3.us-east-1.amazonaws.com` previously as the retry used to work.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
