### PR TITLE
docs: Updated mount command to reflect that it requires Go 1.13 or newer

### DIFF
--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -192,6 +192,9 @@ Stopping the mount manually:
     # OS X
     umount /path/to/local/mount
 
+**Note**: As of ` + "`rclone` 1.52.2, `rclone mount`" + ` now requires Go version 1.13
+or newer on some platforms depending on the underlying FUSE library in use.
+
 ### Installing on Windows
 
 To run rclone ` + commandName + ` on Windows, you will need to


### PR DESCRIPTION
After being confused as to why the mount command disappeared from my rclone after updating, I discovered it was due to https://github.com/rclone/rclone/commit/17b4058ee944ab660b30593a858ff9d591b62a3b, so decided to add a note to the docs about it.