### PR TITLE
b2: don't include the bucket name in public link file prefixes

### DIFF
--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -1353,7 +1353,7 @@ func (f *Fs) getDownloadAuthorization(ctx context.Context, bucket, remote string
 	}
 	var request = api.GetDownloadAuthorizationRequest{
 		BucketID:               bucketID,
-		FileNamePrefix:         f.opt.Enc.FromStandardPath(path.Join(f.root, remote)),
+		FileNamePrefix:         f.opt.Enc.FromStandardPath(path.Join(f.rootDirectory, remote)),
 		ValidDurationInSeconds: validDurationInSeconds,
 	}
 	var response api.GetDownloadAuthorizationResponse


### PR DESCRIPTION
#### What is the purpose of this change?

Including the bucket name as part of the `fileNamePrefix` passed to
`b2_get_download_authorization` results in a link valid for objects that
have the bucket name as part of the object path; e.g.,

    rclone link :b2:some-bucket/some-file

would result in a public link valid for the object
`some-bucket/some-file` in the `some-bucket` bucket (in rclone-remote
parlance, `:b2:some-bucket/some-bucket/some-file`). This will almost
certainly result in a broken link.

The B2 docs don't explicitly specify this behavior, but the example
given for `fileNamePrefix` provides some clarification.

See https://www.backblaze.com/b2/docs/b2_get_download_authorization.html.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

- - -
I'm not sure if it's worth it to try to add tests for this? B2 will happily mint a token for files/directories that don't exist. The simple way to test would be to have the `PublicLink` test try to download the file using the link (without authentication), but I'm not sure that will work for all backends.

I got impatient running all of the fstests, so I ended up just running the public link tests:
```
$ go test -run TestIntegration/FsMkdir/FsPutFiles/PublicLink -v
=== RUN   TestIntegration
    fstests.go:418: Using remote "TestB2:"
=== RUN   TestIntegration/FsMkdir
=== RUN   TestIntegration/FsMkdir/FsPutFiles
=== RUN   TestIntegration/FsMkdir/FsPutFiles/PublicLink
--- PASS: TestIntegration (5.80s)
    --- PASS: TestIntegration/FsMkdir (4.93s)
        --- PASS: TestIntegration/FsMkdir/FsPutFiles (4.12s)
            --- PASS: TestIntegration/FsMkdir/FsPutFiles/PublicLink (2.46s)
PASS
ok  	github.com/rclone/rclone/backend/b2	5.804
```

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

I did some searching, and the only thing I found that looked like it may be related is https://forum.rclone.org/t/i-cant-figure-it-out-how-to-use-b2-download-auth-duration/14494.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist


- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate. (n/a - see above)
- [x] I have added documentation for the changes if appropriate. (n/a)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
