### PR TITLE
selfupdate: add instructions on reverting the update

### DIFF
--- a/cmd/selfupdate/help.go
+++ b/cmd/selfupdate/help.go
@@ -6,9 +6,29 @@ This command downloads the latest release of rclone and replaces
 the currently running binary. The download is verified with a hashsum
 and cryptographically signed signature.
 
-The |--version VER| flag, if given, will update to a concrete version
+If used without flags (or with implied |--stable| flag), this command
+will install the latest stable release. However, some issues may be fixed
+(or features added) only in the latest beta release. In such cases you should
+run the command with the |--beta| flag, i.e. |rclone selfupdate --beta|.
+You can check in advance what version would be installed by adding the
+|--check| flag, then repeat the command without it when you are satisfied.
+
+Sometimes the rclone team may recommend you a concrete beta or stable
+rclone release to troubleshoot your issue or add a bleeding edge feature.
+The |--version VER| flag, if given, will update to the concrete version
 instead of the latest one. If you omit micro version from |VER| (for
 example |1.53|), the latest matching micro version will be used.
+
+Upon successful update rclone will print a message that contains a previous
+version number. You will need it if you later decide to revert your update
+for some reason. Then you'll have to note the previous version and run the
+following command: |rclone selfupdate [--beta] OLDVER|.
+If the old version contains only dots and digits (for example |v1.54.0|)
+then it's a stable release so you won't need the |--beta| flag. Beta releases
+have an additional information similar to |v1.54.0-beta.5111.06f1c0c61|.
+(if you are a developer and use a locally built rclone, the version number
+will end with |-DEV|, you will have to rebuild it as it obvisously can't
+be distributed).
 
 If you previously installed rclone via a package manager, the package may
 include local documentation or configure services. You may wish to update
@@ -19,4 +39,9 @@ inaccurate after it.
 
 Note: Windows forbids deletion of a currently running executable so this
 command will rename the old executable to 'rclone.old.exe' upon success.
+
+Please note that this command was not available before rclone version 1.55.
+If it fails for you with the message |unknown command "selfupdate"| then
+you will need to update manually following the install instructions located
+at https://rclone.org/install/
 `

--- a/cmd/selfupdate/selfupdate.go
+++ b/cmd/selfupdate/selfupdate.go
@@ -146,15 +146,8 @@ func InstallUpdate(ctx context.Context, opt *Options) error {
 		return errors.Wrap(err, "unable to detect new version")
 	}
 
-	if newVersion == "" {
-		var err error
-		_, newVersion, _, err = versionCmd.GetVersion(siteURL + "/version.txt")
-		if err != nil {
-			return errors.Wrap(err, "unable to detect new version")
-		}
-	}
-
-	if newVersion == fs.Version {
+	oldVersion := fs.Version
+	if newVersion == oldVersion {
 		fmt.Println("rclone is up to date")
 		return nil
 	}
@@ -166,7 +159,7 @@ func InstallUpdate(ctx context.Context, opt *Options) error {
 		} else {
 			err := installPackage(ctx, opt.Beta, newVersion, siteURL, opt.Package)
 			if err == nil {
-				fmt.Printf("Successfully updated rclone package to version %s\n", newVersion)
+				fmt.Printf("Successfully updated rclone package from version %s to version %s\n", oldVersion, newVersion)
 			}
 			return err
 		}
@@ -218,7 +211,7 @@ func InstallUpdate(ctx context.Context, opt *Options) error {
 
 	err = replaceExecutable(targetFile, newFile, savedFile)
 	if err == nil {
-		fmt.Printf("Successfully updated rclone to version %s\n", newVersion)
+		fmt.Printf("Successfully updated rclone from version %s to version %s\n", oldVersion, newVersion)
 	}
 	return err
 }


### PR DESCRIPTION
#### What is the purpose of this change?

This PR polishes the selfupdate command a little to aid users with reverting updates:
- the success message will mention a previous version number
- the help synopsis will include instructions on reverting the update and help to identify betas or development builds
- the help will tell more about beta updates and include a fallback for old rclone version

These details are useful for those who submit new github requests or posts on forum
but will be gathered in the single place.

Additionally: removed a dead piece of code, probably a refactoring leftover.

#### Was the change discussed in an issue or in the forum before?

Yes, in #5096

I cannot include this fix right there because #5096 is a backlog PR and has a special lifecycle.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
