### PR TITLE
fichier: implement copy & move

### DIFF
--- a/backend/fichier/object.go
+++ b/backend/fichier/object.go
@@ -72,6 +72,10 @@ func (o *Object) SetModTime(context.Context, time.Time) error {
 	//return errors.New("setting modtime is not supported for 1fichier remotes")
 }
 
+func (o *Object) setMetaData(file File) {
+	o.file = file
+}
+
 // Open opens the file for read.  Call Close() on the returned io.ReadCloser
 func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
 	fs.FixRangeOption(options, o.file.Size)

--- a/backend/fichier/structs.go
+++ b/backend/fichier/structs.go
@@ -1,5 +1,10 @@
 package fichier
 
+// FileInfoRequest is the request structure of the corresponding request
+type FileInfoRequest struct {
+	URL string `json:"url"`
+}
+
 // ListFolderRequest is the request structure of the corresponding request
 type ListFolderRequest struct {
 	FolderID int `json:"folder_id"`
@@ -49,6 +54,39 @@ type MakeFolderResponse struct {
 	FolderID int    `json:"folder_id"`
 }
 
+// MoveFileRequest is the request structure of the corresponding request
+type MoveFileRequest struct {
+	URLs     []string `json:"urls"`
+	FolderID int      `json:"destination_folder_id"`
+	Rename   string   `json:"rename,omitempty"`
+}
+
+// MoveFileResponse is the response structure of the corresponding request
+type MoveFileResponse struct {
+	Status string   `json:"status"`
+	URLs   []string `json:"urls"`
+}
+
+// CopyFileRequest is the request structure of the corresponding request
+type CopyFileRequest struct {
+	URLs     []string `json:"urls"`
+	FolderID int      `json:"folder_id"`
+	Rename   string   `json:"rename,omitempty"`
+}
+
+// CopyFileResponse is the response structure of the corresponding request
+type CopyFileResponse struct {
+	Status string     `json:"status"`
+	Copied int        `json:"copied"`
+	URLs   []FileCopy `json:"urls"`
+}
+
+// FileCopy is used in the the CopyFileResponse
+type FileCopy struct {
+	FromURL string `json:"from_url"`
+	ToURL   string `json:"to_url"`
+}
+
 // GetUploadNodeResponse is the response structure of the corresponding request
 type GetUploadNodeResponse struct {
 	ID  string `json:"id"`
@@ -86,7 +124,6 @@ type EndFileUploadResponse struct {
 
 // File is the structure how 1Fichier returns a File
 type File struct {
-	ACL         int    `json:"acl"`
 	CDN         int    `json:"cdn"`
 	Checksum    string `json:"checksum"`
 	ContentType string `json:"content-type"`

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -330,7 +330,7 @@ upon backend specific capabilities.
 
 | Name                         | Purge | Copy | Move | DirMove | CleanUp | ListR | StreamUpload | LinkSharing | About | EmptyDir |
 | ---------------------------- |:-----:|:----:|:----:|:-------:|:-------:|:-----:|:------------:|:------------:|:-----:| :------: |
-| 1Fichier                     | No    | No   | No   | No      | No      | No    | No           | No           |   No  |  Yes |
+| 1Fichier                     | No    | Yes   | Yes   | No      | No      | No    | No           | No           |   No  |  Yes |
 | Amazon Drive                 | Yes   | No   | Yes  | Yes     | No [#575](https://github.com/rclone/rclone/issues/575) | No  | No  | No [#2178](https://github.com/rclone/rclone/issues/2178) | No  | Yes |
 | Amazon S3                    | No    | Yes  | No   | No      | Yes     | Yes   | Yes          | No [#2178](https://github.com/rclone/rclone/issues/2178) | No  | No |
 | Backblaze B2                 | No    | Yes  | No   | No      | Yes     | Yes   | Yes          | Yes          | No  | No |


### PR DESCRIPTION
1fichier has supported copy and move for a while now and I finally had a few minutes to implement it in rclone. Makes the 1fichier backend so much more usable :)

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
