### PR TITLE
Remove --drive-alternate-export in favor of exportLinks

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -813,24 +813,6 @@ Impersonate this user when using a service account.
 - Type:        string
 - Default:     ""
 
-#### --drive-alternate-export
-
-Use alternate export URLs for google documents export.,
-
-If this option is set this instructs rclone to use an alternate set of
-export URLs for drive documents.  Users have reported that the
-official export URLs can't export large documents, whereas these
-unofficial ones can.
-
-See rclone issue [#2243](https://github.com/rclone/rclone/issues/2243) for background,
-[this google drive issue](https://issuetracker.google.com/issues/36761333) and
-[this helpful post](https://www.labnol.org/internet/direct-links-for-google-drive/28356/).
-
-- Config:      alternate_export
-- Env Var:     RCLONE_DRIVE_ALTERNATE_EXPORT
-- Type:        bool
-- Default:     false
-
 #### --drive-upload-cutoff
 
 Cutoff for switching to chunked upload


### PR DESCRIPTION
#### What is the purpose of this change?

`--drive-alternate-export` is not necessary anymore, `exportLinks` file field provides links which can handle export of big files.

#### Was the change discussed in an issue or in the forum before?

No
#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
