### PR TITLE
compress: doc and test fixups

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,7 @@ Current active maintainers of rclone are:
 | Fabian Möller    | @B4dM4n           |                              |
 | Alex Chen        | @Cnly             | onedrive backend             |
 | Sandeep Ummadi   | @sandeepkru       | azureblob backend            |
-| Sebastian Bünger | @buengese         | jottacloud & yandex backends |
+| Sebastian Bünger | @buengese         | jottacloud, yandex & compress backends |
 | Ivan Andreev     | @ivandeex         | chunker & mailru backends    |
 | Max Sum          | @Max-Sum          | union backend                |
 | Fred             | @creativeprojects | seafile backend              |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Please see [the full list of all storage providers and their features](https://r
   * [Check](https://rclone.org/commands/rclone_check/) mode to check for file hash equality
   * Can sync to and from network, e.g. two different cloud accounts
   * Optional large file chunking ([Chunker](https://rclone.org/chunker/))
+  * Optional transparent compression ([Compress](https://rclone.org/compress/))
   * Optional encryption ([Crypt](https://rclone.org/crypt/))
   * Optional cache ([Cache](https://rclone.org/cache/))
   * Optional FUSE mount ([rclone mount](https://rclone.org/commands/rclone_mount/))

--- a/backend/compress/compress.go
+++ b/backend/compress/compress.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"regexp"
 	"strings"
 	"time"
@@ -472,7 +471,8 @@ func (f *Fs) putCompress(ctx context.Context, in io.Reader, src fs.ObjectInfo, o
 	}
 
 	// Transfer the data
-	o, err := operations.Rcat(ctx, f.Fs, makeDataName(src.Remote(), src.Size(), f.mode), ioutil.NopCloser(wrappedIn), src.ModTime(ctx))
+	o, err := put(ctx, wrappedIn, f.wrapInfo(src, makeDataName(src.Remote(), src.Size(), f.mode), src.Size()), options...)
+	//o, err := operations.Rcat(ctx, f.Fs, makeDataName(src.Remote(), src.Size(), f.mode), ioutil.NopCloser(wrappedIn), src.ModTime(ctx))
 	if err != nil {
 		if o != nil {
 			removeErr := o.Remove(ctx)

--- a/bin/make_manual.py
+++ b/bin/make_manual.py
@@ -35,6 +35,7 @@ docs = [
     "chunker.md",
     "sharefile.md",
     "crypt.md",
+    "compress.md",
     "dropbox.md",
     "filefabric.md",
     "ftp.md",

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -27,6 +27,7 @@ See the following for detailed instructions for
   * [Cache](/cache/)
   * [Chunker](/chunker/) - transparently splits large files for other remotes
   * [Citrix ShareFile](/sharefile/)
+  * [Compress](/compress/)
   * [Crypt](/crypt/) - to encrypt other remotes
   * [DigitalOcean Spaces](/s3/#digitalocean-spaces)
   * [Dropbox](/dropbox/)

--- a/docs/layouts/chrome/navbar.html
+++ b/docs/layouts/chrome/navbar.html
@@ -69,6 +69,7 @@
           <a class="dropdown-item" href="/box/"><i class="fa fa-archive"></i> Box</a>
           <a class="dropdown-item" href="/cache/"><i class="fa fa-archive"></i> Cache</a>
           <a class="dropdown-item" href="/chunker/"><i class="fa fa-cut"></i> Chunker (splits large files)</a>
+          <a class="dropdown-item" href="/compress/"><i class="fa fa-file-archive-o"></i> Compress (transparent gzip compression)</a>
           <a class="dropdown-item" href="/sharefile/"><i class="fas fa-share-square"></i> Citrix ShareFile</a>
           <a class="dropdown-item" href="/crypt/"><i class="fa fa-lock"></i> Crypt (encrypts the others)</a>
           <a class="dropdown-item" href="/dropbox/"><i class="fab fa-dropbox"></i> Dropbox</a>


### PR DESCRIPTION
Hopefully fixes #4797.
I didn't add anything to `docs/overview.md` as the other overlay remotes aren't listed there either. I also decided to add myself as the maintainer for the compress backend.