### PR TITLE
swift: support copying large objects

### DIFF
--- a/backend/swift/swift_test.go
+++ b/backend/swift/swift_test.go
@@ -80,6 +80,7 @@ func (f *Fs) InternalTest(t *testing.T) {
 	t.Run("NoChunk", f.testNoChunk)
 	t.Run("WithChunk", f.testWithChunk)
 	t.Run("WithChunkFail", f.testWithChunkFail)
+	t.Run("CopyLargeObject", f.testCopyLargeObject)
 }
 
 func (f *Fs) testWithChunk(t *testing.T) {
@@ -152,6 +153,41 @@ func (f *Fs) testWithChunkFail(t *testing.T) {
 	})
 	require.NoError(t, err)
 	require.Empty(t, objs)
+}
+
+func (f *Fs) testCopyLargeObject(t *testing.T) {
+	preConfChunkSize := f.opt.ChunkSize
+	preConfChunk := f.opt.NoChunk
+	f.opt.NoChunk = false
+	f.opt.ChunkSize = 1024 * fs.Byte
+	defer func() {
+		//restore old config after test
+		f.opt.ChunkSize = preConfChunkSize
+		f.opt.NoChunk = preConfChunk
+	}()
+
+	file := fstest.Item{
+		ModTime: fstest.Time("2020-12-31T04:05:06.499999999Z"),
+		Path:    "large.txt",
+		Size:    -1, // use unknown size during upload
+	}
+	const contentSize = 2048
+	contents := random.String(contentSize)
+	buf := bytes.NewBufferString(contents)
+	uploadHash := hash.NewMultiHasher()
+	in := io.TeeReader(buf, uploadHash)
+
+	file.Size = -1
+	obji := object.NewStaticObjectInfo(file.Path, file.ModTime, file.Size, true, nil, nil)
+	ctx := context.TODO()
+	obj, err := f.Features().PutStream(ctx, in, obji)
+	require.NoError(t, err)
+	require.NotEmpty(t, obj)
+	remoteTarget := "large.txt (copy)"
+	objTarget, err := f.Features().Copy(ctx, obj, remoteTarget)
+	require.NoError(t, err)
+	require.NotEmpty(t, objTarget)
+	require.Equal(t, obj.Size(), objTarget.Size())
 }
 
 var _ fstests.InternalTester = (*Fs)(nil)

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/gabriel-vasile/mimetype v1.1.2
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
-	github.com/google/uuid v1.2.0 // indirect
+	github.com/google/uuid v1.2.0
 	github.com/hanwen/go-fuse/v2 v2.0.3
 	github.com/iguanesolutions/go-systemd/v5 v5.0.0
 	github.com/jcmturner/gokrb5/v8 v8.4.2


### PR DESCRIPTION
#### What is the purpose of this change?

The max size object in swift is 5G, if we copy object what greater than 5G (large object) the operation will fail.

#### Was the change discussed in an issue or in the forum before?

I run test local.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
