### PR TITLE
build: replace xgo with NDK for Android builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -213,50 +213,89 @@ jobs:
         # Deploy binaries if enabled in config && not a PR && not a fork
         if: matrix.deploy && github.head_ref == '' && github.repository == 'rclone/rclone'
 
-  xgo:
-    timeout-minutes: 60
-    name: "xgo cross compile"
-    runs-on: ubuntu-latest
+  android:
+     timeout-minutes: 30
+     name: "android-all"
+     runs-on: ubuntu-latest
+     
+     steps:
+       - name: Checkout
+         uses: actions/checkout@v2
 
-    steps:
+       # Upgrade together with NDK version
+       - name: Set up Go 1.14
+         uses: actions/setup-go@v1
+         with:
+           go-version: 1.14
 
-      - name: Checkout
-        uses: actions/checkout@v1
-        with:
-          # Checkout into a fixed path to avoid import path problems on go < 1.11
-          path: ./src/github.com/rclone/rclone
+       # Upgrade together with Go version. Using a GitHub-provided version saves around 2 minutes.
+       - name: Force NDK version
+         run: echo "y" | sudo ${ANDROID_HOME}/tools/bin/sdkmanager --install "ndk;21.4.7075529" | grep -v = || true
 
-      - name: Set environment variables
-        shell: bash
-        run: |
-          echo 'GOPATH=${{ runner.workspace }}' >> $GITHUB_ENV
-          echo '${{ runner.workspace }}/bin' >> $GITHUB_PATH
+       - name: Go module cache
+         uses: actions/cache@v2
+         with:
+           path: ~/go/pkg/mod
+           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+           restore-keys: |
+             ${{ runner.os }}-go-
 
