### PR TITLE
mount: docs: make note about mounting as network drive in windows less confusing

### DIFF
--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -162,7 +162,7 @@ FUSE.
 First set up your remote using ` + "`rclone config`" + `.  Check it works with ` + "`rclone ls`" + ` etc.
 
 You can either run mount in foreground mode or background (daemon) mode. Mount runs in
-foreground mode by default, use the --daemon flag to specify background mode.
+foreground mode by default, use the ` + "`--daemon`" + ` flag to specify background mode.
 Background mode is only supported on Linux and OSX, you can only run mount in
 foreground mode on Windows.
 
@@ -172,7 +172,8 @@ is an **empty** **existing** directory.
     rclone ` + commandName + ` remote:path/to/files /path/to/local/mount
 
 Or on Windows like this where ` + "`X:`" + ` is an unused drive letter
-or use a path to **non-existent** directory.
+or (unless [mounting as a network drive](#network-drive)) use a path
+to **non-existent** subdirectory of an **existing** parent directory or drive.
 
     rclone ` + commandName + ` remote:path/to/files X:
     rclone ` + commandName + ` remote:path/to/files C:\path\to\nonexistent\directory
@@ -226,39 +227,42 @@ alternatively using [the nssm service manager](https://nssm.cc/usage).
 
 #### Mount as a network drive
 
-By default, rclone will mount the remote as a normal drive. However,
-you can also mount it as a **Network Drive** (or **Network Share**, as
-mentioned in some places)
+By default, rclone will mount the remote as a normal, fixed disk drive. However,
+you can also mount it as a remote network drive, also known as a network share.
 
-Unlike other systems, Windows provides a different filesystem type for
-network drives.  Windows and other programs treat the network drives
-and fixed/removable drives differently: In network drives, many I/O
-operations are optimized, as the high latency and low reliability
-(compared to a normal drive) of a network is expected.
+Unlike other operating systems, Microsoft Windows provides a different filesystem
+type for network and fixed drives. It optimises access on the assumption fixed
+disk drives are fast and reliable, while network drives have relatively high latency
+and less reliability. Some settings can also be differentiated between the two types,
+for example that Windows Explorer should just display icons and not create preview
+thumbnails for image and video files on network drives.
 
-Although many people prefer network shares to be mounted as normal
-system drives, this might cause some issues, such as programs not
-working as expected or freezes and errors while operating with the
-mounted remote in Windows Explorer. If you experience any of those,
-consider mounting rclone remotes as network shares, as Windows expects
-normal drives to be fast and reliable, while cloud storage is far from
-that.  See also [Limitations](#limitations) section below for more
-info
+If you mount an rclone remote using the default, fixed drive mode and experience
+unexpected program errors, freezes or other issues, consider mounting the remotes
+as a network drive instead.
 
-Add "--fuse-flag --VolumePrefix=\server\share" to your "mount"
-command, **replacing "share" with any other name of your choice if you
-are mounting more than one remote**. Otherwise, the mountpoints will
-conflict and your mounted filesystems will overlap.
+See also [Limitations](#limitations) section below for more info.
+
+To mount as network drive, add ` + "`--fuse-flag --VolumePrefix=\\server\\share`" + `
+to your ` + commandName + ` command. You may replace the names "server" and "share"
+with whatever you like, as long as the combination is unique when you are mounting
+more than one drive (or else the mount command will fail). The "share" name will
+treated as the volume label for the mapped drive, shown in Windows Explorer etc, while
+` + "`\\\\server\\share`" + ` will be reported as the remote UNC path by
+` + "`net use`" + ` etc, just like a normal network drive mapping.
+
+You must use the method of mounting to a drive letter, as mounting to a directory
+path is not supported in this case (a limitation Windows imposes on junctions).
 
 [Read more about drive mapping](https://en.wikipedia.org/wiki/Drive_mapping)
 
 ### Limitations
 
-Without the use of "--vfs-cache-mode" this can only write files
+Without the use of ` + "`--vfs-cache-mode`" + ` this can only write files
 sequentially, it can only seek when reading.  This means that many
 applications won't work with their files on an rclone mount without
-"--vfs-cache-mode writes" or "--vfs-cache-mode full".  See the [File
-Caching](#file-caching) section for more info.
+` + "`--vfs-cache-mode writes`" + ` or ` + "`--vfs-cache-mode full`" + `.
+See the [File Caching](#file-caching) section for more info.
 
 The bucket based remotes (e.g. Swift, S3, Google Compute Storage, B2,
 Hubic) do not support the concept of empty directories, so empty
@@ -278,7 +282,7 @@ for solutions to make ` + commandName + ` more reliable.
 
 ### Attribute caching
 
-You can use the flag --attr-timeout to set the time the kernel caches
+You can use the flag ` + "`--attr-timeout`" + ` to set the time the kernel caches
 the attributes (size, modification time, etc.) for directory entries.
 
 The default is "1s" which caches files just long enough to avoid
@@ -292,10 +296,10 @@ few problems such as
 and [excessive time listing directories](https://github.com/rclone/rclone/issues/2095#issuecomment-371141147).
 
 The kernel can cache the info about a file for the time given by
-"--attr-timeout". You may see corruption if the remote file changes
+` + "`--attr-timeout`" + `. You may see corruption if the remote file changes
 length during this window.  It will show up as either a truncated file
-or a file with garbage on the end.  With "--attr-timeout 1s" this is
-very unlikely but not impossible.  The higher you set "--attr-timeout"
+or a file with garbage on the end.  With ` + "`--attr-timeout 1s`" + ` this is
+very unlikely but not impossible.  The higher you set ` + "`--attr-timeout`" + `
 the more likely it is.  The default setting of "1s" is the lowest
 setting which mitigates the problems above.
 
@@ -323,18 +327,18 @@ will see all files and folders immediately in this mode.
 
 ### chunked reading ###
 
---vfs-read-chunk-size will enable reading the source objects in parts.
+` + "`--vfs-read-chunk-size`" + ` will enable reading the source objects in parts.
 This can reduce the used download quota for some remotes by requesting only chunks
 from the remote that are actually read at the cost of an increased number of requests.
 
-When --vfs-read-chunk-size-limit is also specified and greater than --vfs-read-chunk-size,
-the chunk size for each open file will get doubled for each chunk read, until the
-specified value is reached. A value of -1 will disable the limit and the chunk size will
-grow indefinitely.
+When ` + "`--vfs-read-chunk-size-limit`" + ` is also specified and greater than
+` + "`--vfs-read-chunk-size`" + `, the chunk size for each open file will get doubled
+for each chunk read, until the specified value is reached. A value of -1 will disable
+the limit and the chunk size will grow indefinitely.
 
-With --vfs-read-chunk-size 100M and --vfs-read-chunk-size-limit 0 the following
-parts will be downloaded: 0-100M, 100M-200M, 200M-300M, 300M-400M and so on.
-When --vfs-read-chunk-size-limit 500M is specified, the result would be
+With ` + "`--vfs-read-chunk-size 100M`" + ` and ` + "`--vfs-read-chunk-size-limit 0`" + `
+the following parts will be downloaded: 0-100M, 100M-200M, 200M-300M, 300M-400M and so on.
+When ` + "`--vfs-read-chunk-size-limit 500M`" + ` is specified, the result would be
 0-100M, 100M-300M, 300M-700M, 700M-1200M, 1200M-1700M and so on.
 ` + vfs.Help,
 		Run: func(command *cobra.Command, args []string) {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

I find the documentation of the mount command a bit confusing, especially regarding windows specific things. So I tried to make it a bit clearer, and also some minor cleanup here and there.

For example the usage of term "network shares" in the section [Mount as a network drive](https://rclone.org/commands/rclone_mount/#mount-as-a-network-drive), I think is used both as a generic term for remote filesystems and for the "shared folder" functionality in windows. For examle it states: "many people prefer network shares to be mounted as normal system drives, this might cause some issues" and then "if you experience any of those, consider mounting rclone remotes as network shares".

*The terms "fixed drive" and "remote (network) drive", as used in [Windows](https://docs.microsoft.com/en-us/windows/win32/api/shlobj_core/nf-shlobj_core-drivetype), could be candidates when specifically pointing at the two mount methods. It could still be a bit confusing terms, though, since you can mount into a directory path or a drive letter - so you can mount as "fixed drive into drive letter" or as "fixed drive into directory", as well as  "network drive into drive letter". Alternative terms are "disk" and "net"/"network", related to the two device objects WinFsp uses for the two mount methods: WinFsp.Disk and WinFsp.Net. I don't know...*

Also I find in my testing that trying to mount with `--fuse-flag --VolumePrefix=\server\share` using a share name that already exists, fails with error messages "Cannot create WinFsp-FUSE file system: invalid mount point." and "Mount failed", but the rather intimidating warning regarding unique share names is probably not necessary since it "just fails". (Maybe this is something that WinFsp has improved since the original text was written?). Also I find that the server name can be changed, not just the share name, and by using different server names you are allowed to use the same share name for multiple mounts. Suggested a "milder" section for this.

I also find that when mounting using the network method only drive letter mounting is allowed, not directory mounting. Mounting with `--fuse-flag --VolumePrefix=\server\share` specifying a directory path (not just drive letter) fails with "Cannot set WinFsp-FUSE file system mount point." and "Mount failed". Added a note about that. EDIT: Confirmed from [WinFsp wiki](https://github.com/billziss-gh/winfsp/wiki/WinFsp-API-winfsp.h), section FspFileSystemSetMountPoint:
> Directories: They can be used as mount points for disk based file systems. cannot be used for network file systems. This is a limitation that Windows imposes on junctions.

Also when mounting using network method, WinFsp supports mapping as network share UNC path only (tested with WinFsp sample utilities airfs/memfs), but rclone always requires also mapping the share into a drive letter - ~due to the two required arguments for specifying remote and mountpoint~. I added a note for it. EDIT: Found out you can actually supply empty string as mountpoint argument, `rclone mount remote: "" --fuse-flag --VolumePrefix=\server\share`, and it works... But it will still map to a drive letter - first free letter counting backwards from Z:, logic from WinFsp method `FspFileSystemSetMountPoint`. So somewhere between rclone and winfsp this method is being called regardless if mountpoint is empty, while WinFsp sample utilities airfs/memfs skips this call if no mountpoint specified. I could not see where this is happening. Anyway, most users probably want to map to drive letter, so perhaps it would be mostly of academic interest to track this down. Rclone will show an error, because it waits for the mountpoint to become ready polling os.Stat, and since it is empty it times out and reports `ERROR : mountpoint "" didn't became available on mount - continuing anyway`. So I guess just leave it as an undocumented trick for now.

... while at the same time, speaking of network share and arguments, I was thinking about the rather obscure option `--fuse-flag --VolumePrefix=\server\share` for enabling the network mode, since the network mode sounds like should be the preferred method in many cases, if it could be made more accessible. I was thinking about the existing `--volname` option, currently used to set custom volume label when mounting using disk method into a drive letter. If one could re-use this argument for setting the "share" name, and then just add a default prefix "\\server\\". But then one would need another flag for specifying disk or network type mounting. Would it work to accept such unc style path as the mountpoint argument? This could solve the note from the previous section as well? For example: `rclone mount remote: \\server\share` would be allowed, and mount as network share?



#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
