### PR TITLE
cmd/obscure: Allow obscure command to accept password on STDIN

### DIFF
--- a/cmd/obscure/obscure.go
+++ b/cmd/obscure/obscure.go
@@ -3,6 +3,9 @@ package obscure
 import (
 	"fmt"
 
+	"io/ioutil"
+	"os"
+
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/spf13/cobra"
@@ -26,13 +29,29 @@ Many equally important things (like access tokens) are not obscured in
 the config file. However it is very hard to shoulder surf a 64
 character hex token.
 
+This command can also accept a password through STDIN instead of an
+argument by passing a hyphen as an argument. Example:
+
+echo "secretpassword" | rclone obscure -
+
+If there is no data on STDIN to read, rclone obscure will default to
+obfuscating the hyphen itself.
+
 If you want to encrypt the config file then please use config file
 encryption - see [rclone config](/commands/rclone_config/) for more
 info.`,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(1, 1, command, args)
+		var password string
+		fi, _ := os.Stdin.Stat()
+		if args[0] == "-" && (fi.Mode()&os.ModeCharDevice) == 0 {
+			bytes, _ := ioutil.ReadAll(os.Stdin)
+			password = string(bytes)
+		} else {
+			password = args[0]
+		}
 		cmd.Run(false, false, command, func() error {
-			obscured := obscure.MustObscure(args[0])
+			obscured := obscure.MustObscure(password)
 			fmt.Println(obscured)
 			return nil
 		})


### PR DESCRIPTION
#### What is the purpose of this change?

`rclone obscure` currently only accepts a command line argument of `password` to generate
an obfuscated password. This is an issue since generating obfuscated passwords programatically
requires sending the plain text password as a shell argument, which can cause problems if the
password contains shell characters, or if the password is from an untrusted source.

This patch opens up STDIN which will allow developers to open the STDIN source and print a password
directly to `rclone obscure`, which can increase safety and convenince.


#### Was the change discussed in an issue or in the forum before?

Unknown. A cursory glance did not turn up any forums posts.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
