### PR TITLE
core/command: Allow rc to execute rclone terminal commands.

### DIFF
--- a/fs/rc/internal.go
+++ b/fs/rc/internal.go
@@ -5,6 +5,7 @@ package rc
 import (
 	"context"
 	"os"
+	"os/exec"
 	"runtime"
 	"time"
 
@@ -334,4 +335,111 @@ func rcSetBlockProfileRate(ctx context.Context, in Params) (out Params, err erro
 	}
 	runtime.SetBlockProfileRate(int(rate))
 	return nil, nil
+}
+
+func init() {
+	Add(Call{
+		Path:         "core/command",
+		AuthRequired: true,
+		Fn:           rcRunCommand,
+		Title:        "Run a rclone terminal command over rc.",
+		Help: `This takes the following parameters
+
+- command - a string with the command name
+- arg - a list of arguments for the backend command
+- opt - a map of string to string of options
+
+Returns
+
+- result - result from the backend command
+- error	 - set if rclone exits with an error code
+
+For example
+
+    rclone rc core/command command=ls -a mydrive:/ -o max-depth=1
+	rclone rc core/command -a ls -a mydrive:/ -o max-depth=1
+
+Returns
+
+` + "```" + `
+{
+	"error": false,
+	"result": "<Raw command line output>"
+}
+
+OR 
+{
+	"error": true,
+	"result": "<Raw command line output>"
+}
+
+
+`,
+	})
+}
+
+// rcRunCommand runs an rclone command with the given args and flags
+func rcRunCommand(ctx context.Context, in Params) (out Params, err error) {
+
+	command, err := in.GetString("command")
+	if err != nil {
+		command = ""
+	}
+
+	var opt = map[string]string{}
+	err = in.GetStructMissingOK("opt", &opt)
+	if err != nil {
+		return nil, err
+	}
+
+	var arg = []string{}
+	err = in.GetStructMissingOK("arg", &arg)
+	if err != nil {
+		return nil, err
+	}
+
+	var allArgs = []string{}
+	if command != "" {
+		// Add the command eg: ls to the args
+		allArgs = append(allArgs, command)
+	}
+	// Add all from arg
+	for _, cur := range arg {
+		allArgs = append(allArgs, cur)
+	}
+
+	// Add flags to args for eg --max-depth 1 comes in as { max-depth 1 }.
+	// Convert it to [ max-depth, 1 ] and append to args list
+	for key, value := range opt {
+		if len(key) == 1 {
+			allArgs = append(allArgs, "-"+key)
+		} else {
+			allArgs = append(allArgs, "--"+key)
+		}
+		allArgs = append(allArgs, value)
+	}
+
+	// Get the path for the current executable which was used to run rclone.
+	ex, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	cmd := exec.CommandContext(ctx, ex, allArgs...)
+
+	// Run the command and get the output for error and stdout combined.
+	output, err := cmd.CombinedOutput()
+
+	if err != nil {
+		fs.Errorf(nil, "Command error %v", err)
+		return Params{
+			"result": string(output),
+			"error":  true,
+		}, nil
+	}
+
+	return Params{
+		"result": string(output),
+		"error":  false,
+	}, nil
 }

