### PR TITLE
mfs limitation ftp remote

### DIFF
--- a/docs/content/ftp.md
+++ b/docs/content/ftp.md
@@ -236,7 +236,10 @@ through rclone are time of upload.
 Rclone's FTP backend does not support any checksums but can compare
 file sizes.
 
-`rclone about` is not supported by the FTP backend. Backends without this capability cannot determine free space for an `rclone mount` or use policy `mfs` (most free space) as a member of an `rclone union` remote. [More](https://rclone.org/overview/#optional-features)
+`rclone about` is not supported by the FTP backend. Backends without
+this capability cannot determine free space for an rclone mount or
+use policy `mfs` (most free space) as a member of an rclone union
+remote. [More](https://rclone.org/overview/#optional-features)
 
 The implementation of : `--dump headers`,
 `--dump bodies`, `--dump auth` for debugging isn't the same as

--- a/docs/content/ftp.md
+++ b/docs/content/ftp.md
@@ -236,8 +236,7 @@ through rclone are time of upload.
 Rclone's FTP backend does not support any checksums but can compare
 file sizes.
 
-When an FTP remote is a member of an rclone union remote `mfs`
-(most free space) policy is not supported.
+`rclone about` is not supported by the FTP backend. Backends without this capability cannot determine free space for an `rclone mount` or use policy `mfs` (most free space) as a member of an `rclone union` remote. [More](https://rclone.org/overview/#optional-features)
 
 The implementation of : `--dump headers`,
 `--dump bodies`, `--dump auth` for debugging isn't the same as

--- a/docs/content/ftp.md
+++ b/docs/content/ftp.md
@@ -236,6 +236,9 @@ through rclone are time of upload.
 Rclone's FTP backend does not support any checksums but can compare
 file sizes.
 
+When an FTP remote is a member of an rclone union remote `mfs`
+(most free space) policy is not supported.
+
 The implementation of : `--dump headers`,
 `--dump bodies`, `--dump auth` for debugging isn't the same as
 for rclone HTTP based backends - it has less fine grained control.

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -431,7 +431,7 @@ an error.
 
 Backends without about capability cannot determine free space for an
 rclone mount, or use policy `mfs` (most free space) as a member of an
-`rclone union` remote.
+rclone union remote.
 
 ### EmptyDir ###
 

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -318,9 +318,8 @@ remote itself may assign the MIME type.
 
 ## Optional Features ##
 
-All the remotes support a basic set of features, but there are some
-optional features supported by some remotes used to make some
-operations more efficient.
+All rclone remotes support a base command set. Other features depend
+upon backend specific capabilities.
 
 | Name                         | Purge | Copy | Move | DirMove | CleanUp | ListR | StreamUpload | LinkSharing | About | EmptyDir |
 | ---------------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|:------------:|:------------:|:-----:| :------: |
@@ -424,13 +423,15 @@ on the particular cloud provider.
 
 ### About ###
 
-This is used to fetch quota information from the remote, like bytes
-used/free/quota and bytes used in the trash.
+Rclone `about` prints quota information for a remote. Typical output
+includes bytes used, free, quota and in trash.
 
-This is also used to return the space used, available for `rclone mount`.
+If a remote lacks about capability `rclone about remote:`returns
+an error.
 
-If the server can't do `About` then `rclone about` will return an
-error.
+Backends without about capability cannot determine free space for an
+rclone mount, or use policy `mfs` (most free space) as a member of an
+`rclone union` remote.
 
 ### EmptyDir ###
 


### PR DESCRIPTION
Limitation consistent with `rclone about remote:` and mentioned in the rclone forum

#### What is the purpose of this change?

Reflect issue from forum in rclone documentation

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/rclone-union-mfs-most-free-space-not-working-for-ftp/20346
#### Checklist

- [ x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x ] I'm done, this Pull Request is ready for review :-)
