### PR TITLE
Docs: directory filter rules

### DIFF
--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -113,7 +113,7 @@ With `--ignore-case`
 
 ## How filter rules are applied to files
 
-Rclone path / file name filters are made up of one or more of the following flags:
+Rclone path/file name filters are made up of one or more of the following flags:
 
   * `--include`
   * `--include-from`
@@ -171,7 +171,7 @@ classes. [Go regular expression reference](https://golang.org/pkg/regexp/syntax/
 
 ### How filter rules are applied to directories
 
-Rclone commands filter, and are applied to, path/file names not
+Rclone commands are applied to path/file names not
 directories. The entire contents of a directory can be matched
 to a filter by the pattern `directory/*` or recursively by
 `directory/**`.
@@ -185,13 +185,13 @@ recurse into subdirectories. This potentially optimises access to a remote
 by avoiding listing unnecessary directories. Whether optimisation is
 desirable depends on the specific filter rules and source remote content.
 
-Optimisation occurs if either:
+Directory recursion optimisation occurs if either:
 
 * A source remote does not support the rclone `ListR` primitive. local,
 sftp, Microsoft OneDrive and WebDav do not support `ListR`. Google
 Drive and most bucket type storage do. [Full list](https://rclone.org/overview/#optional-features)
 
-* On other remotes, if the rclone command is not naturally recursive,
+* On other remotes (those that support `ListR`), if the rclone command is not naturally recursive, and
 provided it is not run with the `--fast-list` flag. `ls`, `lsf -R` and
 `size` are naturally recursive but `sync`, `copy` and `move` are not.
 


### PR DESCRIPTION

#### What is the purpose of this change?

An attempt to make directory filter rules marginally less confusing inspired by reading 
https://github.com/rclone/rclone/blob/master/docs/content/commands/rclone_hashsum.md

I think the filter documentation is in step with that commit. The prior position when, with `ListR`, --exclude /foo/ did not have an equivalent effect to to --exclude /foo/** was not properly explained in the rewrite I did.

The three bullet points identifying when directory recursion optimisation is applied to the listing trouble me. The two prior attempts at putting the code logic into words were as bad. Maybe something closer go code logic should be incorporated?

#### Was the change discussed in an issue or in the forum before.

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
