### PR TITLE
Fix cache reset.1.53.1

### DIFF
--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -466,9 +466,15 @@ func (c *Cache) retryFailedResets() {
 	if len(c.errItems) != 0 {
 		fs.Debugf(nil, "vfs cache reset: before redoing reset errItems = %v", c.errItems)
 		for itemName := range c.errItems {
-			_, _, err := c.item[itemName].Reset()
-			if err == nil || !fserrors.IsErrNoSpace(err) {
-				// TODO: not trying to handle non-ENOSPC errors yet
+			if retryItem, ok := c.item[itemName]; ok {
+				_, _, err := retryItem.Reset()
+				if err == nil || !fserrors.IsErrNoSpace(err) {
+					// TODO: not trying to handle non-ENOSPC errors yet
+					delete(c.errItems, itemName)
+				}
+			} else {
+				// The retry item was deleted because it was closed.
+				// No need to redo the failed reset now.
 				delete(c.errItems, itemName)
 			}
 		}

--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -609,7 +609,6 @@ func (c *Cache) clean(removeCleanFiles bool) {
 	if os.IsNotExist(err) {
 		return
 	}
-
 	c.mu.Lock()
 	oldItems, oldUsed := len(c.item), fs.SizeSuffix(c.used)
 	c.mu.Unlock()

--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -609,6 +609,7 @@ func (c *Cache) clean(removeCleanFiles bool) {
 	if os.IsNotExist(err) {
 		return
 	}
+	c.updateUsed()
 	c.mu.Lock()
 	oldItems, oldUsed := len(c.item), fs.SizeSuffix(c.used)
 	c.mu.Unlock()

--- a/vfs/vfscache/downloaders/downloaders.go
+++ b/vfs/vfscache/downloaders/downloaders.go
@@ -230,7 +230,11 @@ func (dls *Downloaders) Close(inErr error) (err error) {
 		}
 	}
 	dls.cancel()
+	// dls may have entered the periodical (every 5 seconds) kickWaiters() call
+	// unlock the mutex to allow it to finish so that we can get its dls.wg.Done()
+	dls.mu.Unlock()
 	dls.wg.Wait()
+	dls.mu.Lock()
 	dls.dls = nil
 	dls._dispatchWaiters()
 	dls._closeWaiters(inErr)

--- a/vfs/vfscache/item.go
+++ b/vfs/vfscache/item.go
@@ -43,6 +43,13 @@ import (
 // be taken before Item.mu. writeback may call into Item but Item may
 // **not** call writeback methods with Item.mu held
 
+// LL Item reset is invoked by cache cleaner for synchronous recovery
+// from ENOSPC errors. The reset operation removes the cache file and
+// closes/reopens the downloaders.  Although most parts of reset and
+// other item operations are done with the item mutex held, the mutex
+// is released during fd.WriteAt and downloaders calls. We use preAccess
+// and postAccess calls to serialize reset and other item operations.
+
 // Item is stored in the item map
 //
 // The Info field is written to the backing store to store status
@@ -295,6 +302,8 @@ func (item *Item) _truncateToCurrentSize() (err error) {
 // extended and the extended data will be filled with zeros. The
 // object will be marked as dirty in this case also.
 func (item *Item) Truncate(size int64) (err error) {
+	item.preAccess()
+	defer item.postAccess()
 	item.mu.Lock()
 	defer item.mu.Unlock()
 
@@ -414,6 +423,8 @@ func (item *Item) _dirty() {
 
 // Dirty marks the item as changed and needing writeback
 func (item *Item) Dirty() {
+	item.preAccess()
+	defer item.postAccess()
 	item.mu.Lock()
 	item._dirty()
 	item.mu.Unlock()
@@ -597,6 +608,8 @@ func (item *Item) store(ctx context.Context, storeFn StoreFn) (err error) {
 // Close the cache file
 func (item *Item) Close(storeFn StoreFn) (err error) {
 	// defer log.Trace(item.o, "Item.Close")("err=%v", &err)
+	item.preAccess()
+	defer item.postAccess()
 	var (
 		downloaders   *downloaders.Downloaders
 		syncWriteBack = item.c.opt.WriteBack <= 0
@@ -1198,6 +1211,8 @@ func (item *Item) readAt(b []byte, off int64) (n int, err error) {
 
 // WriteAt bytes to the file at off
 func (item *Item) WriteAt(b []byte, off int64) (n int, err error) {
+	item.preAccess()
+	defer item.postAccess()
 	item.mu.Lock()
 	if item.fd == nil {
 		item.mu.Unlock()
@@ -1288,6 +1303,8 @@ func (item *Item) WriteAtNoOverwrite(b []byte, off int64) (n int, skipped int, e
 // this means flushing the file system's in-memory copy of recently written
 // data to disk.
 func (item *Item) Sync() (err error) {
+	item.preAccess()
+	defer item.postAccess()
 	item.mu.Lock()
 	defer item.mu.Unlock()
 	if item.fd == nil {
@@ -1307,6 +1324,8 @@ func (item *Item) Sync() (err error) {
 
 // rename the item
 func (item *Item) rename(name string, newName string, newObj fs.Object) (err error) {
+	item.preAccess()
+	defer item.postAccess()
 	item.mu.Lock()
 
 	// stop downloader
@@ -1336,6 +1355,5 @@ func (item *Item) rename(name string, newName string, newObj fs.Object) (err err
 		_ = downloaders.Close(nil)
 	}
 	item.c.writeback.Rename(id, newName)
-
 	return err
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
This pull request contains three commits.
(1) fix a deadlock vulnerability in downloaders.Close,
(2) fix retryFailedResets for the case when the item is closed before a reset retry,
and (3) wrap Truncate, WriteAt, Sync, Dirty, rename, and Close operations with
preAccess/postAccess to provide the mutual exclusion needed relative to Reset.
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
