### PR TITLE
fshttp: prevent overlap of HTTP headers in logs

### DIFF
--- a/fs/fshttp/http.go
+++ b/fs/fshttp/http.go
@@ -31,6 +31,7 @@ var (
 	noTransport  = new(sync.Once)
 	tpsBucket    *rate.Limiter // for limiting number of http transactions per second
 	cookieJar, _ = cookiejar.New(&cookiejar.Options{PublicSuffixList: publicsuffix.List})
+	logMutex     sync.Mutex
 )
 
 // StartHTTPTokenBucket starts the token bucket if necessary
@@ -331,15 +332,18 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		if t.dump&fs.DumpAuth == 0 {
 			buf = cleanAuths(buf)
 		}
+		logMutex.Lock()
 		fs.Debugf(nil, "%s", separatorReq)
 		fs.Debugf(nil, "%s (req %p)", "HTTP REQUEST", req)
 		fs.Debugf(nil, "%s", string(buf))
 		fs.Debugf(nil, "%s", separatorReq)
+		logMutex.Unlock()
 	}
 	// Do round trip
 	resp, err = t.Transport.RoundTrip(req)
 	// Logf response
 	if t.dump&(fs.DumpHeaders|fs.DumpBodies|fs.DumpAuth|fs.DumpRequests|fs.DumpResponses) != 0 {
+		logMutex.Lock()
 		fs.Debugf(nil, "%s", separatorResp)
 		fs.Debugf(nil, "%s (req %p)", "HTTP RESPONSE", req)
 		if err != nil {
@@ -349,6 +353,7 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 			fs.Debugf(nil, "%s", string(buf))
 		}
 		fs.Debugf(nil, "%s", separatorResp)
+		logMutex.Unlock()
 	}
 	if err == nil {
 		checkServerTime(req, resp)


### PR DESCRIPTION
#### What is the purpose of this change?

Multi-line HTTP header debug messages can overlap in output/logs, making them difficult to parse. This fix wraps multi-line HTTP debug messages in a mutex to prevent the overlap.

#### Was the change discussed in an issue or in the forum before?

Not to my knowledge.

#### Checklist

- [X ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [N/A ] I have added tests for all changes in this PR if appropriate.
- [N/A ] I have added documentation for the changes if appropriate.
- [X ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X ] I'm done, this Pull Request is ready for review :-)
