### PR TITLE
GitHub issue templates: Add GH Etiquette.

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug.md
+++ b/.github/ISSUE_TEMPLATE/Bug.md
@@ -37,6 +37,14 @@ The Rclone Developers
 
 -->
 
+<!--- Please keep the note below for others who read your bug report. -->
+
+### How to use GitHub
+
+* Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you are affected by the same issue.
+* Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
+* Subscribe to receive notifications on status change and new comments.
+
 
 #### The associated forum post URL from `https://forum.rclone.org`
 

--- a/.github/ISSUE_TEMPLATE/Feature.md
+++ b/.github/ISSUE_TEMPLATE/Feature.md
@@ -26,6 +26,14 @@ The Rclone Developers
 
 -->
 
+<!--- Please keep the note below for others who read your feature request. -->
+
+### How to use GitHub
+
+* Please use the 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to show that you are affected by the same issue.
+* Please don't comment if you have no relevant information to add. It's just extra noise for everyone subscribed to this issue.
+* Subscribe to receive notifications on status change and new comments.
+
 
 #### The associated forum post URL from `https://forum.rclone.org`
 


### PR DESCRIPTION
### Forum post
https://forum.rclone.org/t/issue-templates-sthap-1-me-tooing/23667  
@jtagcat:
Nextcloud has this at the top of issue templates:
_code snippet, see git diff_
Thoughts on adding something similar to the rclone repo? I'd add a link to the forum, maybe even https://forum.rclone.org/t/how-to-ask-for-assistance/8379.

While going through issues, there's just so many 'looks long and seems to have something important', but is yet an another '+1 me too'. (example: [#1778: iCloud](https://github.com/rclone/rclone/issues/1778))

There might be possible pushback, discouraging contributions? Thoughts?

@ncw:
That is an interesting idea. I wish GitHub could let us put a bit of boiler plate on each issue, but this seems like a good idea.

Please open a new issue on Github and we can discuss this further.

### What will this add?

Making a PR that can be edited, and as a boilerplate, instead of an issue.

 - Should a link to the forums be included in both, only feature req, or neither? 3 points is just enough to be brief, and not looking like too much to read.
 - I'd say 'how to use' sets the conversation up as offensive. 'GitHub etiquette' sounds better to me.


### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~
- [ ] ~~I have added documentation for the changes if appropriate.~~
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
