### PR TITLE
jottacloud: rename unused variable to _ in jottacloud.go

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -353,7 +353,7 @@ func doAuthV1(ctx context.Context, srv *rest.Client, username, password string) 
 				authCode = strings.Replace(authCode, "-", "", -1) // remove any "-" contained in the code so we have a 6 digit number
 				opts.ExtraHeaders = make(map[string]string)
 				opts.ExtraHeaders["X-Jottacloud-Otp"] = authCode
-				resp, err = srv.CallJSON(ctx, &opts, nil, &jsonToken)
+				_, err = srv.CallJSON(ctx, &opts, nil, &jsonToken)
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Another fix from the [lgtm static analysis](https://lgtm.com/projects/g/rclone/rclone/) (It's a minor style fix really). Just rename an unused response to `_` to ensure that the you don't actually want to use it.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
Briefly in #4539 as its one other static fixes mentioned
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [] I have added tests for all changes in this PR if appropriate.
- [] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)

This is the last fix from the lgtm static analysis that is an easy fix. 

Most of the remaining ones are either style recommendations in JS/Python or security fixes that complain because you can access the file system through user provided get values in potentially unsafe ways. The latter obviously needs a redesign to fix properly or adding // noqa comments to stop the static analysis from caring.