--- a/fs/rc/internal_test.go
+++ b/fs/rc/internal_test.go
@@ -5,8 +5,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/rclone/rclone/fstest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -125,17 +123,11 @@ func TestCoreQuit(t *testing.T) {
 // core/command: Runs a raw rclone command
 func TestCoreCommand(t *testing.T) {
 	call := Calls.Get("core/command")
-	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	in := Params{
-		"command": "ls",
-		"opt": map[string]string{
-			"max-depth": "1",
-		},
-		"arg": []string{
-			r.FremoteName,
-		},
+		"command": "version",
+		"opt":     map[string]string{},
+		"arg":     []string{},
 	}
 	got, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)

--- a/fs/rc/internal_test.go
+++ b/fs/rc/internal_test.go
@@ -3,6 +3,8 @@ package rc
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"runtime"
 	"testing"
@@ -135,10 +137,13 @@ func TestCoreQuit(t *testing.T) {
 func TestCoreCommand(t *testing.T) {
 	call := Calls.Get("core/command")
 
+	var httpResponse http.ResponseWriter = httptest.NewRecorder()
+
 	in := Params{
-		"command": "version",
-		"opt":     map[string]string{},
-		"arg":     []string{},
+		"command":   "version",
+		"opt":       map[string]string{},
+		"arg":       []string{},
+		"_response": &httpResponse,
 	}
 	got, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)

--- a/fs/rc/internal_test.go
+++ b/fs/rc/internal_test.go
@@ -2,6 +2,8 @@ package rc
 
 import (
 	"context"
+	"fmt"
+	"os"
 	"runtime"
 	"testing"
 
@@ -12,6 +14,15 @@ import (
 	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/rclone/rclone/fs/version"
 )
+
+func TestMain(m *testing.M) {
+	// Pretend to be rclone version if we have a version string parameter
+	if os.Args[len(os.Args)-1] == "version" {
+		fmt.Printf("rclone %s\n", fs.Version)
+		os.Exit(0)
+	}
+	os.Exit(m.Run())
+}
 
 func TestInternalNoop(t *testing.T) {
 	call := Calls.Get("rc/noop")
@@ -132,8 +143,6 @@ func TestCoreCommand(t *testing.T) {
 	got, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 
-	errorBool, err := got.GetBool("error")
-	require.NoError(t, err)
-
-	require.Equal(t, errorBool, false)
+	assert.Equal(t, fmt.Sprintf("rclone %s\n", fs.Version), got["result"])
+	assert.Equal(t, false, got["error"])
 }

--- a/fs/rc/internal_test.go
+++ b/fs/rc/internal_test.go
@@ -5,6 +5,8 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/rclone/rclone/fstest"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -118,4 +120,28 @@ func TestCoreQuit(t *testing.T) {
 	}
 	_, err := call.Fn(context.Background(), in)
 	require.Error(t, err)
+}
+
+// core/command: Runs a raw rclone command
+func TestCoreCommand(t *testing.T) {
+	call := Calls.Get("core/command")
+	r := fstest.NewRun(t)
+	defer r.Finalise()
+
+	in := Params{
+		"command": "ls",
+		"opt": map[string]string{
+			"max-depth": "1",
+		},
+		"arg": []string{
+			r.FremoteName,
+		},
+	}
+	got, err := call.Fn(context.Background(), in)
+	require.NoError(t, err)
+
+	errorBool, err := got.GetBool("error")
+	require.NoError(t, err)
+
+	require.Equal(t, errorBool, false)
 }

--- a/fs/rc/params.go
+++ b/fs/rc/params.go
@@ -120,7 +120,7 @@ func (p Params) GetHTTPResponseWriter() (*http.ResponseWriter, error) {
 	}
 	request, ok := value.(*http.ResponseWriter)
 	if !ok {
-		return nil, ErrParamInvalid{errors.Errorf("expecting http.ResponseWriter value for key %q (was %T)", key, value)}
+		return nil, ErrParamInvalid{errors.Errorf("expecting *http.ResponseWriter value for key %q (was %T)", key, value)}
 	}
 	return request, nil
 }

--- a/fs/rc/params.go
+++ b/fs/rc/params.go
@@ -91,7 +91,7 @@ func (p Params) Get(key string) (interface{}, error) {
 	return value, nil
 }
 
-// GetHTTPRequest gets a http.Request parameter associated with the request with the key "HttpRequest"
+// GetHTTPRequest gets a http.Request parameter associated with the request with the key "_request"
 //
 // If the parameter isn't found then error will be of type
 // ErrParamNotFound and the returned value will be nil.
@@ -104,6 +104,23 @@ func (p Params) GetHTTPRequest() (*http.Request, error) {
 	request, ok := value.(*http.Request)
 	if !ok {
 		return nil, ErrParamInvalid{errors.Errorf("expecting http.request value for key %q (was %T)", key, value)}
+	}
+	return request, nil
+}
+
+// GetHTTPResponseWriter gets a http.ResponseWriter parameter associated with the request with the key "_response"
+//
+// If the parameter isn't found then error will be of type
+// ErrParamNotFound and the returned value will be nil.
+func (p Params) GetHTTPResponseWriter() (*http.ResponseWriter, error) {
+	key := "_response"
+	value, err := p.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	request, ok := value.(*http.ResponseWriter)
+	if !ok {
+		return nil, ErrParamInvalid{errors.Errorf("expecting http.ResponseWriter value for key %q (was %T)", key, value)}
 	}
 	return request, nil
 }

--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -265,6 +265,10 @@ func (s *Server) handlePost(w http.ResponseWriter, r *http.Request, path string)
 		in["_request"] = r
 	}
 
+	if call.NeedsResponse {
+		in["_response"] = &w
+	}
+
 	// Check to see if it is async or not
 	isAsync, err := in.GetBool("_async")
 	if rc.NotErrParamNotFound(err) {

--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -266,7 +266,7 @@ func (s *Server) handlePost(w http.ResponseWriter, r *http.Request, path string)
 	}
 
 	if call.NeedsResponse {
-		in["_response"] = &w
+		in["_response"] = w
 	}
 
 	// Check to see if it is async or not

--- a/fs/rc/registry.go
+++ b/fs/rc/registry.go
@@ -17,12 +17,13 @@ type Func func(ctx context.Context, in Params) (out Params, err error)
 // Call defines info about a remote control function and is used in
 // the Add function to create new entry points.
 type Call struct {
-	Path         string // path to activate this RC
-	Fn           Func   `json:"-"` // function to call
-	Title        string // help for the function
-	AuthRequired bool   // if set then this call requires authorisation to be set
-	Help         string // multi-line markdown formatted help
-	NeedsRequest bool   // if set then this call will be passed the original request object as _request
+	Path          string // path to activate this RC
+	Fn            Func   `json:"-"` // function to call
+	Title         string // help for the function
+	AuthRequired  bool   // if set then this call requires authorisation to be set
+	Help          string // multi-line markdown formatted help
+	NeedsRequest  bool   // if set then this call will be passed the original request object as _request
+	NeedsResponse bool   // if set then this call will be passed the original response object as _response
 }
 
 // Registry holds the list of all the registered remote control functions


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
This will allow rclone to run the commands which are not available directly through rc, over rc.

This api will spawn a temporary instance of rclone to execute the command. Then it will return the raw command output.
This will also help in the development of a web-based rclone terminal. (
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
