### PR TITLE
s3: Added error handling for minio-specific error code 429

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1346,6 +1346,7 @@ func (f *Fs) Features() *fs.Features {
 // retryErrorCodes is a slice of error codes that we will retry
 // See: https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html
 var retryErrorCodes = []int{
+	429, // Minio Specific - TooManyRequests: Too Many Requests
 	500, // Internal Server Error - "We encountered an internal error. Please try again."
 	503, // Service Unavailable/Slow Down - "Reduce your request rate"
 }


### PR DESCRIPTION
s3: Added error handling for minio-specific error code 429 indicating too many requests

Signed-off-by: Anagh Kumar Baranwal <6824881+darthShadow@users.noreply.github.com>

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

s3: Added error handling for minio-specific error code 429 indicating too many requests

#### Was the change discussed in an issue or in the forum before?

N/A

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
