### PR TITLE
fs: add support for flag --no-console on windows to hide the console …

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -382,6 +382,11 @@ func initConfig() {
 	// Finish parsing any command line flags
 	configflags.SetFlags(ci)
 
+	// Hide console window
+	if ci.NoConsole {
+		terminal.HideConsole()
+	}
+
 	// Load filters
 	err := filterflags.Reload(ctx)
 	if err != nil {

--- a/fs/config.go
+++ b/fs/config.go
@@ -121,6 +121,7 @@ type ConfigInfo struct {
 	DownloadHeaders        []*HTTPOption
 	Headers                []*HTTPOption
 	RefreshTimes           bool
+	NoConsole              bool
 }
 
 // NewConfig creates a new config with everything set to the default

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -124,6 +124,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.StringArrayVarP(flagSet, &downloadHeaders, "header-download", "", nil, "Set HTTP header for download transactions")
 	flags.StringArrayVarP(flagSet, &headers, "header", "", nil, "Set HTTP header for all transactions")
 	flags.BoolVarP(flagSet, &ci.RefreshTimes, "refresh-times", "", ci.RefreshTimes, "Refresh the modtime of remote files.")
+	flags.BoolVarP(flagSet, &ci.NoConsole, "no-console", "", ci.NoConsole, "Hide console window. Supported on Windows only.")
 }
 
 // ParseHeaders converts the strings passed in via the header flags into HTTPOptions

--- a/lib/terminal/hidden_other.go
+++ b/lib/terminal/hidden_other.go
@@ -1,0 +1,7 @@
+// +build !windows
+
+package terminal
+
+// HideConsole is only supported on windows
+func HideConsole() {
+}

--- a/lib/terminal/hidden_windows.go
+++ b/lib/terminal/hidden_windows.go
@@ -1,0 +1,19 @@
+// +build windows
+
+package terminal
+
+import (
+	"syscall"
+)
+
+// HideConsole hides the console window and activates another window
+func HideConsole() {
+	getConsoleWindow := syscall.NewLazyDLL("kernel32.dll").NewProc("GetConsoleWindow")
+	showWindow := syscall.NewLazyDLL("user32.dll").NewProc("ShowWindow")
+	if getConsoleWindow.Find() == nil && showWindow.Find() == nil {
+		hwnd, _, _ := getConsoleWindow.Call()
+		if hwnd != 0 {
+			showWindow.Call(hwnd, 0)
+		}
+	}
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Add option to hide rclone's console window, with a new flag `--no-console`. Mostly relevant in combination with remote control, mount, web gui etc commands, but also long running sync operations etc, and especially when starting rclone automatically from task scheduler or windows service (nssm).

The implementation is based on Syncthing's:
https://github.com/syncthing/syncthing/commit/80dca96ee822d2f1a23cadb2a6868e1322a8d90b

Note: When starting `rclone` with `--no-console` from "run" dialog, desktop shortcut etc, the console window "flashes" briefly on startup, before it gets set to hidden. If you start up `cmd.exe` and then execute `rclone` with `--no-console` from there, it actually hides the existing cmd.exe window, and when rclone process exits the cmd process is left running hidden. This can perhaps be a bit surprising for users, but I do not know a way around it (this is how Syncthing does it as well).

PS: Should it be called --no-console or --hide-console, or something else? Syncthing used no-console, and rclone already have some --no-... flags so I kept that.

PS 2: It would be nice to include this in a doc page for the typical use case of auto-starting rclone for mount etc. The following from Syncthing is really detailed and well written and could serve as an inspiration: https://docs.syncthing.net/users/autostart.html

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

The actual option has not been discussed, but tips and workarounds on how to hide the console window has been discussed numerous times.

https://forum.rclone.org/t/how-to-mount-a-personal-jottacloud-as-a-drive-on-win10/21601/37
https://forum.rclone.org/t/autostart-mount-on-windows-without-cmd-popping-up/20896

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] ~I have added tests for all changes in this PR if appropriate.~
- [X] ~I have added documentation for the changes if appropriate.~
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
