### PR TITLE
config: fix issues with memory-only config file paths

### DIFF
--- a/cmd/version/version_test.go
+++ b/cmd/version/version_test.go
@@ -26,12 +26,12 @@ func TestVersionWorksWithoutAccessibleConfigFile(t *testing.T) {
 	}
 	// re-wire
 	oldOsStdout := os.Stdout
-	oldConfigPath := config.ConfigPath
-	config.ConfigPath = path
+	oldConfigPath := config.GetConfigPath()
+	assert.NoError(t, config.SetConfigPath(path))
 	os.Stdout = nil
 	defer func() {
 		os.Stdout = oldOsStdout
-		config.ConfigPath = oldConfigPath
+		assert.NoError(t, config.SetConfigPath(oldConfigPath))
 	}()
 
 	cmd.Root.SetArgs([]string{"version"})

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -653,8 +653,8 @@ for Rclone to use it, it will never be created automatically.
 If you run `rclone config file` you will see where the default
 location is for you.
 
-Use this flag to override the config location, e.g. `rclone
---config=".myconfig" config`.
+Use this flag to override the config location, e.g.
+`rclone config --config="rclone.conf"`.
 
 If the location is set to empty string `""` or the special value
 `/notfound`, or the os null device represented by value `NUL` on

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/rclone/rclone/fs/fspath"
 	"github.com/rclone/rclone/fs/rc"
+	"github.com/rclone/rclone/lib/file"
 	"github.com/rclone/rclone/lib/random"
 )
 
