### PR TITLE
ftp: add --ftp-ask-password to prompt for password when needed

### DIFF
--- a/docs/content/ftp.md
+++ b/docs/content/ftp.md
@@ -180,6 +180,15 @@ FTP password.
 - Type:        string
 - Default:     ""
 
+#### --ftp-ask-password
+
+Ask for password when connecting to a FTP server and no password is configured.
+
+- Config:       ask_password
+- Env Var:      RCLONE_FTP_ASK_PASSWORD
+- Type:         bool
+- Default:      false
+
 #### --ftp-tls
 
 Use Implicit FTPS (FTP over TLS).


### PR DESCRIPTION
This adds a flag `ask_password` to `ftp` backend that prompts the user for password whenever a password is not set.

This closes #5160 and I implemented it to work similar to how `--sftp-ask-password` functions