### PR TITLE
docs: Updated sync and dedupe command docs #4429

### DIFF
--- a/cmd/dedupe/dedupe.go
+++ b/cmd/dedupe/dedupe.go
@@ -32,8 +32,8 @@ By default ` + "`dedupe`" + ` interactively finds files with duplicate
 names and offers to delete all but one or rename them to be
 different. This is known as deduping by name.
 
-Deduping by name is only useful with backends like Google Drive which
-can have duplicate file names. It can be run on wrapping backends
+Deduping by name is only useful with a small group of backends (e.g. Google Drive,
+Opendrive) that can have duplicate file names. It can be run on wrapping backends
 (e.g. crypt) if they wrap a backend which supports duplicate file
 names.
 

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -27,7 +27,8 @@ var commandDefinition = &cobra.Command{
 Sync the source to the destination, changing the destination
 only.  Doesn't transfer unchanged files, testing by size and
 modification time or MD5SUM.  Destination is updated to match
-source, including deleting files if necessary.
+source, including deleting files if necessary (except duplicate
+objects, see below).
 
 **Important**: Since this can cause data loss, test first with the
 ` + "`--dry-run` or the `--interactive`/`-i`" + ` flag.
@@ -35,7 +36,8 @@ source, including deleting files if necessary.
     rclone sync -i SOURCE remote:DESTINATION
 
 Note that files in the destination won't be deleted if there were any
-errors at any point.
+errors at any point.  Duplicate objects (files with the same name, on
+those providers that support it) are also not yet handled.
 
 It is always the contents of the directory that is synced, not the
 directory so when source:path is a directory, it's the contents of
@@ -46,6 +48,9 @@ If dest:path doesn't exist, it is created and the source:path contents
 go there.
 
 **Note**: Use the ` + "`-P`" + `/` + "`--progress`" + ` flag to view real-time transfer statistics
+
+**Note**: Use the ` + "`rclone dedupe`" + ` command to deal with "Duplicate object/directory found in source/destination - ignoring" errors.
+See [this forum post](https://forum.rclone.org/t/sync-not-clearing-duplicates/14372) for more info.
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(2, 2, command, args)


### PR DESCRIPTION
Update the docs regarding sync and dedupe commands with info regarding handling duplicate objects.  See ticket #4429.