### PR TITLE
mount: more user friendly mounting as network drive on windows

### DIFF
--- a/cmd/cmount/mount.go
+++ b/cmd/cmount/mount.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/billziss-gh/cgofuse/fuse"
@@ -46,28 +45,9 @@ func mountOptions(VFS *vfs.VFS, device string, mountpoint string, opt *mountlib.
 		options = append(options, "-o", "debug")
 	}
 
-	// Determine if ExtraOptions already has an opt in
-	hasExtraOption := func(optionName string) bool {
-		optionName += "="
-		for _, option := range opt.ExtraOptions {
-			suboptions := strings.Split(option, ",")
-			for _, suboption := range suboptions {
-				if strings.HasPrefix(suboption, optionName) {
-					return true
-				}
-			}
-		}
-		return false
-	}
-
 	if runtime.GOOS == "windows" {
-		// Setting uid and gid to -1 by default, which mean current user in WinFsp
-		if !hasExtraOption("uid") {
-			options = append(options, "-o", "uid=-1")
-		}
-		if !hasExtraOption("gid") {
-			options = append(options, "-o", "gid=-1")
-		}
+		options = append(options, "-o", "uid=-1")
+		options = append(options, "-o", "gid=-1")
 		options = append(options, "--FileSystemName=rclone")
 		if opt.VolumeName != "" {
 			if opt.NetworkMode {

--- a/cmd/cmount/mount.go
+++ b/cmd/cmount/mount.go
@@ -50,8 +50,11 @@ func mountOptions(VFS *vfs.VFS, device string, mountpoint string, opt *mountlib.
 	hasExtraOption := func(optionName string) bool {
 		optionName += "="
 		for _, option := range opt.ExtraOptions {
-			if strings.HasPrefix(option, optionName) {
-				return true
+			suboptions := strings.Split(option, ",")
+			for _, suboption := range suboptions {
+				if strings.HasPrefix(suboption, optionName) {
+					return true
+				}
 			}
 		}
 		return false

--- a/cmd/cmount/mountpoint_other.go
+++ b/cmd/cmount/mountpoint_other.go
@@ -1,0 +1,23 @@
+// +build cmount
+// +build cgo
+// +build !windows
+
+package cmount
+
+import (
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/rclone/rclone/cmd/mountlib"
+)
+
+func getMountpoint(mountPath string, opt *mountlib.Options) (string, error) {
+	fi, err := os.Stat(mountPath)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to retrieve mount path information")
+	}
+	if !fi.IsDir() {
+		return "", errors.New("mount path is not a directory")
+	}
+	return mountPath, nil
+}

--- a/cmd/cmount/mountpoint_windows.go
+++ b/cmd/cmount/mountpoint_windows.go
@@ -1,0 +1,189 @@
+// +build cmount
+// +build cgo
+// +build windows
+
+package cmount
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+
+	"github.com/pkg/errors"
+	"github.com/rclone/rclone/cmd/mountlib"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/lib/file"
+)
+
+var isDriveRegex = regexp.MustCompile(`^[a-zA-Z]\:$`)
+var isDriveRootPathRegex = regexp.MustCompile(`^[a-zA-Z]\:\\$`)
+var isDriveOrRootPathRegex = regexp.MustCompile(`^[a-zA-Z]\:\\?$`)
+var isNetworkSharePathRegex = regexp.MustCompile(`^\\\\[^\\]+\\[^\\]`)
+
+// isNetworkSharePath returns true if the given string is a valid network share path,
+// in the basic UNC format "\\Server\Share\Path", where the first two path components
+// are required ("\\Server\Share", which represents the volume).
+// Extended-length UNC format "\\?\UNC\Server\Share\Path" is not considered, as it is
+// not supported by cgofuse/winfsp.
+// Note: There is a UNCPath function in lib/file, but it refers to any extended-length
+// paths using prefix "\\?\", and not necessarily network resource UNC paths.
+func isNetworkSharePath(l string) bool {
+	return isNetworkSharePathRegex.MatchString(l)
+}
+
+// isDrive returns true if given string is a drive letter followed by the volume separator, e.g. "X:".
+// This is the format supported by cgofuse/winfsp for mounting as drive.
+// Extended-length format "\\?\X:" is not considered, as it is not supported by cgofuse/winfsp.
+func isDrive(l string) bool {
+	return isDriveRegex.MatchString(l)
+}
+
+// isDriveRootPath returns true if given string is a drive letter followed by the volume separator,
+// as well as a path separator, e.g. "X:\". This is a format often used instead of the format without the
+// trailing path separator to denote a drive or volume, in addition to representing the drive's root directory.
+// This format is not accepted by cgofuse/winfsp for mounting as drive, but can easily be by trimming off
+// the path separator. Extended-length format "\\?\X:\" is not considered.
+func isDriveRootPath(l string) bool {
+	return isDriveRootPathRegex.MatchString(l)
+}
+
+// isDriveOrRootPath returns true if given string is a drive letter followed by the volume separator,
+// and optionally a path separator. See isDrive and isDriveRootPath functions.
+func isDriveOrRootPath(l string) bool {
+	return isDriveOrRootPathRegex.MatchString(l)
+}
+
+// isDefaultPath returns true if given string is a special keyword used to trigger default mount.
+func isDefaultPath(l string) bool {
+	return l == "" || l == "*"
+}
+
+// getUnusedDrive find unused drive letter and returns string with drive letter followed by volume separator.
+func getUnusedDrive() (string, error) {
+	driveLetter := file.FindUnusedDriveLetter()
+	if driveLetter == 0 {
+		return "", errors.New("could not find unused drive letter")
+	}
+	mountpoint := string(driveLetter) + ":" // Drive letter with volume separator only, no trailing backslash, which is what cgofuse/winfsp expects
+	fs.Logf(nil, "Assigning drive letter %q", mountpoint)
+	return mountpoint, nil
+}
+
+// handleDefaultMountpath handles the case where mount path is not set, or set to a special keyword.
+// This will automatically pick an unused drive letter to use as mountpoint.
+func handleDefaultMountpath() (string, error) {
+	return getUnusedDrive()
+}
+
+// handleNetworkShareMountpath handles the case where mount path is a network share path.
+// Sets volume name option and returns a mountpoint string.
+func handleNetworkShareMountpath(mountpath string, opt *mountlib.Options) (string, error) {
+	// Assuming mount path is a valid network share path (UNC format, "\\Server\Share").
+	// Always mount as network drive, regardless of the NetworkMode option.
+	// Find an unused drive letter to use as mountpoint, the the supplied path can
+	// be used as volume prefix (network share path) instead of mountpoint.
+	if !opt.NetworkMode {
+		fs.Debugf(nil, "Forcing --network-mode because mountpoint path is network share UNC format")
+		opt.NetworkMode = true
+	}
+	mountpoint, err := getUnusedDrive()
+	if err != nil {
+		return "", err
+	}
+	return mountpoint, nil
+}
+
+// handleLocalMountpath handles the case where mount path is a local file system path.
+func handleLocalMountpath(mountpath string, opt *mountlib.Options) (string, error) {
+	// Assuming path is drive letter or directory path, not network share (UNC) path.
+	// If drive letter: Must be given as a single character followed by ":" and nothing else.
+	// Else, assume directory path: Directory must not exist, but its parent must.
+	if _, err := os.Stat(mountpath); err == nil {
+		return "", errors.New("mountpoint path already exists: " + mountpath)
+	} else if !os.IsNotExist(err) {
+		return "", errors.Wrap(err, "failed to retrieve mountpoint path information")
+	}
+	//if isDriveRootPath(mountpath) { // Assume intention with "X:\" was "X:"
+	//	mountpoint = mountpath[:len(mountpath)-1] // WinFsp needs drive mountpoints without trailing path separator
+	if !isDrive(mountpath) {
+		// Assuming directory path, since it is not a pure drive letter string such as "X:".
+		// Drive letter string can be used as is, since we have already checked it does not exist,
+		// but directory path needs more checks.
+		if opt.NetworkMode {
+			fs.Errorf(nil, "Ignoring --network-mode as it is not supported with directory mountpoint")
+			opt.NetworkMode = false
+		}
+		parent := filepath.Join(mountpath, "..")
+		if parent == "" || parent == "." {
+			return "", errors.New("mountpoint directory is not valid: " + parent)
+		}
+		if os.IsPathSeparator(parent[len(parent)-1]) { // Ends in a separator only if it is the root directory
+			return "", errors.New("mountpoint directory is at root: " + parent)
+		}
+		if _, err := os.Stat(parent); err != nil {
+			if os.IsNotExist(err) {
+				return "", errors.New("parent of mountpoint directory does not exist: " + parent)
+			}
+			return "", errors.Wrap(err, "failed to retrieve mountpoint directory parent information")
+		}
+	}
+	return mountpath, nil
+}
+
+// handleVolumeName handles the volume name option.
+func handleVolumeName(opt *mountlib.Options, volumeName string) {
+	// If volumeName parameter is set, then just set that into options replacing any existing value.
+	// Else, ensure the volume name option is a valid network share UNC path if network mode,
+	// and ensure network mode if configured volume name is already UNC path.
+	if volumeName != "" {
+		opt.VolumeName = volumeName
+	} else if opt.VolumeName != "" { // Should always be true due to code in mountlib caller
+		// Use value of given volume name option, but check if it is disk volume name or network volume prefix
+		if isNetworkSharePath(opt.VolumeName) {
+			// Specified volume name is network share UNC path, assume network mode and use it as volume prefix
+			opt.VolumeName = opt.VolumeName[1:] // WinFsp requires volume prefix as UNC-like path but with only a single backslash
+			if !opt.NetworkMode {
+				// Specified volume name is network share UNC path, force network mode and use it as volume prefix
+				fs.Debugf(nil, "Forcing network mode due to network share (UNC) volume name")
+				opt.NetworkMode = true
+			}
+		} else if opt.NetworkMode {
+			// Plain volume name treated as share name in network mode, append to hard coded "\\server" prefix to get full volume prefix.
+			opt.VolumeName = "\\server\\" + opt.VolumeName
+		}
+	} else if opt.NetworkMode {
+		// Hard coded default
+		opt.VolumeName = "\\server\\share"
+	}
+}
+
+// getMountpoint handles mounting details on Windows,
+// where disk and network based file systems are treated different.
+func getMountpoint(mountpath string, opt *mountlib.Options) (mountpoint string, err error) {
+
+	// First handle mountpath
+	var volumeName string
+	if isDefaultPath(mountpath) {
+		// Mount path indicates defaults, which will automatically pick an unused drive letter.
+		mountpoint, err = handleDefaultMountpath()
+	} else if isNetworkSharePath(mountpath) {
+		// Mount path is a valid network share path (UNC format, "\\Server\Share" prefix).
+		mountpoint, err = handleNetworkShareMountpath(mountpath, opt)
+		// In this case the volume name is taken from the mount path, will replace any existing volume name option.
+		volumeName = mountpath[1:] // WinFsp requires volume prefix as UNC-like path but with only a single backslash
+	} else {
+		// Mount path is drive letter or directory path.
+		mountpoint, err = handleLocalMountpath(mountpath, opt)
+	}
+
+	// Second handle volume name
+	handleVolumeName(opt, volumeName)
+
+	// Done, return mountpoint to be used, together with updated mount options.
+	if opt.NetworkMode {
+		fs.Debugf(nil, "Network mode mounting is enabled")
+	} else {
+		fs.Debugf(nil, "Network mode mounting is disabled")
+	}
+	return
+}

--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -35,12 +35,6 @@ func mountOptions(VFS *vfs.VFS, device string, opt *mountlib.Options) (options [
 	if opt.AsyncRead {
 		options = append(options, fuse.AsyncRead())
 	}
-	if opt.NoAppleDouble {
-		options = append(options, fuse.NoAppleDouble())
-	}
-	if opt.NoAppleXattr {
-		options = append(options, fuse.NoAppleXattr())
-	}
 	if opt.AllowNonEmpty {
 		options = append(options, fuse.AllowNonEmptyMount())
 	}

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -201,6 +201,13 @@ When running in background mode the user will have to stop the mount manually:
 The umount operation can fail, for example when the mountpoint is busy.
 When that happens, it is the user's responsibility to stop the mount manually.
 
+The size of the mounted file system will be set according to information retrieved
+from the remote, the same as returned by the [rclone about](https://rclone.org/commands/rclone_about/)
+command. Remotes with unlimited storage may report the used size only,
+then an additional 1PB of free space is assumed. If the remote does not
+[support](https://rclone.org/overview/#optional-features) the about feature
+at all, then 1PB is set as both the total and the free size.
+
 **Note**: As of ` + "`rclone` 1.52.2, `rclone mount`" + ` now requires Go version 1.13
 or newer on some platforms depending on the underlying FUSE library in use.
 

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -297,6 +297,33 @@ must be with just a single backslash prefix in this case.
 
 See also [Limitations](#limitations) section below.
 
+#### Windows filesystem permissions
+
+The FUSE emulation layer on Windows must convert between the POSIX-based
+permission model used in FUSE, and the permission model used in Windows,
+based on access-control lists (ACL).
+
+The mounted filesystem will normally get three entries in its access-control list (ACL),
+representing permissions for the POSIX permission scopes: Owner, group and others.
+By default, the owner and group will be taken from the current user, and the built-in
+group "Everyone" will be used to represent others. The user/group can be customized
+with FUSE options "UserName" and "GroupName",
+e.g. ` + "`-o UserName=user123 -o GroupName=\"Authenticated Users\"`" + `.
+
+The permissions on each entry will be set according to
+[options](#options) ` + "`--dir-perms`" + ` and ` + "`--file-perms`" + `,
+which takes a value in traditional [numeric notation](https://en.wikipedia.org/wiki/File-system_permissions#Numeric_notation),
+where the default corresponds to ` + "`--file-perms 0666 --dir-perms 0777`" + `.
+
+Note that the mapping of permissions is not always trivial, and the result
+you see in Windows Explorer may not be exactly like you expected.
+For example, when setting a value that includes write access, this will be
+mapped to individual permissions "write attributes", "write data" and "append data",
+but not "write extended attributes" (WinFsp does not support extended attributes,
+see [this](https://github.com/billziss-gh/winfsp/wiki/NTFS-Compatibility)).
+Windows will then show this as basic permission "Special" instead of "Write",
+because "Write" includes the "write extended attributes" permission.
+
 #### Windows caveats
 
 Note that drives created as Administrator are not visible by other
@@ -382,7 +409,7 @@ after the mountpoint has been successfully set up.
 Units having the rclone ` + commandName + ` service specified as a requirement
 will see all files and folders immediately in this mode.
 
-### chunked reading ###
+### chunked reading
 
 ` + "`--vfs-read-chunk-size`" + ` will enable reading the source objects in parts.
 This can reduce the used download quota for some remotes by requesting only chunks

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -84,25 +84,26 @@ var (
 func AddFlags(flagSet *pflag.FlagSet) {
 	rc.AddOption("mount", &Opt)
 	flags.BoolVarP(flagSet, &Opt.DebugFUSE, "debug-fuse", "", Opt.DebugFUSE, "Debug the FUSE internals - needs -v.")
-	flags.BoolVarP(flagSet, &Opt.AllowNonEmpty, "allow-non-empty", "", Opt.AllowNonEmpty, "Allow mounting over a non-empty directory (not Windows).")
-	flags.BoolVarP(flagSet, &Opt.AllowRoot, "allow-root", "", Opt.AllowRoot, "Allow access to root user (not Windows).")
-	flags.BoolVarP(flagSet, &Opt.AllowOther, "allow-other", "", Opt.AllowOther, "Allow access to other users (not Windows).")
-	flags.BoolVarP(flagSet, &Opt.DefaultPermissions, "default-permissions", "", Opt.DefaultPermissions, "Makes kernel enforce access control based on the file mode.")
-	flags.BoolVarP(flagSet, &Opt.WritebackCache, "write-back-cache", "", Opt.WritebackCache, "Makes kernel buffer writes before sending them to rclone. Without this, writethrough caching is used.")
-	flags.FVarP(flagSet, &Opt.MaxReadAhead, "max-read-ahead", "", "The number of bytes that can be prefetched for sequential reads.")
 	flags.DurationVarP(flagSet, &Opt.AttrTimeout, "attr-timeout", "", Opt.AttrTimeout, "Time for which file/directory attributes are cached.")
 	flags.StringArrayVarP(flagSet, &Opt.ExtraOptions, "option", "o", []string{}, "Option for libfuse/WinFsp. Repeat if required.")
 	flags.StringArrayVarP(flagSet, &Opt.ExtraFlags, "fuse-flag", "", []string{}, "Flags or arguments to be passed direct to libfuse/WinFsp. Repeat if required.")
-	flags.BoolVarP(flagSet, &Opt.Daemon, "daemon", "", Opt.Daemon, "Run mount as a daemon (background mode).")
-	flags.StringVarP(flagSet, &Opt.VolumeName, "volname", "", Opt.VolumeName, "Set the volume name (not supported by all OSes).")
-	flags.DurationVarP(flagSet, &Opt.DaemonTimeout, "daemon-timeout", "", Opt.DaemonTimeout, "Time limit for rclone to respond to kernel (not supported by all OSes).")
-	flags.BoolVarP(flagSet, &Opt.AsyncRead, "async-read", "", Opt.AsyncRead, "Use asynchronous reads.")
-	if runtime.GOOS == "darwin" {
-		flags.BoolVarP(flagSet, &Opt.NoAppleDouble, "noappledouble", "", Opt.NoAppleDouble, "Sets the OSXFUSE option noappledouble.")
-		flags.BoolVarP(flagSet, &Opt.NoAppleXattr, "noapplexattr", "", Opt.NoAppleXattr, "Sets the OSXFUSE option noapplexattr.")
-	} else if runtime.GOOS == "windows" {
-		flags.BoolVarP(flagSet, &Opt.NetworkMode, "network-mode", "", Opt.NetworkMode, "Mount as remote network drive, instead of fixed disk drive.")
-	}
+	// Non-Windows only
+	flags.BoolVarP(flagSet, &Opt.Daemon, "daemon", "", Opt.Daemon, "Run mount as a daemon (background mode). Not supported on Windows.")
+	flags.DurationVarP(flagSet, &Opt.DaemonTimeout, "daemon-timeout", "", Opt.DaemonTimeout, "Time limit for rclone to respond to kernel. Not supported on Windows.")
+	flags.BoolVarP(flagSet, &Opt.DefaultPermissions, "default-permissions", "", Opt.DefaultPermissions, "Makes kernel enforce access control based on the file mode. Not supported on Windows.")
+	flags.BoolVarP(flagSet, &Opt.AllowNonEmpty, "allow-non-empty", "", Opt.AllowNonEmpty, "Allow mounting over a non-empty directory. Not supported on Windows.")
+	flags.BoolVarP(flagSet, &Opt.AllowRoot, "allow-root", "", Opt.AllowRoot, "Allow access to root user. Not supported on Windows.")
+	flags.BoolVarP(flagSet, &Opt.AllowOther, "allow-other", "", Opt.AllowOther, "Allow access to other users. Not supported on Windows.")
+	flags.BoolVarP(flagSet, &Opt.AsyncRead, "async-read", "", Opt.AsyncRead, "Use asynchronous reads. Not supported on Windows.")
+	flags.FVarP(flagSet, &Opt.MaxReadAhead, "max-read-ahead", "", "The number of bytes that can be prefetched for sequential reads. Not supported on Windows.")
+	flags.BoolVarP(flagSet, &Opt.WritebackCache, "write-back-cache", "", Opt.WritebackCache, "Makes kernel buffer writes before sending them to rclone. Without this, writethrough caching is used. Not supported on Windows.")
+	// Windows and OSX
+	flags.StringVarP(flagSet, &Opt.VolumeName, "volname", "", Opt.VolumeName, "Set the volume name. Supported on Windows and OSX only.")
+	// OSX only
+	flags.BoolVarP(flagSet, &Opt.NoAppleDouble, "noappledouble", "", Opt.NoAppleDouble, "Ignore Apple Double (._) and .DS_Store files. Supported on OSX only.")
+	flags.BoolVarP(flagSet, &Opt.NoAppleXattr, "noapplexattr", "", Opt.NoAppleXattr, "Ignore all \"com.apple.*\" extended attributes. Supported on OSX only.")
+	// Windows only
+	flags.BoolVarP(flagSet, &Opt.NetworkMode, "network-mode", "", Opt.NetworkMode, "Mount as remote network drive, instead of fixed disk drive. Supported on Windows only")
 }
 
 // Check if folder is empty
@@ -165,10 +166,9 @@ FUSE.
 
 First set up your remote using ` + "`rclone config`" + `.  Check it works with ` + "`rclone ls`" + ` etc.
 
-You can either run mount in foreground mode or background (daemon) mode. Mount runs in
-foreground mode by default, use the ` + "`--daemon`" + ` flag to specify background mode.
-Background mode is only supported on Linux and OSX, you can only run mount in
-foreground mode on Windows.
+On Linux and OSX, you can either run mount in foreground mode or background (daemon) mode.
+Mount runs in foreground mode by default, use the ` + "`--daemon`" + ` flag to specify background mode.
+You can only run mount in foreground mode on Windows.
 
 On Linux/macOS/FreeBSD Start the mount like this where ` + "`/path/to/local/mount`" + `
 is an **empty** **existing** directory.

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -44,6 +44,7 @@ type Options struct {
 	NoAppleXattr       bool
 	DaemonTimeout      time.Duration // OSXFUSE only
 	AsyncRead          bool
+	NetworkMode        bool // Windows only
 }
 
 // DefaultOpt is the default values for creating the mount
@@ -99,6 +100,8 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	if runtime.GOOS == "darwin" {
 		flags.BoolVarP(flagSet, &Opt.NoAppleDouble, "noappledouble", "", Opt.NoAppleDouble, "Sets the OSXFUSE option noappledouble.")
 		flags.BoolVarP(flagSet, &Opt.NoAppleXattr, "noapplexattr", "", Opt.NoAppleXattr, "Sets the OSXFUSE option noapplexattr.")
+	} else if runtime.GOOS == "windows" {
+		flags.BoolVarP(flagSet, &Opt.NetworkMode, "network-mode", "", Opt.NetworkMode, "Mount as remote network drive, instead of fixed disk drive.")
 	}
 }
 

--- a/lib/file/driveletter_other.go
+++ b/lib/file/driveletter_other.go
@@ -1,0 +1,8 @@
+//+build !windows
+
+package file
+
+// FindUnusedDriveLetter does nothing except on Windows.
+func FindUnusedDriveLetter() (driveLetter uint8) {
+	return 0
+}

--- a/lib/file/driveletter_windows.go
+++ b/lib/file/driveletter_windows.go
@@ -1,0 +1,22 @@
+//+build windows
+
+package file
+
+import (
+	"os"
+)
+
+// FindUnusedDriveLetter searches mounted drive list on the system
+// (starting from Z: and ending at D:) for unused drive letter.
+// Returns the letter found (like 'Z') or zero value.
+func FindUnusedDriveLetter() (driveLetter uint8) {
+	// Do not use A: and B:, because they are reserved for floppy drive.
+	// Do not use C:, because it is normally used for main drive.
+	for l := uint8('Z'); l >= uint8('D'); l-- {
+		_, err := os.Stat(string(l) + ":" + string(os.PathSeparator))
+		if os.IsNotExist(err) {
+			return l
+		}
+	}
+	return 0
+}

--- a/vfs/help.go
+++ b/vfs/help.go
@@ -206,6 +206,12 @@ on disk cache file.
     --vfs-read-wait duration   Time to wait for in-sequence read before seeking. (default 20ms)
     --vfs-write-wait duration  Time to wait for in-sequence write before giving error. (default 1s)
 
+When using VFS write caching (--vfs-cache-mode with value writes or full),
+the global flag --transfers can be set to adjust the number of parallel uploads of
+modified files from cache (the related global flag --checkers have no effect on mount).
+
+    --transfers int  Number of file transfers to run in parallel. (default 4)
+
 ### VFS Case Sensitivity
 
 Linux file systems are case-sensitive: two files can differ only

--- a/vfs/vfsflags/vfsflags_unix.go
+++ b/vfs/vfsflags/vfsflags_unix.go
@@ -10,11 +10,11 @@ import (
 
 // add any extra platform specific flags
 func platformFlags(flagSet *pflag.FlagSet) {
-	flags.IntVarP(flagSet, &Opt.Umask, "umask", "", Opt.Umask, "Override the permission bits set by the filesystem.")
+	flags.IntVarP(flagSet, &Opt.Umask, "umask", "", Opt.Umask, "Override the permission bits set by the filesystem. Not supported on Windows.")
 	Opt.Umask = unix.Umask(0) // read the umask
 	unix.Umask(Opt.Umask)     // set it back to what it was
 	Opt.UID = uint32(unix.Geteuid())
 	Opt.GID = uint32(unix.Getegid())
-	flags.Uint32VarP(flagSet, &Opt.UID, "uid", "", Opt.UID, "Override the uid field set by the filesystem.")
-	flags.Uint32VarP(flagSet, &Opt.GID, "gid", "", Opt.GID, "Override the gid field set by the filesystem.")
+	flags.Uint32VarP(flagSet, &Opt.UID, "uid", "", Opt.UID, "Override the uid field set by the filesystem. Not supported on Windows.")
+	flags.Uint32VarP(flagSet, &Opt.GID, "gid", "", Opt.GID, "Override the gid field set by the filesystem. Not supported on Windows.")
 }

--- a/vfs/vfstest/fs.go
+++ b/vfs/vfstest/fs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/walk"
 	"github.com/rclone/rclone/fstest"
+	"github.com/rclone/rclone/lib/file"
 	"github.com/rclone/rclone/vfs"
 	"github.com/rclone/rclone/vfs/vfscommon"
 	"github.com/rclone/rclone/vfs/vfsflags"
@@ -155,16 +156,13 @@ func findMountPath() string {
 	}
 
 	// Find a free drive letter
+	letter := file.FindUnusedDriveLetter()
 	drive := ""
-	for letter := 'E'; letter <= 'Z'; letter++ {
+	if letter == 0 {
+		log.Fatalf("Couldn't find free drive letter for test")
+	} else {
 		drive = string(letter) + ":"
-		_, err := os.Stat(drive + "\\")
-		if os.IsNotExist(err) {
-			goto found
-		}
 	}
-	log.Fatalf("Couldn't find free drive letter for test")
-found:
 	return drive
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

On Windows one can mount in one of two modes: fixed disk drive or network drive. Currently the default is disk drive, and to mount as network drive you must pass argument --VolumePrefix into libfuse/WinFsp via the --fuse-flag option in rclone mount:

```
rclone mount remote: X: --fuse-flag --VolumePrefix=\server\share
```

This syntax is a bit convoluted, especially if the network mode is more or less the preferred method (too little user experience myself, but sounds it from what I read it). My intention is to make it a bit more elegant and user-friendly - make the choice between fixed vs network drive mounting more "native" to rclone, and possibly also making the network mode the default.

See also discussion in #4714.

**Part 1: Network mode option**

The existing `--volname` option, currently used to set custom volume label when mounting using disk method into a drive letter, could be re-used for setting the "share" name, and then just add a default prefix `\server\` to mount as network path `\\server\share`. Now we need a new method for selecting disk or network type mounting: We can introduce a new dedicated rclone option to select mode:
```
rclone mount remote: X: --network-mode
rclone mount remote: X: --network-mode --volname myshare
rclone mount remote: X: --network-mode=false
```

Update a:

Added support for specifying the full volume prefix in the `--volname` option. Using regular Windows UNC path style, with double leading backslash, instead of the WinFsp single backslash style. Also found that a subfolder path is legal (added note below). If specified value is UNC style then network mode is implied, regardless of --network-mode. Examples:

```
rclone mount remote: X: --network-mode --volname \\myserver\myshare
rclone mount remote: X: --network-mode --volname \\myserver\myshare\some\folder
```

**Part 2: UNC path as mountpoint**

An even more elegant approach would be to make rclone accept a Windows UNC style path as the mountpoint argument, such as `rclone mount remote: \\server\share`, and then use that as the "hint" to select network type mounting. One issue then is that from rclone it is not possible to mount as network drive without mapping to drive letter.

From discussion in #4714:
*This is something which is supported by WinFsp, but not by current implementation of rclone and/or cgofuse. You can actually supply an empty string as mountpoint argument, rclone mount remote: `"" --fuse-flag --VolumePrefix=\server\share`, and it works... But it will still map to a drive letter - first free letter counting backwards from Z:, logic from WinFsp method FspFileSystemSetMountPoint (which seems to be always called, while WinFsp sample utilities airfs/memfs skips calling this method when no mountpoint is specified, and then the network share is mounted but not mapped to drive letter). Rclone will show an error, because it waits for the mountpoint to become ready polling os.Stat, and since it is empty it times out and reports `ERROR : mountpoint "" didn't became available on mount - continuing anyway`, but it works as an undocumented trick for now.*

What I did do (for now) is, when UNC path is specified, then automatically find a free drive letter and mount that. As noted above this is just what will be done if an empty mountpoint is sent to cgofuse, but by implementing this in rclone it will know exactly what drive letter is picked.

**Part 3: Fixes #2678**

Implemented syntax for automatically picking drive letter (without having to use the unc path method from above, so auto drive letter and auto volume prefix / share path), based on tip on feature request #2678 "Use next available drive letter on Windows" in comments. Mountpoint "*" or "" (empty string) will be used to trigger this feature.


**Part 4: Cleanup handling of os specific mount options**

Were wondering if os-specific flags... should be just that, 
```
if runtime.GOOS == "windows" {
	flags.BoolVarP(flagSet, &Opt.NetworkMode, "network-mode", "", Opt.NetworkMode, "Mount as drive type remote network drive, instead of fixed disk drive.")
}
```
or instead documented as such:
```
flags.BoolVarP(flagSet, &Opt.NetworkMode, "network-mode", "", Opt.NetworkMode, "Mount as drive type remote network drive, instead of fixed disk drive (Windows only).")
```

Found later [this](https://forum.rclone.org/t/cant-delete-empty-directory-because-of-ds-store/13003/2), which indicates it should be available on all os and just documented:
>Confusingly these aren't in the docs as they are macOS only and the docs are built on a linux machine. This is probably an oversight!

Done:
- Moved `--noappledouble` and `--noapplexattr` from Darwin specific section and documented as OSX specific, according to comment [here](https://forum.rclone.org/t/cant-delete-empty-directory-because-of-ds-store/13003/2).
- Ignoring `--daemon-timeout`, `--allow-non-empty`, `--allow-other` and `--allow-root` entirely on windows, since the mount "backend" does not support them anyway, and documented this. Also documented that `--deamon`, `--async-read` and `--write-back-cache` are not supported on windows (these were already ignored).
- Ignoring  `--noappledouble` and `--noapplexattr` on "cmd\mount" since it no longer supports OSX (see [this](https://forum.rclone.org/t/rclone-mount-and-macos-testers-needed/17527) and [this](https://github.com/bazil/fuse/blob/88ebede33592c7147c85956887ac4ece38c241b9/options.go#L80-L88)).
- Documented `--volname` as Windows and OSX specific.



**Examples:**

`rclone mount remote: *`
- Mount using default mode, default volume name, automatic assigning a free drive letter.

`rclone mount remote: \\server\share`
- Mount using specific volume prefix (network share path), implicit --network-mode=true, automatic assigning a free drive letter.

`rclone mount remote: \\server\share --network-mode=false`
- Same as above, option "--network-mode=false" silently ignored due to UNC path (or should we warn user?)

`rclone mount remote: X: --volname share`
- Mounting as drive letter X: in default mode (which should be network, implied `--network-mode=true`?). If network mode the volume name "share" is used after an implicit prefix "\\server\" as the volume prefix (resulting in mounted network share unc path \\server\share).

`rclone mount remote: X: --network-mode --volname \\myserver\myshare`
- Mounting as drive letter X: in network mode, with full volume prefix "\\myserver\myshare", which will be shown as the mounted network share unc path.

`rclone mount remote: X: --network-mode --volname \\myserver\myshare\some\folder`
- Same as above, but mounting as a subfolder path into the network share, which seems perfectly valid.

`rclone mount remote: X: --network-mode=false --volname \\myserver\myshare`
- Mounting as drive letter X: in forced network mode, --network-mode=false is ignored, with full volume prefix "\\myserver\myshare", which will be shown as the mounted network share unc path.

`rclone mount remote: X: --volname share --network-mode=true`
- Explicit network mode (on).

`rclone mount remote: X: --volname share --network-mode=false`
- Explicit disk mode (network mode off).

`rclone mount remote: X: --fuse-flag --VolumePrefix=\server\share`
- Works just as in previous versions

`rclone mount remote: X: --fuse-flag --VolumePrefix=\server\share`
- Works just as in previous versions

`rclone mount jfs_dev_crypt: X: --network-mode --volname \\myserver\myshare --fuse-flag --VolumePrefix=\server\share --fuse-flag --VolumePrefix=\server2\share2`
- The volume prefix is specified three times here, last oe wins (nothing rclone does at the moment, WinFsp handles it this way), so will be mounted as `\\server2\share2`.

**Some additional notes:**

* When mounting with directory path the path must not exist, but the parent must! Added a check for this, so that rclone reports an error (instead of relaying error from WinFsp).
* When mounting with drive letter it must be specified in the form "X:", trying "X:\" (with backslash) leads to error:  `Cannot create WinFsp-FUSE file system: invalid mount point.`. This will now be caught by the parent path error check above.
* When mounting as network drive it is not possible to mount into directory path (just drive letter). Added check for this.
* When mouting as network drive using a share name that already exists fails with error messages "Cannot create WinFsp-FUSE file system: invalid mount point.`. No additional check implemented for this, so error will come from WinFsp.
* When mounting as network drive, the volume prefix must use single backslash path `\server\testing` instead of the standard windows unc format `\\server\share` when sent to cgofuse/winfsp: `--VolumePrefix=\server\testing`. When specifying unc path as mountpoint this is handled automatically, when using --fuse-flag the error will come from WinFsp.
* When mounting as network drive, the volume prefix must at least have the `\server\share` part (which identifies the volume), but can also include subfolder path such as `\server\share\some\folder`.

**Questions and TODOs:**

- Needs manual testing, possible corner cases etc. Perhaps a beta release with volunteer testers. Are there relevant unit tests that should be considered?

- Make mounting as network drive the new default, or keep existing disk mode as default?
  - I do not know specifically which positive and negative effects either approach have, but from what I read I get a feeling that network drive should normally be the preferred mode, at least assuming mounting of a remote/cloud backend which does not offer you "near-disk" speed.
  - One limitation with the network mode is that you cannot mount into a directory, you must mount it to a drive letter.
  - One approach could be to always use disk mode when mounting into directory path, and default to network mode when mounting to drive letter (and all other cases).
  - Another approach, since the UNC mountpoint syntax above (using implicit --network-mode=true) makes network mode fell more "native" to rclone, would be to keep disk mode (`--network-mode=false`) as default when mounting into directory path and drive letter, same as in previous versions, and when mounting to a drive letter one would have to use the flag `--network-mode` or set an UNC path as `--volname` to enable network mode. If one does not need to set specific drive letter using the unc path as "mountpoint" in the command syntax is quite nice.

- Should it be checked for, and warned or removed, explicit --VolumePrefix option, in the highly likely case that user is still including the arguments needed in the previous versions? It seems that the last one will be used, and all other silently ignored; when mount code passes `--VolumePrefix=\\server\\share --VolumePrefix=\\server\\share2` into cgofuse it will mount as "\\server\share2". Any fuse options/flags user specifies on the command line are added last, after any set from rclone code, so user specified ones will "win".

- Continuing from previous point, but more generally: Currently the "-o uid" and "-o gid" options are checked for, and default set only if not set by user, but for "--FileSystemName", "--VolumePrefix" and "-o volname" a default value are set without checking if already set by user. Seems the checking for uid/gid were introduced after a [forum discussion](https://forum.rclone.org/t/issue-with-rclone-mount-and-resilio-sync/14730/28), but there are no conclusion there that this made any difference. From my testing it works perfectly fine to set these multiple times, last one wins. This includes "-o uid" and "-o gid"! I can add to rclone mount `-o gid=11 -o gid=-1` and the resulting mount has "Domain Users" (-1) on it. If i use `-o gid=11 -o gid=-1 -o gid=11` it gets "Authenticated Users" (11) instead. Setting `--FileSystemName=xxx` means it gets filesystem "FUSE-xxx" and not "FUSE-rclone" even though rclone always sets "--FileSystemName=rclone". Edit: Confirmed by https://github.com/billziss-gh/winfsp/issues/204#issuecomment-441845116. So, for consistency, should we just remove the checking of uid/gid from code and rely on the fact that cfgofuse/WinFsp is handling this well, and in a way that lets rclone users override anything set by rclone on their command line? If not, the check function had a tiny miss: You can specify multiple options such as both uid and gid in the same comma separated string, so both `-o uid=-1 -o gid=11` and `-o uid=-1,gid=11` have same result, but the check function did only consider the first. Added a commit to fix this (just splitting on comma, which could still have an issue if individual values are allowed to contain quoted strings with commas or something like that)... just to be followed by a commit that removes the check entirely..!

- And another "spin-off" from the previous point: You can set username and groupnames now, and don't have to find the POSIX uid int numbers. For example group name can be set as `-o GroupName="Authenticated Users"` or `--fuse-flag --GroupName="Authenticated Users"` (both works). Same with "UserName". See https://github.com/rclone/rclone/issues/3216#issuecomment-509412571 (tip from comments). Not sure if this deserves documentation? Maybe not, can't document everyfuse/WinFsp option there is, unless they are especially relevant.
Edit: Found these new options has already been mentioned in forum: https://forum.rclone.org/t/the-winfsp-thread-how-new-features-affect-rclone/12488/3

- Error handling in rclone for invalid paths etc, or rely on winfsp/cgofuse to report understandable error message? This merge request introduces a somewhat fair amount of error handling in rclone part, but there are still many cases where winfsp fails and its error is reported back to user.

~- Update main documentation of the mount command. Note: Consider changes in #4714! Need to merge those first, and then update further.~

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

Not directly. But related merge request #4714 and issue #2678.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate. *TODO: Are there any existing unit tests that should be extended?*
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
