### PR TITLE
operations: move verbosly log name of the destination object

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -501,8 +501,11 @@ func Copy(ctx context.Context, f fs.Fs, dst fs.Object, remote string, src fs.Obj
 			return newDst, err
 		}
 	}
-
-	fs.Infof(src, actionTaken)
+	if src.String() != newDst.String() {
+		fs.Infof(src, "%s to: %s", actionTaken, newDst.String())
+	} else {
+		fs.Infof(src, actionTaken)
+	}
 	return newDst, err
 }
 
@@ -556,7 +559,12 @@ func Move(ctx context.Context, fdst fs.Fs, dst fs.Object, remote string, src fs.
 		newDst, err = doMove(ctx, src, remote)
 		switch err {
 		case nil:
-			fs.Infof(src, "Moved (server-side)")
+			if src.String() != newDst.String() {
+				fs.Infof(src, "Moved (server-side) to: %s", newDst.String())
+			} else {
+				fs.Infof(src, "Moved (server-side)")
+			}
+
 			return newDst, nil
 		case fs.ErrorCantMove:
 			fs.Debugf(src, "Can't move, switching to copy")


### PR DESCRIPTION

#### What is the purpose of this change?

If the object is moved rclone prints name of the destination object into the info log in verbose mode .

#### Was the change discussed in an issue or in the forum before?

fixes: #4658 
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
