### PR TITLE
onedrive: Support addressing site by server-relative URL

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net/http"
 	"path"
+	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -119,9 +120,15 @@ func init() {
 			var opts rest.Opts
 			var finalDriveID string
 			var siteID string
+			var relativePath string
 			switch config.Choose("Your choice",
-				[]string{"onedrive", "sharepoint", "driveid", "siteid", "search"},
-				[]string{"OneDrive Personal or Business", "Root Sharepoint site", "Type in driveID", "Type in SiteID", "Search a Sharepoint site"},
+				[]string{"onedrive", "sharepoint", "url", "driveid", "siteid", "path", "search"},
+				[]string{
+					"OneDrive Personal or Business",
+					"Root Sharepoint site", "Sharepoint site URL",
+					"Type in driveID", "Type in SiteID",
+					"Sharepoint site by server-relative URL", "Search a Sharepoint site",
+				},
 				false) {
 
 			case "onedrive":
@@ -142,6 +149,20 @@ func init() {
 			case "siteid":
 				fmt.Printf("Paste your Site ID here> ")
 				siteID = config.ReadLine()
+			case "url":
+				fmt.Println("Example: \"https://contoso.sharepoint.com/sites/mysite\" or \"mysite\"")
+				fmt.Printf("Paste your Site URL here> ")
+				siteURL := config.ReadLine()
+				re := regexp.MustCompile(`https://.*\.sharepoint.com/sites/(.*)`)
+				match := re.FindStringSubmatch(siteURL)
+				if len(match) == 2 {
+					relativePath = "/sites/" + match[1]
+				} else {
+					relativePath = "/sites/" + siteURL
+				}
+			case "path":
+				fmt.Printf("Enter server-relative URL here> ")
+				relativePath = config.ReadLine()
 			case "search":
 				fmt.Printf("What to search for> ")
 				searchTerm := config.ReadLine()
@@ -166,6 +187,21 @@ func init() {
 					}
 					siteID = sites.Sites[config.ChooseNumber("Chose drive to use:", 0, len(sites.Sites)-1)].SiteID
 				}
+			}
+
+			// if we use server-relative URL for finding the drive
+			if relativePath != "" {
+				opts = rest.Opts{
+					Method:  "GET",
+					RootURL: graphURL,
+					Path:    "/sites/root:" + relativePath,
+				}
+				site := siteResource{}
+				_, err := srv.CallJSON(ctx, &opts, nil, &site)
+				if err != nil {
+					log.Fatalf("Failed to query available site by relative path: %v", err)
+				}
+				siteID = site.SiteID
 			}
 
 			// if we have a siteID we need to ask for the drives

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -122,12 +122,15 @@ func init() {
 			var siteID string
 			var relativePath string
 			switch config.Choose("Your choice",
-				[]string{"onedrive", "sharepoint", "url", "driveid", "siteid", "path", "search"},
+				[]string{"onedrive", "sharepoint", "url", "search", "driveid", "siteid", "path"},
 				[]string{
 					"OneDrive Personal or Business",
-					"Root Sharepoint site", "Sharepoint site URL",
-					"Type in driveID", "Type in SiteID",
-					"Sharepoint site by server-relative URL", "Search a Sharepoint site",
+					"Root Sharepoint site",
+					"Sharepoint site name or URL (e.g. mysite or https://contoso.sharepoint.com/sites/mysite)",
+					"Search for a Sharepoint site",
+					"Type in driveID (advanced)",
+					"Type in SiteID (advanced)",
+					"Sharepoint server-relative path (advanced, e.g. /teams/hr)",
 				},
 				false) {
 


### PR DESCRIPTION
#### What is the purpose of this change?

Allow for addressing site by SPO URL, e.g. `https://contoso.sharepoint.com/sites/mysite` or `mysite`
1. By URL is more friendly than finding the site-id
2. For too many SPO sites, like more than 200, using URL is the only way

This method is using [server-relative URL](https://docs.microsoft.com/en-us/graph/api/site-get?view=graph-rest-1.0&tabs=http#access-a-site-by-server-relative-url), thus also adding a "low-level" support for it.

ref: https://docs.microsoft.com/en-us/graph/api/site-get?view=graph-rest-1.0&tabs=http#access-a-site-by-server-relative-url
ref2: https://docs.microsoft.com/en-us/graph/api/resources/sharepoint?view=graph-rest-1.0#sharepoint-api-root-resources