### PR TITLE
sync: don't warn about --no-traverse when --files-from is set

### DIFF
--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -155,7 +155,7 @@ func newSyncCopyMove(ctx context.Context, fdst, fsrc fs.Fs, deleteMode fs.Delete
 	// Input context - cancel this for graceful stop
 	s.inCtx, s.inCancel = context.WithCancel(s.ctx)
 	if s.noTraverse && s.deleteMode != fs.DeleteModeOff {
-		if (!fi.HaveFilesFrom()) {
+		if !fi.HaveFilesFrom() {
 			fs.Errorf(nil, "Ignoring --no-traverse with sync")
 		}
 		s.noTraverse = false

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -155,7 +155,9 @@ func newSyncCopyMove(ctx context.Context, fdst, fsrc fs.Fs, deleteMode fs.Delete
 	// Input context - cancel this for graceful stop
 	s.inCtx, s.inCancel = context.WithCancel(s.ctx)
 	if s.noTraverse && s.deleteMode != fs.DeleteModeOff {
-		fs.Errorf(nil, "Ignoring --no-traverse with sync")
+		if (!fi.HaveFilesFrom()) {
+			fs.Errorf(nil, "Ignoring --no-traverse with sync")
+		}
 		s.noTraverse = false
 	}
 	s.trackRenamesStrategy, err = parseTrackRenamesStrategy(ci.TrackRenamesStrategy)


### PR DESCRIPTION
#### What is the purpose of this change?

Suppress spurious error message when performing `rclone sync` with `--files-from` and `--no-traverse` flags.

The `rclone sync` command logs an error if the `--no-traverse` flag is specified, as traversing destination directories is necessary to compare them with the source for syncing.

However, when the `--files-from` flag is present, the `--no-traverse` flag modifies the file listing behavior to query each specified path individually rather than traversing the directory listing (see the [docs](https://rclone.org/filtering/#files-from-read-list-of-source-file-names)).  This functionality works as expected with the sync operation, so this PR adds a check to suppress the error message in this case.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~ (n/a)
- [ ] ~~I have added documentation for the changes if appropriate.~~ (n/a)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
