### PR TITLE
docs: fix invalid option name in example of crypt config

### DIFF
--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -60,7 +60,7 @@ Choose a number from below, or type in your own value
    \ "true"
  2 / Don't encrypt directory names, leave them intact.
    \ "false"
-filename_encryption> 1
+directory_name_encryption> 1
 Password or pass phrase for encryption.
 y) Yes type in my own password
 g) Generate random password


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix invalid option name in the example code block of `crypt config` in crypt.md.

#### Was the change discussed in an issue or in the forum before?

no

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
