### PR TITLE
b2: docs for download_url with private buckets

### DIFF
--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -155,7 +155,9 @@ to start uploading.`,
 
 This is usually set to a Cloudflare CDN URL as Backblaze offers
 free egress for data downloaded through the Cloudflare network.
-This is probably only useful for a public bucket.
+Rclone works with private buckets by sending an "Authorization" header.
+If the custom endpoint rewrites the requests for authentication,
+e.g., in Cloudflare Workers, this header needs to be handled properly.
 Leave blank if you want to use the endpoint provided by Backblaze.`,
 			Advanced: true,
 		}, {


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The current authentication scheme works without creating a public download endpoint for a private bucket as in the B2 official blog. On the contrary, if the existing authorization header gets duplicated in the Cloudflare Workers script, one might receive 401 Unauthorized errors. This commit add some info about this behavior to the doc to help smooth the setup process.


#### Was the change discussed in an issue or in the forum before?

As discussed in the [forum](https://forum.rclone.org/t/backblaze-b2-with-cloudflare-worker-conflicts-on-the-authorization/21353).

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

I'm not sure where I should squash the commit. I'll make changes if required.