### PR TITLE
about.md long desc. incl. link to list of backends

### DIFF
--- a/cmd/about/about.go
+++ b/cmd/about/about.go
@@ -44,7 +44,7 @@ var commandDefinition = &cobra.Command{
 	Use:   "about remote:",
 	Short: `Get quota information from the remote.`,
 	Long: `
-` + "`rclone about"` + `prints quota information about a remote to standard
+` + "`rclone about`" + `prints quota information about a remote to standard
 output. The output is typically used, free, quota and trash contents.
 
 E.g. Typical output from` + "`rclone about remote:`" + `is:

--- a/cmd/about/about.go
+++ b/cmd/about/about.go
@@ -44,10 +44,10 @@ var commandDefinition = &cobra.Command{
 	Use:   "about remote:",
 	Short: `Get quota information from the remote.`,
 	Long: `
-Get quota information from the remote, like bytes used/free/quota and bytes
-used in the trash. Not supported by all remotes.
+` + "`rclone about"` + `prints quota information about a remote to standard
+output. The output is typically used, free, quota and trash contents.
 
-This will print to stdout something like this:
+E.g. Typical output from` + "`rclone about remote:`" + `is:
 
     Total:   17G
     Used:    7.444G
@@ -59,16 +59,15 @@ Where the fields are:
 
   * Total: total size available.
   * Used: total size used
-  * Free: total amount this user could upload.
-  * Trashed: total amount in the trash
+  * Free: total space available to this user.
+  * Trashed: total space used by trash
   * Other: total amount in other storage (e.g. Gmail, Google Photos)
   * Objects: total number of objects in the storage
 
-Note that not all the backends provide all the fields - they will be
-missing if they are not known for that backend.  Where it is known
-that the value is unlimited the value will also be omitted.
+Not all backends print all fields. Information is not included if it is not
+provided by a backend. Where the value is unlimited it is omitted.
 
-Use the --full flag to see the numbers written out in full, e.g.
+Applying a ` + "`--full`" + ` flag to the command prints the bytes in full, e.g.
 
     Total:   18253611008
     Used:    7993453766
@@ -76,7 +75,7 @@ Use the --full flag to see the numbers written out in full, e.g.
     Trashed: 104857602
     Other:   8849156022
 
-Use the --json flag for a computer readable output, e.g.
+A ` + "`--json`" + `flag generates conveniently computer readable output, e.g.
 
     {
         "total": 18253611008,
@@ -85,6 +84,8 @@ Use the --json flag for a computer readable output, e.g.
         "other": 8849156022,
         "free": 1411001220
     }
+	
+Not all backends support the ` + "`rclone about`" + ` command. [List](https://rclone.org/overview/#optional-features)
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(1, 1, command, args)


### PR DESCRIPTION
Minor rework of about.md including addition of link to list of backends that support rclone about.

Are quoted string segments with spaces in OK? - ie `rclone about remote:`

#### What is the purpose of this change?

Link to list of backends that support rclone about

#### Was the change discussed in an issue or in the forum before?

It is linked to https://github.com/rclone/rclone/pull/4774

#### Checklist

- [ x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x ] I'm done, this Pull Request is ready for review :-)
