### PR TITLE
restic: rest server metrics

### DIFF
--- a/cmd/serve/restic/prometheus.go
+++ b/cmd/serve/restic/prometheus.go
@@ -1,0 +1,81 @@
+package restic
+
+import (
+	"net/http"
+	"regexp"
+	"strings"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	promRegistry                         = prometheus.NewRegistry()
+	promRegisterer prometheus.Registerer = promRegistry
+	promGatherer   prometheus.Gatherer   = promRegistry
+)
+
+var metricLabelList = []string{"repo", "type"}
+
+var (
+	metricBlobWriteTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "restic_serve_blob_write_total",
+		Help: "Total number of blob written",
+	}, metricLabelList)
+
+	metricBlobWriteBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "restic_serve_blob_write_bytes_total",
+		Help: "Total number of bytes written to blob",
+	}, metricLabelList)
+
+	metricBlobReadTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "restic_serve_blob_read_total",
+		Help: "Total number of blob read",
+	}, metricLabelList)
+
+	metricBlobReadBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "restic_serve_blob_read_bytes_total",
+		Help: "Total number of bytes read from blob",
+	}, metricLabelList)
+
+	metricBlobDeleteTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "restic_serve_blob_delete_total",
+		Help: "Total number of blob deleted",
+	}, metricLabelList)
+
+	metricBlobDeleteBytesTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "restic_serve_blob_delete_bytes_total",
+		Help: "Total number of bytes of blob deleted",
+	}, metricLabelList)
+)
+
+func init() {
+	promRegisterer.MustRegister(metricBlobWriteTotal)
+	promRegisterer.MustRegister(metricBlobWriteBytesTotal)
+	promRegisterer.MustRegister(metricBlobReadTotal)
+	promRegisterer.MustRegister(metricBlobReadBytesTotal)
+	promRegisterer.MustRegister(metricBlobDeleteTotal)
+	promRegisterer.MustRegister(metricBlobDeleteBytesTotal)
+}
+
+func promHandler() http.Handler {
+	return promhttp.InstrumentMetricHandler(
+		promRegisterer, promhttp.HandlerFor(promGatherer, promhttp.HandlerOpts{
+			Registry: promRegisterer,
+		}),
+	)
+}
+
+var blobRe = regexp.MustCompile(`(.+)/(data|index|keys|locks|snapshots)/(.+)`)
+
+func getMetricLabels(r *http.Request, remote string) prometheus.Labels {
+	path := strings.Trim(remote, "/")
+	matches := blobRe.FindStringSubmatch(path)
+	if matches == nil {
+		return nil
+	}
+	return prometheus.Labels{
+		"repo": matches[1],
+		"type": matches[2],
+	}
+}

--- a/cmd/serve/restic/prometheus.go
+++ b/cmd/serve/restic/prometheus.go
@@ -66,7 +66,7 @@ func promHandler() http.Handler {
 	)
 }
 
-var blobRe = regexp.MustCompile(`((.+))?(data|index|keys|locks|snapshots)/(.+)`)
+var blobRe = regexp.MustCompile(`((.+)/)?(data|index|keys|locks|snapshots)/(.+)`)
 
 func getMetricLabels(r *http.Request, remote string) prometheus.Labels {
 	remote = strings.Trim(remote, "/")


### PR DESCRIPTION
#### What is the purpose of this change?

I wanted to have metrics like the restic rest server has -> https://github.com/restic/rest-server.
So i've implemented a /metrics endpoint in the restic serve command with a `--prometheus` flag to enable it.
But i was wondering if the right place for those metrics is the rc server.
Like it will be a private field of `accounting.StatsInfo` and will be a part of core/stats if they are available.
And the metrics will be served by the prometheus registry already present in the accounting package.