### PR TITLE
copyurl: add option to print resulting auto-filename

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -1635,6 +1635,7 @@ func copyURLFn(ctx context.Context, dstFileName string, url string, dstFileNameF
 		if dstFileName == "." || dstFileName == "/" {
 			return errors.Errorf("CopyURL failed: file name wasn't found in url")
 		}
+		fs.Debugf(dstFileName, "File name found in url")
 	}
 	return fn(ctx, dstFileName, resp.Body, resp.ContentLength, modTime)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Added new option:

> -p, --print-filename   Print the resulting name from --auto-filename

Example usage (PowerShell):
```
$x = .\rclone.exe copyurl https://www.youtube.com/watch?v=SzuZnh91U8E C:\Temp -a -p
PS > Write-Host "Downloaded file: ${x}"
Downloaded file: watch
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
https://github.com/rclone/rclone/issues/5094

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
