### PR TITLE
HDFS: Fix permissions for when directory is created

### DIFF
--- a/backend/hdfs/object.go
+++ b/backend/hdfs/object.go
@@ -109,7 +109,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	dirname := path.Dir(realpath)
 	fs.Debugf(o.fs, "update [%s]", realpath)
 
-	err := o.fs.client.MkdirAll(dirname, 755)
+	err := o.fs.client.MkdirAll(dirname, 0755)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The permissions for when a directory is created in HDFS was incorrect. It was an invalid decimal to octal conversion that was converting `755` to `1363` or `d-wxrw--wt`. This means that the user creating the directory couldn't read it on a second pass, therefore breaking `rclone copy` when creating directories.

This varied from how `rclone mkdir` functioned for HDFS, which was `0755`, the proper octal.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
