### PR TITLE
selfupdate: dont detect FUSE if build is static

### DIFF
--- a/cmd/cmount/mount.go
+++ b/cmd/cmount/mount.go
@@ -21,6 +21,7 @@ import (
 	"github.com/rclone/rclone/cmd/mountlib"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/lib/atexit"
+	"github.com/rclone/rclone/lib/buildinfo"
 	"github.com/rclone/rclone/vfs"
 )
 
@@ -35,6 +36,7 @@ func init() {
 		cmd.Aliases = append(cmd.Aliases, "cmount")
 	}
 	mountlib.AddRc("cmount", mount)
+	buildinfo.Tags = append(buildinfo.Tags, "cmount")
 }
 
 // Find the option string in the current options

--- a/cmd/selfupdate/help.go
+++ b/cmd/selfupdate/help.go
@@ -27,7 +27,7 @@ If the old version contains only dots and digits (for example |v1.54.0|)
 then it's a stable release so you won't need the |--beta| flag. Beta releases
 have an additional information similar to |v1.54.0-beta.5111.06f1c0c61|.
 (if you are a developer and use a locally built rclone, the version number
-will end with |-DEV|, you will have to rebuild it as it obvisously can't
+will end with |-DEV|, you will have to rebuild it as it obviously can't
 be distributed).
 
 If you previously installed rclone via a package manager, the package may

--- a/cmd/selfupdate/selfupdate.go
+++ b/cmd/selfupdate/selfupdate.go
@@ -143,14 +143,9 @@ func InstallUpdate(ctx context.Context, opt *Options) error {
 		return errors.New("--stable and --beta are mutually exclusive")
 	}
 
-	gotCmount := false
-	for _, tag := range buildinfo.Tags {
-		if tag == "cmount" {
-			gotCmount = true
-			break
-		}
-	}
-	if gotCmount && !cmount.ProvidedBy(runtime.GOOS) {
+	// The `cmount` tag is added by cmd/cmount/mount.go only if build is static.
+	_, tags := buildinfo.GetLinkingAndTags()
+	if strings.Contains(" "+tags+" ", " cmount ") && !cmount.ProvidedBy(runtime.GOOS) {
 		return errors.New("updating would discard the mount FUSE capability, aborting")
 	}
 

--- a/lib/buildinfo/cmount.go
+++ b/lib/buildinfo/cmount.go
@@ -1,7 +1,0 @@
-// +build cmount
-
-package buildinfo
-
-func init() {
-	Tags = append(Tags, "cmount")
-}

--- a/lib/buildinfo/tags.go
+++ b/lib/buildinfo/tags.go
@@ -6,6 +6,8 @@ import (
 )
 
 // Tags contains slice of build tags
+// The `cmount` tag is added by cmd/cmount/mount.go only if build is static.
+// Other tags including `cgo` are detected in this package.
 var Tags []string
 
 // GetLinkingAndTags tells how the rclone executable was linked


### PR DESCRIPTION
#### What is the purpose of this change?

Before this patch selfupdate detected ANY build with `cmount` tag as a build
having libFUSE capabilities. However, only dynamic builds really have it.
The official Linux builds are static and have the `cmount `tag as of the time
of this writing. This results in inability to update official Linux binaries.

This patch fixes that.
The build can be fixed independently by #5199

#### Was the change discussed in an issue or in the forum before?

- https://forum.rclone.org/t/rclone-1-55-release/23217/11
- #5190
- #5199

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
