### PR TITLE
Docs: / versus /* or /**

### DIFF
--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -14,6 +14,13 @@ lists; file age and size, or presence of a file in a directory. Bucket
 based remotes without the concept of directory apply filters to object
 key, age and size in an analogous way.
 
+* Rclone filter patterns differ from rsync. Whereas
+`/foo/` matches a directory foo and its
+contents in rsync, in rclone that it is a directory filter.
+Rclone directory filters can optimise listing of a remote.
+In rclone, to refer to a directory and its contents at a
+single level use `/foo/*` or `/foo/**` to recurse. *
+
 Rclone `purge` does not obey filters.
 
 To test filters without risk of damage to data, apply them to `rclone


### PR DESCRIPTION

#### What is the purpose of this change?

Attempt to put prominently in docs the rsync - rclone filter difference. I was drawn to this by https://github.com/rclone/rclone/issues/3375 because I'm not sure if @ncw 's Commit there changes the behaviour.

#### Was the change discussed in an issue or in the forum before?

There have been several forum posts but the key prompt for me was 
https://github.com/rclone/rclone/issues/3375
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
