### PR TITLE
address stringent ineffectual assignment check in golangci-lint

### DIFF
--- a/backend/cache/cache_internal_test.go
+++ b/backend/cache/cache_internal_test.go
@@ -1034,7 +1034,7 @@ func (r *run) updateObjectRemote(t *testing.T, f fs.Fs, remote string, data1 []b
 	objInfo1 := object.NewStaticObjectInfo(remote, time.Now(), int64(len(data1)), true, nil, f)
 	objInfo2 := object.NewStaticObjectInfo(remote, time.Now(), int64(len(data2)), true, nil, f)
 
-	obj, err = f.Put(context.Background(), in1, objInfo1)
+	_, err = f.Put(context.Background(), in1, objInfo1)
 	require.NoError(t, err)
 	obj, err = f.NewObject(context.Background(), remote)
 	require.NoError(t, err)

--- a/backend/chunker/chunker_internal_test.go
+++ b/backend/chunker/chunker_internal_test.go
@@ -495,11 +495,11 @@ func testPreventCorruption(t *testing.T, f *Fs) {
 	billyChunk4Name := billyChunkName(4)
 	_, err = f.base.NewObject(ctx, billyChunk4Name)
 	require.NoError(t, err)
-	billyChunk4, err := f.NewObject(ctx, billyChunk4Name)
+	_, err = f.NewObject(ctx, billyChunk4Name)
 	assertOverlapError(err)
 
 	f.opt.FailHard = false
-	billyChunk4, err = f.NewObject(ctx, billyChunk4Name)
+	billyChunk4, err := f.NewObject(ctx, billyChunk4Name)
 	assert.NoError(t, err)
 	require.NotNil(t, billyChunk4)
 


### PR DESCRIPTION
#### What is the purpose of this change?

Today the `golangci-lint` tool began reporting errors in two places of rclone test code.
Apparently its `ineffectual assignment` check has become more stringent.
This quick fix addresses it and restores commits health on the master branch.
It's recommended to back-port it on the stable branch as it affects health of all future commits.

#### Was the change discussed in an issue or in the forum before?

No. It's an early bird.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
