### PR TITLE
gcs: add support for anonymous access

### DIFF
--- a/docs/content/googlecloudstorage.md
+++ b/docs/content/googlecloudstorage.md
@@ -194,6 +194,13 @@ the rclone config file, you can set `service_account_credentials` with
 the actual contents of the file instead, or set the equivalent
 environment variable.
 
+### Anonymous Access ###
+
+For downloads of objects that permit public access you can configure rclone
+to use anonymous access by setting `anonymous` to `true`.
+With unauthorized access you can't write or create files but only read or list
+those buckets and objects that have public read access.
+
 ### Application Default Credentials ###
 
 If no other source of credentials is provided, rclone will fall back


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Currently credentials are required to download a public bucket file
    which is not really necessary and makes automated usage more complex.
    Add a new option "anonymous" which when enabled configures the
    gcs backend to use an anonymous HTTP client. This of course only works
    for read access and trying to write will lead to errors like that:
    "googleapi: Error 401: Anonymous caller does not not have
    storage.objects.create access to the Google Cloud Storage object.",
    as expected. By default the anonymous access option is disabled so that
    the GCS Application Default Credentials are still used by default as
    before and an error is given if they can't be found.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
no

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

I didn't add tests - does this apply? I tested it manually but it could be tested with some hardcoded public bucket.