### PR TITLE
Fix test failure in different local time zones

### DIFF
--- a/fs/parseduration.go
+++ b/fs/parseduration.go
@@ -88,8 +88,9 @@ func parseDurationDates(age string, epoch time.Time) (t time.Duration, err error
 	return t, err
 }
 
-// ParseDuration parses a duration string. Accept ms|s|m|h|d|w|M|y suffixes. Defaults to second if not provided
-func ParseDuration(age string) (d time.Duration, err error) {
+// parseDurationFromNow parses a duration string. Allows ParseDuration to match the time
+// package and easier testing within the fs package.
+func parseDurationFromNow(age string, getNow func() time.Time) (d time.Duration, err error) {
 	if age == "off" {
 		return time.Duration(DurationOff), nil
 	}
@@ -105,12 +106,17 @@ func ParseDuration(age string) (d time.Duration, err error) {
 		return d, nil
 	}
 
-	d, err = parseDurationDates(age, time.Now())
+	d, err = parseDurationDates(age, getNow())
 	if err == nil {
 		return d, nil
 	}
 
 	return d, err
+}
+
+// ParseDuration parses a duration string. Accept ms|s|m|h|d|w|M|y suffixes. Defaults to second if not provided
+func ParseDuration(age string) (time.Duration, error) {
+	return parseDurationFromNow(age, time.Now)
 }
 
 // ReadableString parses d into a human readable duration.

--- a/fs/parseduration_test.go
+++ b/fs/parseduration_test.go
@@ -15,6 +15,11 @@ import (
 var _ pflag.Value = (*Duration)(nil)
 
 func TestParseDuration(t *testing.T) {
+	now := time.Date(2020, 9, 5, 8, 15, 5, 250, time.UTC)
+	getNow := func() time.Time {
+		return now
+	}
+
 	for _, test := range []struct {
 		in   string
 		want time.Duration
@@ -37,12 +42,12 @@ func TestParseDuration(t *testing.T) {
 		{"1x", 0, true},
 		{"off", time.Duration(DurationOff), false},
 		{"1h2m3s", time.Hour + 2*time.Minute + 3*time.Second, false},
-		{"2001-02-03", time.Since(time.Date(2001, 2, 3, 0, 0, 0, 0, time.UTC)), false},
-		{"2001-02-03 10:11:12", time.Since(time.Date(2001, 2, 3, 10, 11, 12, 0, time.UTC)), false},
-		{"2001-02-03T10:11:12", time.Since(time.Date(2001, 2, 3, 10, 11, 12, 0, time.UTC)), false},
-		{"2001-02-03T10:11:12.123Z", time.Since(time.Date(2001, 2, 3, 10, 11, 12, 123, time.UTC)), false},
+		{"2001-02-03", now.Sub(time.Date(2001, 2, 3, 0, 0, 0, 0, time.UTC)), false},
+		{"2001-02-03 10:11:12", now.Sub(time.Date(2001, 2, 3, 10, 11, 12, 0, time.UTC)), false},
+		{"2001-02-03T10:11:12", now.Sub(time.Date(2001, 2, 3, 10, 11, 12, 0, time.UTC)), false},
+		{"2001-02-03T10:11:12.123Z", now.Sub(time.Date(2001, 2, 3, 10, 11, 12, 123, time.UTC)), false},
 	} {
-		duration, err := ParseDuration(test.in)
+		duration, err := parseDurationFromNow(test.in, getNow)
 		if test.err {
 			require.Error(t, err)
 		} else {
@@ -58,6 +63,11 @@ func TestParseDuration(t *testing.T) {
 }
 
 func TestDurationString(t *testing.T) {
+	now := time.Date(2020, 9, 5, 8, 15, 5, 250, time.UTC)
+	getNow := func() time.Time {
+		return now
+	}
+
 	for _, test := range []struct {
 		in   time.Duration
 		want string
@@ -88,7 +98,7 @@ func TestDurationString(t *testing.T) {
 		got := Duration(test.in).String()
 		assert.Equal(t, test.want, got)
 		// Test the reverse
-		reverse, err := ParseDuration(test.want)
+		reverse, err := parseDurationFromNow(test.want, getNow)
 		assert.NoError(t, err)
 		assert.Equal(t, test.in, reverse)
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
To fix a broken unit test.

TestParseDuration relied on an elapsed time calculation which
would vary based on the system local time. Fix the test by not relying
on the system time location. Also make the test more deterministic
by injecting time in tests rather than using system time.



#### Was the change discussed in an issue or in the forum before?

#4529

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
