### PR TITLE
add --s3-no-head-object

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2985,7 +2985,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 		return nil, err
 	}
 	if resp.LastModified == nil {
-		fs.Logf(o, "Failed to read last modified: %v", err)
+		fs.Logf(o, "Failed to read last modified from GET: %v", err)
 	}
 	o.setMetaData(aws.StringValue(resp.ETag), resp.ContentLength, resp.LastModified, resp.Metadata, aws.StringValue(resp.ContentType), aws.StringValue(resp.StorageClass))
 	return resp.Body, nil

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2840,18 +2840,18 @@ func (o *Object) readMetaData(ctx context.Context) (err error) {
 	if resp.LastModified == nil {
 		fs.Logf(o, "Failed to read last modified from HEAD: %v", err)
 	}
-	o.setMetaData(aws.StringValue(resp.ETag), resp.ContentLength, resp.LastModified, resp.Metadata, aws.StringValue(resp.ContentType), aws.StringValue(resp.StorageClass))
+	o.setMetaData(resp.ETag, resp.ContentLength, resp.LastModified, resp.Metadata, resp.ContentType, resp.StorageClass)
 	return nil
 }
 
-func (o *Object) setMetaData(etag string, contentLength *int64, lastModified *time.Time, meta map[string]*string, mimeType string, storageClass string) {
+func (o *Object) setMetaData(etag *string, contentLength *int64, lastModified *time.Time, meta map[string]*string, mimeType *string, storageClass *string) {
 	var size int64
 	// Ignore missing Content-Length assuming it is 0
 	// Some versions of ceph do this due their apache proxies
 	if contentLength != nil {
 		size = *contentLength
 	}
-	o.setMD5FromEtag(etag)
+	o.setMD5FromEtag(aws.StringValue(etag))
 	o.bytes = size
 	o.meta = meta
 	if o.meta == nil {
@@ -2868,13 +2868,13 @@ func (o *Object) setMetaData(etag string, contentLength *int64, lastModified *ti
 			o.md5 = hex.EncodeToString(md5sumBytes)
 		}
 	}
-	o.storageClass = storageClass
+	o.storageClass = aws.StringValue(storageClass)
 	if lastModified == nil {
 		o.lastModified = time.Now()
 	} else {
 		o.lastModified = *lastModified
 	}
-	o.mimeType = mimeType
+	o.mimeType = aws.StringValue(mimeType)
 }
 
 // ModTime returns the modification time of the object
@@ -2987,7 +2987,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	if resp.LastModified == nil {
 		fs.Logf(o, "Failed to read last modified from GET: %v", err)
 	}
-	o.setMetaData(aws.StringValue(resp.ETag), resp.ContentLength, resp.LastModified, resp.Metadata, aws.StringValue(resp.ContentType), aws.StringValue(resp.StorageClass))
+	o.setMetaData(resp.ETag, resp.ContentLength, resp.LastModified, resp.Metadata, resp.ContentType, resp.StorageClass)
 	return resp.Body, nil
 }
 

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2985,7 +2985,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 		return nil, err
 	}
 	if resp.LastModified == nil {
-		fs.Logf(o, "Failed to read last modified from GET: %v", err)
+		fs.Logf(o, "Failed to read last modified: %v", err)
 	}
 	o.setMetaData(resp.ETag, resp.ContentLength, resp.LastModified, resp.Metadata, resp.ContentType, resp.StorageClass)
 	return resp.Body, nil

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1222,13 +1222,12 @@ very small even with this flag.
 			Default:  false,
 			Advanced: true,
 		}, {
-			}, {
-				Name: "no_head_object",
-				Help: `If set, don't HEAD objects`,
-				Default:  false,
-				Advanced: true,
-			}, {
-				Name:     config.ConfigEncoding,
+			Name:     "no_head_object",
+			Help:     `If set, don't HEAD objects`,
+			Default:  false,
+			Advanced: true,
+		}, {
+			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,
 			Advanced: true,
 			// Any UTF-8 character is valid in a key, however it can't handle
@@ -1700,7 +1699,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		GetTier:           true,
 		SlowModTime:       true,
 	}).Fill(ctx, f)
