### PR TITLE
systemd log integration

### DIFF
--- a/fs/log/log.go
+++ b/fs/log/log.go
@@ -3,7 +3,6 @@ package log
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"log"
 	"os"
@@ -12,7 +11,6 @@ import (
 	"strings"
 
 	systemd "github.com/iguanesolutions/go-systemd/v5"
-	sysdjournald "github.com/iguanesolutions/go-systemd/v5/journald"
 	"github.com/rclone/rclone/fs"
 	"github.com/sirupsen/logrus"
 )
@@ -155,28 +153,4 @@ func InitLogging() {
 // Redirected returns true if the log has been redirected from stdout
 func Redirected() bool {
 	return Opt.UseSyslog || Opt.File != ""
-}
-
-var logLevelToStringSystemd = []string{
-	fs.LogLevelEmergency: sysdjournald.EmergPrefix,
-	fs.LogLevelAlert:     sysdjournald.AlertPrefix,
-	fs.LogLevelCritical:  sysdjournald.CritPrefix,
-	fs.LogLevelError:     sysdjournald.ErrPrefix,
-	fs.LogLevelWarning:   sysdjournald.WarningPrefix,
-	fs.LogLevelNotice:    sysdjournald.NoticePrefix,
-	fs.LogLevelInfo:      sysdjournald.InfoPrefix,
-	fs.LogLevelDebug:     sysdjournald.DebugPrefix,
-}
-
-// Starts systemd logging
-func startSystemdLog() {
-	log.SetFlags(0)
-	fs.LogPrint = func(level fs.LogLevel, text string) {
-		var prefix string
-		if level < fs.LogLevel(len(logLevelToStringSystemd)) {
-			prefix = logLevelToStringSystemd[level]
-		}
-		text = fmt.Sprintf("%s%-6s: %s", prefix, level, text)
-		_ = log.Output(4, text)
-	}
 }

--- a/fs/log/systemd.go
+++ b/fs/log/systemd.go
@@ -1,0 +1,16 @@
+// Systemd interface for non-Unix variants only
+
+// +build windows nacl plan9
+
+package log
+
+import (
+	"log"
+	"runtime"
+)
+
+// Enables systemd logs if configured or if auto detected
+func startSystemdLog() bool {
+	log.Fatalf("--log-systemd not supported on %s platform", runtime.GOOS)
+	return false
+}

--- a/fs/log/systemd_unix.go
+++ b/fs/log/systemd_unix.go
@@ -1,0 +1,50 @@
+// Systemd interface for Unix variants only
+
+// +build !windows,!nacl,!plan9
+
+package log
+
+import (
+	"fmt"
+	"log"
+	"strings"
+
+	sysdjournald "github.com/iguanesolutions/go-systemd/v5/journald"
+	"github.com/rclone/rclone/fs"
+)
+
+// Enables systemd logs if configured or if auto detected
+func startSystemdLog() bool {
+	flagsStr := "," + Opt.Format + ","
+	var flags int
+	if strings.Contains(flagsStr, ",longfile,") {
+		flags |= log.Llongfile
+	}
+	if strings.Contains(flagsStr, ",shortfile,") {
+		flags |= log.Lshortfile
+	}
+	log.SetFlags(flags)
+	fs.LogPrint = func(level fs.LogLevel, text string) {
+		text = fmt.Sprintf("%s%-6s: %s", systemdLogPrefix(level), level, text)
+		_ = log.Output(4, text)
+	}
+	return true
+}
+
+var logLevelToSystemdPrefix = []string{
+	fs.LogLevelEmergency: sysdjournald.EmergPrefix,
+	fs.LogLevelAlert:     sysdjournald.AlertPrefix,
+	fs.LogLevelCritical:  sysdjournald.CritPrefix,
+	fs.LogLevelError:     sysdjournald.ErrPrefix,
+	fs.LogLevelWarning:   sysdjournald.WarningPrefix,
+	fs.LogLevelNotice:    sysdjournald.NoticePrefix,
+	fs.LogLevelInfo:      sysdjournald.InfoPrefix,
+	fs.LogLevelDebug:     sysdjournald.DebugPrefix,
+}
+
+func systemdLogPrefix(l fs.LogLevel) string {
+	if l >= fs.LogLevel(len(logLevelToSystemdPrefix)) {
+		return ""
+	}
+	return logLevelToSystemdPrefix[l]
+}


### PR DESCRIPTION
#### What is the purpose of this change?

The thing was to not make auto systemd detection if `--log-file` was set.

So this proposal only auto detect systemd integration if `--log-file` is not set.
And if both `--log-file` and `--log-systemd` are set then systemd integration is disabled since logs will not go into stdout/err.

I also moved `--log-systemd` from config flags to log flags to keep log flags together.

There is also the case when `--syslog` and `--log-systemd` are both set. In this PR since the `startSysLog` function is called after `enableSystemdLog` function and they both override the fs.LogPrint variable, the systemd integration will always be disabled.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/pull/4609

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
