### PR TITLE
backlog: ticket templates should recommend to update rclone

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -5,25 +5,42 @@ about: Report a problem with rclone
 
 <!--
 
-Welcome :-) We understand you are having a problem with rclone; we want to help you with that!
+We understand you are having a problem with rclone; we want to help you with that!
 
-If you've just got a question or aren't sure if you've found a bug then please use the rclone forum:
+**STOP and READ**
+**YOUR POST WILL BE REMOVED IF IT IS LOW QUALITY**:
+Please show the effort you've put in to solving the problem and please be specific.
+People are volunteering their time to help! Low effort posts are not likely to get good answers!
+
+If you think you might have found a bug, try to replicate it with the latest beta (or stable).
+The update instructions are available at https://rclone.org/commands/rclone_selfupdate/
+
+If you can still replicate it or just got a question then please use the rclone forum:
 
     https://forum.rclone.org/
 
-instead of filing an issue for a quick response.
+for a quick response instead of filing an issue on this repo.
 
-If you think you might have found a bug, please can you try to replicate it with the latest beta?
+If nothing else helps, then please fill in the info below which helps us help you.
 
-    https://beta.rclone.org/
-    
-If you can still replicate it with the latest beta, then please fill in the info below which makes our lives much easier.  A log with -vv will make our day :-)
+**DO NOT REDACT** any information except passwords/keys/personal info.
+
+You should use 3 backticks to begin and end your paste to make it readable.
+
+Make sure to include a log obtained with '-vv'.
+
+You can also use '-vv --log-file bug.log' and a service such as https://pastebin.com or https://gist.github.com/
 
 Thank you
 
 The Rclone Developers
 
 -->
+
+
+#### The associated forum post URL from `https://forum.rclone.org`
+
+
 
 #### What is the problem you are having with rclone?
 
@@ -37,7 +54,7 @@ The Rclone Developers
 
 
 
-####  Which cloud storage system are you using? (e.g. Google Drive)
+#### Which cloud storage system are you using? (e.g. Google Drive)
 
 
 

--- a/.github/ISSUE_TEMPLATE/Feature.md
+++ b/.github/ISSUE_TEMPLATE/Feature.md
@@ -7,12 +7,16 @@ about: Suggest a new feature or enhancement for rclone
 
 Welcome :-)
 
-So you've got an idea to improve rclone? We love that! You'll be glad to hear we've incorporated hundreds of ideas from contributors already.
+So you've got an idea to improve rclone? We love that!
+You'll be glad to hear we've incorporated hundreds of ideas from contributors already.
 
-Here is a checklist of things to do:
+Probably the latest beta (or stable) release has your feature, so try to update your rclone.
+The update instructions are available at https://rclone.org/commands/rclone_selfupdate/
 
-  1. Please search the old issues first for your idea and +1 or comment on an existing issue if possible.
-  2. Discuss on the forum first: https://forum.rclone.org/
+If it still isn't there, here is a checklist of things to do:
+
+  1. Search the old issues for your idea and +1 or comment on an existing issue if possible.
+  2. Discuss on the forum: https://forum.rclone.org/
   3. Make a feature request issue (this is the right place!).
   4. Be prepared to get involved making the feature :-)
 
@@ -21,6 +25,10 @@ Looking forward to your great idea!
 The Rclone Developers
 
 -->
+
+
+#### The associated forum post URL from `https://forum.rclone.org`
+
 
 
 #### What is your current rclone version (output from `rclone version`)?


### PR DESCRIPTION
#### What is the purpose of this change?

This PR partially implements #5074 
It adds useful recommendations from the forum ticket templates to the github issue templates
and recommends users to run `rclone selfupdate`.

It blocks on #5080 but should be merged separately
#5080 can be merged after successful review but will be released with rclone 1.55
This PR will affect rclone github templates immediately after merge on master.

Let's review this now but merge together with 1.55 release

#### Was the change discussed in an issue or in the forum before?

#5074
https://forum.rclone.org/t/previously-working-rclone-backup-now-giving-error-unknown-command-rcat-for-rclone/22507/14

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
