### PR TITLE
plugins: Move plugins cache path initialization to initPluginsOrError.

### DIFF
--- a/fs/rc/webgui/plugins.go
+++ b/fs/rc/webgui/plugins.go
@@ -68,13 +68,6 @@ var (
 	initMutex                = &sync.Mutex{}
 )
 
-func init() {
-	cachePath = filepath.Join(config.CacheDir, "webgui")
-	PluginsPath = filepath.Join(cachePath, "plugins")
-	pluginsConfigPath = filepath.Join(PluginsPath, "config")
-
-}
-
 // Plugins represents the structure how plugins are saved onto disk
 type Plugins struct {
 	mutex         sync.Mutex
@@ -96,6 +89,9 @@ func initPluginsOrError() error {
 	initMutex.Lock()
 	defer initMutex.Unlock()
 	if !initSuccess {
+		cachePath = filepath.Join(config.CacheDir, "webgui")
+		PluginsPath = filepath.Join(cachePath, "plugins")
+		pluginsConfigPath = filepath.Join(PluginsPath, "config")
 		loadedPlugins = newPlugins(availablePluginsJSONPath)
 		err := loadedPlugins.readFromFile()
 		if err != nil {


### PR DESCRIPTION
Fixes #4951.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