-	if f.rootBucket != "" && f.rootDirectory != "" && !opt.NoHeadObject{
+	if f.rootBucket != "" && f.rootDirectory != "" && !opt.NoHeadObject {
 		// Check to see if the (bucket,directory) is actually an existing file
 		oldRoot := f.root
 		newRoot, leaf := path.Split(oldRoot)

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2987,7 +2987,9 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	if resp.LastModified == nil {
 		fs.Logf(o, "Failed to read last modified: %v", err)
 	}
-	o.setMetaData(resp.ETag, resp.ContentLength, resp.LastModified, resp.Metadata, resp.ContentType, resp.StorageClass)
+	if o.fs.opt.NoHeadObject {
+		o.setMetaData(resp.ETag, resp.ContentLength, resp.LastModified, resp.Metadata, resp.ContentType, resp.StorageClass)
+	}
 	return resp.Body, nil
 }
 


### PR DESCRIPTION
Could you add --s3-no-head-object to reduce HTTP Head?

The results are as follows:

################################
  Before add --s3-no-head-object
################################

$ ./go/bin/rclone --checksum --dump headers --log-level DEBUG --no-traverse copy --files-from in.txt aws:noaa-goes17 dst
2021/03/18 14:38:31 DEBUG : Using config file from "/home/xxxx/.config/rclone/rclone.conf"
2021/03/18 14:38:31 DEBUG : rclone: Version "v1.55.0-beta.5314.e59acd16c" starting with parameters ["./go/bin/rclone" "--checksum" "--dump" "headers" "--log-level" "DEBUG" "--no-traverse" "copy" "--files-from" "in.txt" "aws:noaa-goes17" "dst"]
2021/03/18 14:38:31 DEBUG : Creating backend with remote "aws:noaa-goes17"
2021/03/18 14:38:31 DEBUG : You have specified to dump information. Please be noted that the Accept-Encoding as shown may not be correct in the request and the response may not show Content-Encoding if the go standard libraries auto gzip encoding was in effect. In this case the body of the request will be gunzipped before showing it.
2021/03/18 14:38:31 DEBUG : Creating backend with remote "dst"
2021/03/18 14:38:31 DEBUG : fs cache: renaming cache item "dst" to be canonical "/home/xxxx/dst"
2021/03/18 14:38:31 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:38:31 DEBUG : HTTP REQUEST (req 0xc0005e6e00)
2021/03/18 14:38:31 DEBUG : HEAD /ABI-L2-ACMC/2021/004/03/OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc HTTP/1.1
Host: noaa-goes17.s3.us-east-1.amazonaws.com
User-Agent: rclone/v1.55.0-beta.5314.e59acd16c

2021/03/18 14:38:31 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:38:33 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:38:33 DEBUG : HTTP RESPONSE (req 0xc0005e6e00)
2021/03/18 14:38:33 DEBUG : HTTP/1.1 200 OK
Content-Length: 379423
Accept-Ranges: bytes
Content-Type: binary/octet-stream
Date: Thu, 18 Mar 2021 05:38:32 GMT
Etag: "2a4b3f55fefcf6f143d51458805989f9"
Last-Modified: Mon, 04 Jan 2021 03:04:41 GMT
Server: AmazonS3
X-Amz-Id-2: YSzRDUF3Z6toCMdbhSkZHn0d3okVQT1sweRev1j5n7X82PgIp9hRZw+5F8Ox9j/4KdHSRqGad4s=
X-Amz-Request-Id: 2RFCVK2F12WMZK3C
X-Amz-Storage-Class: INTELLIGENT_TIERING

2021/03/18 14:38:33 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:38:33 DEBUG : Local file system at /home/xxxx/dst: Waiting for checks to finish
2021/03/18 14:38:33 DEBUG : Local file system at /home/xxxx/dst: Waiting for transfers to finish
2021/03/18 14:38:33 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:38:33 DEBUG : HTTP REQUEST (req 0xc00003f000)
2021/03/18 14:38:33 DEBUG : GET /ABI-L2-ACMC/2021/004/03/OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc HTTP/1.1
Host: noaa-goes17.s3.us-east-1.amazonaws.com
User-Agent: rclone/v1.55.0-beta.5314.e59acd16c
Accept-Encoding: gzip

2021/03/18 14:38:33 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:38:33 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:38:33 DEBUG : HTTP RESPONSE (req 0xc00003f000)
2021/03/18 14:38:33 DEBUG : HTTP/1.1 200 OK
Content-Length: 379423
Accept-Ranges: bytes
Content-Type: binary/octet-stream
Date: Thu, 18 Mar 2021 05:38:33 GMT
Etag: "2a4b3f55fefcf6f143d51458805989f9"
Last-Modified: Mon, 04 Jan 2021 03:04:41 GMT
Server: AmazonS3
X-Amz-Id-2: r59MxTPb/FZFed4ehopah6oNWtjKPPmZiVXC4a8UJ994aMIl3QGbXq6wxXNNXrpcW3lQWNrOy4I=
X-Amz-Request-Id: KTK4ZCGT58ED41FY
X-Amz-Storage-Class: INTELLIGENT_TIERING

2021/03/18 14:38:33 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:38:35 DEBUG : ABI-L2-ACMC/2021/004/03/OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc: MD5 = 2a4b3f55fefcf6f143d51458805989f9 OK
2021/03/18 14:38:35 INFO  : ABI-L2-ACMC/2021/004/03/OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc: Copied (new)
2021/03/18 14:38:35 INFO  : 
Transferred:   	  370.530k / 370.530 kBytes, 100%, 224.636 kBytes/s, ETA 0s
Transferred:            1 / 1, 100%
Elapsed time:         3.3s

2021/03/18 14:38:35 DEBUG : 5 go routines active

$ ./go/bin/rclone --dump headers --log-level DEBUG --no-traverse lsf aws:noaa-goes17/ABI-L2-ACMC/2021/004/03/
2021/03/18 14:42:29 DEBUG : Using config file from "/home/xxxx/.config/rclone/rclone.conf"
2021/03/18 14:42:29 DEBUG : rclone: Version "v1.55.0-beta.5314.e59acd16c" starting with parameters ["./go/bin/rclone" "--dump" "headers" "--log-level" "DEBUG" "--no-traverse" "lsf" "aws:noaa-goes17/ABI-L2-ACMC/2021/004/03/"]
2021/03/18 14:42:29 DEBUG : Creating backend with remote "aws:noaa-goes17/ABI-L2-ACMC/2021/004/03/"
2021/03/18 14:42:29 DEBUG : You have specified to dump information. Please be noted that the Accept-Encoding as shown may not be correct in the request and the response may not show Content-Encoding if the go standard libraries auto gzip encoding was in effect. In this case the body of the request will be gunzipped before showing it.
2021/03/18 14:42:29 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:42:29 DEBUG : HTTP REQUEST (req 0xc00003e900)
2021/03/18 14:42:29 DEBUG : HEAD /ABI-L2-ACMC/2021/004/03 HTTP/1.1
Host: noaa-goes17.s3.us-east-1.amazonaws.com
User-Agent: rclone/v1.55.0-beta.5314.e59acd16c

2021/03/18 14:42:29 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:42:31 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:42:31 DEBUG : HTTP RESPONSE (req 0xc00003e900)
2021/03/18 14:42:31 DEBUG : HTTP/1.1 404 Not Found
Connection: close
Content-Type: application/xml
Date: Thu, 18 Mar 2021 05:42:29 GMT
Server: AmazonS3
X-Amz-Id-2: p14yrJ5OrevWIvByP6vxFfv4nWrV0JE1Z80M0G77W+b6dQuRHGnJJf8lRt3RsqHRpGj8FbSMKjI=
X-Amz-Request-Id: 74WAE89KTXNMX1SN

2021/03/18 14:42:31 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:42:31 DEBUG : fs cache: renaming cache item "aws:noaa-goes17/ABI-L2-ACMC/2021/004/03/" to be canonical "aws:noaa-goes17/ABI-L2-ACMC/2021/004/03"
2021/03/18 14:42:31 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:42:31 DEBUG : HTTP REQUEST (req 0xc000586800)
2021/03/18 14:42:31 DEBUG : GET /?delimiter=%2F&encoding-type=url&max-keys=1000&prefix=ABI-L2-ACMC%2F2021%2F004%2F03%2F HTTP/1.1
Host: noaa-goes17.s3.us-east-1.amazonaws.com
User-Agent: rclone/v1.55.0-beta.5314.e59acd16c
Accept-Encoding: gzip

2021/03/18 14:42:31 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:42:31 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:42:31 DEBUG : HTTP RESPONSE (req 0xc000586800)
2021/03/18 14:42:31 DEBUG : HTTP/1.1 200 OK
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Thu, 18 Mar 2021 05:42:31 GMT
Server: AmazonS3
X-Amz-Bucket-Region: us-east-1
X-Amz-Id-2: AUTr2yHY7wlLupu7Gdcv0R6n9Qk7RL1GsyJ13NcY5t4EsbYpt5UqPbz0dSUqWZkbHyXwMkWGZOc=
X-Amz-Request-Id: JD6X73VKCNM0P5ME

2021/03/18 14:42:31 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc
OR_ABI-L2-ACMC-M6_G17_s20210040306178_e20210040308551_c20210040309214.nc
OR_ABI-L2-ACMC-M6_G17_s20210040311178_e20210040313551_c20210040314215.nc
OR_ABI-L2-ACMC-M6_G17_s20210040316178_e20210040318551_c20210040319240.nc
OR_ABI-L2-ACMC-M6_G17_s20210040321178_e20210040323551_c20210040324219.nc
OR_ABI-L2-ACMC-M6_G17_s20210040326178_e20210040328551_c20210040329204.nc
OR_ABI-L2-ACMC-M6_G17_s20210040331178_e20210040333551_c20210040334246.nc
OR_ABI-L2-ACMC-M6_G17_s20210040336178_e20210040338551_c20210040339206.nc
OR_ABI-L2-ACMC-M6_G17_s20210040341178_e20210040343551_c20210040344207.nc
OR_ABI-L2-ACMC-M6_G17_s20210040346178_e20210040348551_c20210040349228.nc
OR_ABI-L2-ACMC-M6_G17_s20210040351178_e20210040353551_c20210040354213.nc
OR_ABI-L2-ACMC-M6_G17_s20210040356178_e20210040358551_c20210040359203.nc
2021/03/18 14:42:31 DEBUG : 5 go routines active



################################
  After add --s3-no-head-object
################################

$ ./go/bin/rclone --checksum --dump headers --log-level DEBUG --no-traverse --s3-no-head-object copy --files-from in.txt aws:noaa-goes17 dst
2021/03/18 14:32:30 DEBUG : Using config file from "/home/xxxx/.config/rclone/rclone.conf"
2021/03/18 14:32:30 DEBUG : rclone: Version "v1.55.0-beta.5314.e59acd16c" starting with parameters ["./go/bin/rclone" "--checksum" "--dump" "headers" "--log-level" "DEBUG" "--no-traverse" "--s3-no-head-object" "copy" "--files-from" "in.txt" "aws:noaa-goes17" "dst"]
2021/03/18 14:32:30 DEBUG : Creating backend with remote "aws:noaa-goes17"
2021/03/18 14:32:30 DEBUG : aws: detected overridden config - adding "{EVwtF}" suffix to name
2021/03/18 14:32:30 DEBUG : You have specified to dump information. Please be noted that the Accept-Encoding as shown may not be correct in the request and the response may not show Content-Encoding if the go standard libraries auto gzip encoding was in effect. In this case the body of the request will be gunzipped before showing it.
2021/03/18 14:32:30 DEBUG : fs cache: renaming cache item "aws:noaa-goes17" to be canonical "aws{EVwtF}:noaa-goes17"
2021/03/18 14:32:30 DEBUG : Creating backend with remote "dst"
2021/03/18 14:32:30 DEBUG : fs cache: renaming cache item "dst" to be canonical "/home/xxxx/dst"
2021/03/18 14:32:30 DEBUG : Local file system at /home/xxxx/dst: Waiting for checks to finish
2021/03/18 14:32:30 DEBUG : ABI-L2-ACMC/2021/004/03/OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc: Sizes differ (src 0 vs dst 379423)
2021/03/18 14:32:30 DEBUG : Local file system at /home/xxxx/dst: Waiting for transfers to finish
2021/03/18 14:32:30 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:32:30 DEBUG : HTTP REQUEST (req 0xc00066c200)
2021/03/18 14:32:30 DEBUG : GET /ABI-L2-ACMC/2021/004/03/OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc HTTP/1.1
Host: noaa-goes17.s3.us-east-1.amazonaws.com
User-Agent: rclone/v1.55.0-beta.5314.e59acd16c
Accept-Encoding: gzip

2021/03/18 14:32:30 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:32:32 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:32:32 DEBUG : HTTP RESPONSE (req 0xc00066c200)
2021/03/18 14:32:32 DEBUG : HTTP/1.1 200 OK
Content-Length: 379423
Accept-Ranges: bytes
Content-Type: binary/octet-stream
Date: Thu, 18 Mar 2021 05:32:32 GMT
Etag: "2a4b3f55fefcf6f143d51458805989f9"
Last-Modified: Mon, 04 Jan 2021 03:04:41 GMT
Server: AmazonS3
X-Amz-Id-2: OGGvMdnEtuQ81qN6Agy1XPNUC5KcCSxfV2vceh9mJwD7NQsMsMh+A2LTMtpfenei4Omun1nynNs=
X-Amz-Request-Id: EWHREDZEJR847ACN
X-Amz-Storage-Class: INTELLIGENT_TIERING

2021/03/18 14:32:32 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:32:33 DEBUG : ABI-L2-ACMC/2021/004/03/OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc: MD5 = 2a4b3f55fefcf6f143d51458805989f9 OK
2021/03/18 14:32:33 INFO  : ABI-L2-ACMC/2021/004/03/OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc: Copied (replaced existing)
2021/03/18 14:32:33 INFO  : 
Transferred:   	  370.530k / 370.530 kBytes, 100%, 109.964 kBytes/s, ETA 0s
Checks:                 1 / 1, 100%
Transferred:            1 / 1, 100%
Elapsed time:         3.4s

2021/03/18 14:32:33 DEBUG : 5 go routines active

$ ./go/bin/rclone --dump headers --log-level DEBUG --no-traverse --s3-no-head-object lsf aws:noaa-goes17/ABI-L2-ACMC/2021/004/03/
2021/03/18 14:30:23 DEBUG : Using config file from "/home/xxxx/.config/rclone/rclone.conf"
2021/03/18 14:30:23 DEBUG : rclone: Version "v1.55.0-beta.5314.e59acd16c" starting with parameters ["./go/bin/rclone" "--dump" "headers" "--log-level" "DEBUG" "--no-traverse" "--s3-no-head-object" "lsf" "aws:noaa-goes17/ABI-L2-ACMC/2021/004/03/"]
2021/03/18 14:30:23 DEBUG : Creating backend with remote "aws:noaa-goes17/ABI-L2-ACMC/2021/004/03/"
2021/03/18 14:30:23 DEBUG : aws: detected overridden config - adding "{EVwtF}" suffix to name
2021/03/18 14:30:23 DEBUG : You have specified to dump information. Please be noted that the Accept-Encoding as shown may not be correct in the request and the response may not show Content-Encoding if the go standard libraries auto gzip encoding was in effect. In this case the body of the request will be gunzipped before showing it.
2021/03/18 14:30:23 DEBUG : fs cache: renaming cache item "aws:noaa-goes17/ABI-L2-ACMC/2021/004/03/" to be canonical "aws{EVwtF}:noaa-goes17/ABI-L2-ACMC/2021/004/03"
2021/03/18 14:30:23 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:30:23 DEBUG : HTTP REQUEST (req 0xc0000a6900)
2021/03/18 14:30:23 DEBUG : GET /?delimiter=%2F&encoding-type=url&max-keys=1000&prefix=ABI-L2-ACMC%2F2021%2F004%2F03%2F HTTP/1.1
Host: noaa-goes17.s3.us-east-1.amazonaws.com
User-Agent: rclone/v1.55.0-beta.5314.e59acd16c
Accept-Encoding: gzip

2021/03/18 14:30:23 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/03/18 14:30:25 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/03/18 14:30:25 DEBUG : HTTP RESPONSE (req 0xc0000a6900)
2021/03/18 14:30:25 DEBUG : HTTP/1.1 200 OK
Transfer-Encoding: chunked
Content-Type: application/xml
Date: Thu, 18 Mar 2021 05:30:24 GMT
Server: AmazonS3
X-Amz-Bucket-Region: us-east-1
X-Amz-Id-2: WNrnjq8Bu+f1ZIF+glSBZxSxohiz70sx08LKsreIHqMwj9hI2zZLafhF62dBUGnVjgJdJlmw+38=
X-Amz-Request-Id: RQG36PS3AJ6TF5X4

2021/03/18 14:30:25 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
OR_ABI-L2-ACMC-M6_G17_s20210040301178_e20210040303551_c20210040304250.nc
OR_ABI-L2-ACMC-M6_G17_s20210040306178_e20210040308551_c20210040309214.nc
OR_ABI-L2-ACMC-M6_G17_s20210040311178_e20210040313551_c20210040314215.nc
OR_ABI-L2-ACMC-M6_G17_s20210040316178_e20210040318551_c20210040319240.nc
OR_ABI-L2-ACMC-M6_G17_s20210040321178_e20210040323551_c20210040324219.nc
OR_ABI-L2-ACMC-M6_G17_s20210040326178_e20210040328551_c20210040329204.nc
OR_ABI-L2-ACMC-M6_G17_s20210040331178_e20210040333551_c20210040334246.nc
OR_ABI-L2-ACMC-M6_G17_s20210040336178_e20210040338551_c20210040339206.nc
OR_ABI-L2-ACMC-M6_G17_s20210040341178_e20210040343551_c20210040344207.nc
OR_ABI-L2-ACMC-M6_G17_s20210040346178_e20210040348551_c20210040349228.nc
OR_ABI-L2-ACMC-M6_G17_s20210040351178_e20210040353551_c20210040354213.nc
OR_ABI-L2-ACMC-M6_G17_s20210040356178_e20210040358551_c20210040359203.nc
2021/03/18 14:30:25 DEBUG : 5 go routines active