### PR TITLE
Platform independent memory-only config option to be used in build

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -686,8 +686,8 @@ to run in "portable" mode by downloading rclone executable to a
 writable directory and then create an empty file `rclone.conf` in the
 same directory.
 
-If the location is set to empty string `""` or the special value
-`/notfound`, or the os null device represented by value `NUL` on
+If the location is set to empty string `""` or path to a file
+with name `notfound`, or the os null device represented by value `NUL` on
 Windows and `/dev/null` on Unix systems, then rclone will keep the
 config file in memory only.
 
@@ -1920,11 +1920,12 @@ Nevertheless, rclone will read any configuration file found
 according to the rules described [above](https://rclone.org/docs/#config-config-file).
 If an encrypted configuration file is found, this means you will be prompted for
 password (unless using `--password-command`). To avoid this, you can bypass
-the loading of the configuration file by overriding the location with an empty
-string `""` or the special value `/notfound`, or the os null device represented
-by value `NUL` on Windows and `/dev/null` on Unix systems (before rclone
-version 1.55 only this null device alternative was supported).
-E.g. `rclone --config="" genautocomplete bash`.
+the loading of the default configuration file by overriding the location,
+e.g. with one of the documented special values for memory-only configuration:
+
+```
+rclone genautocomplete bash --config=""
+```
 
 Developer options
 -----------------

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -29,7 +29,7 @@ import (
 const (
 	configFileName       = "rclone.conf"
 	hiddenConfigFileName = "." + configFileName
-	noConfigFile         = "/notfound"
+	noConfigFile         = "notfound"
 
 	// ConfigToken is the key used to store the token under
 	ConfigToken = "token"
@@ -113,16 +113,12 @@ var (
 	Password = random.Password
 )
 
-var (
-	configPath   string
-	noConfigPath string
-)
+var configPath string
 
 func init() {
 	// Set the function pointers up in fs
 	fs.ConfigFileGet = FileGetFlag
 	fs.ConfigFileSet = SetValueAndSave
-	noConfigPath, _ = filepath.Abs(noConfigFile)
 	configPath = makeConfigPath()
 }
 
@@ -320,15 +316,12 @@ func SetConfigPath(path string) (err error) {
 	var cfgPath string
 	if path == "" || path == os.DevNull {
 		cfgPath = ""
+	} else if filepath.Base(path) == noConfigFile {
+		cfgPath = ""
 	} else if err = file.IsReserved(path); err != nil {
 		return err
-	} else {
-		if cfgPath, err = filepath.Abs(path); err != nil {
-			return err
-		}
-		if cfgPath == noConfigPath {
-			cfgPath = ""
-		}
+	} else if cfgPath, err = filepath.Abs(path); err != nil {
+		return err
 	}
 	configPath = cfgPath
 	return nil


### PR DESCRIPTION
#### What is the purpose of this change?

Two things:
1. Run tests with memory-only configuration on all platforms (dependent on the next).
2. Continuation of  https://github.com/rclone/rclone/pull/5223:

    Case 1. --config /dev/null on Linux
    Case 2. --config NUL on Windows
    Case 3. --config ""
    Case 4. --config notfound

   Extending case 4 to any path where `notfound` is the file/base name.


##### Background for part 1

Previously used RCLONE_CONFIG="/notfound", assuming it was path to a non-existant file. Then at some point in time (quite recently) we started detecting this, as well as empty string and os null device, as an indicator of memory-only config. On most platforms the tests therefore automatically started to run with memory-only config. But on Windows the tests are run from Git (MSYS2) bash, which convertes the "/" into its internal filesystem root being the Git (MSYS2) installation directory. This means on Windows, the tests are now run with config path `C:/Program Files/Git/notfound`. No big deal, but its a discrepancy between tests run on Windows and Unix platforms, and also it is a bit confusing since the configured "reserved name" /notfound now is easily mistaken for a memory-only config.

##### Background for part 2

While doing part 1 another problem came up, due to the facts:

- /notfound does not work from Git/MSYS2 bash because it convertes the "/" into its internal filesystem root being the Git/ MSYS2 installation directory, and therefore rclone gets an absolute path which is not at the root and does not catch this as the memory-only identifier.
- Null device name is different on Windows and Linux.
- Environment variable cannot be set to empty string on Windows, there is no difference between unset variable and empty string variable.

The result of all this is that one cannot enable memory only config by setting environment variable RCLONE_CONFIG from a command that are executed on both Linux and on Windows via Git/MSYS2 bash... Which is exactly what I tried to do in the above mentioned PR, changing rclone's makefile for running the quick tests into using memory only config.

Fixed by checking any path where `notfound` is the file/base name, not just absolute path from root.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/pull/5223#issuecomment-817974404

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
