### PR TITLE
build: replace go 1.16-beta1 by 1.16-rc1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
 
           - job_name: go1.16
             os: ubuntu-latest
-            go: '1.16.0-beta1'
+            go: '1.16.0-rc1'
             quicktest: true
             racequicktest: true
 


### PR DESCRIPTION
#### What is the purpose of this change?

The rclone ci/cd is currently using go `1.16-beta1`
which was phased out from github today
and replaced by go `1.16-rc1` resulting in build errors like
```
Run actions/setup-go@v2
Setup go  version spec 1.16.0-beta1
Attempting to download 1.16.0-beta1...
matching 1.16.0-beta1...
Not found in manifest.  Falling back to download directly from Go
Error: Unable to find Go version '1.16.0-beta1' for platform linux and architecture x64.
```
This PR fixes that.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
