### PR TITLE
Use build tags in the `version` and `selfupdate` commands

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -36,6 +36,7 @@ import (
 	"github.com/rclone/rclone/fs/rc/rcflags"
 	"github.com/rclone/rclone/fs/rc/rcserver"
 	"github.com/rclone/rclone/lib/atexit"
+	"github.com/rclone/rclone/lib/buildinfo"
 	"github.com/rclone/rclone/lib/random"
 	"github.com/rclone/rclone/lib/terminal"
 	"github.com/spf13/cobra"
@@ -74,9 +75,13 @@ const (
 
 // ShowVersion prints the version to stdout
 func ShowVersion() {
+	linking, tagString := buildinfo.GetLinkingAndTags()
 	fmt.Printf("rclone %s\n", fs.Version)
-	fmt.Printf("- os/arch: %s/%s\n", runtime.GOOS, runtime.GOARCH)
-	fmt.Printf("- go version: %s\n", runtime.Version())
+	fmt.Printf("- os/type: %s\n", runtime.GOOS)
+	fmt.Printf("- os/arch: %s\n", runtime.GOARCH)
+	fmt.Printf("- go/version: %s\n", runtime.Version())
+	fmt.Printf("- go/linking: %s\n", linking)
+	fmt.Printf("- go/tags: %s\n", tagString)
 }
 
 // NewFsFile creates an Fs from a name but may point to a file.

--- a/cmd/cmount/arch.go
+++ b/cmd/cmount/arch.go
@@ -1,0 +1,7 @@
+package cmount
+
+// ProvidedBy returns true if the rclone build for the given OS
+// provides support for lib/cgo-fuse
+func ProvidedBy(osName string) bool {
+	return osName == "windows" || osName == "darwin"
+}

--- a/cmd/cmount/mount.go
+++ b/cmd/cmount/mount.go
@@ -26,7 +26,7 @@ import (
 
 func init() {
 	name := "cmount"
-	cmountOnly := runtime.GOOS == "windows" || runtime.GOOS == "darwin"
+	cmountOnly := ProvidedBy(runtime.GOOS)
 	if cmountOnly {
 		name = "mount"
 	}

--- a/cmd/selfupdate/help.go
+++ b/cmd/selfupdate/help.go
@@ -37,6 +37,10 @@ your OS) to update these too. This command with the default |--package zip|
 will update only the rclone executable so the local manual may become
 inaccurate after it.
 
+The |rclone mount| command (https://rclone.org/commands/rclone_mount/) may
+or may not support extended FUSE options depending on the build and OS.
+|selfupdate| will refuse to update if the capability would be discarded.
+
 Note: Windows forbids deletion of a currently running executable so this
 command will rename the old executable to 'rclone.old.exe' upon success.
 

--- a/cmd/selfupdate/selfupdate.go
+++ b/cmd/selfupdate/selfupdate.go
@@ -21,9 +21,11 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/rclone/rclone/cmd"
+	"github.com/rclone/rclone/cmd/cmount"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/fshttp"
+	"github.com/rclone/rclone/lib/buildinfo"
 	"github.com/rclone/rclone/lib/random"
 	"github.com/spf13/cobra"
 
@@ -139,6 +141,17 @@ func InstallUpdate(ctx context.Context, opt *Options) error {
 	// Find the latest release number
 	if opt.Stable && opt.Beta {
 		return errors.New("--stable and --beta are mutually exclusive")
+	}
+
+	gotCmount := false
+	for _, tag := range buildinfo.Tags {
+		if tag == "cmount" {
+			gotCmount = true
+			break
+		}
+	}
+	if gotCmount && !cmount.ProvidedBy(runtime.GOOS) {
+		return errors.New("updating would discard the mount FUSE capability, aborting")
 	}
 
 	newVersion, siteURL, err := GetVersion(ctx, opt.Beta, opt.Version)

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -29,14 +29,21 @@ var commandDefinition = &cobra.Command{
 	Use:   "version",
 	Short: `Show the version number.`,
 	Long: `
-Show the version number, the go version and the architecture.
+Show the rclone version number, the go version, the build target OS and
+architecture, build tags and the type of executable (static or dynamic).
 
-Eg
+For example:
 
     $ rclone version
-    rclone v1.41
-    - os/arch: linux/amd64
-    - go version: go1.10
+    rclone v1.54
+    - os/type: linux
+    - os/arch: amd64
+    - go/version: go1.16
+    - go/linking: static
+    - go/tags: none
+
+Note: before rclone version 1.55 the os/type and os/arch lines were merged,
+      and the "go/version" line was tagged as "go version".
 
 If you supply the --check flag, then it will do an online check to
 compare your version with the latest release and the latest beta.
@@ -89,9 +96,7 @@ func GetVersion(url string) (v *semver.Version, vs string, date time.Time, err e
 		return v, vs, date, err
 	}
 	vs = strings.TrimSpace(string(bodyBytes))
-	if strings.HasPrefix(vs, "rclone ") {
-		vs = vs[7:]
-	}
+	vs = strings.TrimPrefix(vs, "rclone ")
 	vs = strings.TrimRight(vs, "β")
 	date, err = http.ParseTime(resp.Header.Get("Last-Modified"))
 	if err != nil {

--- a/fs/rc/internal.go
+++ b/fs/rc/internal.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/rclone/rclone/lib/atexit"
+	"github.com/rclone/rclone/lib/buildinfo"
 )
 
 func init() {
@@ -179,6 +180,8 @@ This shows the current version of go and the go runtime
 - os - OS in use as according to Go
 - arch - cpu architecture in use according to Go
 - goVersion - version of Go runtime in use
+- linking - type of rclone executable (static or dynamic)
+- goTags - space separated build tags or "none"
 
 `,
 	})
@@ -190,6 +193,7 @@ func rcVersion(ctx context.Context, in Params) (out Params, err error) {
 	if err != nil {
 		return nil, err
 	}
+	linking, tagString := buildinfo.GetLinkingAndTags()
 	out = Params{
 		"version":    fs.Version,
 		"decomposed": version.Slice(),
@@ -198,6 +202,8 @@ func rcVersion(ctx context.Context, in Params) (out Params, err error) {
 		"os":         runtime.GOOS,
 		"arch":       runtime.GOARCH,
 		"goVersion":  runtime.Version(),
+		"linking":    linking,
+		"goTags":     tagString,
 	}
 	return out, nil
 }
@@ -425,9 +431,7 @@ func rcRunCommand(ctx context.Context, in Params) (out Params, err error) {
 		allArgs = append(allArgs, command)
 	}
 	// Add all from arg
-	for _, cur := range arg {
-		allArgs = append(allArgs, cur)
-	}
+	allArgs = append(allArgs, arg...)
 
 	// Add flags to args for e.g. --max-depth 1 comes in as { max-depth 1 }.
 	// Convert it to [ max-depth, 1 ] and append to args list

--- a/lib/buildinfo/cgo.go
+++ b/lib/buildinfo/cgo.go
@@ -1,0 +1,7 @@
+// +build cgo
+
+package buildinfo
+
+func init() {
+	Tags = append(Tags, "cgo")
+}

--- a/lib/buildinfo/cmount.go
+++ b/lib/buildinfo/cmount.go
@@ -1,0 +1,7 @@
+// +build cmount
+
+package buildinfo
+
+func init() {
+	Tags = append(Tags, "cmount")
+}

--- a/lib/buildinfo/tags.go
+++ b/lib/buildinfo/tags.go
@@ -1,0 +1,30 @@
+package buildinfo
+
+import (
+	"sort"
+	"strings"
+)
+
+// Tags contains slice of build tags
+var Tags []string
+
+// GetLinkingAndTags tells how the rclone executable was linked
+// and returns space separated build tags or the string "none".
+func GetLinkingAndTags() (linking, tagString string) {
+	linking = "static"
+	tagList := []string{}
+	for _, tag := range Tags {
+		if tag == "cgo" {
+			linking = "dynamic"
+		} else {
+			tagList = append(tagList, tag)
+		}
+	}
+	if len(tagList) > 0 {
+		sort.Strings(tagList)
+		tagString = strings.Join(tagList, " ")
+	} else {
+		tagString = "none"
+	}
+	return
+}


### PR DESCRIPTION
Use build tags in the `version` and `selfupdate` commands

#### What is the purpose of this change?

Knowing build tags would be useful.
For example, only `cmount` builds support passing custom libfuse flags.
(See #3545 for an example why it matters).

As stated in https://github.com/golang/go/issues/7007#issuecomment-66089610, golang does not and will not provide any runtime API for finding build tags on the fly:
> Build tags are for building. I do not want them to be exposed in the runtime.
> if you need to know ... you can write different files with different build tags and different initialized ... variables

This PR uses this very technique to initialize an internal array of build tags.
The technique has a limitation that every detectable tag must be known in advance.
Currently only the `cmount` and `cgo` tags are supported.

Knowing whether it is a CGO enabled build or not (so whether it is static or dynamic) would be really useful for debugging DNS problems.
As described in the go documentation (https://golang.org/cmd/cgo), when cgo builds a dynamic executable, it marks itself by the `cgo` build tag.

This PR makes `rclone version` show a list of predefined build tags or `none`.
The `cgo` tag will not be included in the list but used to determine whether the rclone binary is static or dynamic.

Additionally this PR makes `rclone selfupdate` aware of the `cmount` build tag to detect whether the FUSE support is in.
An update will be refused if the running executable supports FUSE semantics but the update would discard it and consequently break tooling wrappers.

#### Was the change discussed in an issue or in the forum before?

Proposed in https://forum.rclone.org/t/rclone-cmount-on-linux/22602/4

Fixes #5091

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

#### Testing

It is hard to test build capabilities automatically as CI/CD builds heavily depend on the build environment.
Instead, I will run the following manual test:

```
$ CGO_ENABLED=0 go build -o rclone-static . ; ./rclone-static version
rclone v1.55.0-DEV
- os/arch: linux/amd64
- go version: go1.16
- executable: static
- tags: none

$ CGO_ENABLED=1 go build -o rclone-dynamic . ; ./rclone-dynamic version
rclone v1.55.0-DEV
- os/arch: linux/amd64
- go version: go1.16
- executable: dynamic
- tags: none

$ xgo -image=billziss/xgo-cgofuse -targets=linux/amd64 -tags=cmount . ; ./rclone-linux-amd64 version
rclone v1.55.0-DEV
- os/arch: linux/amd64
- go version: go1.13.4
- executable: dynamic
- tags: cmount
```

#### Merging

I think this PR can be merged as two commits, where one patches the `version` command and the other patches `selfupdate`.
