### PR TITLE
testserver: speed up initialize of TestSeafile for Seafile integration tests

### DIFF
--- a/fstest/testserver/init.d/TestSeafile
+++ b/fstest/testserver/init.d/TestSeafile
@@ -21,8 +21,20 @@ COMPOSE_DIR=$(dirname "$0")/seafile
 start() {
     docker-compose --project-directory ${COMPOSE_DIR} --project-name ${NAME} --file ${COMPOSE_DIR}/docker-compose.yml up -d
 
-    # it takes some time for the database to be created
-    sleep 60
+    # wait for Seafile server to start
+    seafile_endpoint="http://${SEAFILE_IP}:${SEAFILE_PORT}/"
+    wait_seconds=1
+    echo -n "Waiting for Seafile server to start"
+    for iterations in `seq 1 60`;
+    do
+      http_code=$(curl -s -o /dev/null -L -w '%{http_code}' "$seafile_endpoint" || true;)
+      if [ "$http_code" -eq 200 ]; then
+        echo
+        break
+      fi
+      echo -n "."
+      sleep $wait_seconds
+    done
 
     # authentication token answer should be like: {"token":"dbf58423f1632b5b679a13b0929f1d0751d9250c"}
     TOKEN=`curl --silent \


### PR DESCRIPTION
#### What is the purpose of this change?

We must run Seafile server in docker environment before Seafile integration tests can be run. We don't have to sleep for 60 seconds to have everything ready. We can assume everything is ready when Seafile webserver returns status code 200. Seafile Dockerfile (https://github.com/haiwen/seafile-docker/blob/master/image/seafile/Dockerfile) runs scripts/start.py where is defined that before init_seafile_server() we always wait for mysql wait_for_mysql() (https://github.com/haiwen/seafile-docker/blob/master/scripts/start.py) so We know database has been created and integration tests are ready to run.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
