### PR TITLE
mount: allow mounting to root directory on windows

### DIFF
--- a/cmd/cmount/mountpoint_windows.go
+++ b/cmd/cmount/mountpoint_windows.go
@@ -114,11 +114,12 @@ func handleLocalMountpath(mountpath string, opt *mountlib.Options) (string, erro
 			fs.Errorf(nil, "Ignoring --network-mode as it is not supported with directory mountpoint")
 			opt.NetworkMode = false
 		}
-		parent := filepath.Join(mountpath, "..")
-		if parent == "" || parent == "." {
-			return "", errors.New("mountpoint parent path is not valid: " + parent)
+		var err error
+		if mountpath, err = filepath.Abs(mountpath); err != nil { // Ensures parent is found but also more informative log messages
+			return "", errors.Wrap(err, "mountpoint path is not valid: "+mountpath)
 		}
-		if _, err := os.Stat(parent); err != nil {
+		parent := filepath.Join(mountpath, "..")
+		if _, err = os.Stat(parent); err != nil {
 			if os.IsNotExist(err) {
 				return "", errors.New("parent of mountpoint directory does not exist: " + parent)
 			}

--- a/cmd/cmount/mountpoint_windows.go
+++ b/cmd/cmount/mountpoint_windows.go
@@ -103,8 +103,9 @@ func handleLocalMountpath(mountpath string, opt *mountlib.Options) (string, erro
 	} else if !os.IsNotExist(err) {
 		return "", errors.Wrap(err, "failed to retrieve mountpoint path information")
 	}
-	//if isDriveRootPath(mountpath) { // Assume intention with "X:\" was "X:"
-	//	mountpoint = mountpath[:len(mountpath)-1] // WinFsp needs drive mountpoints without trailing path separator
+	if isDriveRootPath(mountpath) { // Assume intention with "X:\" was "X:"
+		mountpath = mountpath[:len(mountpath)-1] // WinFsp needs drive mountpoints without trailing path separator
+	}
 	if !isDrive(mountpath) {
 		// Assuming directory path, since it is not a pure drive letter string such as "X:".
 		// Drive letter string can be used as is, since we have already checked it does not exist,
@@ -115,10 +116,7 @@ func handleLocalMountpath(mountpath string, opt *mountlib.Options) (string, erro
 		}
 		parent := filepath.Join(mountpath, "..")
 		if parent == "" || parent == "." {
-			return "", errors.New("mountpoint directory is not valid: " + parent)
-		}
-		if os.IsPathSeparator(parent[len(parent)-1]) { // Ends in a separator only if it is the root directory
-			return "", errors.New("mountpoint directory is at root: " + parent)
+			return "", errors.New("mountpoint parent path is not valid: " + parent)
 		}
 		if _, err := os.Stat(parent); err != nil {
 			if os.IsNotExist(err) {

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -179,15 +179,15 @@ is an **empty** **existing** directory:
 
 On Windows you can start a mount in different ways. See [below](#mounting-modes-on-windows)
 for details. The following examples will mount to an automatically assigned drive,
-to specific drive letter |X:|, to path |C:\path\to\nonexistent\directory|
-(which must be **non-existent** subdirectory of an **existing** parent directory or drive,
+to specific drive letter |X:|, to path |C:\path\parent\mount|
+(where parent directory or drive must exist, and mount must **not** exist,
 and is not supported when [mounting as a network drive](#mounting-modes-on-windows)), and
 the last example will mount as network share |\\cloud\remote| and map it to an
 automatically assigned drive:
 
     rclone @ remote:path/to/files *
     rclone @ remote:path/to/files X:
-    rclone @ remote:path/to/files C:\path\to\nonexistent\directory
+    rclone @ remote:path/to/files C:\path\parent\mount
     rclone @ remote:path/to/files \\cloud\remote
 
 When the program ends while in foreground mode, either via Ctrl+C or receiving
@@ -241,14 +241,14 @@ and experience unexpected program errors, freezes or other issues, consider moun
 as a network drive instead.
 
 When mounting as a fixed disk drive you can either mount to an unused drive letter,
-or to a path - which must be **non-existent** subdirectory of an **existing** parent
+or to a path representing a **non-existent** subdirectory of an **existing** parent
 directory or drive. Using the special value |*| will tell rclone to
 automatically assign the next available drive letter, starting with Z: and moving backward.
 Examples:
 
     rclone @ remote:path/to/files *
     rclone @ remote:path/to/files X:
-    rclone @ remote:path/to/files C:\path\to\nonexistent\directory
+    rclone @ remote:path/to/files C:\path\parent\mount
     rclone @ remote:path/to/files X:
 
 Option |--volname| can be used to set a custom volume name for the mounted


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Fixed bug in mount on Windows introduced in 1.54.0, where mounting on root directory is no longer possible.

Edit: Added a second commit that also fixes a less critical issue regarding relative paths when mounting to directory. More details below. Let me know if you want me to move this to a separate MR or something..

##### Done

- Removed incorrect error return for mountpath that represents a directry at root level on existing drive.
- Also removed the distinction between `X:` and `X:\`: The latter will be converted to `X:` and used for drive letter mount, previously it would be reported as error "parent of mountpoint directory does not exist". Any other paths logically representing the same, such as `X:\some\folder\..\..` will still be reported as error: "parent of mountpoint directory does not exist".
- Edit (second commit): Calling filepath.Abs on the supplied mount path, which fixes handling of relative paths (see below). It is also better as the debug log message "Mounting on .." will show the actual path used, e.g. when mounting to `C:some\..\crazy\..\..\path` (which actually works)
##### Examples:

If C: exists and X: does not:

`rclone mount remote: C:` fails (mountpoint path already exists)
`rclone mount remote: C:\` fails (mountpoint path already exists)
`rclone mount remote: C:\MyMount` works (directory mounting)
`rclone mount remote: C:\test\abc\..\..\MyMount` works (same result as with `C:\MyMount`)

`rclone mount remote: X:` works (drive mounting)
`rclone mount remote: X:\` works (drive mounting)
`rclone mount remote: X:\MyMount` fails (parent of mountpoint directory does not exist)

##### ~Possible future~ Additional improvements (relative paths):

In the released version some relative paths work, but others that should/could does not:

`rclone mount remote: .` fails, but that is correct (mountpoint path already exists)
`rclone mount remote: MyMount` fails, which it should not (trying to find parent path fails)
`rclone mount remote: .\MyMount` fails, same as above
`rclone mount remote: ..\MyMount` works

Fixed this with the second commit, so any ©️ ®️ kind of relative path work as expected.

##### Sorry for introducing the bug

##### Bad excuses

Part of the issue were due to the following consideration: When user tries to mount to path D:\\", which is illegal (in WinFsp), should it be reported as an error to inform the user that this is illegal, or should rclone just assume the intention was to mount as a drive letter and fix it to "D:"? And then the other part was not understanding correctly how the filepath.Clean function, implicitely called from filepath.Join, manipulates the path (which is, by the way, the reason for using internal regex methods to classify the path) There *could* still be some remaining corner cases, depending on how os.Stat vs filepath.Clean etc handles different crazy variants...

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

https://forum.rclone.org/t/fatal-error-failed-to-mount-fuse/22119

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
