### PR TITLE
docker.bash: work correctly with multi-ip containers

### DIFF
--- a/fstest/testserver/init.d/docker.bash
+++ b/fstest/testserver/init.d/docker.bash
@@ -2,13 +2,13 @@
 
 stop() {
     if status ; then
-        docker stop $NAME
+        docker stop "$NAME"
         echo "$NAME stopped"
     fi
 }
 
 status() {
-    if docker ps --format "{{.Names}}" | grep ^${NAME}$ >/dev/null ; then
+    if docker ps --format '{{.Names}}' | grep -q "^${NAME}$" ; then
         echo "$NAME running"
     else
         echo "$NAME not running"
@@ -18,5 +18,5 @@ status() {
 }
 
 docker_ip() {
-    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $NAME    
+    docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{"\n"}}{{end}}' "$NAME" | head -1
 }

--- a/fstest/testserver/testserver.go
+++ b/fstest/testserver/testserver.go
@@ -91,7 +91,7 @@ func start(name string) error {
 				continue
 			}
 
-			// fs.Debugf(name, "key = %q, envKey = %q, value = %q", key, envKey, value)
+			// fs.Debugf(name, "key = %q, envKey = %q, value = %q", key, envKey(name, string(key)), value)
 			err = os.Setenv(envKey(name, string(key)), string(value))
 			if err != nil {
 				return err


### PR DESCRIPTION
#### What is the purpose of this change?

Currently if container under test has multiple IP addresses,
the `docker_ip` function from `docker.sh` will return a gibberish.
This patch makes it return the first address found.
Additionally, I apply shellcheck on `docker.sh`.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
