### PR TITLE
fstest: apply shellcheck on rclone-serve.bash

### DIFF
--- a/fstest/testserver/init.d/rclone-serve.bash
+++ b/fstest/testserver/init.d/rclone-serve.bash
@@ -7,21 +7,21 @@ DATADIR=/tmp/${NAME}-data
 
 stop() {
     if status ; then
-        pid=$(cat ${PIDFILE})
-        kill $pid
-        rm ${PIDFILE}
+        pid=$(cat "$PIDFILE")
+        kill "$pid"
+        rm "$PIDFILE"
         echo "$NAME stopped"
     fi
 }
 
 status() {
-    if [ -e ${PIDFILE} ]; then
-        pid=$(cat ${PIDFILE})
-        if kill -0 &>1 > /dev/null $pid; then
+    if [ -e "$PIDFILE" ]; then
+        pid=$(cat "$PIDFILE")
+        if kill -0 "$pid" >/dev/null 2>&1; then
             # echo "$NAME running"
             return 0
         else
-            rm ${PIDFILE}
+            rm "$PIDFILE"
         fi
     fi
     # echo "$NAME not running"
@@ -30,12 +30,13 @@ status() {
 
 run() {
     if ! status ; then
-        mkdir -p ${DATADIR}
-        nohup "$@" >>/tmp/${NAME}.log 2>&1 </dev/null &
+        mkdir -p "$DATADIR"
+        nohup "$@" >> "/tmp/${NAME}.log" 2>&1 </dev/null &
         pid=$!
-        echo $pid > ${PIDFILE}
-        disown $pid
+        echo $pid > "$PIDFILE"
+        disown "$pid"
     fi
 }
 
-. $(dirname "$0")/run.bash
+# shellcheck disable=SC1090
+. "$(dirname "$0")/run.bash"


### PR DESCRIPTION
#### What is the purpose of this change?

I am working on a PR with a test which runs `rclone serve webdav` in docker.
I noticed that every run of `test_all` leaves empty files named `1` in the source directory.
Guilty is the line  `kill -0 &>1 > /dev/null` in [rclone-serve.bash](https://github.com/rclone/rclone/commit/45e8bea8d099db946faa2af7342f8152c5c12f96#diff-55f3aaae89c3c87d29ada578033b27f1b731e5390cf5577cc6571fb9e1a983bfR20) introduced by commit https://github.com/rclone/rclone/commit/45e8bea8d099db946faa2af7342f8152c5c12f96
While it was enough to replace `&>1 >/dev/null` by `2>&1 >/dev/null` or by `&>/dev/null`, I went further.

I applied _shellcheck_ on `rclone-serve.bash` and fixed all warnings, mostly by quoting bare shell variables. Integration test continue to work for me. The result is here.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
