### PR TITLE
dropbox: add support for viewing shared files and folders

### DIFF
--- a/docs/content/dropbox.md
+++ b/docs/content/dropbox.md
@@ -202,6 +202,39 @@ Impersonate this user when using a business account.
 - Type:        string
 - Default:     ""
 
+#### --dropbox-shared-files
+
+Instructs rclone to work on individual shared files.
+
+In this mode rclone's features are extremely limited - only list (ls, lsl, etc.) 
+operations and read operations (e.g. downloading) are supported in this mode.
+All other operations will be disabled.
+
+- Config:      shared_files
+- Env Var:     RCLONE_DROPBOX_SHARED_FILES
+- Type:        bool
+- Default:     false
+
+#### --dropbox-shared-folders
+
+Instructs rclone to work on shared folders.
+			
+When this flag is used with no path only the List operation is supported and 
+all available shared folders will be listed. If you specify a path the first part 
+will be interpreted as the name of shared folder. Rclone will then try to mount this 
+shared to the root namespace. On success shared folder rclone proceeds normally. 
+The shared folder is now pretty much a normal folder and all normal operations 
+are supported. 
+
+Note that we don't unmount the shared folder afterwards so the 
+--dropbox-shared-folders can be omitted after the first use of a particular 
+shared folder.
+
+- Config:      shared_folders
+- Env Var:     RCLONE_DROPBOX_SHARED_FOLDERS
+- Type:        bool
+- Default:     false
+
 #### --dropbox-encoding
 
 This sets the encoding for the backend.


### PR DESCRIPTION
Whoops that turned out to be bigger a change than I had remembered. It also works somewhat differently than `--drive-shared-with-me`. This actually adds 2 flags:
* ``--dropbox-shared-files``: instructs rclone to act on individual shared files (those that show up directly under shared). In this mode rclone's features are extremely limited - only listing shared files and downloading them is supported every other operation will be disabled.
* ``--dropbox-shared-folders``: instructs rclone to operate on shared folders. When this flag is used with an empty root only the List operation is supported and all shared folders will be listed. If you use ``--dropbox-shared-folders`` with a non empty root the first part of the path will be interpreted as the name of shared folder. rclone will then try to mount this shared to the root namespace. If this succeeds shared folder mode will be disabled and rclone proceeds normally. The shared folder is now pretty much a normal folder and all normal operations are supported. Note that we don't unmount the shared folder afterwards so the ``--dropbox-shared-folders`` can be omitted after the first use of a particular shared folder.

Some Extra notes: In order to work with the shared folder we have to mount it the api doesn't really allow working with shared folders without mounting them. I haven't implemented a way for unmounting folders as of right now because I couldn't think of good of doing it. I fully expect something to break If you have name collisions working around this wouldn't be easy.

 There are probably some edge cases I haven't thought of so testing is appreciated.