### PR TITLE
Add --size flag for rclone rcat - closes #4403

### DIFF
--- a/cmd/rcat/rcat.go
+++ b/cmd/rcat/rcat.go
@@ -47,6 +47,10 @@ setting this cutoff too high will decrease your performance.
 Use the |--size| flag to preallocate the file in advance at the remote end
 and actually stream it, even if remote backend doesn't support streaming.
 
+|--size| should be the exact size of the input stream in bytes. If the
+size of the stream is different in length to the |--size| passed in
+then the transfer will likely fail.
+
 Note that the upload can also not be retried because the data is
 not kept around until the upload succeeds. If you need to transfer
 a lot of data, you're better off caching locally and then

--- a/cmd/rcat/rcat.go
+++ b/cmd/rcat/rcat.go
@@ -7,12 +7,19 @@ import (
 	"time"
 
 	"github.com/rclone/rclone/cmd"
+	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/spf13/cobra"
 )
 
+var (
+	size = int64(-1)
+)
+
 func init() {
 	cmd.Root.AddCommand(commandDefinition)
+	cmdFlags := commandDefinition.Flags()
+	flags.Int64VarP(cmdFlags, &size, "size", "", size, "File size hint to preallocate")
 }
 
 var commandDefinition = &cobra.Command{
@@ -37,6 +44,9 @@ must fit into RAM. The cutoff needs to be small enough to adhere
 the limits of your remote, please see there. Generally speaking,
 setting this cutoff too high will decrease your performance.
 
+Use the |--size| flag to preallocate the file in advance at the remote end
+and actually stream it, even if remote backend doesn't support streaming.
+
 Note that the upload can also not be retried because the data is
 not kept around until the upload succeeds. If you need to transfer
 a lot of data, you're better off caching locally and then
@@ -51,7 +61,7 @@ a lot of data, you're better off caching locally and then
 
 		fdst, dstFileName := cmd.NewFsDstFile(args)
 		cmd.Run(false, false, command, func() error {
-			_, err := operations.Rcat(context.Background(), fdst, dstFileName, os.Stdin, time.Now())
+			_, err := operations.RcatSize(context.Background(), fdst, dstFileName, os.Stdin, size, time.Now())
 			return err
 		})
 	},


### PR DESCRIPTION
This allows preallocating space at remote end with `RcatSize`.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

To allow streaming uploads even when remote backend doesn't support them.
`RcatSize` should fall back to regular `Rcat` if `--size` flag is missing.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

See #4403

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
