### PR TITLE
fs: Fix copy & move operations directly to remote

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -511,7 +511,7 @@ func Copy(ctx context.Context, f fs.Fs, dst fs.Object, remote string, src fs.Obj
 			return newDst, err
 		}
 	}
-	if src.String() != newDst.String() {
+	if newDst != nil && src.String() != newDst.String() {
 		fs.Infof(src, "%s to: %s", actionTaken, newDst.String())
 	} else {
 		fs.Infof(src, actionTaken)
@@ -569,7 +569,7 @@ func Move(ctx context.Context, fdst fs.Fs, dst fs.Object, remote string, src fs.
 		newDst, err = doMove(ctx, src, remote)
 		switch err {
 		case nil:
-			if src.String() != newDst.String() {
+			if newDst != nil && src.String() != newDst.String() {
 				fs.Infof(src, "Moved (server-side) to: %s", newDst.String())
 			} else {
 				fs.Infof(src, "Moved (server-side)")


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix the copy and move operations that broke in 127f0fc when copying directly to a remote without a specific destination.

#### Was the change discussed in an issue or in the forum before?

#4747 

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
