### PR TITLE
Add examples for Azure Blob Access Tier to documentation

### DIFF
--- a/docs/content/azureblob.md
+++ b/docs/content/azureblob.md
@@ -280,6 +280,10 @@ tiering blob to "Hot" or "Cool".
 - Env Var:     RCLONE_AZUREBLOB_ACCESS_TIER
 - Type:        string
 - Default:     ""
+- Examples:
+     - "Hot"
+     - "Cool"
+     - "Archive"
 
 #### --azureblob-disable-checksum
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Improve documentation. Azure Blob access tier values are case-sensitive, though this is not indicated anywhere in the documentation. Adding examples with proper casing.

#### Was the change discussed in an issue or in the forum before?

Not that I can see.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
