### PR TITLE
jottacloud: remove clientID/clientSecret from config when using v2 auth

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -373,6 +373,9 @@ func v2config(ctx context.Context, name string, m configmap.Mapper) {
 	fmt.Printf("Login Token> ")
 	loginToken := config.ReadLine()
 
+	m.Set(configClientID, "jottacli")
+	m.Set(configClientSecret, "")
+
 	token, err := doAuthV2(ctx, srv, loginToken, m)
 	if err != nil {
 		log.Fatalf("Failed to get oauth token: %s", err)
@@ -384,7 +387,6 @@ func v2config(ctx context.Context, name string, m configmap.Mapper) {
 
 	fmt.Printf("\nDo you want to use a non standard device/mountpoint e.g. for accessing files uploaded using the official Jottacloud client?\n\n")
 	if config.Confirm(false) {
-		oauthConfig.ClientID = "jottacli"
 		oAuthClient, _, err := oauthutil.NewClient(name, m, oauthConfig)
 		if err != nil {
 			log.Fatalf("Failed to load oAuthClient: %s", err)


### PR DESCRIPTION
#### What is the purpose of this change?
In #4645 we noticed jottacloud token refresh for v2 authentication failing due to oauth clientID and clientSecret being set in the config. Jottacloud v2 authentication uses the static value `jottacli` as clientID and no clientSecret at all and we set them as such but if different values are set config file oauthutil will override them. This happens when a user switched from v1 to v2 authentication because these values are left in the config file.
Given that there is probably good reason for oauthutil to have this behavior I've extended extended the configmap with Delete method so we can explicitly delete these from the config file. There would be other ways to fix this but I don't thing having a delete method for configmap hurts.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
