### PR TITLE
ncdu: add empty folder flag into ncdu browser

### DIFF
--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -357,15 +357,18 @@ func (u *UI) Draw() error {
 			if isDir {
 				mark = '/'
 			}
+			fileFlag := ' '
 			message := ""
 			if !readable {
 				message = " [not read yet]"
 			}
 			if entriesHaveErrors {
 				message = " [some subdirectories could not be read, size may be underestimated]"
+				fileFlag = '.'
 			}
 			if err != nil {
 				message = fmt.Sprintf(" [%s]", err)
+				fileFlag = '!'
 			}
 			extras := ""
 			if u.showCounts {
@@ -388,12 +391,9 @@ func (u *UI) Draw() error {
 				}
 
 			}
-			emptyDir := ""
 			if showEmptyDir {
-				if isDir && count == 0 {
-					emptyDir = "e"
-				} else {
-					emptyDir = " "
+				if isDir && count == 0 && fileFlag == ' ' {
+					fileFlag = 'e'
 				}
 			}
 			if u.showGraph {
@@ -406,7 +406,7 @@ func (u *UI) Draw() error {
 				}
 				extras += "[" + graph[graphBars-bars:2*graphBars-bars] + "] "
 			}
-			Linef(0, y, w, fg, bg, ' ', "%s  %8v %s%c%s%s", emptyDir, fs.SizeSuffix(size), extras, mark, path.Base(entry.Remote()), message)
+			Linef(0, y, w, fg, bg, ' ', "%c %8v %s%c%s%s", fileFlag, fs.SizeSuffix(size), extras, mark, path.Base(entry.Remote()), message)
 			y++
 		}
 	}

--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -289,6 +289,20 @@ func (u *UI) biggestEntry() (biggest int64) {
 	return
 }
 
+// hasEmptyDir returns true if there is empty folder in current listing
+func (u *UI) hasEmptyDir() bool {
+	if u.d == nil {
+		return false
+	}
+	for i := range u.entries {
+		_, count, isDir, _, _, _ := u.d.AttrI(u.sortPerm[i])
+		if isDir && count == 0 {
+			return true
+		}
+	}
+	return false
+}
+
 // Draw the current screen
 func (u *UI) Draw() error {
 	w, h := termbox.Size()
@@ -319,6 +333,7 @@ func (u *UI) Draw() error {
 		if perBar == 0 {
 			perBar = 1
 		}
+		showEmptyDir := u.hasEmptyDir()
 		dirPos := u.dirPosMap[u.path]
 		for i, j := range u.sortPerm[dirPos.offset:] {
 			entry := u.entries[j]
@@ -373,6 +388,14 @@ func (u *UI) Draw() error {
 				}
 
 			}
+			emptyDir := ""
+			if showEmptyDir {
+				if isDir && count == 0 {
+					emptyDir = "e"
+				} else {
+					emptyDir = " "
+				}
+			}
 			if u.showGraph {
 				bars := (size + perBar/2 - 1) / perBar
 				// clip if necessary - only happens during startup
@@ -383,7 +406,7 @@ func (u *UI) Draw() error {
 				}
 				extras += "[" + graph[graphBars-bars:2*graphBars-bars] + "] "
 			}
-			Linef(0, y, w, fg, bg, ' ', "%8v %s%c%s%s", fs.SizeSuffix(size), extras, mark, path.Base(entry.Remote()), message)
+			Linef(0, y, w, fg, bg, ' ', "%s  %8v %s%c%s%s", emptyDir, fs.SizeSuffix(size), extras, mark, path.Base(entry.Remote()), message)
 			y++
 		}
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

Implemented empty folder flag for ncdu browser interface. If there is empty folder in the list the flag e is prepended before size. If there is no empty folder this flag is ommited. It has the same behaviour as original ncdu browser. (https://dev.yorhel.nl/ncdu/man)

#### Was the change discussed in an issue or in the forum before?

Fixes issue: #3369.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
