### PR TITLE
crypt: log hash ok on upload

### DIFF
--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -404,13 +404,16 @@ func (f *Fs) put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options [
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to read destination hash")
 		}
-		if srcHash != "" && dstHash != "" && srcHash != dstHash {
-			// remove object
-			err = o.Remove(ctx)
-			if err != nil {
-				fs.Errorf(o, "Failed to remove corrupted object: %v", err)
+		if srcHash != "" && dstHash != "" {
+			if srcHash != dstHash {
+				// remove object
+				err = o.Remove(ctx)
+				if err != nil {
+					fs.Errorf(o, "Failed to remove corrupted object: %v", err)
+				}
+				return nil, errors.Errorf("corrupted on transfer: %v crypted hash differ %q vs %q", ht, srcHash, dstHash)
 			}
-			return nil, errors.Errorf("corrupted on transfer: %v crypted hash differ %q vs %q", ht, srcHash, dstHash)
+			fs.Debugf(src, "%v = %s OK", ht, srcHash)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

When copying files into non-crypt remotes:

    DEBUG : zip/kdbx.20210314.185330.7z: MD5 = 814e77ae9ae377c3201193c858da46d7 OK
    INFO  : zip/kdbx.20210314.185330.7z: Copied (new)

But when copying file into crypt remote, there is no info about integrity check even if it is performed (unless it fails and it will be reported as part of "corrupted on transfer" error):

    INFO : 01.kdbx: Copied (new)

This change adds the same debug log for crypt remotes.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

https://forum.rclone.org/t/local-copy-operation-fails-with-handle-is-invalid/22880/12

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
