### PR TITLE
Changes to rclone filtering documentation

### DIFF
--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -5,14 +5,15 @@ description: "Filtering, includes and excludes"
 
 # Filtering, includes and excludes #
 
-Rclone filter flags are specified in terms of path/file name
+Filter flags determine which files rclone`sync`, `move`, `ls`, `lsl`,
+`md5sum`, `sha1sum`, `size`, `delete` and `check` commands are applied
+to.
+
+They are specified in terms of path/file name
 patterns; path/file lists; file age and size, or presence of
 a file in a directory. Bucket remotes without the concept of
 directory apply filters to object key, age and size in an
 analogous way.
-
-Filter flags apply to rclone `copy`, `sync`, `move`, `ls`, `lsl`,
-`md5sum`, `sha1sum`, `size`, `delete` and `check` commands.
 
 Rclone `purge` does not obey filters.
 

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -6,8 +6,8 @@ description: "Rclone filtering, includes and excludes"
 # Filtering, includes and excludes
 
 Filter flags determine which files rclone`sync`, `move`, `ls`, `lsl`,
-`md5sum`, `sha1sum`, `size`, `delete`, `check` and similar commands are
-applied to.
+`md5sum`, `sha1sum`, `size`, `delete`, `check` and similar commands
+apply to.
 
 They are specified in terms of path/file name
 patterns; path/file lists; file age and size, or presence of
@@ -57,12 +57,12 @@ pattern-list:
     pattern { `,` pattern }
                 comma-separated (without spaces) patterns
 