@@ -226,16 +227,20 @@ func GetConfigPath() string {
 //
 // Checks for empty string, os null device, or special path, all of which indicates in-memory config.
 func SetConfigPath(path string) (err error) {
+	var cfgPath string
 	if path == "" || path == os.DevNull {
-		configPath = ""
+		cfgPath = ""
+	} else if err = file.IsReserved(path); err != nil {
+		return err
 	} else {
-		if configPath, err = filepath.Abs(path); err != nil {
+		if cfgPath, err = filepath.Abs(path); err != nil {
 			return err
 		}
-		if configPath == noConfigPath {
-			configPath = ""
+		if cfgPath == noConfigPath {
+			cfgPath = ""
 		}
 	}
+	configPath = cfgPath
 	return nil
 }
 

--- a/fs/config/config_test.go
+++ b/fs/config/config_test.go
@@ -12,10 +12,10 @@ import (
 )
 
 func TestConfigLoad(t *testing.T) {
-	oldConfigPath := config.ConfigPath
-	config.ConfigPath = "./testdata/plain.conf"
+	oldConfigPath := config.GetConfigPath()
+	assert.NoError(t, config.SetConfigPath("./testdata/plain.conf"))
 	defer func() {
-		config.ConfigPath = oldConfigPath
+		assert.NoError(t, config.SetConfigPath(oldConfigPath))
 	}()
 	config.ClearConfigPassword()
 	configfile.LoadConfig(context.Background())

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -6,7 +6,6 @@ package configflags
 import (
 	"log"
 	"net"
-	"path/filepath"
 	"strconv"
 	"strings"
 
@@ -23,6 +22,7 @@ var (
 	// these will get interpreted into fs.Config via SetFlags() below
 	verbose         int
 	quiet           bool
+	configPath      string
 	dumpHeaders     bool
 	dumpBodies      bool
 	deleteBefore    bool
@@ -45,7 +45,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.DurationVarP(flagSet, &ci.ModifyWindow, "modify-window", "", ci.ModifyWindow, "Max time diff to be considered the same")
 	flags.IntVarP(flagSet, &ci.Checkers, "checkers", "", ci.Checkers, "Number of checkers to run in parallel.")
 	flags.IntVarP(flagSet, &ci.Transfers, "transfers", "", ci.Transfers, "Number of file transfers to run in parallel.")
-	flags.StringVarP(flagSet, &config.ConfigPath, "config", "", config.ConfigPath, "Config file.")
+	flags.StringVarP(flagSet, &configPath, "config", "", config.GetConfigPath(), "Config file.")
 	flags.StringVarP(flagSet, &config.CacheDir, "cache-dir", "", config.CacheDir, "Directory rclone will use for caching.")
 	flags.BoolVarP(flagSet, &ci.CheckSum, "checksum", "c", ci.CheckSum, "Skip based on checksum (if available) & size, not mod-time & size")
 	flags.BoolVarP(flagSet, &ci.SizeOnly, "size-only", "", ci.SizeOnly, "Skip based on size only, not mod-time or checksum")
@@ -267,10 +267,9 @@ func SetFlags(ci *fs.ConfigInfo) {
 		}
 	}
 
-	// Make the config file absolute
-	configPath, err := filepath.Abs(config.ConfigPath)
-	if err == nil {
-		config.ConfigPath = configPath
+	// Set path to configuration file
+	if err := config.SetConfigPath(configPath); err != nil {
+		log.Fatalf("--config: Failed to set %q as config path: %v", configPath, err)
 	}
 
 	// Set whether multi-thread-streams was set

--- a/fs/config/crypt_test.go
+++ b/fs/config/crypt_test.go
@@ -16,10 +16,10 @@ import (
 
 func TestConfigLoadEncrypted(t *testing.T) {
 	var err error
-	oldConfigPath := config.ConfigPath
-	config.ConfigPath = "./testdata/encrypted.conf"
+	oldConfigPath := config.GetConfigPath()
+	assert.NoError(t, config.SetConfigPath("./testdata/encrypted.conf"))
 	defer func() {
-		config.ConfigPath = oldConfigPath
+		assert.NoError(t, config.SetConfigPath(oldConfigPath))
 		config.ClearConfigPassword()
 	}()
 
@@ -40,13 +40,13 @@ func TestConfigLoadEncrypted(t *testing.T) {
 func TestConfigLoadEncryptedWithValidPassCommand(t *testing.T) {
 	ctx := context.Background()
 	ci := fs.GetConfig(ctx)
-	oldConfigPath := config.ConfigPath
+	oldConfigPath := config.GetConfigPath()
 	oldConfig := *ci
-	config.ConfigPath = "./testdata/encrypted.conf"
+	assert.NoError(t, config.SetConfigPath("./testdata/encrypted.conf"))
 	// using ci.PasswordCommand, correct password
 	ci.PasswordCommand = fs.SpaceSepList{"echo", "asdf"}
 	defer func() {
-		config.ConfigPath = oldConfigPath
+		assert.NoError(t, config.SetConfigPath(oldConfigPath))
 		config.ClearConfigPassword()
 		*ci = oldConfig
 		ci.PasswordCommand = nil
@@ -69,13 +69,13 @@ func TestConfigLoadEncryptedWithValidPassCommand(t *testing.T) {
 func TestConfigLoadEncryptedWithInvalidPassCommand(t *testing.T) {
 	ctx := context.Background()
 	ci := fs.GetConfig(ctx)
-	oldConfigPath := config.ConfigPath
+	oldConfigPath := config.GetConfigPath()
 	oldConfig := *ci
-	config.ConfigPath = "./testdata/encrypted.conf"
+	assert.NoError(t, config.SetConfigPath("./testdata/encrypted.conf"))
 	// using ci.PasswordCommand, incorrect password
 	ci.PasswordCommand = fs.SpaceSepList{"echo", "asdf-blurfl"}
 	defer func() {
-		config.ConfigPath = oldConfigPath
+		assert.NoError(t, config.SetConfigPath(oldConfigPath))
 		config.ClearConfigPassword()
 		*ci = oldConfig
 		ci.PasswordCommand = nil
@@ -92,24 +92,24 @@ func TestConfigLoadEncryptedFailures(t *testing.T) {
 	var err error
 
 	// This file should be too short to be decoded.
-	oldConfigPath := config.ConfigPath
-	config.ConfigPath = "./testdata/enc-short.conf"
-	defer func() { config.ConfigPath = oldConfigPath }()
+	oldConfigPath := config.GetConfigPath()
+	assert.NoError(t, config.SetConfigPath("./testdata/enc-short.conf"))
+	defer func() { assert.NoError(t, config.SetConfigPath(oldConfigPath)) }()
 	err = config.Data.Load()
 	require.Error(t, err)
 
 	// This file contains invalid base64 characters.
-	config.ConfigPath = "./testdata/enc-invalid.conf"
+	assert.NoError(t, config.SetConfigPath("./testdata/enc-invalid.conf"))
 	err = config.Data.Load()
 	require.Error(t, err)
 
 	// This file contains invalid base64 characters.
-	config.ConfigPath = "./testdata/enc-too-new.conf"
+	assert.NoError(t, config.SetConfigPath("./testdata/enc-too-new.conf"))
 	err = config.Data.Load()
 	require.Error(t, err)
 
 	// This file does not exist.
-	config.ConfigPath = "./testdata/filenotfound.conf"
+	assert.NoError(t, config.SetConfigPath("./testdata/filenotfound.conf"))
 	err = config.Data.Load()
 	assert.Equal(t, config.ErrorConfigFileNotFound, err)
 }

--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -535,12 +535,16 @@ func CopyRemote(name string) {
 
 // ShowConfigLocation prints the location of the config file in use
 func ShowConfigLocation() {
-	if _, err := os.Stat(ConfigPath); os.IsNotExist(err) {
-		fmt.Println("Configuration file doesn't exist, but rclone will use this path:")
+	if configPath := GetConfigPath(); configPath == "" {
+		fmt.Println("Configuration is in memory only")
 	} else {
-		fmt.Println("Configuration file is stored at:")
+		if _, err := os.Stat(configPath); os.IsNotExist(err) {
+			fmt.Println("Configuration file doesn't exist, but rclone will use this path:")
+		} else {
+			fmt.Println("Configuration file is stored at:")
+		}
+		fmt.Printf("%s\n", configPath)
 	}
-	fmt.Printf("%s\n", ConfigPath)
 }
 
 // ShowConfig prints the (unencrypted) config options

--- a/fs/config/ui_test.go
+++ b/fs/config/ui_test.go
@@ -34,13 +34,13 @@ func testConfigFile(t *testing.T, configFileName string) func() {
 
 	// temporarily adapt configuration
 	oldOsStdout := os.Stdout
-	oldConfigPath := config.ConfigPath
+	oldConfigPath := config.GetConfigPath()
 	oldConfig := *ci
 	oldConfigFile := config.Data
 	oldReadLine := config.ReadLine
 	oldPassword := config.Password
 	os.Stdout = nil
-	config.ConfigPath = path
+	assert.NoError(t, config.SetConfigPath(path))
 	ci = &fs.ConfigInfo{}
 
 	configfile.LoadConfig(ctx)
@@ -69,7 +69,7 @@ func testConfigFile(t *testing.T, configFileName string) func() {
 		assert.NoError(t, err)
 
 		os.Stdout = oldOsStdout
-		config.ConfigPath = oldConfigPath
+		assert.NoError(t, config.SetConfigPath(oldConfigPath))
 		config.ReadLine = oldReadLine
 		config.Password = oldPassword
 		*ci = oldConfig

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -1317,7 +1317,8 @@ type setConfigFile string
 // Set a config item into the config file
 func (section setConfigFile) Set(key, value string) {
 	if strings.HasPrefix(string(section), ":") {
-		Errorf(nil, "Can't save config %q = %q for on the fly backend %q", key, value, section)
+		Logf(nil, "Can't save config %q = %q for on the fly backend %q", key, value, section)
+		return
 	}
 	Debugf(nil, "Saving config %q = %q in section %q of the config file", key, value, section)
 	err := ConfigFileSet(string(section), key, value)

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -69,7 +69,7 @@ func Initialise() {
 	// parse the flags any more so this doesn't happen
 	// automatically
 	if envConfig := os.Getenv("RCLONE_CONFIG"); envConfig != "" {
-		config.ConfigPath = envConfig
+		_ = config.SetConfigPath(envConfig)
 	}
 	configfile.LoadConfig(ctx)
 	accounting.Start(ctx)

--- a/lib/file/file_other.go
+++ b/lib/file/file_other.go
@@ -13,3 +13,8 @@ import "os"
 // Under both Unix and Windows this will allow open files to be
 // renamed and or deleted.
 var OpenFile = os.OpenFile
+
+// IsReserved checks if path contains a reserved name
+func IsReserved(path string) error {
+	return nil
+}

--- a/lib/file/file_test.go
+++ b/lib/file/file_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -151,4 +152,30 @@ func TestOpenFileOperations(t *testing.T) {
 		"file1,7,false",
 	})
 
+}
+
+// Smoke test the IsReserved function
+func TestIsReserved(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("Skipping test on !windows")
+	}
+	// Regular name
+	require.NoError(t, IsReserved("readme.txt"))
+	require.NoError(t, IsReserved("some/path/readme.txt"))
+	// Empty
+	require.Error(t, IsReserved(""))
+	// Separators only
+	require.Error(t, IsReserved("/"))
+	require.Error(t, IsReserved("////"))
+	require.Error(t, IsReserved("./././././"))
+	// Legacy device name
+	require.Error(t, IsReserved("NUL"))
+	require.Error(t, IsReserved("nul"))
+	require.Error(t, IsReserved("Nul"))
+	require.Error(t, IsReserved("NUL.txt"))
+	require.Error(t, IsReserved("some/path/to/nul.txt"))
+	require.NoError(t, IsReserved("NULL"))
+	// Name end with a space or a period
+	require.Error(t, IsReserved("test."))
+	require.Error(t, IsReserved("test "))
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Solving issues and making it more user friendly with memory-only config.

Ref the following cases described in the issue:

Case 1. --config /dev/null on Linux
Case 2. --config NUL on Windows
Case 3. --config ""
Case 4. --config /notfound

All should be handled by this PR, ~~but I have only tested on Windows~~ tested on Windows 10 and arch linux in WSL.

#### Was the change discussed in an issue or in the forum before?

Fixes #5222

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
