### PR TITLE
crypt: add --crypt-filename-compression option to compress unicode filename before encryption (WIP)

### DIFF
--- a/backend/crypt/cipher_test.go
+++ b/backend/crypt/cipher_test.go
@@ -180,6 +180,17 @@ func TestEncryptFileName(t *testing.T) {
 	assert.Equal(t, "160.\u03c2", c.EncryptFileName("\u03a0"))
 }
 
+func TestCompressFileName(t *testing.T) {
+	// Filename compress on in standard mode
+	c, _ := newCipher(NameEncryptionStandard, "", "", true)
+	assert.Equal(t, "vel9rg44g4cvvfkb30h2gqun3ompvv28gdkbqfen0ga52o3ea82g7trdob92gjk6gjunph1ah38im", c.EncryptFileName("a long long not UNICODE filename"))
+	assert.Equal(t, "s4m9dhma7nnifeenm46j20e6od76m6im1odc8qn71sbc3gabghr0", c.EncryptFileName("長い長いＵＮＩＣＯＤＥファイル名"))
+	// Filename compress disabled in off mode
+	c, _ = newCipher(NameEncryptionOff, "", "", true)
+	assert.Equal(t, "a long long not UNICODE filename.bin", c.EncryptFileName("a long long not UNICODE filename"))
+	assert.Equal(t, "長い長いＵＮＩＣＯＤＥファイル名.bin", c.EncryptFileName("長い長いＵＮＩＣＯＤＥファイル名"))
+}
+
 func TestDecryptFileName(t *testing.T) {
 	for _, test := range []struct {
 		mode           NameEncryptionMode

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -65,6 +65,22 @@ NB If filename_encryption is "off" then this option will do nothing.`,
 				},
 			},
 		}, {
+			Name: "filename_compression",
+			Help: `Option to either compress filenames or not.
+
+NB If filename_encryption is not "standard" then this option will do nothing.`,
+			Default: false,
+			Examples: []fs.OptionExample{
+				{
+					Value: "true",
+					Help:  "Compress filenames.",
+				},
+				{
+					Value: "false",
+					Help:  "Don't compress filenames.",
+				},
+			},
+		}, {
 			Name:       "password",
 			Help:       "Password or pass phrase for encryption.",
 			IsPassword: true,
@@ -125,7 +141,7 @@ func newCipherForConfig(opt *Options) (*Cipher, error) {
 			return nil, errors.Wrap(err, "failed to decrypt password2")
 		}
 	}
-	cipher, err := newCipher(mode, password, salt, opt.DirectoryNameEncryption)
+	cipher, err := newCipher(mode, password, salt, opt.DirectoryNameEncryption, opt.FilenameCompression)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to make cipher")
 	}
@@ -209,6 +225,7 @@ type Options struct {
 	Remote                  string `config:"remote"`
 	FilenameEncryption      string `config:"filename_encryption"`
 	DirectoryNameEncryption bool   `config:"directory_name_encryption"`
+	FilenameCompression     bool   `config:"filename_compression"`
 	Password                string `config:"password"`
 	Password2               string `config:"password2"`
 	ServerSideAcrossConfigs bool   `config:"server_side_across_configs"`

--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -60,7 +60,7 @@ Choose a number from below, or type in your own value
    \ "true"
  2 / Don't encrypt directory names, leave them intact.
    \ "false"
-filename_encryption> 1
+directory_name_encryption> 1
 Password or pass phrase for encryption.
 y) Yes type in my own password
 g) Generate random password

--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -32,7 +32,7 @@ No remotes found - make a new one
 n) New remote
 s) Set configuration password
 q) Quit config
-n/s/q> n   
+n/s/q> n
 name> secret
 Type of storage to configure.
 Choose a number from below, or type in your own value
@@ -61,6 +61,16 @@ Choose a number from below, or type in your own value
  2 / Don't encrypt directory names, leave them intact.
    \ "false"
 directory_name_encryption> 1
+Option to either compress filenames or not.
+
+NB If filename_encryption is not "standard" then this option will do nothing.
+Enter a boolean value (true or false). Press Enter for the default ("false").
+Choose a number from below, or type in your own value
+ 1 / Compress filenames.
+   \ "true"
+ 2 / Don't compress filenames.
+   \ "false"
+filename_compression> 2
 Password or pass phrase for encryption.
 y) Yes type in my own password
 g) Generate random password
@@ -204,7 +214,10 @@ Off
 Standard
 
   * file names encrypted
-  * file names can't be as long (~143 characters)
+  * file names can't be as long
+    * ASCII (7bits) ~143 characters
+    * Alphabetic (Latin, Cyrillic, etc.) ~71 characters
+    * East-Asian (CJK) ~47 characters
   * can use sub paths and copy single files
   * directory structure visible
   * identical files names will have identical uploaded names
@@ -223,7 +236,7 @@ segment names.
 
 There is a possibility with some unicode based filenames that the
 obfuscation is weak and may map lower case characters to upper case
-equivalents. 
+equivalents.
 
 Obfuscation cannot be relied upon for strong protection.
 
@@ -235,9 +248,14 @@ Obfuscation cannot be relied upon for strong protection.
 
 Cloud storage systems have limits on file name length and
 total path length which rclone is more likely to breach using
-"Standard" file name encryption.  Where file names are less thn 156
+"Standard" file name encryption.  Where file names are less thn 143
 characters in length issues should not be encountered, irrespective of
 cloud storage provider.
+
+If you are using non-ASCII file names, you can use the
+[--crypt-filename-compression](#crypt-filename-compression) option to
+store longer file names.  This feature allows non-ASCII file names to
+be stored up to the same length as ASCII file names.
 
 An alternative, future rclone file name encryption mode may tolerate
 backend provider path length limits.
@@ -320,6 +338,22 @@ NB If filename_encryption is "off" then this option will do nothing.
         - Encrypt directory names.
     - "false"
         - Don't encrypt directory names, leave them intact.
+
+#### --crypt-filename-compression
+
+Option to either compress filenames or not.
+
+NB If filename_encryption is not "standard" then this option will do nothing.
+
+- Config:      filename_compression
+- Env Var:     RCLONE_CRYPT_FILENAME_COMPRESSION
+- Type:        bool
+- Default:     false
+- Examples:
+    - "true"
+        - Compress filenames.
+    - "false"
+        - Don't compress filenames.
 
 #### --crypt-password
 

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/buengese/sgzip v0.1.0
 	github.com/calebcase/tmpfile v1.0.2 // indirect
 	github.com/coreos/go-semver v0.3.0
+	github.com/dop251/scsu v0.0.0-20200422003335-8fadfb689669
 	github.com/dropbox/dropbox-sdk-go-unofficial v5.6.0+incompatible
 	github.com/gabriel-vasile/mimetype v1.1.1
 	github.com/gogo/protobuf v1.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,8 @@ github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumC
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
+github.com/dop251/scsu v0.0.0-20200422003335-8fadfb689669 h1:e28M2/odOZjMc1J2ZZwgex6NM9+aqr1nMlTqPLayxbk=
+github.com/dop251/scsu v0.0.0-20200422003335-8fadfb689669/go.mod h1:Gth7Xev0h28tuTayG4HlTZy90IXhiDgV2+MLtJzjpP0=
 github.com/dropbox/dropbox-sdk-go-unofficial v5.6.0+incompatible h1:DtumzkLk2zZ2SeElEr+VNz+zV7l+BTe509cV4sKPXbM=
 github.com/dropbox/dropbox-sdk-go-unofficial v5.6.0+incompatible/go.mod h1:lr+LhMM3F6Y3lW1T9j2U5l7QeuWm87N9+PPXo3yH4qY=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->
**WIP** now. Please advice to this feature.
I will combine the commits into one later.

#### What is the purpose of this change?

Filename encryption inflates its length.
Some remote backends has a limitation of the filename length that counted by *characters* (not bytes).
So, if it contains multi-bytes characters in UTF-8, the filename length was not problematic in the remote can be a problem in the crypt backend.

If remote backend has 255 characters limit.  "standard" mode has limits below.

* ASCII (7bits, 1byte/char) ~143 characters **limited**
* Alphabetic (Latin, Cyrillic, etc., 2bytes/char) ~71 characters **big limited**
* East-Asian (CJK, 3bytes/char) ~47 characters  **extremely limited**
                                                                         
If `--crypt-filename-compression` option is enabled, the filename is compressed by [SCSU (Standard Compression Scheme for Unicode)](https://en.wikipedia.org/wiki/Standard_Compression_Scheme_for_Unicode) before encryption.
This feature allows non-ASCII file names to be stored up to the same length as ASCII file names.

#### Was the change discussed in an issue or in the forum before?

The problem of filename length has been discussed a lot.
However, it seems that the problem extremely limited in East Asian characters has not been discussed.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
