### PR TITLE
Allow storage class header to be set

### DIFF
--- a/backend/googlecloudstorage/googlecloudstorage.go
+++ b/backend/googlecloudstorage/googlecloudstorage.go
@@ -1091,6 +1091,9 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 			object.ContentLanguage = value
 		case "content-type":
 			object.ContentType = value
+		case "x-goog-storage-class":
+			// See https://cloud.google.com/storage/docs/xml-api/put-object-upload
+			object.StorageClass = value
 		default:
 			const googMetaPrefix = "x-goog-meta-"
 			if strings.HasPrefix(lowerKey, googMetaPrefix) {

--- a/docs/content/googlecloudstorage.md
+++ b/docs/content/googlecloudstorage.md
@@ -232,6 +232,7 @@ flag. Google Cloud Storage supports the headers as described in the
 - Content-Encoding
 - Content-Language
 - Content-Type
+- X-Goog-Storage-Class
 - X-Goog-Meta-
 
 Eg `--header-upload "Content-Type text/potato"`


### PR DESCRIPTION
#### What is the purpose of this change?

Allow storage class to be set individually on a bucket, overriding the default storage class setting at the bucket level.

There is a valid reason to want this kind of feature. It allows one to optimize costs. See also [this comment on stackoverflow](https://stackoverflow.com/a/62105146). With the proposed changes to the code, it would now be possible to set a default storage class that is cost-effective in operations cost, but still have individual objects stored using the cheaper COLDLINE or ARCHIVE storage classes.

#### Was the change discussed in an issue or in the forum before?

See issue #3043

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
