### PR TITLE
cmount: Add optional `brew` tag

### DIFF
--- a/cmd/cmount/mount_brew.go
+++ b/cmd/cmount/mount_brew.go
@@ -1,0 +1,32 @@
+// Build for macos with the brew tag to handle the absence
+// of fuse and print an appropriate error message
+
+// +build brew
+// +build darwin
+
+package cmount
+
+import (
+	"github.com/pkg/errors"
+	"github.com/rclone/rclone/cmd/mountlib"
+	"github.com/rclone/rclone/vfs"
+)
+
+func init() {
+	name := "mount"
+	cmd := mountlib.NewMountCommand(name, false, mount)
+	cmd.Aliases = append(cmd.Aliases, "cmount")
+	mountlib.AddRc("cmount", mount)
+}
+
+// mount the file system
+//
+// The mount point will be ready when this returns.
+//
+// returns an error, and an error channel for the serve process to
+// report an error when fusermount is called.
+func mount(_ *vfs.VFS, _ string, _ *mountlib.Options) (<-chan error, func() error, error) {
+	return nil, nil, errors.New("mount is not supported on MacOS when installed via Homebrew. " +
+		"Please install the binaries available at https://rclone." +
+		"org/downloads/ instead if you want to use the mount command")
+}

--- a/cmd/cmount/mount_unsupported.go
+++ b/cmd/cmount/mount_unsupported.go
@@ -1,6 +1,6 @@
 // Build for cmount for unsupported platforms to stop go complaining
 // about "no buildable Go source files "
 
-// +build !linux,!darwin,!freebsd,!windows !cgo !cmount
+// +build !linux,!darwin,!freebsd,!windows !brew !cgo !cmount
 
 package cmount

--- a/cmd/mount/mount_unsupported.go
+++ b/cmd/mount/mount_unsupported.go
@@ -1,7 +1,7 @@
 // Build for mount for unsupported platforms to stop go complaining
 // about "no buildable Go source files "
 
-// Invert the build constraint: linux,go1.13 darwin,go1.13 freebsd,go1.13
+// Invert the build constraint: linux,go1.13 freebsd,go1.13
 //
 // !((linux&&go1.13) || (freebsd&&go1.13))
 // == !(linux&&go1.13) && !(freebsd&&go1.13))


### PR DESCRIPTION
cmount: Add optional `brew` tag to throw an error when using mount in the binaries installed via Homebrew - Fixes #4775

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Add optional `brew` tag to throw an error when using mount in the binaries installed via Homebrew

#### Was the change discussed in an issue or in the forum before?

#4775 

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
