### PR TITLE
check Hashes by Etags if chunk size is equal for s3 to s3 sync

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2661,7 +2661,7 @@ func (o *Object) Remote() string {
 	return o.remote
 }
 
-var matchMd5 = regexp.MustCompile(`^[0-9a-f]{32}$`)
+var matchMd5 = regexp.MustCompile(`^[0-9a-f]{32}(-[0-9]+)?$`)
 
 // Hash returns the Md5sum of an object returning a lowercase hex string
 func (o *Object) Hash(ctx context.Context, t hash.Type) (string, error) {

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1280,7 +1280,7 @@ type Options struct {
 	MemoryPoolFlushTime   fs.Duration          `config:"memory_pool_flush_time"`
 	MemoryPoolUseMmap     bool                 `config:"memory_pool_use_mmap"`
 	DisableHTTP2          bool                 `config:"disable_http2"`
-	useMultipartEtagAsMd5 bool                 `config:"use_multipart_etag_as_md5"`
+	UseMultipartEtagAsMd5 bool                 `config:"use_multipart_etag_as_md5"`
 }
 
 // Fs represents a remote s3 server
@@ -2670,7 +2670,7 @@ func (o *Object) Remote() string {
 // Remote returns the match md5 regexp
 func (o *Object) matchMd5() *regexp.Regexp {
 	matchMd5Str := "^[0-9a-f]{32}$"
-	if o.fs.opt.useMultipartEtagAsMd5 {
+	if o.fs.opt.UseMultipartEtagAsMd5 {
 		matchMd5Str = "^[0-9a-f]{32}(-[0-9]+)?$"
 	}
 	return regexp.MustCompile(matchMd5Str)

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -101,11 +101,11 @@ func checkHashes(ctx context.Context, src fs.ObjectInfo, dst fs.Object, ht hash.
 		md5Hash := md5.New()
 		if len(srcHashes) == 2 && srcHashes[1] == "1" {
 			md5Decoded, _ := hex.DecodeString(dstHash)
-			md5Hash.Write(md5Decoded)
+			_, _ = md5Hash.Write(md5Decoded)
 			dstHash = fmt.Sprintf("%x-1", md5Hash.Sum(nil))
 		} else if len(dstHashes) == 2 && dstHashes[1] == "1" {
 			md5Decoded, _ := hex.DecodeString(srcHash)
-			md5Hash.Write(md5Decoded)
+			_, _ = md5Hash.Write(md5Decoded)
 			srcHash = fmt.Sprintf("%x-1", md5Hash.Sum(nil))
 		} else {
 			fs.Debugf(src, "chunk md5 hashes type differ")

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -100,12 +100,12 @@ func checkHashes(ctx context.Context, src fs.ObjectInfo, dst fs.Object, ht hash.
 	} else if len(srcHashes) != len(dstHashes) {
 		md5Hash := md5.New()
 		if len(srcHashes) == 2 && srcHashes[1] == "1" {
-			md5_decoded, _ := hex.DecodeString(dstHash)
-			md5Hash.Write(md5_decoded)
+			md5Decoded, _ := hex.DecodeString(dstHash)
+			md5Hash.Write(md5Decoded)
 			dstHash = fmt.Sprintf("%x-1", md5Hash.Sum(nil))
 		} else if len(dstHashes) == 2 && dstHashes[1] == "1" {
-			md5_decoded, _ := hex.DecodeString(srcHash)
-			md5Hash.Write(md5_decoded)
+			md5Decoded, _ := hex.DecodeString(srcHash)
+			md5Hash.Write(md5Decoded)
 			srcHash = fmt.Sprintf("%x-1", md5Hash.Sum(nil))
 		} else {
 			fs.Debugf(src, "chunk md5 hashes type differ")


### PR DESCRIPTION
#### What is the purpose of this change?

<!--
Use Etags to check if possible when syncing files between s3
-->

#### Was the change discussed in an issue or in the forum before?


#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
