### PR TITLE
build: Update GitHub Actions to 'ubuntu-20.04'

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
 
         include:
           - job_name: linux
-            os: ubuntu-latest
+            os: ubuntu-20.04
             go: '1.16.x'
             gotags: cmount
             build_flags: '-include "^linux/"'
@@ -70,25 +70,25 @@ jobs:
             deploy: true
 
           - job_name: other_os
-            os: ubuntu-latest
+            os: ubuntu-20.04
             go: '1.16.x'
             build_flags: '-exclude "^(windows/|darwin/|linux/)"'
             compile_all: true
             deploy: true
 
           - job_name: go1.13
-            os: ubuntu-latest
+            os: ubuntu-20.04
             go: '1.13.x'
             quicktest: true
 
           - job_name: go1.14
-            os: ubuntu-latest
+            os: ubuntu-20.04
             go: '1.14.x'
             quicktest: true
             racequicktest: true
 
           - job_name: go1.15
-            os: ubuntu-latest
+            os: ubuntu-20.04
             go: '1.15.x'
             quicktest: true
             racequicktest: true
@@ -125,7 +125,7 @@ jobs:
           sudo chmod 666 /dev/fuse
           sudo chown root:$USER /etc/fuse.conf
           sudo apt-get install fuse libfuse-dev rpm pkg-config
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-20.04'
 
       - name: Install Libraries on macOS
         shell: bash
@@ -204,7 +204,7 @@ jobs:
       - name: Deploy built binaries
         shell: bash
         run: |
-          if [[ "${{ matrix.os }}" == "ubuntu-latest" ]]; then make release_dep_linux ; fi
+          if [[ "${{ matrix.os }}" == "ubuntu-20.04" ]]; then make release_dep_linux ; fi
           if [[ "${{ matrix.os }}" == "windows-latest" ]]; then make release_dep_windows ; fi
           make ci_beta
         env:
@@ -216,7 +216,7 @@ jobs:
   xgo:
     timeout-minutes: 60
     name: "xgo cross compile"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
 

--- a/.github/workflows/build_publish_docker_image.yml
+++ b/.github/workflows/build_publish_docker_image.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         name: Build image job
         steps:
             - name: Checkout master

--- a/.github/workflows/build_publish_release_docker_image.yml
+++ b/.github/workflows/build_publish_release_docker_image.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     build:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-20.04
         name: Build image job
         steps:
             - name: Checkout master


### PR DESCRIPTION
#### What Is The Purpose Of This Change?

GitHub Actions currently runs on 'ubuntu-latest' (18.04/20.04), whereas the Latest One is Available by Specifically Stating the runs on to 'ubuntu-20.04'.

The GitHub Actions 'ubuntu-latest' is Currently in Migration Phase, and might take Several Weeks to Completely Update to Ubuntu 20.04 but Explicitly Stating Ubuntu Version to 20.04, assures Latest Ubuntu Version Every Time GitHub Actions in Initiated.

This PR changes that in Workflow Files.

#### Was The Change Discussed In An Issue or In The Forum Before?

No

#### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have Added Tests for All Changes in This PR, If Appropriate.
- [ ] I have Added Documentation for The Changes If Appropriate.
- [x] All Commit Messages are In [House Style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm Done, This Pull Request is Ready For Review :-)