### PR TITLE
chunker: avoid prehashing of large local files, hash in-transit (fixes #4021)

### DIFF
--- a/backend/chunker/chunker.go
+++ b/backend/chunker/chunker.go
@@ -1130,6 +1130,12 @@ func (c *chunkingReader) wrapStream(ctx context.Context, in io.Reader, src fs.Ob
 
 	switch {
 	case c.fs.useMD5:
+		srcObj := fs.UnWrapObjectInfo(src)
+		if srcObj != nil && srcObj.Fs().Features().SlowHash {
+			fs.Debugf(src, "skip slow MD5 on source file, hashing in-transit")
+			c.hasher = md5.New()
+			break
+		}
 		if c.md5, _ = src.Hash(ctx, hash.MD5); c.md5 == "" {
 			if c.fs.hashFallback {
 				c.sha1, _ = src.Hash(ctx, hash.SHA1)
@@ -1138,6 +1144,12 @@ func (c *chunkingReader) wrapStream(ctx context.Context, in io.Reader, src fs.Ob
 			}
 		}
 	case c.fs.useSHA1:
+		srcObj := fs.UnWrapObjectInfo(src)
+		if srcObj != nil && srcObj.Fs().Features().SlowHash {
+			fs.Debugf(src, "skip slow SHA1 on source file, hashing in-transit")
+			c.hasher = sha1.New()
+			break
+		}
 		if c.sha1, _ = src.Hash(ctx, hash.SHA1); c.sha1 == "" {
 			if c.fs.hashFallback {
 				c.md5, _ = src.Hash(ctx, hash.MD5)


### PR DESCRIPTION
#### What is the purpose of this change?

Chunker by nature is dedicated to handling very large files and supports MD5/SHA1 hashes for composite objects.
When it uploads a new object on target, it requests hashsum from the source. Most remote backends support
a limited set of hashsums keeping them in a metadata field attached to object. The "local" backend is special.
When chunker requests **any** type of hashsum via `src.Hash(<type>)` API, rclone performs live checksumming
right on the local file. If the file is large, this incurs a visible pre-transfer delay, which can explain issues reported
in https://github.com/rclone/rclone/issues/4021.

In fact, chunker does not need the whole checksum to guarantee correctness of the transfer and depends on the
checks performed by underlying remote on the separate chunks. Moreover, chunker can calculate checksum
in-transit to save it in the composite metadata at the end of transfer. This PR adds a check that source file is
local and forces in-transit hashsumming to avoid pre-transfer delays. This check is not configurable and does
not change user-visible behavior since in-transit hashing incurs negligible performance impact.

#### Was the change discussed in an issue or in the forum before?

No. Still waiting for user reply. Likely, this change should help.
Some discussion can be found at https://github.com/rclone/rclone/issues/4021

UPDATE: user reported success

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate (**integration testing is enough**).
- [ ] I have added documentation for the changes if appropriate (**not needed**).
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
