### PR TITLE
Silence the progress output with curl requests

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -53,9 +53,9 @@ export XDG_CONFIG_HOME=config
 #check installed version of rclone to determine if update is necessary
 version=$(rclone --version 2>>errors | head -n 1)
 if [ -z "$install_beta" ]; then
-    current_version=$(curl -f https://downloads.rclone.org/version.txt)
+    current_version=$(curl -fsS https://downloads.rclone.org/version.txt)
 else
-    current_version=$(curl -f https://beta.rclone.org/version.txt)
+    current_version=$(curl -fsS https://beta.rclone.org/version.txt)
 fi
 
 if [ "$version" = "$current_version" ]; then
@@ -123,7 +123,7 @@ else
     rclone_zip="rclone-beta-latest-${OS}-${OS_type}.zip"
 fi
 
-curl -Of "$download_link"
+curl -OfsS "$download_link"
 unzip_dir="tmp_unzip_dir_for_rclone"
 # there should be an entry in this switch for each element of unzip_tools_list
 case "$unzip_tool" in


### PR DESCRIPTION
Having a progress seems to break some automated scripts and there isn't a way to pass some flags to these curl requests to disable them. I don't know if showing the progress is any helpful to be honest.
