### PR TITLE
lib/terminal: add WriteTerminalTitle - fixes #4187

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -35,6 +35,7 @@ import (
 	"github.com/rclone/rclone/fs/rc/rcflags"
 	"github.com/rclone/rclone/fs/rc/rcserver"
 	"github.com/rclone/rclone/lib/atexit"
+	"github.com/rclone/rclone/lib/terminal"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -287,6 +288,11 @@ func Run(Retry bool, showStats bool, cmd *cobra.Command, f func() error) {
 		accounting.GlobalStats().Log()
 	}
 	fs.Debugf(nil, "%d go routines active\n", runtime.NumGoroutine())
+
+	if fs.Config.Progress && fs.Config.ProgressTerminalTitle {
+		// Clear terminal title
+		terminal.WriteTerminalTitle("")
+	}
 
 	// dump all running go-routines
 	if fs.Config.Dump&fs.DumpGoRoutines != 0 {

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1108,6 +1108,11 @@ Note: On Windows until [this bug](https://github.com/Azure/go-ansiterm/issues/26
 is fixed all non-ASCII characters will be replaced with `.` when
 `--progress` is in use.
 
+### --progress-terminal-title ###
+
+This flag, when used with `-P/--progress`, will print the string `ETA: %s`
+to the terminal title.
+
 ### -q, --quiet ###
 
 This flag will limit rclone's output to error messages only.

--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/rc"
+	"github.com/rclone/rclone/lib/terminal"
 )
 
 // MaxCompletedTransfers specifies maximum number of completed transfers in startedTransfers list
@@ -281,6 +282,11 @@ func (s *StatsInfo) String() string {
 		etaString(currentSize, totalSize, speed),
 		xfrchkString,
 	)
+
+	if fs.Config.ProgressTerminalTitle {
+		// Writes ETA to the terminal title
+		terminal.WriteTerminalTitle("ETA: " + etaString(currentSize, totalSize, speed))
+	}
 
 	if !fs.Config.StatsOneLine {
 		_, _ = buf.WriteRune('\n')

--- a/fs/config.go
+++ b/fs/config.go
@@ -106,6 +106,7 @@ type ConfigInfo struct {
 	StatsOneLineDateFormat string // If we want to customize the prefix
 	ErrorOnNoTransfer      bool   // Set appropriate exit code if no files transferred
 	Progress               bool
+	ProgressTerminalTitle  bool
 	Cookie                 bool
 	UseMmap                bool
 	CaCert                 string // Client Side CA

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -110,6 +110,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.StringVarP(flagSet, &fs.Config.StatsOneLineDateFormat, "stats-one-line-date-format", "", fs.Config.StatsOneLineDateFormat, "Enables --stats-one-line-date and uses custom formatted date. Enclose date string in double quotes (\"). See https://golang.org/pkg/time/#Time.Format")
 	flags.BoolVarP(flagSet, &fs.Config.ErrorOnNoTransfer, "error-on-no-transfer", "", fs.Config.ErrorOnNoTransfer, "Sets exit code 9 if no files are transferred, useful in scripts")
 	flags.BoolVarP(flagSet, &fs.Config.Progress, "progress", "P", fs.Config.Progress, "Show progress during transfer.")
+	flags.BoolVarP(flagSet, &fs.Config.ProgressTerminalTitle, "progress-terminal-title", "", fs.Config.ProgressTerminalTitle, "Show progress on the terminal title. Requires -P/--progress.")
 	flags.BoolVarP(flagSet, &fs.Config.Cookie, "use-cookies", "", fs.Config.Cookie, "Enable session cookiejar.")
 	flags.BoolVarP(flagSet, &fs.Config.UseMmap, "use-mmap", "", fs.Config.UseMmap, "Use mmap allocator (see docs).")
 	flags.StringVarP(flagSet, &fs.Config.CaCert, "ca-cert", "", fs.Config.CaCert, "CA certificate used to verify servers")

--- a/lib/terminal/terminal.go
+++ b/lib/terminal/terminal.go
@@ -60,6 +60,9 @@ const (
 	HiMagentaBg = "\x1b[105m"
 	HiCyanBg    = "\x1b[106m"
 	HiWhiteBg   = "\x1b[107m"
+
+	ChangeTitle = "\033]0;"
+	BEL         = "\007"
 )
 
 var (

--- a/lib/terminal/terminal_normal.go
+++ b/lib/terminal/terminal_normal.go
@@ -3,6 +3,7 @@
 package terminal
 
 import (
+	"fmt"
 	"os"
 
 	"golang.org/x/crypto/ssh/terminal"
@@ -28,4 +29,9 @@ func IsTerminal(fd int) bool {
 // returned does not include the \n.
 func ReadPassword(fd int) ([]byte, error) {
 	return terminal.ReadPassword(fd)
+}
+
+// WriteTerminalTitle writes a string to the terminal title
+func WriteTerminalTitle(title string) {
+	fmt.Printf(ChangeTitle + title + BEL)
 }

--- a/lib/terminal/terminal_unsupported.go
+++ b/lib/terminal/terminal_unsupported.go
@@ -21,3 +21,8 @@ func IsTerminal(fd int) bool {
 func ReadPassword(fd int) ([]byte, error) {
 	return nil, errors.New("can't read password")
 }
+
+// WriteTerminalTitle writes a string to the terminal title
+func WriteTerminalTitle(title string) {
+	// Since there's nothing to return, this is a NOOP
+}


### PR DESCRIPTION
Fixes #4187

#### What is the purpose of this change?

Adds the flag `--print-progress-title` which, when used with `-P/--progress`, will print the string "ETA: ..." to the terminal title.

#### Was the change discussed in an issue or in the forum before?

This was discussed on #4187.

#### Checklist

- [`x`] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [`x`] I have added documentation for the changes if appropriate.
- [`x`] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [`x`] I'm done, this Pull Request is ready for review :-)
