### PR TITLE
backend/tardigrade: use negative offset

### DIFF
--- a/backend/tardigrade/object.go
+++ b/backend/tardigrade/object.go
@@ -148,13 +148,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (_ io.ReadC
 			case s && !e:
 				offset = opt.Start
 			case !s && e:
-				object, err := o.fs.project.StatObject(ctx, bucketName, bucketPath)
-				if err != nil {
-					return nil, err
-				}
-
-				offset = object.System.ContentLength - opt.End
-				length = opt.End
+				offset = -opt.End
 			}
 		case *fs.SeekOption:
 			offset = opt.Offset


### PR DESCRIPTION
#### What is the purpose of this change?

v1.4.6 of uplink allows us to do a negative offset from the end of the
file. This removes a round trip when requesting the last N bytes of a
file.

Previous to v1.4.6 of uplink it wasn't possible to do a negative offset
on download. This meant that to fulfill the semantics of http range
headers it was necessary to first fetch the size of the object via a
stat call and compute absolute offset and length.

#### Was the change discussed in an issue or in the forum before?

No, but it was mentioned in a previous PR

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
