### PR TITLE
mailru: fix invalid timestamp on corrupted files (fixes #4229)

### DIFF
--- a/backend/mailru/api/m1.go
+++ b/backend/mailru/api/m1.go
@@ -117,7 +117,7 @@ type ListItem struct {
 	Name      string `json:"name"`
 	Home      string `json:"home"`
 	Size      int64  `json:"size"`
-	Mtime     int64  `json:"mtime,omitempty"`
+	Mtime     uint64 `json:"mtime,omitempty"`
 	Hash      string `json:"hash,omitempty"`
 	VirusScan string `json:"virus_scan,omitempty"`
 	Tree      string `json:"tree,omitempty"`

--- a/backend/mailru/mailru.go
+++ b/backend/mailru/mailru.go
@@ -656,9 +656,14 @@ func (f *Fs) itemToDirEntry(ctx context.Context, item *api.ListItem) (entry fs.D
 	if err != nil {
 		return nil, -1, err
 	}
+	mTime := int64(item.Mtime)
+	if mTime < 0 {
+		fs.Debugf(f, "Fixing invalid timestamp %d on mailru file %q", mTime, remote)
+		mTime = 0
+	}
 	switch item.Kind {
 	case "folder":
-		dir := fs.NewDir(remote, time.Unix(item.Mtime, 0)).SetSize(item.Size)
+		dir := fs.NewDir(remote, time.Unix(mTime, 0)).SetSize(item.Size)
 		dirSize := item.Count.Files + item.Count.Folders
 		return dir, dirSize, nil
 	case "file":
@@ -672,7 +677,7 @@ func (f *Fs) itemToDirEntry(ctx context.Context, item *api.ListItem) (entry fs.D
 			hasMetaData: true,
 			size:        item.Size,
 			mrHash:      binHash,
-			modTime:     time.Unix(item.Mtime, 0),
+			modTime:     time.Unix(mTime, 0),
 		}
 		return file, -1, nil
 	default:


### PR DESCRIPTION
#### What is the purpose of this change?

An rclone user encountered an old corrupted file that resulted in an invalid modifcation timestamp
returned by mail.ru server as a large unsigned integer bitwise representing int64 "-1".
Currently mail.ru backend keeps server timestamps as signed int64 and the above number results
in panic during json unmarshaling.
This issue is rare and cannot be easily reproduced in a test.

This fix makes mail.ru backend catch invalid timestamps and replace them by Unix epoch "1970-01-01-...".
The reporter confirmed that this change fixes issue for them
(see https://github.com/rclone/rclone/issues/4229#issuecomment-630050995).

#### Was the change discussed in an issue or in the forum before?

Yes, in the bug report https://github.com/rclone/rclone/issues/4229

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate (**no, confirmed by user**)
- [ ] I have added documentation for the changes if appropriate (**no, bugfixes need no docs**)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
