### PR TITLE
build: replace go 1.16-rc1 by 1.16.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         include:
           - job_name: linux
             os: ubuntu-latest
-            go: '1.16.0-rc1'
+            go: '1.16.x'
             gotags: cmount
             build_flags: '-include "^linux/"'
             check: true
@@ -34,7 +34,7 @@ jobs:
 
           - job_name: mac_amd64
             os: macOS-latest
-            go: '1.16.0-rc1'
+            go: '1.16.x'
             gotags: 'cmount'
             build_flags: '-include "^darwin/amd64" -cgo'
             quicktest: true
@@ -43,14 +43,14 @@ jobs:
 
           - job_name: mac_arm64
             os: macOS-latest
-            go: '1.16.0-rc1'
+            go: '1.16.x'
             gotags: 'cmount'
             build_flags: '-include "^darwin/arm64" -cgo -macos-arch arm64 -macos-sdk macosx11.1 -cgo-cflags=-I/usr/local/include -cgo-ldflags=-L/usr/local/lib'
             deploy: true
 
           - job_name: windows_amd64
             os: windows-latest
-            go: '1.16.0-rc1'
+            go: '1.16.x'
             gotags: cmount
             build_flags: '-include "^windows/amd64" -cgo'
             build_args: '-buildmode exe'
@@ -60,7 +60,7 @@ jobs:
 
           - job_name: windows_386
             os: windows-latest
-            go: '1.16.0-rc1'
+            go: '1.16.x'
             gotags: cmount
             goarch: '386'
             cgo: '1'
@@ -71,7 +71,7 @@ jobs:
 
           - job_name: other_os
             os: ubuntu-latest
-            go: '1.16.0-rc1'
+            go: '1.16.x'
             build_flags: '-exclude "^(windows/|darwin/|linux/)"'
             compile_all: true
             deploy: true


### PR DESCRIPTION
#### What is the purpose of this change?

The rclone ci/cd is currently using go `1.16-rc1`
which was phased out from github today
and replaced by go `1.16.x` resulting in build errors like
```
Error: Unable to find Go version '1.16.0-rc1' for platform linux and architecture x64.
```
This PR fixes that.

#### Was the change discussed in an issue or in the forum before?

No

Refer to golang downloads at https://golang.org/dl/

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
