### PR TITLE
rcd: Added systemd notification during the 'rclone rcd' command call.

### DIFF
--- a/cmd/rcd/rcd.go
+++ b/cmd/rcd/rcd.go
@@ -3,10 +3,13 @@ package rcd
 import (
 	"context"
 	"log"
+	"sync"
 
+	sysdnotify "github.com/iguanesolutions/go-systemd/v5/notify"
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/rc/rcflags"
 	"github.com/rclone/rclone/fs/rc/rcserver"
+	"github.com/rclone/rclone/lib/atexit"
 	"github.com/spf13/cobra"
 )
 
@@ -48,6 +51,22 @@ See the [rc documentation](/rc/) for more info on the rc flags.
 			log.Fatal("rc server not configured")
 		}
 
+		// Notify stopping on exit
+		var finaliseOnce sync.Once
+		finalise := func() {
+			finaliseOnce.Do(func() {
+				_ = sysdnotify.Stopping()
+			})
+		}
+		fnHandle := atexit.Register(finalise)
+		defer atexit.Unregister(fnHandle)
+
+		// Notify ready to systemd
+		if err := sysdnotify.Ready(); err != nil {
+			log.Fatalf("failed to notify ready to systemd: %v", err)
+		}
+
 		s.Wait()
+		finalise()
 	},
 }


### PR DESCRIPTION
rcd: Added systemd notification during the 'rclone rcd' command call. This also fixes #5073 

Signed-off-by: Naveen Honest Raj <naveendurai19@gmail.com>

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
When running `rclone rcd` command, there is no systemd notification sent. There are cases where the end user depends on such systemd notification and this enhancement I worked on in this PR will come in handy.

#### Was the change discussed in an issue or in the forum before?
Yes, it is discussed here. (https://github.com/rclone/rclone/issues/5073#issuecomment-788024498)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
