### PR TITLE
Fix uploadfile only works for root of the fs

### DIFF
--- a/fs/operations/rc.go
+++ b/fs/operations/rc.go
@@ -6,6 +6,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -253,7 +254,7 @@ func rcSingleCommand(ctx context.Context, in rc.Params, name string, noRemote bo
 					return nil, err
 				}
 				if p.FileName() != "" {
-					obj, err := Rcat(ctx, f, p.FileName(), p, time.Now())
+					obj, err := Rcat(ctx, f, filepath.Join(remote, p.FileName()), p, time.Now())
 					if err != nil {
 						return nil, err
 					}

--- a/fs/operations/rc.go
+++ b/fs/operations/rc.go
@@ -6,7 +6,7 @@ import (
 	"mime"
 	"mime/multipart"
 	"net/http"
-	"path/filepath"
+	"path"
 	"strings"
 	"time"
 
@@ -254,7 +254,7 @@ func rcSingleCommand(ctx context.Context, in rc.Params, name string, noRemote bo
 					return nil, err
 				}
 				if p.FileName() != "" {
-					obj, err := Rcat(ctx, f, filepath.Join(remote, p.FileName()), p, time.Now())
+					obj, err := Rcat(ctx, f, path.Join(remote, p.FileName()), p, time.Now())
 					if err != nil {
 						return nil, err
 					}

--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -450,11 +451,13 @@ func TestUploadFile(t *testing.T) {
 	testFileName := "test.txt"
 	testFileContent := "Hello World"
 	r.WriteFile(testFileName, testFileContent, t1)
+	testItem1 := fstest.NewItem(testFileName, testFileContent, t1)
+	testItem2 := fstest.NewItem(filepath.Join("subdir", testFileName), testFileContent, t1)
 
 	currentFile, err := os.Open(path.Join(r.LocalName, testFileName))
 	require.NoError(t, err)
 
-	formReader, contentType, _, err := rest.MultipartUpload(currentFile, url.Values{}, "content", testFileName)
+	formReader, contentType, _, err := rest.MultipartUpload(currentFile, url.Values{}, "file", testFileName)
 	require.NoError(t, err)
 
 	httpReq := httptest.NewRequest("POST", "/", formReader)
@@ -469,7 +472,30 @@ func TestUploadFile(t *testing.T) {
 	_, err = call.Fn(context.Background(), in)
 	require.NoError(t, err)
 
-	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{fstest.NewItem(testFileName, testFileContent, t1)}, nil, fs.ModTimeNotSupported)
+	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{testItem1}, nil, fs.ModTimeNotSupported)
+
+	assert.NoError(t, r.Fremote.Mkdir(context.Background(), "subdir"))
+
+	currentFile, err = os.Open(path.Join(r.LocalName, testFileName))
+	require.NoError(t, err)
+
+	formReader, contentType, _, err = rest.MultipartUpload(currentFile, url.Values{}, "file", testFileName)
+	require.NoError(t, err)
+
+	httpReq = httptest.NewRequest("POST", "/", formReader)
+	httpReq.Header.Add("Content-Type", contentType)
+
+	in = rc.Params{
+		"_request": httpReq,
+		"fs":       r.FremoteName,
+		"remote":   "subdir",
+	}
+
+	_, err = call.Fn(context.Background(), in)
+	require.NoError(t, err)
+
+	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{testItem1, testItem2}, nil, fs.ModTimeNotSupported)
+
 }
 
 // operations/command: Runs a backend command

--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -7,7 +7,6 @@ import (
 	"net/url"
 	"os"
 	"path"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -452,7 +451,7 @@ func TestUploadFile(t *testing.T) {
 	testFileContent := "Hello World"
 	r.WriteFile(testFileName, testFileContent, t1)
 	testItem1 := fstest.NewItem(testFileName, testFileContent, t1)
-	testItem2 := fstest.NewItem(filepath.Join("subdir", testFileName), testFileContent, t1)
+	testItem2 := fstest.NewItem(path.Join("subdir", testFileName), testFileContent, t1)
 
 	currentFile, err := os.Open(path.Join(r.LocalName, testFileName))
 	require.NoError(t, err)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
This bug ignored the remote parameter while uploading a file, thus the file will appear only in the root of the fs. This PR fixes that and adds test for it
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
No

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