-character classes (see [ref](https://golang.org/pkg/regexp/syntax/)) include:
+character classes (see [Go regular expression reference](https://golang.org/pkg/regexp/syntax/)) include:
 
     Named character classes (eg [\d], [^\d], [\D], [^\D])
     Perl character classes (eg \s, \S, \w, \W)
     ASCII character classes (eg [[:alnum:]], [[:alpha:]], [[:punct:]], [[:xdigit:]])
-        - 
+
 If the filter pattern starts with a `/` then it only matches
 at the top level of the directory tree,
 **relative to the root of the remote** (not necessarily the root
@@ -71,30 +71,28 @@ starting at the **end of the path/file name** but it only matches
 a complete path element - it must match from a `/`
 separator or the beginning of the path/file.
 
-Eg
-
-    file.jpg  - matches "file.jpg"
-              - matches "directory/file.jpg"
-              - doesn't match "afile.jpg"
-              - doesn't match "directory/afile.jpg"
-    /file.jpg - matches "file.jpg" in the root directory of the remote
-              - doesn't match "afile.jpg"
-              - doesn't match "directory/file.jpg"
+    file.jpg   - matches "file.jpg"
+               - matches "directory/file.jpg"
+               - doesn't match "afile.jpg"
+               - doesn't match "directory/afile.jpg"
+    /file.jpg  - matches "file.jpg" in the root directory of the remote
+               - doesn't match "afile.jpg"
+               - doesn't match "directory/file.jpg"
 
 **Important** Use `/` in path/file name patterns and not `\` even if
 running on Microsoft Windows.
 
 Simple patterns are case sensitive unless the `--ignore-case` flag is used.
 
-    Without `--ignore-case` (default)
+Without `--ignore-case` (default)
 
-        potato - matches "potato"
-               - doesn't match "POTATO"
+    potato - matches "potato"
+           - doesn't match "POTATO"
 
-    With `--ignore-case`
+With `--ignore-case`
 
-        potato - matches "potato"
-               - matches "POTATO"
+    potato - matches "potato"
+           - matches "POTATO"
 
 ## How filter rules are applied to files
 
@@ -151,8 +149,8 @@ for a command add the `--dump filters` flag. Running an rclone command
 with `--dump filters` and `--vv` flags lists the internal filter elements
 and shows how they are applied to each source path/file. There is not
 currently a means provided to pass regular expression filter options into
-rclone directly though filter rules based on character classes contain
-some elements. [Go regular expression reference](https://golang.org/pkg/regexp/syntax/)
+rclone directly though character class filter rules contain
+elements. [Go regular expression reference](https://golang.org/pkg/regexp/syntax/)
 
 ### How filter rules are applied to directories
 

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -257,11 +257,6 @@ Option `exclude-if-present` creates a directory exclude rule based
 on the presence of a file in a directory and takes precedence over
 other rclone directory filter rules.
 
-Rclone's treatment of directories contrasts with rsync. The rsync
-filter pattern `/directory/` matches all files in the directory
-but in rclone merely specifies a directory filter. To match the rsync
-interpretation `/directory/**` would be specified in rclone.
-
 ### `--exclude` - Exclude files matching pattern ###
 
 Excludes path/file names from an rclone command based on a single exclude

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -1,13 +1,13 @@
 ---
-title: "Filtering"
-description: "Filtering, includes and excludes"
+title: "Rclone Filtering"
+description: "Rclone filtering, includes and excludes"
 ---
 
-# Filtering, includes and excludes #
+# Filtering, includes and excludes
 
 Filter flags determine which files rclone`sync`, `move`, `ls`, `lsl`,
-`md5sum`, `sha1sum`, `size`, `delete` and `check` commands are applied
-to.
+`md5sum`, `sha1sum`, `size`, `delete`, `check` and similar commands are
+applied to.
 
 They are specified in terms of path/file name
 patterns; path/file lists; file age and size, or presence of
@@ -30,14 +30,14 @@ Eg `rclone copy "remote:dir*.jpg" /path/to/dir` does not have a filter effect.
 `--filter...` flags in an rclone command. The results may not be what
 you expect. Instead use a `--filter...` flag.
 
-## Patterns for matching path/file names ##
+## Patterns for matching path/file names
 
-### Pattern syntax ###
+### Pattern syntax
 
-Rclone's matching rules follow a glob style:
+Rclone matching rules follow a glob style:
 
     `*`         matches any sequence of non-separator (`/`) characters
-    `**`        matches any sequence of characters
+    `**`        matches any sequence of characters including `/` separators
     `?`         matches any single non-separator (`/`) character
     `[` [ `!` ] { character-range } `]`
                 character class (must be non-empty)
@@ -57,6 +57,12 @@ pattern-list:
     pattern { `,` pattern }
                 comma-separated (without spaces) patterns
 
+character classes (see [ref](https://golang.org/pkg/regexp/syntax/)) include:
+
+    Named character classes (eg [\d], [^\d], [\D], [^\D])
+    Perl character classes (eg \s, \S, \w, \W)
+    ASCII character classes (eg [[:alnum:]], [[:alpha:]], [[:punct:]], [[:xdigit:]])
+        - 
 If the filter pattern starts with a `/` then it only matches
 at the top level of the directory tree,
 **relative to the root of the remote** (not necessarily the root
@@ -64,6 +70,8 @@ of the drive). If it does not start with `/` then it is matched
 starting at the **end of the path/file name** but it only matches
 a complete path element - it must match from a `/`
 separator or the beginning of the path/file.
+
+Eg
 
     file.jpg  - matches "file.jpg"
               - matches "directory/file.jpg"
@@ -76,65 +84,19 @@ separator or the beginning of the path/file.
 **Important** Use `/` in path/file name patterns and not `\` even if
 running on Microsoft Windows.
 
-Eg `*` matches anything but not a `/` separator:
+Simple patterns are case sensitive unless the `--ignore-case` flag is used.
 
-    *.jpg  - matches "file.jpg"
-           - matches "directory/file.jpg"
-           - doesn't match "file.jpg/something"
+    Without `--ignore-case` (default)
 
-Eg `**` matches anything, including slash (`/`) separators:
+        potato - matches "potato"
+               - doesn't match "POTATO"
 
-    dir/** - matches "dir/file.jpg"
-           - matches "dir/dir1/dir2/file.jpg"
-           - doesn't match "directory/file.jpg"
-           - doesn't match "adir/file.jpg"
+    With `--ignore-case`
 
-Eg `rclone --exclude /dir1/** ls remote:` lists all of `remote`
-except for root directory `dir1` and all the files contained within it
-or its subdirectories.
+        potato - matches "potato"
+               - matches "POTATO"
 
-Eg `?` matches any character except a slash `/` separator:
-
-    l?ss  - matches "less"
-          - matches "lass"
-          - doesn't match "floss"
-
-Eg `[` and `]` together make a character class, such as `[a-z]`, `[aeiou]`
-or `[[:alpha:]]`:
-
-    h[ae]llo - matches "hello"
-             - matches "hallo"
-             - doesn't match "hullo"
-
-
-
-Eg `{` and `}` define a choice from a comma separated list of
-patterns, any of which might match. The patterns can contain wildcards:
-
-    {one,two}_potato - matches "one_potato"
-                     - matches "two_potato"
-                     - doesn't match "three_potato"
-                     - doesn't match "_potato"
-
-Eg Special characters can be escaped with a `\` before them:
-
-    \*.jpg       - matches "*.jpg"
-    \\.jpg       - matches "\.jpg"
-    \[one\].jpg  - matches "[one].jpg"
-
-Eg Patterns are case sensitive unless the `--ignore-case` flag is used.
-
-Without `--ignore-case` (default)
-
-    potato - matches "potato"
-           - doesn't match "POTATO"
-
-With `--ignore-case`
-
-    potato - matches "potato"
-           - matches "POTATO"
-
-## How filter rules are applied to files ##
+## How filter rules are applied to files
 
 Rclone path / file name filters are made up of one or more of the following flags:
 
@@ -189,9 +151,10 @@ for a command add the `--dump filters` flag. Running an rclone command
 with `--dump filters` and `--vv` flags lists the internal filter elements
 and shows how they are applied to each source path/file. There is not
 currently a means provided to pass regular expression filter options into
-rclone directly. [Go regular expression reference](https://golang.org/pkg/regexp/syntax/)
+rclone directly though filter rules based on character classes contain
+some elements. [Go regular expression reference](https://golang.org/pkg/regexp/syntax/)
 
-### How filter rules are applied to directories ###
+### How filter rules are applied to directories
 
 Rclone commands filter, and are applied to, path/file names not
 directories. The entire contents of a directory can be matched
@@ -209,7 +172,7 @@ desirable depends on the specific filter rules and source remote content.
 
 Optimisation occurs if either:
 
-* The source remote does not support rclone's `ListR` primitive. `local`,
+* A source remote does not support the rclone `ListR` primitive. `local`,
 `sftp`, `Microsoft OneDrive` and `WebDav` do not support `ListR`. Google
 Drive and most bucket type storage do. [Full list](https://rclone.org/overview/#optional-features)
 
@@ -217,7 +180,7 @@ Drive and most bucket type storage do. [Full list](https://rclone.org/overview/#
 provided it is not run with the `--fast-list` flag. `ls`, `lsf -R` and
 `size` are recursive but `sync`, `copy` and `move` are not. 
 
-* Whenever the `--disable-ListR` flag is applied to an rclone command.
+* Whenever the `--disable ListR` flag is applied to an rclone command.
 
 Rclone commands imply directory filter rules from path/file filter
 rules. To view the directory filter rules rclone has implied for a
@@ -258,7 +221,7 @@ Option `exclude-if-present` creates a directory exclude rule based
 on the presence of a file in a directory and takes precedence over
 other rclone directory filter rules.
 
-### `--exclude` - Exclude files matching pattern ###
+### `--exclude` - Exclude files matching pattern
 
 Excludes path/file names from an rclone command based on a single exclude
 rule. 
@@ -272,21 +235,22 @@ processed in.
 `--exclude` has no effect when combined with `--files-from` or
 `--files-from-raw` flags.
 
-Eg `rclone ls remote: --exclude *.bak` to exclude all .bak files
+Eg `rclone ls remote: --exclude *.bak` excludes all .bak files
 from listing.
 
-Eg `rclone  size remote: --exclude /dir/**` to return the total size of
+Eg `rclone size remote: "--exclude /dir/**"` returns the total size of
 all files on `remote:` excluding those in root directory `dir` and sub
 directories.
 
-Eg `rclone ls remote: --exclude '*\[{JP,KR,HK,CN,RU,PL,AU,GB,FR}\]*'`
-to list the files in `remote:` with `[JP]` or `[KR]` or `[HK]` etc. in
+Eg on Microsoft Windows `rclone ls remote: --exclude "*\[{JP,KR,HK}\]*"`
+lists the files in `remote:` with `[JP]` or `[KR]` or `[HK]` in
 their name. The single quotes prevent the shell from interpreting the `\`
-characters. The `\` characters escape the `[` and `]` so rclone's filter
+characters. The `\` characters escape the `[` and `]` so ran clone filter
 treats them literally rather than as a character-range. The `{` and `}`
-define an rclone pattern list.
+define an rclone pattern list. For other operating systems single quotes are
+required ie `rclone ls remote: --exclude '*\[{JP,KR,HK}\]*'`
 
-### `--exclude-from` - Read exclude patterns from file ###
+### `--exclude-from` - Read exclude patterns from file
 
 Excludes path/file names from an rclone command based on rules in a
 named file. The file contains a list of remarks and pattern rules. 
@@ -299,7 +263,7 @@ For an example `exclude-file.txt`:
 
 `rclone ls remote: --exclude-from exclude-file.txt` lists the files on
 `remote:` except those named `file2.jpg` or with a suffix `.bak`. That is
-equivalent to `rclone ls remote: --exclude 'file2.jpg' --exclude '*.bak'`.
+equivalent to `rclone ls remote: --exclude file2.jpg --exclude "*.bak"`.
 
 This flag can be repeated. See above for the order filter flags are
 processed in.
@@ -315,7 +279,7 @@ are applied to an rclone command.
 
 `--exclude-from` followed by `-` reads filter rules from standard input. 
 
-### `--include` - Include files matching pattern ###
+### `--include` - Include files matching pattern
 
 Adds a single include rule based on path/file names to an rclone
 command.
@@ -326,13 +290,13 @@ processed in.
 `--include` has no effect when combined with `--files-from` or
 `--files-from-raw` flags.
 
-`--include` implies `--exclude **` at the end of rclone's internal
+`--include` implies `--exclude **` at the end of an rclone internal
 filter list. Therefore if you mix `--include` and `--include-from`
 flags with `--exclude`, `--exclude-from`, `--filter` or `--filter-from`,
 you must use include rules for all the files you want in the include
 statement. For more flexibility use the `--filter-from` flag.
 
-Eg `rclone ls remote: --include '*.{png,jpg}'` lists the files on
+Eg `rclone ls remote: --include "*.{png,jpg}"` lists the files on
 `remote:` with suffix `.png` and `.jpg`. All other files are excluded.
 
 Eg multiple rclone copy commands can be combined with `--include` and a
@@ -343,9 +307,14 @@ pattern-list.
 
 is equivalent to:
 
-    rclone copy /vol1 remote: --include={A,B}/**
+    rclone copy /vol1 remote: --include "{A,B}/**"
 
-### `--include-from` - Read include patterns from file ###
+Eg `rclone ls remote:/wheat --include "??[^[:punct:]]*"` lists the
+files `remote:` directory `wheat` (and subdirectories) whose third
+character is not punctuation. This example uses
+an [ASCII character class](https://golang.org/pkg/regexp/syntax/).
+
+### `--include-from` - Read include patterns from file
 
 Adds path/file names to an rclone command based on rules in a
 named file. The file contains a list of remarks and pattern rules. 
@@ -358,7 +327,7 @@ For an example `include-file.txt`:
 
 `rclone ls remote: --include-from include-file.txt` lists the files on
 `remote:` with name `file2.avi` or suffix `.jpg`. That is equivalent to
-`rclone ls remote: --include 'file2.avi' --include '*.jpg'`.
+`rclone ls remote: --include file2.avi --include "*.jpg"`.
 
 This flag can be repeated. See above for the order filter flags are
 processed in.
@@ -366,7 +335,7 @@ processed in.
 The `--include-from` flag is useful where multiple include filter rules
 are applied to an rclone command.
 
-`--include-from` implies `--exclude **` at the end of rclone's internal
+`--include-from` implies `--exclude **` at the end of an rclone internal
 filter list. Therefore if you mix `--include` and `--include-from`
 flags with `--exclude`, `--exclude-from`, `--filter` or `--filter-from`,
 you must use include rules for all the files you want in the include
@@ -377,10 +346,10 @@ statement. For more flexibility use the `--filter-from` flag.
 
 `--exclude-from` followed by `-` reads filter rules from standard input. 
 
-### `--filter` - Add a file-filtering rule ###
+### `--filter` - Add a file-filtering rule
 
-Specifies path/file names to an rclone command based on a single
-include or exclude rule in `+` or `-` format. 
+Specifies path/file names to an rclone command, based on a single
+include or exclude rule, in `+` or `-` format. 
 
 This flag can be repeated. See above for the order filter flags are
 processed in.
@@ -399,7 +368,7 @@ that rule.
 Eg `rclone ls remote: --filter "- *.bak"` excludes all `.bak` files
 from a list of `remote:`.
 
-### `--filter-from` - Read filtering patterns from a file ###
+### `--filter-from` - Read filtering patterns from a file
 
 Adds path/file names to an rclone command based on rules in a
 named file. The file contains a list of remarks and pattern rules. Include
@@ -452,7 +421,7 @@ Eg for an alternative `filter-file.txt`:
 
 Only file 42.doc is listed. Prior rules are cleared by the `!`.
 
-### `--files-from` - Read list of source-file names ###
+### `--files-from` - Read list of source-file names
 
 Adds path/files to an rclone command from a list in a named file.
 Rclone processes the path/file names in the order of the list, and
@@ -484,7 +453,8 @@ to right along the command line.
 
 Paths within the `--files-from` file are interpreted as starting
 with the root specified in the rclone command.  Leading `/` separators are
-ignored. See [--files-from-raw](#files-from-raw-read-list-of-source-file-names-without-any-processing) if you need the input to be processed in a raw manner.
+ignored. See [--files-from-raw](#files-from-raw-read-list-of-source-file-names-without-any-processing) if
+you need the input to be processed in a raw manner.
 
 Eg for a file `files-from.txt`:
 
@@ -538,7 +508,7 @@ Then there will be an extra `home` directory on the remote:
     /home/user1/dir/ford → remote:backup/home/user1/dir/ford
     /home/user2/prefect  → remote:backup/home/user2/prefect
 
-### `--files-from-raw` - Read list of source-file names without any processing ###
+### `--files-from-raw` - Read list of source-file names without any processing
 
 This flag is the same as `--files-from` except that input is read in a
 raw manner. Lines with leading / trailing whitespace, and lines starting
@@ -546,7 +516,7 @@ with `;` or `#` are read without any processing. [rclone lsf](/commands/rclone_l
 a compatible format that can be used to export file lists from remotes for
 input to `--files-from-raw`. 
 
-### `--ignore-case` - make searches case insensitive ###
+### `--ignore-case` - make searches case insensitive
 
 By default rclone filter patterns are case sensitive. The `--ignore-case`
 flag makes all of the filters patterns on the command line case
@@ -555,7 +525,7 @@ insensitive.
 Eg `--include "zaphod.txt"` does not match a file `Zaphod.txt`. With
 `--ignore-case` a match is made.
 
-## Quoting shell metacharacters ##
+## Quoting shell metacharacters
 
 Rclone commands with filter patterns containing shell metacharacters may
 not as work as expected in your shell and may require quoting.
@@ -566,20 +536,17 @@ Eg linux, OSX (`*` metacharacter)
   * `--include '*.jpg'`
   * `--include='*.jpg'`
 
-Microsoft Windows expansion is done by the command not shell so `--include *.jpg` does
-not require quoting.
+Microsoft Windows expansion is done by the command, not shell, so
+`--include *.jpg` does not require quoting.
 
-If the rclone error
+If the rclone error 
 `Command .... needs .... arguments maximum: you provided .... non flag arguments:`
-is encountered, the cause is commonly spaces within the name of a remote
-or flag. It can be corrected by quoting the values containing the spaces.
+is encountered, the cause is commonly spaces within the name of a
+remote or flag value. The fix then is to quote values containing spaces.
 
-Eg `rclone ls remote 1: --exclude /my documents/**` can be quoted
-`rclone ls 'remote 1:' --exclude '/my documents/**`.
+## Other filters
 
-## Other filters ##
-
-### `--min-size` - Don't transfer any file smaller than this ###
+### `--min-size` - Don't transfer any file smaller than this
 
 Controls the minimum size file within the scope of an rclone command.
 Default units are `kBytes` but abbreviations `k`, `M`, or `G` are valid.
@@ -587,7 +554,7 @@ Default units are `kBytes` but abbreviations `k`, `M`, or `G` are valid.
 Eg `rclone ls remote: --min-size 50k` lists files on `remote:` of 50kByte
 size or larger.
 
-### `--max-size` - Don't transfer any file larger than this ###
+### `--max-size` - Don't transfer any file larger than this
 
 Controls the maximum size file within the scope of an rclone command.
 Default units are `kBytes` but abbreviations `k`, `M`, or `G` are valid.
@@ -595,7 +562,7 @@ Default units are `kBytes` but abbreviations `k`, `M`, or `G` are valid.
 Eg `rclone ls remote: --max-size 1G` lists files on `remote:` of 1GByte
 size or smaller.
 
-### `--max-age` - Don't transfer any file older than this ###
+### `--max-age` - Don't transfer any file older than this
 
 Controls the maximum age of files within the scope of an rclone command.
 Default units are seconds or the following abbreviations are valid:
@@ -622,7 +589,7 @@ formats:
 Eg `rclone ls remote: --max-age 2d` lists files on `remote:` of 2 days
 old or less.
 
-### `--min-age` - Don't transfer any file younger than this ###
+### `--min-age` - Don't transfer any file younger than this
 
 Controls the minimum age of files within the scope of an rclone command.
 (see `--max-age` for valid formats)
@@ -632,9 +599,9 @@ Controls the minimum age of files within the scope of an rclone command.
 Eg `rclone ls remote: --min-age 2d` lists files on `remote:` of 2 days
 old or more.
 
-## Other flags ##
+## Other flags
 
-### `--delete-excluded` - Delete files on dest excluded from sync ###
+### `--delete-excluded` - Delete files on dest excluded from sync
 
 **Important** this flag is dangerous to your data - use with `--dry-run`
 and `-v` first.
@@ -642,22 +609,21 @@ and `-v` first.
 In conjunction with `rclone sync` the `--delete-excluded deletes any files
 on the destination which are excluded from the command.
 
-Eg 'rclone sync -i A: B:' can be modified with this flag and a filter
-flag:
+Eg the scope of `rclone sync -i A: B:` can be restricted:
 
     rclone --min-size 50k --delete-excluded sync A: B:
 
 All files on `B:` which are less than 50 kBytes are deleted
 because they are excluded from the rclone sync command. 
 
-### `--dump filters` - dump the filters to the output ###
+### `--dump filters` - dump the filters to the output
 
 Dumps the defined filters to standard output in regular expression
 format.
 
 Useful for debugging.
 
-## Exclude directory based on a file ##
+## Exclude directory based on a file
 
 The `--exclude-if-present` flag controls whether a directory is
 within the scope of an rclone command based on the presence of a
@@ -675,4 +641,13 @@ Eg for the following directory structure:
 The command `rclone ls --exclude-if-present .ignore dir1` does
 not list `dir3`, `file3` or `.ignore`.
 
-`--exclude-if-present` can only be used once in an rclone command..
+`--exclude-if-present` can only be used once in an rclone command.
+
+## Common pitfalls
+
+The most frequent filter support issues on
+the [rclone forum](https://https://forum.rclone.org/) are:
+
+* Not using paths relative to the root of the remote
+* Not using / to match from the root of a remote
+* Not using ** to match the contents of a directory

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -23,7 +23,7 @@ ls`, or with the `--dry-run` and `-vv` flags.
 Rclone filter patterns can only be used in filter command line options, not
 in the specification of a remote.
 
-Eg `rclone copy "remote:dir*.jpg" /path/to/dir` does not have a filter effect.
+E.g. `rclone copy "remote:dir*.jpg" /path/to/dir` does not have a filter effect.
 `rclone copy remote:dir /path/to/dir --include "*.jpg"` does.
 
 **Important** Avoid mixing any two of `--include...`, `--exclude...` or
@@ -59,9 +59,9 @@ pattern-list:
 
 character classes (see [Go regular expression reference](https://golang.org/pkg/regexp/syntax/)) include:
 
-    Named character classes (eg [\d], [^\d], [\D], [^\D])
-    Perl character classes (eg \s, \S, \w, \W)
-    ASCII character classes (eg [[:alnum:]], [[:alpha:]], [[:punct:]], [[:xdigit:]])
+    Named character classes (e.g. [\d], [^\d], [\D], [^\D])
+    Perl character classes (e.g. \s, \S, \w, \W)
+    ASCII character classes (e.g. [[:alnum:]], [[:alpha:]], [[:punct:]], [[:xdigit:]])
 
 If the filter pattern starts with a `/` then it only matches
 at the top level of the directory tree,
@@ -161,7 +161,7 @@ to a filter by the pattern `directory/*` or recursively by
 
 Directory filter rules are defined with a closing `/` separator.
 
-Eg `/directory/subdirectory/` is an rclone directory filter rule.
+E.g. `/directory/subdirectory/` is an rclone directory filter rule.
 
 Rclone commands can use directory filter rules to determine whether they
 recurse into subdirectories. This potentially optimises access to a remote
@@ -184,7 +184,7 @@ Rclone commands imply directory filter rules from path/file filter
 rules. To view the directory filter rules rclone has implied for a
 command specify the `--dump filters` flag.
 
-Eg for an include rule
+E.g. for an include rule
 
     /a/*.jpg
 
@@ -196,12 +196,12 @@ Directory filter rules specified in an rclone command can limit
 the scope of an rclone command but path/file filters still have
 to be specified.
 
-Eg `rclone ls remote: --include /directory/` will not match any
+E.g. `rclone ls remote: --include /directory/` will not match any
 files. Because it is an `--include` option the `--exclude **` rule
 is implied, and the `\directory\` pattern serves only to optimise
 access to the remote by ignoring everything outside of that directory.
 
-Eg `rclone ls remote: --filter-from filter-list.txt` with a file
+E.g. `rclone ls remote: --filter-from filter-list.txt` with a file
 `filter-list.txt`:
 
     - /dir1/
@@ -233,14 +233,14 @@ processed in.
 `--exclude` has no effect when combined with `--files-from` or
 `--files-from-raw` flags.
 
-Eg `rclone ls remote: --exclude *.bak` excludes all .bak files
+E.g. `rclone ls remote: --exclude *.bak` excludes all .bak files
 from listing.
 
-Eg `rclone size remote: "--exclude /dir/**"` returns the total size of
+E.g. `rclone size remote: "--exclude /dir/**"` returns the total size of
 all files on `remote:` excluding those in root directory `dir` and sub
 directories.
 
-Eg on Microsoft Windows `rclone ls remote: --exclude "*\[{JP,KR,HK}\]*"`
+E.g. on Microsoft Windows `rclone ls remote: --exclude "*\[{JP,KR,HK}\]*"`
 lists the files in `remote:` with `[JP]` or `[KR]` or `[HK]` in
 their name. The single quotes prevent the shell from interpreting the `\`
 characters. The `\` characters escape the `[` and `]` so ran clone filter
@@ -294,10 +294,10 @@ flags with `--exclude`, `--exclude-from`, `--filter` or `--filter-from`,
 you must use include rules for all the files you want in the include
 statement. For more flexibility use the `--filter-from` flag.
 
-Eg `rclone ls remote: --include "*.{png,jpg}"` lists the files on
+E.g. `rclone ls remote: --include "*.{png,jpg}"` lists the files on
 `remote:` with suffix `.png` and `.jpg`. All other files are excluded.
 
-Eg multiple rclone copy commands can be combined with `--include` and a
+E.g. multiple rclone copy commands can be combined with `--include` and a
 pattern-list.
 
     rclone copy /vol1/A remote:A
@@ -307,7 +307,7 @@ is equivalent to:
 
     rclone copy /vol1 remote: --include "{A,B}/**"
 
-Eg `rclone ls remote:/wheat --include "??[^[:punct:]]*"` lists the
+E.g. `rclone ls remote:/wheat --include "??[^[:punct:]]*"` lists the
 files `remote:` directory `wheat` (and subdirectories) whose third
 character is not punctuation. This example uses
 an [ASCII character class](https://golang.org/pkg/regexp/syntax/).
@@ -363,7 +363,7 @@ that rule.
 `--filter` should not be used with `--include`, `--include-from`,
 `--exclude` or `--exclude-from` flags.
 
-Eg `rclone ls remote: --filter "- *.bak"` excludes all `.bak` files
+E.g. `rclone ls remote: --filter "- *.bak"` excludes all `.bak` files
 from a list of `remote:`.
 
 ### `--filter-from` - Read filtering patterns from a file
@@ -379,7 +379,7 @@ processed in.
 Arrange the order of filter rules with the most restrictive first and
 work down.
 
-Eg For `filter-file.txt`:
+E.g. For `filter-file.txt`:
 
     # a sample filter rule file
     - secret*.jpg
@@ -398,7 +398,7 @@ everything in the directory `dir` at the root of `remote`, except
 `remote:dir/Trash` which it excludes.  Everything else is excluded.
 
 
-Eg for an alternative `filter-file.txt`:
+E.g. for an alternative `filter-file.txt`:
 
     - secret*.jpg
     + *.jpg
@@ -409,7 +409,7 @@ Eg for an alternative `filter-file.txt`:
 Files `file1.jpg`, `file3.png` and `file2.avi` are listed whilst
 `secret17.jpg` and files without the suffix .jpg` or `.png` are excluded.
 
-Eg for an alternative `filter-file.txt`:
+E.g. for an alternative `filter-file.txt`:
 
     + *.jpg
     + *.gif
@@ -454,7 +454,7 @@ with the root specified in the rclone command.  Leading `/` separators are
 ignored. See [--files-from-raw](#files-from-raw-read-list-of-source-file-names-without-any-processing) if
 you need the input to be processed in a raw manner.
 
-Eg for a file `files-from.txt`:
+E.g. for a file `files-from.txt`:
 
     # comment
     file1.jpg
@@ -466,7 +466,7 @@ copies the following, if they exist, and only those files.
     /home/me/pics/file1.jpg        → remote:pics/file1.jpg
     /home/me/pics/subdir/file2.jpg → remote:pics/subdir/file2.jpg
 
-Eg to copy the following files referenced by their absolute paths:
+E.g. to copy the following files referenced by their absolute paths:
 
     /home/user1/42
     /home/user1/dir/ford
@@ -520,7 +520,7 @@ By default rclone filter patterns are case sensitive. The `--ignore-case`
 flag makes all of the filters patterns on the command line case
 insensitive.
 
-Eg `--include "zaphod.txt"` does not match a file `Zaphod.txt`. With
+E.g. `--include "zaphod.txt"` does not match a file `Zaphod.txt`. With
 `--ignore-case` a match is made.
 
 ## Quoting shell metacharacters
@@ -528,7 +528,7 @@ Eg `--include "zaphod.txt"` does not match a file `Zaphod.txt`. With
 Rclone commands with filter patterns containing shell metacharacters may
 not as work as expected in your shell and may require quoting.
 
-Eg linux, OSX (`*` metacharacter)
+E.g. linux, OSX (`*` metacharacter)
 
   * `--include \*.jpg`
   * `--include '*.jpg'`
@@ -549,7 +549,7 @@ remote or flag value. The fix then is to quote values containing spaces.
 Controls the minimum size file within the scope of an rclone command.
 Default units are `kBytes` but abbreviations `k`, `M`, or `G` are valid.
 
-Eg `rclone ls remote: --min-size 50k` lists files on `remote:` of 50kByte
+E.g. `rclone ls remote: --min-size 50k` lists files on `remote:` of 50kByte
 size or larger.
 
 ### `--max-size` - Don't transfer any file larger than this
@@ -557,7 +557,7 @@ size or larger.
 Controls the maximum size file within the scope of an rclone command.
 Default units are `kBytes` but abbreviations `k`, `M`, or `G` are valid.
 
-Eg `rclone ls remote: --max-size 1G` lists files on `remote:` of 1GByte
+E.g. `rclone ls remote: --max-size 1G` lists files on `remote:` of 1GByte
 size or smaller.
 
 ### `--max-age` - Don't transfer any file older than this
@@ -584,7 +584,7 @@ formats:
 
 `--max-age` applies only to files and not to directories.
 
-Eg `rclone ls remote: --max-age 2d` lists files on `remote:` of 2 days
+E.g. `rclone ls remote: --max-age 2d` lists files on `remote:` of 2 days
 old or less.
 
 ### `--min-age` - Don't transfer any file younger than this
@@ -594,7 +594,7 @@ Controls the minimum age of files within the scope of an rclone command.
 
 `--min-age` applies only to files and not to directories.
 
-Eg `rclone ls remote: --min-age 2d` lists files on `remote:` of 2 days
+E.g. `rclone ls remote: --min-age 2d` lists files on `remote:` of 2 days
 old or more.
 
 ## Other flags
@@ -607,7 +607,7 @@ and `-v` first.
 In conjunction with `rclone sync` the `--delete-excluded deletes any files
 on the destination which are excluded from the command.
 
-Eg the scope of `rclone sync -i A: B:` can be restricted:
+E.g. the scope of `rclone sync -i A: B:` can be restricted:
 
     rclone --min-size 50k --delete-excluded sync A: B:
 
@@ -629,7 +629,7 @@ named file within it.
 
 This flag has a priority over other filter flags.
 
-Eg for the following directory structure:
+E.g. for the following directory structure:
 
     dir1/file1
     dir1/dir2/file2

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -5,31 +5,64 @@ description: "Filtering, includes and excludes"
 
 # Filtering, includes and excludes #
 
-Rclone has a sophisticated set of include and exclude rules. Some of
-these are based on patterns and some on other things like file size.
+Rclone filter flags are specified in terms of path/file name
+patterns; path/file lists; file age and size, or presence of
+a file in a directory. Bucket remotes without the concept of
+directory apply filters to object key, age and size in an
+analogous way.
 
-The filters are applied for the `copy`, `sync`, `move`, `ls`, `lsl`,
-`md5sum`, `sha1sum`, `size`, `delete` and `check` operations.
-Note that `purge` does not obey the filters.
+Filter flags apply to rclone `copy`, `sync`, `move`, `ls`, `lsl`,
+`md5sum`, `sha1sum`, `size`, `delete` and `check` commands.
 
-Each path as it passes through rclone is matched against the include
-and exclude rules like `--include`, `--exclude`, `--include-from`,
-`--exclude-from`, `--filter`, or `--filter-from`. The simplest way to
-try them out is using the `ls` command, or `--dry-run` together with
-`-v`. `--filter-from`, `--exclude-from`, `--include-from`, `--files-from`,
-`--files-from-raw` understand `-` as a file name to mean read from standard
-input.
+Rclone `purge` does not obey filters.
 
-## Patterns ##
+To test filters without risk of damage to data, apply them to `rclone
+ls`, or with the `--dry-run` and `-vv` flags.
 
-The patterns used to match files for inclusion or exclusion are based
-on "file globs" as used by the unix shell.
+Rclone filter patterns can only be used in filter command line options, not
+in the specification of a remote.
 
-If the pattern starts with a `/` then it only matches at the top level
-of the directory tree, **relative to the root of the remote** (not
-necessarily the root of the local drive). If it doesn't start with `/`
-then it is matched starting at the **end of the path**, but it will
-only match a complete path element:
+Eg `rclone copy "remote:dir*.jpg" /path/to/dir` does not have a filter effect.
+`rclone copy remote:dir /path/to/dir --include "*.jpg"` does.
+
+**Important** Avoid mixing any two of `--include...`, `--exclude...` or
+`--filter...` flags in an rclone command. The results may not be what
+you expect. Instead use a `--filter...` flag.
+
+## Patterns for matching path/file names ##
+
+### Pattern syntax ###
+
+Rclone's matching rules follow a glob style:
+
+    `*`         matches any sequence of non-separator (`/`) characters
+    `**`        matches any sequence of characters
+    `?`         matches any single non-separator (`/`) character
+    `[` [ `!` ] { character-range } `]`
+                character class (must be non-empty)
+    `{` pattern-list `}`
+                pattern alternatives
+    c           matches character c (c != `*`, `**`, `?`, `\`, `[`, `{`, `}`)
+    `\` c       matches character c
+
+character-range:
+
+    c           matches character c (c != `\\`, `-`, `]`)
+    `\` c       matches character c
+    lo `-` hi   matches character c for lo <= c <= hi
+
+pattern-list:
+
+    pattern { `,` pattern }
+                comma-separated (without spaces) patterns
+
+If the filter pattern starts with a `/` then it only matches
+at the top level of the directory tree,
+**relative to the root of the remote** (not necessarily the root
+of the drive). If it does not start with `/` then it is matched
+starting at the **end of the path/file name** but it only matches
+a complete path element - it must match from a `/`
+separator or the beginning of the path/file.
 
     file.jpg  - matches "file.jpg"
               - matches "directory/file.jpg"
@@ -39,52 +72,56 @@ only match a complete path element:
               - doesn't match "afile.jpg"
               - doesn't match "directory/file.jpg"
 
-**Important** Note that you must use `/` in patterns and not `\` even
-if running on Windows.
+**Important** Use `/` in path/file name patterns and not `\` even if
+running on Microsoft Windows.
 
-A `*` matches anything but not a `/`.
+Eg `*` matches anything but not a `/` separator:
 
     *.jpg  - matches "file.jpg"
            - matches "directory/file.jpg"
            - doesn't match "file.jpg/something"
 
-Use `**` to match anything, including slashes (`/`).
+Eg `**` matches anything, including slash (`/`) separators:
 
     dir/** - matches "dir/file.jpg"
            - matches "dir/dir1/dir2/file.jpg"
            - doesn't match "directory/file.jpg"
            - doesn't match "adir/file.jpg"
 
-A `?` matches any character except a slash `/`.
+Eg `rclone --exclude /dir1/** ls remote:` lists all of `remote`
+except for root directory `dir1` and all the files contained within it
+or its subdirectories.
+
+Eg `?` matches any character except a slash `/` separator:
 
     l?ss  - matches "less"
           - matches "lass"
           - doesn't match "floss"
 
-A `[` and `]` together make a character class, such as `[a-z]` or
-`[aeiou]` or `[[:alpha:]]`.  See the [go regexp
-docs](https://golang.org/pkg/regexp/syntax/) for more info on these.
+Eg `[` and `]` together make a character class, such as `[a-z]`, `[aeiou]`
+or `[[:alpha:]]`:
 
     h[ae]llo - matches "hello"
              - matches "hallo"
              - doesn't match "hullo"
 
-A `{` and `}` define a choice between elements.  It should contain a
-comma separated list of patterns, any of which might match.  These
-patterns can contain wildcards.
+
+
+Eg `{` and `}` define a choice from a comma separated list of
+patterns, any of which might match. The patterns can contain wildcards:
 
     {one,two}_potato - matches "one_potato"
                      - matches "two_potato"
                      - doesn't match "three_potato"
                      - doesn't match "_potato"
 
-Special characters can be escaped with a `\` before them.
+Eg Special characters can be escaped with a `\` before them:
 
     \*.jpg       - matches "*.jpg"
     \\.jpg       - matches "\.jpg"
     \[one\].jpg  - matches "[one].jpg"
 
-Patterns are case sensitive unless the `--ignore-case` flag is used.
+Eg Patterns are case sensitive unless the `--ignore-case` flag is used.
 
 Without `--ignore-case` (default)
 
@@ -96,82 +133,9 @@ With `--ignore-case`
     potato - matches "potato"
            - matches "POTATO"
 
-Note also that rclone filter globs can only be used in one of the
-filter command line flags, not in the specification of the remote, so
-`rclone copy "remote:dir*.jpg" /path/to/dir` won't work - what is
-required is `rclone --include "*.jpg" copy remote:dir /path/to/dir`
+## How filter rules are applied to files ##
 
-### Directories ###
-
-Rclone keeps track of directories that could match any file patterns.
-
-Eg if you add the include rule
-
-    /a/*.jpg
-
-Rclone will synthesize the directory include rule
-
-    /a/
-
-If you put any rules which end in `/` then it will only match
-directories.
-
-Directory matches are **only** used to optimise directory access
-patterns - you must still match the files that you want to match.
-Directory matches won't optimise anything on bucket based remotes (e.g.
-s3, swift, google compute storage, b2) which don't have a concept of
-directory.
-
-### Differences between rsync and rclone patterns ###
-
-Rclone implements bash style `{a,b,c}` glob matching which rsync doesn't.
-
-Rclone always does a wildcard match so `\` must always escape a `\`.
-
-## How the rules are used ##
-
-Rclone maintains a combined list of include rules and exclude rules.
-
-Each file is matched in order, starting from the top, against the rule
-in the list until it finds a match.  The file is then included or
-excluded according to the rule type.
-
-If the matcher fails to find a match after testing against all the
-entries in the list then the path is included.
-
-For example given the following rules, `+` being include, `-` being
-exclude,
-
-    - secret*.jpg
-    + *.jpg
-    + *.png
-    + file2.avi
-    - *
-
-This would include
-
-  * `file1.jpg`
-  * `file3.png`
-  * `file2.avi`
-
-This would exclude
-
-  * `secret17.jpg`
-  * non `*.jpg` and `*.png`
-
-A similar process is done on directory entries before recursing into
-them.  This only works on remotes which have a concept of directory
-(Eg local, google drive, onedrive, amazon drive) and not on bucket
-based remotes (e.g. s3, swift, google compute storage, b2).
-
-## Adding filtering rules ##
-
-Filtering rules are added with the following command line flags.
-
-### Repeating options ##
-
-You can repeat the following options to add more than one rule of that
-type.
+Rclone filters are made up of one or more of the following flags:
 
   * `--include`
   * `--include-from`
@@ -179,108 +143,280 @@ type.
   * `--exclude-from`
   * `--filter`
   * `--filter-from`
-  * `--filter-from-raw`
 
-**Important** You should not use `--include*` together with `--exclude*`. 
-It may produce different results than you expected. In that case try to use: `--filter*`.
+There can be more than one instance of individual flags.
 
-Note that all the options of the same type are processed together in
-the order above, regardless of what order they were placed on the
-command line.
+Rclone internally uses a combined list of all the include and exclude
+rules. The order in which rules are processed can influence the result
+of the filter.
 
-So all `--include` options are processed first in the order they
-appeared on the command line, then all `--include-from` options etc.
+All flags of the same type are processed together in the order
+above, regardless of what order the different types of flags are
+included on the command line.
 
-To mix up the order includes and excludes, the `--filter` flag can be
-used.
+Multiple instances of the same flag are processed from left
+to right according to their position in the command line.
+
+To mix up the order of processing includes and excludes use `--filter...`
+flags. 
+
+Within `--include-from`, `--exclude-from` and `--filter-from` flags
+rules are processed from top to bottom of the referenced file..
+
+If there is an `--include` or `--include-from` flag specified, rclone
+implies a `- **` rule which it adds to the bottom of the internal rule
+list. Specifying a `+` rule with a `--filter...` flag does not imply
+that rule.
+
+Each path/file name passed through rclone is matched against the
+combined filter list. At first match to a rule the path/file name
+is included or excluded and no further filter rules are processed for
+that path/file.
+
+If rclone does not find a match, after testing against all rules
+(including the implied rule if appropriate), the path/file name
+is included.
+
+Any path/file included at that stage is processed by the rclone
+command.
+
+`--files-from` and `--files-from-raw` flags over-ride and cannot be
+combined with other filter options.
+
+To see the internal combined rule list, in regular expression form,
+for a command add the `--dump filters` flag. Running an rclone command
+with `--dump filters` and `--vv` flags lists the internal filter elements
+and shows how they are applied to each source path/file. There is not
+currently a means provided to pass regular expression filter options into
+rclone directly. [Go regular expression reference](https://golang.org/pkg/regexp/syntax/)
+
+### How filter rules are applied to directories ###
+
+Rclone commands filter, and are applied to, path/file names not
+directories. The entire contents of a directory can be matched
+to a filter by the pattern `directory/*` or recursively by
+`directory/**`.
+
+Directory filter rules are defined with a closing `/` separator.
+
+Eg `/directory/subdirectory/` is an rclone directory filter rule.
+
+Rclone commands can use directory filter rules to determine whether they
+recurse into subdirectories. This potentially optimises access to a remote
+by avoiding listing unnecessary directories. Whether optimisation is
+desirable depends on the specific filter rules and source remote content.
+
+Optimisation occurs if either:
+
+* The source remote does not support rclone's `ListR` primitive. `local`,
+`sftp`, `Microsoft OneDrive` and `WebDav` do not support `ListR`. Google
+Drive and most bucket type storage do. [Full list](https://rclone.org/overview/#optional-features)
+
+* On other remotes, if the rclone command is not naturally recursive,
+provided it is not run with the `--fast-list` flag. `ls`, `lsf -R` and
+`size` are recursive but `sync`, `copy` and `move` are not. 
+
+* Whenever the `--disable-ListR` flag is applied to an rclone command.
+
+Rclone commands imply directory filter rules from path/file filter
+rules. To view the directory filter rules rclone has implied for a
+command specify the `--dump filters` flag.
+
+Eg for an include rule
+
+    /a/*.jpg
+
+Rclone implies the directory include rule
+
+    /a/
+
+Directory filter rules specified in an rclone command can limit
+the scope of an rclone command but path/file filters still have
+to be specified.
+
+Eg `rclone ls remote: --include /directory/` will not match any
+files. Because it is an `--include` option the `--exclude **` rule
+is implied, and the `\directory\` pattern serves only to optimise
+access to the remote by ignoring everything outside of that directory.
+
+Eg `rclone ls remote: --filter-from filter-list.txt` with a file
+`filter-list.txt`:
+
+    - /dir1/
+    - /dir2/
+    + *.pdf
+    - **
+
+All files in directories `dir1` or `dir2` or their subdirectories
+are completely excluded from the listing. Only files of suffix
+`'pdf` in the root of `remote:` or its subdirectories are listed.
+The `- **` rule prevents listing of any path/files not previously
+matched by the rules above.
+
+Option `exclude-if-present` creates a directory exclude rule based
+on the presence of a file in a directory and takes precedence over
+other rclone directory filter rules.
+
+Rclone's treatment of directories contrasts with rsync. The rsync
+filter pattern `/directory/` matches all files in the directory
+but in rclone merely specifies a directory filter. To match the rsync
+interpretation `/directory/**` would be specified in rclone.
 
 ### `--exclude` - Exclude files matching pattern ###
 
-Add a single exclude rule with `--exclude`.
+Excludes path/file names from an rclone command based on a single exclude
+rule. 
 
-This flag can be repeated.  See above for the order the flags are
+This flag can be repeated. See above for the order filter flags are
 processed in.
 
-Eg `--exclude *.bak` to exclude all bak files from the sync.
+`--exclude` should not be used with `--include`, `--include-from`,
+`--filter` or `--filter-from` flags.
+
+`--exclude` has no effect when combined with `--files-from` or
+`--files-from-raw` flags.
+
+Eg `rclone ls remote: --exclude *.bak` to exclude all .bak files
+from listing.
+
+Eg `rclone  size remote: --exclude /dir/**` to return the total size of
+all files on `remote:` excluding those in root directory `dir` and sub
+directories.
+
+Eg `rclone ls remote: --exclude '*\[{JP,KR,HK,CN,RU,PL,AU,GB,FR}\]*'
+to list the files in `remote:` with `[JP]` or `[KR]` or `[HK]` etc. in
+their name. The single quotes prevent the shell from interpreting the `\`
+characters. The `\` characters escape the `[` and `]` so rclone's filter
+treats them literally rather than as a character-range. The `{` and `}`
+define an rclone pattern list.
 
 ### `--exclude-from` - Read exclude patterns from file ###
 
-Add exclude rules from a file.
+Excludes path/file names from an rclone command based on rules in a
+named file. The file contains a list of remarks and pattern rules. 
 
-This flag can be repeated.  See above for the order the flags are
-processed in.
-
-Prepare a file like this `exclude-file.txt`
+For an example `exclude-file.txt`:
 
     # a sample exclude rule file
     *.bak
     file2.jpg
 
-Then use as `--exclude-from exclude-file.txt`.  This will sync all
-files except those ending in `bak` and `file2.jpg`.
+`rclone ls remote: --exclude-from exclude-file.txt` lists the files on
+`remote:` except those named `file2.jpg` or with a suffix `.bak`. That is
+equivalent to `rclone ls remote: --exclude 'file2.jpg' --exclude '*.bak'`.
 
-This is useful if you have a lot of rules.
+This flag can be repeated. See above for the order filter flags are
+processed in.
+
+The `--exclude-from` flag is useful where multiple exclude filter rules
+are applied to an rclone command.
+
+`--exclude-from` should not be used with `--include`, `--include-from`,
+`--filter` or `--filter-from` flags.
+
+`--exclude-from` has no effect when combined with `--files-from` or
+`--files-from-raw` flags.
+
+`--exclude-from` followed by `-` reads filter rules from standard input. 
 
 ### `--include` - Include files matching pattern ###
 
-Add a single include rule with `--include`.
+Adds a single include rule based on path/file names to an rclone
+command.
 
-This flag can be repeated.  See above for the order the flags are
+This flag can be repeated. See above for the order filter flags are
 processed in.
 
-Eg `--include *.{png,jpg}` to include all `png` and `jpg` files in the
-backup and no others.
+`--include` has no effect when combined with `--files-from` or
+`--files-from-raw` flags.
 
-This adds an implicit `--exclude *` at the very end of the filter
-list. This means you can mix `--include` and `--include-from` with the
-other filters (e.g. `--exclude`) but you must include all the files you
-want in the include statement.  If this doesn't provide enough
-flexibility then you must use `--filter-from`.
+`--include` implies `--exclude **` at the end of rclone's internal
+filter list. Therefore if you mix `--include` and `--include-from`
+flags with `--exclude`, `--exclude-from`, `--filter` or `--filter-from`,
+you must use include rules for all the files you want in the include
+statement. For more flexibility use the `--filter-from` flag.
+
+Eg `rclone ls remote: --include '*.{png,jpg}'` lists the files on
+`remote:` with suffix `.png` and `.jpg`. All other files are excluded.
+
+Eg multiple rclone copy commands can be combined with `--include` and a
+pattern-list.
+
+    rclone copy /vol1/A remote:A
+    rclone copy /vol1/B remote:B
+
+is equivalent to:
+
+    rclone copy /vol1 remote: --include={A,B}/**
 
 ### `--include-from` - Read include patterns from file ###
 
-Add include rules from a file.
+Adds path/file names to an rclone command based on rules in a
+named file. The file contains a list of remarks and pattern rules. 
 
-This flag can be repeated.  See above for the order the flags are
-processed in.
-
-Prepare a file like this `include-file.txt`
+For an example `include-file.txt`:
 
     # a sample include rule file
     *.jpg
-    *.png
     file2.avi
 
-Then use as `--include-from include-file.txt`.  This will sync all
-`jpg`, `png` files and `file2.avi`.
+`rclone ls remote: --include-from include-file.txt` lists the files on
+`remote:` with name `file2.avi` or suffix `.jpg`. That is equivalent to
+`rclone ls remote: --include 'file2.avi' --include '*.jpg'`.
 
-This is useful if you have a lot of rules.
+This flag can be repeated. See above for the order filter flags are
+processed in.
 
-This adds an implicit `--exclude *` at the very end of the filter
-list. This means you can mix `--include` and `--include-from` with the
-other filters (e.g. `--exclude`) but you must include all the files you
-want in the include statement.  If this doesn't provide enough
-flexibility then you must use `--filter-from`.
+The `--include-from` flag is useful where multiple include filter rules
+are applied to an rclone command.
+
+`--include-from` implies `--exclude **` at the end of rclone's internal
+filter list. Therefore if you mix `--include` and `--include-from`
+flags with `--exclude`, `--exclude-from`, `--filter` or `--filter-from`,
+you must use include rules for all the files you want in the include
+statement. For more flexibility use the `--filter-from` flag.
+
+`--exclude-from` has no effect when combined with `--files-from` or
+`--files-from-raw` flags.
+
+`--exclude-from` followed by `-` reads filter rules from standard input. 
 
 ### `--filter` - Add a file-filtering rule ###
 
-This can be used to add a single include or exclude rule.  Include
-rules start with `+ ` and exclude rules start with `- `.  A special
-rule called `!` can be used to clear the existing rules.
+Specifies path/file names to an rclone command based on a single
+include or exclude rule in `+` or `-` format. 
 
-This flag can be repeated.  See above for the order the flags are
+This flag can be repeated. See above for the order filter flags are
 processed in.
 
-Eg `--filter "- *.bak"` to exclude all bak files from the sync.
+'--filter +` differs from `--include`. In the case of `--include` rclone
+implies a `--exclude *` rule which it adds to the bottom of the internal rule
+list. Specifying a `+` rule with a `--filter...` flag does not imply
+that rule.
+
+`--filter` has no effect when combined with `--files-from` or
+`--files-from-raw` flags.
+
+`--filter` should not be used with `--include`, `--include-from`,
+`--exclude` or `--exclude-from` flags.
+
+Eg `rclone ls remote: --filter "- *.bak"` excludes all `.bak` files
+from a list of `remote:`.
 
 ### `--filter-from` - Read filtering patterns from a file ###
 
-Add include/exclude rules from a file.
+Adds path/file names to an rclone command based on rules in a
+named file. The file contains a list of remarks and pattern rules. Include
+rules start with `+ ` and exclude rules with `- `. `!` clears existing
+rules. Rules are processed in the order they are defined.
 
-This flag can be repeated.  See above for the order the flags are
+This flag can be repeated. See above for the order filter flags are
 processed in.
 
-Prepare a file like this `filter-file.txt`
+Arrange the order of filter rules with the most restrictive first and
+work down.
+
+Eg For `filter-file.txt`:
 
     # a sample filter rule file
     - secret*.jpg
@@ -292,225 +428,255 @@ Prepare a file like this `filter-file.txt`
     # exclude everything else
     - *
 
-Then use as `--filter-from filter-file.txt`.  The rules are processed
-in the order that they are defined.
+`rclone ls remote: --filter-from filter-file.txt` lists the path/files on
+`remote:` including all `jpg` and `png` files, excluding any
+matching `secret*.jpg` and including `file2.avi`.  It also includes
+everything in the directory `dir` at the root of `remote`, except
+`remote:dir/Trash` which it excludes.  Everything else is excluded.
 
-This example will include all `jpg` and `png` files, exclude any files
-matching `secret*.jpg` and include `file2.avi`.  It will also include
-everything in the directory `dir` at the root of the sync, except
-`dir/Trash` which it will exclude.  Everything else will be excluded
-from the sync.
+
+Eg for an alternative `filter-file.txt`:
+
+    - secret*.jpg
+    + *.jpg
+    + *.png
+    + file2.avi
+    - *
+
+Files `file1.jpg`, `file3.png` and `file2.avi` are listed whilst
+`secret17.jpg` and files without the suffix .jpg` or `.png` are excluded.
+
+Eg for an alternative `filter-file.txt`:
+
+    + *.jpg
+    + *.gif
+    !
+    + 42.doc
+    - *
+
+Only file 42.doc is listed. Prior rules are cleared by the `!`.
 
 ### `--files-from` - Read list of source-file names ###
 
-This reads a list of file names from the file passed in and **only**
-these files are transferred.  The **filtering rules are ignored**
-completely if you use this option.
+Adds path/files to an rclone command from a list in a named file.
+Rclone processes the path/file names in the order of the list, and
+no others.
 
-`--files-from` expects a list of files as its input. Leading / trailing
-whitespace is stripped from the input lines and lines starting with `#`
-and `;` are ignored.
+Other filter flags (`--include`, `--include-from`, `--exclude`,
+`--exclude-from`, `--filter` and `--filter-from`) are ignored when
+`--files-from` is used.
 
-Rclone will traverse the file system if you use `--files-from`,
-effectively using the files in `--files-from` as a set of filters.
-Rclone will not error if any of the files are missing.
+`--files-from` expects a list of files as its input. Leading or
+trailing whitespace is stripped from the input lines. Lines starting
+with `#` or `;` are ignored.
 
-If you use `--no-traverse` as well as `--files-from` then rclone will
-not traverse the destination file system, it will find each file
-individually using approximately 1 API call. This can be more
-efficient for small lists of files.
+Rclone commands with a `--files-from` flag traverse the remote,
+treating the names in `--files-from` as a set of filters.
 
-This option can be repeated to read from more than one file.  These
-are read in the order that they are placed on the command line.
+If the `--no-traverse` and `--files-from` flags are used together
+an rclone command does not traverse the remote. Instead it addresses
+each path/file named in the file individually. For each path/file name, that
+requires typically 1 API call. This can be efficient for a short `--files-from`
+list and a remote containing many files.
 
-Paths within the `--files-from` file will be interpreted as starting
-with the root specified in the command.  Leading `/` characters are
-ignored. See [--files-from-raw](#files-from-raw-read-list-of-source-file-names-without-any-processing)
-if you need the input to be processed in a raw manner.
+Rclone commands do not error if any names in the `--files-from` file are
+missing from the source remote.
 
-For example, suppose you had `files-from.txt` with this content:
+The `--files-from` flag can be repeated in a single rclone command to
+read path/file names from more than one file. The files are read from left
+to right along the command line.
+
+Paths within the `--files-from` file are interpreted as starting
+with the root specified in the rclone command.  Leading `/` separators are
+ignored. See [--files-from-raw](#files-from-raw-read-list-of-source-file-names-without-any-processing) if you need the input to be processed in a raw manner.
+
+Eg for a file `files-from.txt`:
 
     # comment
     file1.jpg
     subdir/file2.jpg
 
-You could then use it like this:
-
-    rclone copy --files-from files-from.txt /home/me/pics remote:pics
-
-This will transfer these files only (if they exist)
+`rclone copy --files-from files-from.txt /home/me/pics remote:pics`
+copies the following, if they exist, and only those files.
 
     /home/me/pics/file1.jpg        → remote:pics/file1.jpg
     /home/me/pics/subdir/file2.jpg → remote:pics/subdir/file2.jpg
 
-To take a more complicated example, let's say you had a few files you
-want to back up regularly with these absolute paths:
+Eg to copy the following files referenced by their absolute paths:
 
-    /home/user1/important
-    /home/user1/dir/file
-    /home/user2/stuff
+    /home/user1/42
+    /home/user1/dir/ford
+    /home/user2/prefect
 
-To copy these you'd find a common subdirectory - in this case `/home`
+First find a common subdirectory - in this case `/home`
 and put the remaining files in `files-from.txt` with or without
 leading `/`, e.g.
 
-    user1/important
-    user1/dir/file
-    user2/stuff
+    user1/42
+    user1/dir/ford
+    user2/prefect
 
-You could then copy these to a remote like this
+Then copy these to a remote:
 
     rclone copy --files-from files-from.txt /home remote:backup
 
-The 3 files will arrive in `remote:backup` with the paths as in the
-`files-from.txt` like this:
+The three files are transferred as follows:
 
-    /home/user1/important → remote:backup/user1/important
-    /home/user1/dir/file  → remote:backup/user1/dir/file
-    /home/user2/stuff     → remote:backup/user2/stuff
+    /home/user1/42       → remote:backup/user1/important
+    /home/user1/dir/ford → remote:backup/user1/dir/file
+    /home/user2/prefect  → remote:backup/user2/stuff
 
-You could of course choose `/` as the root too in which case your
-`files-from.txt` might look like this.
+Alternatively if `/` is chosen as root `files-from.txt` would be:
 
-    /home/user1/important
-    /home/user1/dir/file
-    /home/user2/stuff
+    /home/user1/42
+    /home/user1/dir/ford
+    /home/user2/prefect
 
-And you would transfer it like this
+The copy command would be:
 
     rclone copy --files-from files-from.txt / remote:backup
 
-In this case there will be an extra `home` directory on the remote:
+Then there will be an extra `home` directory on the remote:
 
-    /home/user1/important → remote:backup/home/user1/important
-    /home/user1/dir/file  → remote:backup/home/user1/dir/file
-    /home/user2/stuff     → remote:backup/home/user2/stuff
+    /home/user1/42       → remote:backup/home/user1/42
+    /home/user1/dir/ford → remote:backup/home/user1/dir/ford
+    /home/user2/prefect  → remote:backup/home/user2/prefect
 
 ### `--files-from-raw` - Read list of source-file names without any processing ###
-This option is same as `--files-from` with the only difference being that the input
-is read in a raw manner. This means that lines with leading/trailing whitespace and
-lines starting with `;` or `#` are read without any processing. [rclone lsf](/commands/rclone_lsf/)
-has a compatible format that can be used to export file lists from remotes, which
-can then be used as an input to `--files-from-raw`.
+
+This flag is the same as `--files-from` except that input is read in a
+raw manner. Lines with leading / trailing whitespace, and lines starting
+with `;` or `#` are read without any processing. [rclone lsf](/commands/rclone_lsf/) has
+a compatible format that can be used to export file lists from remotes for
+input to `--files-from-raw`. 
+
+### `--ignore-case` - make searches case insensitive ###
+
+By default rclone filter patterns are case sensitive. The `--ignore-case`
+flag makes all of the filters patterns on the command line case
+insensitive.
+
+Eg `--include "zaphod.txt"` does not match a file `Zaphod.txt`. With
+`--ignore-case` a match is made.
+
+## Quoting shell metacharacters ##
+
+Rclone commands with filter patterns containing shell metacharacters may
+not as work as expected in your shell and may require quoting.
+
+Eg linux, OSX (`*` metacharacter)
+
+  * `--include \*.jpg`
+  * `--include '*.jpg'`
+  * `--include='*.jpg'`
+
+Microsoft Windows expansion is done by the command not shell so `--include *.jpg` does
+not require quoting.
+
+If the rclone error
+`Command .... needs .... arguments maximum: you provided .... non flag arguments:`
+is encountered, the cause is commonly spaces within the name of a remote
+or flag. It can be corrected by quoting the values containing the spaces.
+
+Eg `rclone ls remote 1: --exclude /my documents/**` can be quoted
+`rclone ls 'remote 1:' --exclude '/my documents/**`.
+
+## Other filters ##
 
 ### `--min-size` - Don't transfer any file smaller than this ###
 
-This option controls the minimum size file which will be transferred.
-This defaults to `kBytes` but a suffix of `k`, `M`, or `G` can be
-used.
+Controls the minimum size file within the scope of an rclone command.
+Default units are `kBytes` but abbreviations `k`, `M`, or `G` are valid.
 
-For example `--min-size 50k` means no files smaller than 50kByte will be
-transferred.
+Eg `rclone ls remote: --min-size 50k` lists files on `remote:` of 50kByte
+size or larger.
 
 ### `--max-size` - Don't transfer any file larger than this ###
 
-This option controls the maximum size file which will be transferred.
-This defaults to `kBytes` but a suffix of `k`, `M`, or `G` can be
-used.
+Controls the maximum size file within the scope of an rclone command.
+Default units are `kBytes` but abbreviations `k`, `M`, or `G` are valid.
 
-For example `--max-size 1G` means no files larger than 1GByte will be
-transferred.
+Eg `rclone ls remote: --max-size 1G` lists files on `remote:` of 1GByte
+size or smaller.
 
 ### `--max-age` - Don't transfer any file older than this ###
 
-This option controls the maximum age of files to transfer.  Give in
-seconds or with a suffix of:
+Controls the maximum age of files within the scope of an rclone command.
+Default units are seconds or the following abbreviations are valid:
 
   * `ms` - Milliseconds
-  * `s` - Seconds
-  * `m` - Minutes
-  * `h` - Hours
-  * `d` - Days
-  * `w` - Weeks
-  * `M` - Months
-  * `y` - Years
+  * `s`  - Seconds
+  * `m`  - Minutes
+  * `h`  - Hours
+  * `d`  - Days
+  * `w`  - Weeks
+  * `M`  - Months
+  * `y`  - Years
 
-For example `--max-age 2d` means no files older than 2 days will be
-transferred.
-
-This can also be an absolute time in one of these formats
+`--max-age` can also be specified as an absolute time in the following
+formats:
 
 - RFC3339 - e.g. "2006-01-02T15:04:05Z07:00"
 - ISO8601 Date and time, local timezone - "2006-01-02T15:04:05"
 - ISO8601 Date and time, local timezone - "2006-01-02 15:04:05"
 - ISO8601 Date - "2006-01-02" (YYYY-MM-DD)
 
+`--max-age` applies only to files and not to directories.
+
+Eg `rclone ls remote: --max-age 2d` lists files on `remote:` of 2 days
+old or less.
+
 ### `--min-age` - Don't transfer any file younger than this ###
 
-This option controls the minimum age of files to transfer.  Give in
-seconds or with a suffix (see `--max-age` for list of suffixes)
+Controls the minimum age of files within the scope of an rclone command.
+(see `--max-age` for valid formats)
 
-For example `--min-age 2d` means no files younger than 2 days will be
-transferred.
+`--min-age` applies only to files and not to directories.
+
+Eg `rclone ls remote: --min-age 2d` lists files on `remote:` of 2 days
+old or more.
+
+## Other flags ##
 
 ### `--delete-excluded` - Delete files on dest excluded from sync ###
 
-**Important** this flag is dangerous - use with `--dry-run` and `-v` first.
+**Important** this flag is dangerous to your data - use with `--dry-run`
+and `-v` first.
 
-When doing `rclone sync` this will delete any files which are excluded
-from the sync on the destination.
+In conjunction with `rclone sync` the `--delete-excluded deletes any files
+on the destination which are excluded from the command.
 
-If for example you did a sync from `A` to `B` without the `--min-size 50k` flag
-
-    rclone sync -i A: B:
-
-Then you repeated it like this with the `--delete-excluded`
+Eg 'rclone sync -i A: B:' can be modified with this flag and a filter
+flag:
 
     rclone --min-size 50k --delete-excluded sync A: B:
 
-This would delete all files on `B` which are less than 50 kBytes as
-these are now excluded from the sync.
-
-Always test first with `--dry-run` and `-v` before using this flag.
+All files on `B:` which are less than 50 kBytes are deleted
+because they are excluded from the rclone sync command. 
 
 ### `--dump filters` - dump the filters to the output ###
 
-This dumps the defined filters to the output as regular expressions.
+Dumps the defined filters to standard output in regular expression
+format.
 
 Useful for debugging.
 
-### `--ignore-case` - make searches case insensitive ###
-
-Normally filter patterns are case sensitive.  If this flag is supplied
-then filter patterns become case insensitive.
-
-Normally a `--include "file.txt"` will not match a file called
-`FILE.txt`.  However if you use the `--ignore-case` flag then
-`--include "file.txt"` this will match a file called `FILE.txt`.
-
-## Quoting shell metacharacters ##
-
-The examples above may not work verbatim in your shell as they have
-shell metacharacters in them (e.g. `*`), and may require quoting.
-
-Eg linux, OSX
-
-  * `--include \*.jpg`
-  * `--include '*.jpg'`
-  * `--include='*.jpg'`
-
-In Windows the expansion is done by the command not the shell so this
-should work fine
-
-  * `--include *.jpg`
-
 ## Exclude directory based on a file ##
 
-It is possible to exclude a directory based on a file, which is
-present in this directory. Filename should be specified using the
-`--exclude-if-present` flag. This flag has a priority over the other
-filtering flags.
+The `--exclude-if-present` flag controls whether a directory is
+within the scope of an rclone command based on the presence of a
+named file within it.
 
-Imagine, you have the following directory structure:
+This flag has a priority over other filter flags.
+
+Eg for the following directory structure:
 
     dir1/file1
     dir1/dir2/file2
     dir1/dir2/dir3/file3
     dir1/dir2/dir3/.ignore
 
-You can exclude `dir3` from sync by running the following command:
+The command `rclone ls --exclude-if-present .ignore dir1` does
+not list `dir3`, `file3` or `.ignore`.
 
-    rclone sync -i --exclude-if-present .ignore dir1 remote:backup
-
-Currently only one filename is supported, i.e. `--exclude-if-present`
-should not be used multiple times.
+`--exclude-if-present` can only be used once in an rclone command..

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -146,11 +146,11 @@ combined with other filter options.
 
 To see the internal combined rule list, in regular expression form,
 for a command add the `--dump filters` flag. Running an rclone command
-with `--dump filters` and `--vv` flags lists the internal filter elements
+with `--dump filters` and `-vv` flags lists the internal filter elements
 and shows how they are applied to each source path/file. There is not
 currently a means provided to pass regular expression filter options into
-rclone directly though character class filter rules contain
-elements. [Go regular expression reference](https://golang.org/pkg/regexp/syntax/)
+rclone directly though character class filter rules contain character
+classes. [Go regular expression reference](https://golang.org/pkg/regexp/syntax/)
 
 ### How filter rules are applied to directories
 
@@ -647,5 +647,6 @@ The most frequent filter support issues on
 the [rclone forum](https://https://forum.rclone.org/) are:
 
 * Not using paths relative to the root of the remote
-* Not using / to match from the root of a remote
-* Not using ** to match the contents of a directory
+* Not using `/` to match from the root of a remote
+* Not using `**` to match the contents of a directory
+

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -135,7 +135,7 @@ With `--ignore-case`
 
 ## How filter rules are applied to files ##
 
-Rclone filters are made up of one or more of the following flags:
+Rclone path / file name filters are made up of one or more of the following flags:
 
   * `--include`
   * `--include-from`
@@ -283,7 +283,7 @@ Eg `rclone  size remote: --exclude /dir/**` to return the total size of
 all files on `remote:` excluding those in root directory `dir` and sub
 directories.
 
-Eg `rclone ls remote: --exclude '*\[{JP,KR,HK,CN,RU,PL,AU,GB,FR}\]*'
+Eg `rclone ls remote: --exclude '*\[{JP,KR,HK,CN,RU,PL,AU,GB,FR}\]*'`
 to list the files in `remote:` with `[JP]` or `[KR]` or `[HK]` etc. in
 their name. The single quotes prevent the shell from interpreting the `\`
 characters. The `\` characters escape the `[` and `]` so rclone's filter
@@ -389,9 +389,9 @@ include or exclude rule in `+` or `-` format.
 This flag can be repeated. See above for the order filter flags are
 processed in.
 
-'--filter +` differs from `--include`. In the case of `--include` rclone
-implies a `--exclude *` rule which it adds to the bottom of the internal rule
-list. Specifying a `+` rule with a `--filter...` flag does not imply
+`--filter +` differs from `--include`. In the case of `--include` rclone
+implies an `--exclude *` rule which it adds to the bottom of the internal rule
+list. `--filter...+` does not imply
 that rule.
 
 `--filter` has no effect when combined with `--files-from` or


### PR DESCRIPTION
This is an attempt at rewriting the rclone filter documentation page as much by way of an RFC as PR.

I have drawn largely from what appears to be the strong original structure of the page; existing text, and forum comment.

The term flag is used throughout rather than differentiating `--` options with non binary values. That diverges from some standard practice but is consistent with messages in the rclone binary and `go` documentation.

The term directory not folder is used throughout.

I tried referring to objects more broadly rather than files and it just did not seem to work. Apart from a note at the top the explanations refer entirely to paths, directories and files. My justification is that bucket store users understand the concept of files. Not all users of directory aware storage are so familiar with objects, keys and metadata.

Many of the changes I have made involve moving issues into what seemed to me to be more relevant parts of the original page structure. I still find the content repetitious and overly long but that may be inevitable when users can only be expected to read the section of the page they think most relevant.

Removed the rsync material entirely.

The structure of the page is intended to work with a hugo toc card from html Header2 to Header3.

My original intention was to establish a separate examples section. I have instead retained examples in each section, added to them and tried to make clear what is reference and what example.

The changes draw on Github and Forum issues too numerous to mention. for instance:

https://forum.rclone.org/t/certain-exclusion-flags-seem-to-be-ignored/20049/2
https://github.com/rclone/rclone/issues/4719 - original issue
https://github.com/rclone/rclone/issues/4713 - useful suggestions to improve the documentation on filters
https://github.com/rclone/rclone/issues/4739 - object or file
https://github.com/rclone/rclone/issues/4756 - flag or object
https://github.com/rclone/rclone/issues/4738 - toc

I am **especially** grateful to @ncw for his https://forum.rclone.org/t/object-key-remote-directory-filter-clarification/20386/2 and making sense of directory filters for me.

@ncw has a fun (and useful) online filter app at https://filterdemo.rclone.org/ I have not referred to it at this stage though I particularly like the fact that it is tied to the same codebase as an rclone version.

I have added cautions about mixing the `--filter...` flags with `--exclude...` or `--include...`. The same issues seem to arise as already recognised between the latter two. Issue https://github.com/rclone/rclone/issues/4741 relates to this.

The formal summary of glob syntax introduced at the top of the page is shamelessly stolen from https://godoc.org/github.com/gobwas/glob

I have tried not to alter too many header descriptions and thereby break existing links to them. Notably the final heading on the page deserves to be altered to include the flag name but that might be best addressed as part of a general sweep to shorten heading names more suitable for toc.

The reference to 'lass' in the example has been retained to confuse all those not of Scottish or Yorkshire heritage.

Some of my activity was to remove ambiguity and I anticipate suggestions to roll that back where it has become overly complex.

I tried particularly to bring together and make clear material about directory filters. It was previously scattered throughout the page and I couldn't understand it. I am particularly grateful for the explanations I received about directory filters though any remaining errors are entirely my own.

Removed erroneous references to non existent `--filter...` flags.

In some ways the best person to write this page would be one with no knowledge whatsoever of how rclone filters work. The further I got into it the better qualified I found myself to be.

E&OE

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Clarifications and corrections to rclone filtering documentation

#### Was the change discussed in an issue or in the forum before?

Yes, and I welcome further discussion. This is more really by way of RFC than PR

Edit: Note that rsync material now removed completely

#### Checklist

- [ x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x ] I'm done, this Pull Request is ready for review :-)
