### PR TITLE
vfs: Fix a cache deadlock and some concurrency control issues

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -400,6 +400,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.1.1 h1:2vfRuCMp5sSVIDSqO8oNnWJq7mPa6KVP3iPIwFBuy8A=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.1/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=

--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -466,9 +466,15 @@ func (c *Cache) retryFailedResets() {
 	if len(c.errItems) != 0 {
 		fs.Debugf(nil, "vfs cache reset: before redoing reset errItems = %v", c.errItems)
 		for itemName := range c.errItems {
-			_, _, err := c.item[itemName].Reset()
-			if err == nil || !fserrors.IsErrNoSpace(err) {
-				// TODO: not trying to handle non-ENOSPC errors yet
+			if retryItem, ok := c.item[itemName]; ok {
+				_, _, err := retryItem.Reset()
+				if err == nil || !fserrors.IsErrNoSpace(err) {
+					// TODO: not trying to handle non-ENOSPC errors yet
+					delete(c.errItems, itemName)
+				}
+			} else {
+				// The retry item was deleted because it was closed.
+				// No need to redo the failed reset now.
 				delete(c.errItems, itemName)
 			}
 		}

--- a/vfs/vfscache/downloaders/downloaders.go
+++ b/vfs/vfscache/downloaders/downloaders.go
@@ -230,7 +230,11 @@ func (dls *Downloaders) Close(inErr error) (err error) {
 		}
 	}
 	dls.cancel()
+	// dls may have entered the periodical (every 5 seconds) kickWaiters() call
+	// unlock the mutex to allow it to finish so that we can get its dls.wg.Done()
+	dls.mu.Unlock()
 	dls.wg.Wait()
+	dls.mu.Lock()
 	dls.dls = nil
 	dls._dispatchWaiters()
 	dls._closeWaiters(inErr)


### PR DESCRIPTION
This patch includes three fixes.
(1) fix a deadlock vulnerability in downloaders.Close,
(2) fix retryFailedResets for the case when the item is closed before a reset retry,
and (3) wrap Truncate, WriteAt, Sync, Dirty, rename, and Close operations with
preAccess/postAccess to provide the mutual exclusion needed relative to Reset.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
