### PR TITLE
s3: pre-fetch object options before update - fixes #5243

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -3264,6 +3264,30 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	if o.fs.opt.StorageClass != "" {
 		req.StorageClass = &o.fs.opt.StorageClass
 	}
+
+	// Before apply options, pre-fetch current values
+	if headResp, err := o.headObject(ctx); err != nil {
+		if !errors.Is(err, fs.ErrorObjectNotFound) {
+			return err
+		}
+	} else {
+		if headResp.CacheControl != nil {
+			req.CacheControl = headResp.CacheControl
+		}
+		if headResp.ContentDisposition != nil {
+			req.ContentDisposition = headResp.ContentDisposition
+		}
+		if headResp.ContentEncoding != nil {
+			req.ContentEncoding = headResp.ContentEncoding
+		}
+		if headResp.ContentLanguage != nil {
+			req.ContentLanguage = headResp.ContentLanguage
+		}
+		if headResp.ContentType != nil {
+			req.ContentType = headResp.ContentType
+		}
+	}
+
 	// Apply upload options
 	for _, option := range options {
 		key, value := option.Header()


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
Get and set the current options with headObject to prevent the options from being wiped.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
#5243 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
