### PR TITLE
chunker: disable ListR to fix missing files on Drive

### DIFF
--- a/backend/chunker/chunker.go
+++ b/backend/chunker/chunker.go
@@ -296,6 +296,8 @@ func NewFs(name, rpath string, m configmap.Mapper) (fs.Fs, error) {
 		ServerSideAcrossConfigs: true,
 	}).Fill(f).Mask(baseFs).WrapsFs(f, baseFs)
 
+	f.features.Disable("ListR") // Recursive listing may cause chunker skip files
+
 	return f, err
 }
 


### PR DESCRIPTION
#### What is the purpose of this change?

Chunker needs to detect groups of files that form a compund object in the underlying directory.
Currently it uses a dead simple approach: it sorts directory listing by name and finds consecutive groups of file names with a common prefix that satisfies mask.
This approach requires that variable name part must be on the end of file name, for sorting to work.
This pre-condition is backed by the strict check at https://github.com/rclone/rclone/blob/v1.52-stable/backend/chunker/chunker.go#L413.

However, the other requirement has no check: the directory listing must be fed in a single piece.
But, if underlying remote (eg. `drive`) supports the `ListR` interface, the listing for a single directory could come in pieces
sorted one-by-one (see https://github.com/rclone/rclone/blob/v1.52-stable/backend/chunker/chunker.go#L660)
resulting in object parts randomly missing their compound group.

A complete solution will have `processEntries` routine keep directory scan state instead of sorting and let ListR feed partial listings in random order.
This PR is a workaround that simply marks chunker as incompatible with ListR.

#### Was the change discussed in an issue or in the forum before?

Update: this issue was reported in https://github.com/rclone/rclone/issues/3972

The reporter confirmed that this workaround dismisses their issue (see https://github.com/rclone/rclone/issues/3972#issuecomment-632938201).
However, the ticket will stay open until finally solved by a later PR.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate (**no, it's a bugfix**).
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
