### PR TITLE
fs: fix canonical name construction for local backends

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -1370,7 +1370,7 @@ func NewFs(ctx context.Context, path string) (Fs, error) {
 func ConfigString(f Fs) string {
 	name := f.Name()
 	root := f.Root()
-	if name == "local" && f.Features().IsLocal {
+	if name == "local" || f.Features().IsLocal {
 		return root
 	}
 	return name + ":" + root


### PR DESCRIPTION

#### What is the purpose of this change?

Name of the local fs was hard coded as a requirement for returning
naked root path. This is in conflict with Features().IsLocal because
fs can be of local type but with a different name.

This is making "local" to be an option not a condition for returning
naked root path.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
