### PR TITLE
b2: fixed possible crash when accessing Backblaze b2 remote

### DIFF
--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -708,7 +708,7 @@ func (f *Fs) list(ctx context.Context, bucket, directory, prefix string, addBuck
 			remote := file.Name[len(prefix):]
 			// Check for directory
 			isDirectory := remote == "" || strings.HasSuffix(remote, "/")
-			if isDirectory {
+			if isDirectory && len(remote) > 1 {
 				remote = remote[:len(remote)-1]
 			}
 			if addBucket {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix a crash when a b2 remote is accessed.

#### Was the change discussed in an issue or in the forum before?

Did not find any discussions about this specific crash.

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ x] I have added tests for all changes in this PR if appropriate.
- [x ] I have added documentation for the changes if appropriate.
- [ x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)

Here is a copy of the crash that should be fixed (at least I get a list of the files instead of a crash).

```
$ rclone ls -vv b2:bucket/dir
2021/01/25 18:08:43 DEBUG : rclone: Version "v1.53.4" starting with parameters ["rclone" "ls" "-vv" "b2:bucket/dir"]
2021/01/25 18:08:43 DEBUG : Using config file from "/etc/rclone/rclone.conf"
2021/01/25 18:08:43 DEBUG : Creating backend with remote "b2:bucket/dir"
panic: runtime error: slice bounds out of range [:-1]

goroutine 1 [running]:
github.com/rclone/rclone/backend/b2.(*Fs).list(0xc00000a1e0, 0x1d86ec0, 0xc00003e098, 0xc000040370, 0x14, 0xc000040385, 0x2f, 0x7ffcea68b7fa, 0x2f, 0xc000000100, ...)
	github.com/rclone/rclone/backend/b2/b2.go:706 +0xb7c
github.com/rclone/rclone/backend/b2.(*Fs).ListR.func1(0xc000040370, 0x14, 0xc000040385, 0x2f, 0x7ffcea68b7fa, 0x2f, 0x0, 0xc00054f8d0, 0x40d990)
	github.com/rclone/rclone/backend/b2/b2.go:829 +0x130
github.com/rclone/rclone/backend/b2.(*Fs).ListR(0xc00000a1e0, 0x1d86ec0, 0xc00003e098, 0x0, 0x0, 0xc000854c80, 0x191db01, 0xc000854c80)
	github.com/rclone/rclone/backend/b2/b2.go:856 +0x378
github.com/rclone/rclone/fs/walk.listR(0x1d86ec0, 0xc00003e098, 0x1d9c9e0, 0xc00000a1e0, 0x0, 0x0, 0x1860101, 0xc00042bc90, 0xc000474c60, 0x0, ...)
	github.com/rclone/rclone/fs/walk/walk.go:286 +0x182
github.com/rclone/rclone/fs/walk.ListR(0x1d86ec0, 0xc00003e098, 0x1d9c9e0, 0xc00000a1e0, 0x0, 0x0, 0xc00054fa00, 0xffffffffffffffff, 0x1, 0xc00042bc90, ...)
	github.com/rclone/rclone/fs/walk/walk.go:152 +0x1c5
github.com/rclone/rclone/fs/operations.ListFn(0x1d86ec0, 0xc00003e098, 0x1d9c9e0, 0xc00000a1e0, 0xc00087d6c0, 0x1a9c32c, 0x5)
	github.com/rclone/rclone/fs/operations/operations.go:753 +0xb5
github.com/rclone/rclone/fs/operations.List(0x1d86ec0, 0xc00003e098, 0x1d9c9e0, 0xc00000a1e0, 0x1d4fc40, 0xc00000e018, 0xc000458848, 0xc000164100)
	github.com/rclone/rclone/fs/operations/operations.go:777 +0x8c
github.com/rclone/rclone/cmd/ls.glob..func1.1(0xc00054fb00, 0x7a3be6)
	github.com/rclone/rclone/cmd/ls/ls.go:37 +0x65
github.com/rclone/rclone/cmd.Run(0x7ffcea680000, 0x27dd260, 0xc00054fd58)
	github.com/rclone/rclone/cmd/cmd.go:246 +0xcb
github.com/rclone/rclone/cmd/ls.glob..func1(0x27dd260, 0xc000404150, 0x1, 0x3)
	github.com/rclone/rclone/cmd/ls/ls.go:36 +0xd5
github.com/spf13/cobra.(*Command).execute(0x27dd260, 0xc000404120, 0x3, 0x3, 0x27dd260, 0xc000404120)
	github.com/spf13/cobra@v1.0.0/command.go:846 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x27d6420, 0x0, 0x4062c5, 0xc00007e058)
	github.com/spf13/cobra@v1.0.0/command.go:950 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	github.com/spf13/cobra@v1.0.0/command.go:887
github.com/rclone/rclone/cmd.Main()
	github.com/rclone/rclone/cmd/cmd.go:520 +0xaa
main.main()
	github.com/rclone/rclone/rclone.go:14 +0x25
```