### PR TITLE
Don't Open Browser when Google Drive Service Account Credentials Specified

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -199,7 +199,7 @@ func init() {
 				m.Set("root_folder_id", "appDataFolder")
 			}
 
-			if opt.ServiceAccountFile == "" {
+			if opt.ServiceAccountFile == "" && opt.ServiceAccountCredentials == "" {
 				err = oauthutil.Config(ctx, "drive", name, m, driveConfig, nil)
 				if err != nil {
 					log.Fatalf("Failed to configure token: %v", err)


### PR DESCRIPTION
Fixes #5104

#### What is the purpose of this change?

rClone opens Browser when Service Account Credential is given which is Not Required. The same doesn't happens when Service Account File is given. This PR is supposed to fix this.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/5104

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