-      - name: Cross-compile rclone
-        run: |
-          docker pull billziss/xgo-cgofuse
-          GO111MODULE=off go get -v github.com/karalabe/xgo # don't add to go.mod
-          # xgo \
-          #     -image=billziss/xgo-cgofuse \
-          #     -targets=darwin/amd64,linux/386,linux/amd64,windows/386,windows/amd64 \
-          #     -tags cmount \
-          #     -dest build \
-          #     .
-          xgo \
-              -image=billziss/xgo-cgofuse \
-              -targets=android/* \
-              -dest build \
-              .
+       - name: arm-v7a Set environment variables
+         shell: bash
+         run: |
+           echo "CC=$(echo $ANDROID_HOME/ndk/21.4.7075529/toolchains/llvm/prebuilt/linux-x86_64/bin/armv7a-linux-androideabi16-clang)" >> $GITHUB_ENV
+           echo "CC_FOR_TARGET=$CC" >> $GITHUB_ENV
+           echo 'GOOS=android' >> $GITHUB_ENV
+           echo 'GOARCH=arm' >> $GITHUB_ENV
+           echo 'GOARM=7' >> $GITHUB_ENV
+           echo 'CGO_ENABLED=1' >> $GITHUB_ENV
+           echo 'CGO_LDFLAGS=-fuse-ld=lld -s -w' >> $GITHUB_ENV
+       - name: arm-v7a build
+         run: go build -v -tags android -trimpath -o build/rclone-android-16-armv7a .
 
-      - name: Build rclone
-        shell: bash
-        run: |
-          make
+       - name: arm64-v8a Set environment variables
+         shell: bash
+         run: |
+           echo "CC=$(echo $ANDROID_HOME/ndk/21.4.7075529/toolchains/llvm/prebuilt/linux-x86_64/bin/aarch64-linux-android21-clang)" >> $GITHUB_ENV
+           echo "CC_FOR_TARGET=$CC" >> $GITHUB_ENV
+           echo 'GOOS=android' >> $GITHUB_ENV
+           echo 'GOARCH=arm64' >> $GITHUB_ENV
+           echo 'CGO_ENABLED=1' >> $GITHUB_ENV
+           echo 'CGO_LDFLAGS=-fuse-ld=lld -s -w' >> $GITHUB_ENV
 
-      - name: Upload artifacts
-        run: |
-          make ci_upload
-        env:
-          RCLONE_CONFIG_PASS: ${{ secrets.RCLONE_CONFIG_PASS }}
-        # Upload artifacts if not a PR && not a fork
-        if: github.head_ref == '' && github.repository == 'rclone/rclone'
+       - name: arm64-v8a build
+         run: go build -v -tags android -trimpath -o build/rclone-android-21-armv8a .
+
+       - name: x86 Set environment variables
+         shell: bash
+         run: |
+           echo "CC=$(echo $ANDROID_HOME/ndk/21.4.7075529/toolchains/llvm/prebuilt/linux-x86_64/bin/i686-linux-android16-clang)" >> $GITHUB_ENV
+           echo "CC_FOR_TARGET=$CC" >> $GITHUB_ENV
+           echo 'GOOS=android' >> $GITHUB_ENV
+           echo 'GOARCH=386' >> $GITHUB_ENV
+           echo 'CGO_ENABLED=1' >> $GITHUB_ENV
+           echo 'CGO_LDFLAGS=-fuse-ld=lld -s -w' >> $GITHUB_ENV
+
+       - name: x86 build
+         run: go build -v -tags android -trimpath -o build/rclone-android-16-x86 .
+
+       - name: x64 Set environment variables
+         shell: bash
+         run: |
+           echo "CC=$(echo $ANDROID_HOME/ndk/21.4.7075529/toolchains/llvm/prebuilt/linux-x86_64/bin/x86_64-linux-android21-clang)" >> $GITHUB_ENV
+           echo "CC_FOR_TARGET=$CC" >> $GITHUB_ENV
+           echo 'GOOS=android' >> $GITHUB_ENV
+           echo 'GOARCH=amd64' >> $GITHUB_ENV
+           echo 'CGO_ENABLED=1' >> $GITHUB_ENV
+           echo 'CGO_LDFLAGS=-fuse-ld=lld -s -w' >> $GITHUB_ENV
+
+       - name: x64 build
+         run: go build -v -tags android -trimpath -o build/rclone-android-21-x64 .
+
+       - name: Upload artifacts
+         run: |
+           make ci_upload
+         env:
+           RCLONE_CONFIG_PASS: ${{ secrets.RCLONE_CONFIG_PASS }}
+         # Upload artifacts if not a PR && not a fork
+         if: github.head_ref == '' && github.repository == 'rclone/rclone'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -240,6 +240,15 @@ jobs:
            restore-keys: |
              ${{ runner.os }}-go-
 
+       - name: Set global environment variables
+         shell: bash
+         run: |
+           echo "VERSION=$(make version)" >> $GITHUB_ENV
+
+       - name: build native rclone
+         run: |
+           make
+
        - name: arm-v7a Set environment variables
          shell: bash
          run: |
@@ -251,7 +260,7 @@ jobs:
            echo 'CGO_ENABLED=1' >> $GITHUB_ENV
            echo 'CGO_LDFLAGS=-fuse-ld=lld -s -w' >> $GITHUB_ENV
        - name: arm-v7a build
-         run: go build -v -tags android -trimpath -o build/rclone-android-16-armv7a .
+         run: go build -v -tags android -trimpath -ldflags '-s -X github.com/rclone/rclone/fs.Version='${VERSION} -o build/rclone-android-16-armv7a .
 
        - name: arm64-v8a Set environment variables
          shell: bash
@@ -264,7 +273,7 @@ jobs:
            echo 'CGO_LDFLAGS=-fuse-ld=lld -s -w' >> $GITHUB_ENV
 
        - name: arm64-v8a build
-         run: go build -v -tags android -trimpath -o build/rclone-android-21-armv8a .
+         run: go build -v -tags android -trimpath -ldflags '-s -X github.com/rclone/rclone/fs.Version='${VERSION} -o build/rclone-android-21-armv8a .
 
        - name: x86 Set environment variables
          shell: bash
@@ -277,7 +286,7 @@ jobs:
            echo 'CGO_LDFLAGS=-fuse-ld=lld -s -w' >> $GITHUB_ENV
 
        - name: x86 build
-         run: go build -v -tags android -trimpath -o build/rclone-android-16-x86 .
+         run: go build -v -tags android -trimpath -ldflags '-s -X github.com/rclone/rclone/fs.Version='${VERSION} -o build/rclone-android-16-x86 .
 
        - name: x64 Set environment variables
          shell: bash
@@ -290,7 +299,7 @@ jobs:
            echo 'CGO_LDFLAGS=-fuse-ld=lld -s -w' >> $GITHUB_ENV
 
        - name: x64 build
-         run: go build -v -tags android -trimpath -o build/rclone-android-21-x64 .
+         run: go build -v -tags android -trimpath -ldflags '-s -X github.com/rclone/rclone/fs.Version='${VERSION} -o build/rclone-android-21-x64 .
 
        - name: Upload artifacts
          run: |


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Replace xgo (unmaintained) with a standalone NDK-based compiler toolchain for Android builds. Everything works, but I obviously couldn't test the upload step. Binaries for all 4 architectures are written to a `build` folder.

#### Was the change discussed in an issue or in the forum before?

Request: https://github.com/x0b/rcx/issues/123

Related (xgo iOS): https://github.com/rclone/rclone/issues/5124

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
