### PR TITLE
azureblob: Add container public access level support. Fixes #5045

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -223,10 +223,13 @@ This option controls how often unused buffers will be removed from the pool.`,
 			Default: string(azblob.PublicAccessNone),
 			Examples: []fs.OptionExample{
 				{
-					Value: "blob",
+					Value: string(azblob.PublicAccessNone),
+					Help:  "The container and its blobs can be accessed only with an authorized request. It's a default value",
+				}, {
+					Value: string(azblob.PublicAccessBlob),
 					Help:  "Blob data within this container can be read via anonymous request.",
 				}, {
-					Value: "container",
+					Value: string(azblob.PublicAccessContainer),
 					Help:  "Allow full public read access for container and blob data.",
 				},
 			},


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Add option to set public access level of a container with a new flag `azureblob-public-access`. Mostly useful when to create container using command `mkdir` however it should be useful for `sync` or `copy` command. Flag must require value and should be either `blob` or `container` or `''`(empty).
Flag is useful when the container is being created as part of the command. 

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
Discussed the actual option required for this change along with other important points.
<!--
Link issues and relevant forum posts here.
-->
https://forum.rclone.org/t/azure-container-and-set-public-access-to-read-only/22363
https://github.com/rclone/rclone/issues/5045

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

