### PR TITLE
rc: avoid +Inf value for speed in core/stats

### DIFF
--- a/fs/accounting/accounting.go
+++ b/fs/accounting/accounting.go
@@ -214,7 +214,10 @@ func (acc *Account) averageLoop() {
 			acc.values.mu.Lock()
 			// Add average of last second.
 			elapsed := now.Sub(acc.values.lpTime).Seconds()
-			avg := float64(acc.values.lpBytes) / elapsed
+			avg := 0.0
+			if elapsed > 0 {
+				avg = float64(acc.values.lpBytes) / elapsed
+			}
 			// Soft start the moving average
 			if period < averagePeriod {
 				period++
@@ -442,7 +445,11 @@ func (acc *Account) speed() (bps, current float64) {
 	}
 	// Calculate speed from first read.
 	total := float64(time.Now().Sub(acc.values.start)) / float64(time.Second)
-	bps = float64(acc.values.bytes) / total
+	if total > 0 {
+		bps = float64(acc.values.bytes) / total
+	} else {
+		bps = 0.0
+	}
 	current = acc.values.avg
 	return
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Ensure there is no divide by zero in speed reported by rc core/stats command.

Issue #5132 reports getting +Inf values, have not been able to test that case - just did an attempt at a "blindfolded quick fix" (is that a thing?)...

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#5132

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
