### PR TITLE
Workaround and Policy for Google Drive API

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -1197,3 +1197,10 @@ for rclone to be able to get its token-id (but as this only happens during
 the remote configuration, it's not such a big deal). 
 
 (Thanks to @balazer on github for these instructions.)
+
+Sometimes, creation of an OAuth consent in Google API Console fails due to an error message
+“The request failed because changes to one of the field of the resource is not supported”.
+As a convenient workaround, the necessary Google Drive API key can be created on the
+[Python Quickstart](https://developers.google.com/drive/api/v3/quickstart/python) page.
+Just push the Enable the Drive API button to receive the Client ID and Secret.
+Note that it will automatically create a new project in the API Console.

--- a/docs/content/privacy.md
+++ b/docs/content/privacy.md
@@ -53,9 +53,13 @@ Users are advised to use social media platforms wisely and communicate / engage 
 
 This website may use social sharing buttons which help share web content directly from web pages to the social media platform in question. Users are advised before using such social sharing buttons that they do so at their own discretion and note that the social media platform may track and save your request to share a web page respectively through your social media platform account.
 
-### Use of Google User Data ###
+## Use of Cloud API User Data ##
 
-Rclone allows accessing the user content stored in [Google Drive](/drive/), which is governed by the [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy). Rclone only provides the authenticated end user with access to the files available in their Google Drive associated by the OAuth token via the publicly exposed Google Drive API. Rclone allows storing the OAuth credentials on the user machine in the local configuration file. Rclone does not share any Google user data with third parties.
+Rclone is a command line program to manage files on cloud storage. Its sole purpose is to access and manipulate user content in the [supported](/overview/) cloud storage systems from a local machine of the end user. For accessing the user content via the cloud provider API, Rclone uses authentication mechanisms, such as OAuth or HTTP Cookies, depending on the particular cloud provider offerings. Use of these authentication mechanisms and user data is governed by the privacy policies mentioned in the [Resources & Further Information](/privacy/#resources-further-information) section and followed by the privacy policy of Rclone.
+
+* Rclone provides the end user with access to their files available in a storage system associated by the authentication credentials via the publicly exposed API of the storage system.
+* Rclone allows storing the authentication credentials on the user machine in the local configuration file.
+* Rclone does not share any user data with third parties.
 
 ## Resources & Further Information ##
 
@@ -65,4 +69,5 @@ Rclone allows accessing the user content stored in [Google Drive](/drive/), whic
   * [Twitter Privacy Policy](https://twitter.com/privacy)
   * [Facebook Privacy Policy](https://www.facebook.com/about/privacy/)
   * [Google Privacy Policy](https://www.google.com/privacy.html)
+  * [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy)
   * [Sample Website Privacy Policy](http://www.jamieking.co.uk/resources/free_sample_privacy_policy.html)

--- a/docs/content/privacy.md
+++ b/docs/content/privacy.md
@@ -53,6 +53,10 @@ Users are advised to use social media platforms wisely and communicate / engage 
 
 This website may use social sharing buttons which help share web content directly from web pages to the social media platform in question. Users are advised before using such social sharing buttons that they do so at their own discretion and note that the social media platform may track and save your request to share a web page respectively through your social media platform account.
 
+### Use of Google User Data ###
+
+Rclone allows accessing the user content stored in [Google Drive](/drive/), which is governed by the [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy). Rclone only provides the authenticated end user with access to the files available in their Google Drive associated by the OAuth token via the publicly exposed Google Drive API. Rclone allows storing the OAuth credentials on the user machine in the local configuration file. Rclone does not share any Google user data with third parties.
+
 ## Resources & Further Information ##
 
   * [Data Protection Act 1998](http://www.legislation.gov.uk/ukpga/1998/29/contents)


### PR DESCRIPTION
#### What is the purpose of this change?

When I was trying to create and verify a Google Drive API key as according to the present instruction, it did not work for me. I found a workaround that is based on [Python Quickstart](https://developers.google.com/drive/api/v3/quickstart/python) and added the corresponding bit of documentation.

Later, after submitting the app for review, I received a message from Google Cloud Trust & Safety Team that asked for the clear description of how Google user data are used, which is governed by the [Google API Services User Data Policy](https://developers.google.com/terms/api-services-user-data-policy). I added a section to the Privacy Policy and hope that it helps one in passing this screening.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
