### PR TITLE
restic: refactor to use lib/http

### DIFF
--- a/cmd/serve/restic/restic_appendonly_test.go
+++ b/cmd/serve/restic/restic_appendonly_test.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
 	"github.com/rclone/rclone/cmd"
-	"github.com/rclone/rclone/cmd/serve/httplib/httpflags"
 	"github.com/rclone/rclone/fs/config/configfile"
 	"github.com/stretchr/testify/require"
 )
@@ -128,10 +128,12 @@ func TestResticHandler(t *testing.T) {
 
 	// make a new file system in the temp dir
 	f := cmd.NewFsSrc([]string{tempdir})
-	srv := NewServer(f, &httpflags.Opt)
+	srv := newServer(f)
+	router := chi.NewRouter()
+	srv.Bind(router)
 
 	// create the repo
-	checkRequest(t, srv.ServeHTTP,
+	checkRequest(t, router.ServeHTTP,
 		newRequest(t, "POST", "/?create=true", nil),
 		[]wantFunc{wantCode(http.StatusOK)})
 
@@ -139,7 +141,7 @@ func TestResticHandler(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			for i, seq := range test.seq {
 				t.Logf("request %v: %v %v", i, seq.req.Method, seq.req.URL.Path)
-				checkRequest(t, srv.ServeHTTP, seq.req, seq.want)
+				checkRequest(t, router.ServeHTTP, seq.req, seq.want)
 			}
 		})
 	}

--- a/cmd/serve/restic/restic_appendonly_test.go
+++ b/cmd/serve/restic/restic_appendonly_test.go
@@ -128,7 +128,7 @@ func TestResticHandler(t *testing.T) {
 
 	// make a new file system in the temp dir
 	f := cmd.NewFsSrc([]string{tempdir})
-	srv := newServer(f)
+	srv := newService(f)
 	router := chi.NewRouter()
 	srv.Bind(router)
 

--- a/cmd/serve/restic/restic_privaterepos_test.go
+++ b/cmd/serve/restic/restic_privaterepos_test.go
@@ -1,7 +1,6 @@
 package restic
 
 import (
-	"context"
 	"crypto/rand"
 	"io"
 	"io/ioutil"
@@ -10,17 +9,16 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/rclone/rclone/cmd/serve/httplib"
-
+	"github.com/go-chi/chi/v5"
 	"github.com/rclone/rclone/cmd"
-	"github.com/rclone/rclone/cmd/serve/httplib/httpflags"
+	"github.com/rclone/rclone/lib/http/auth"
 	"github.com/stretchr/testify/require"
 )
 
 // newAuthenticatedRequest returns a new HTTP request with the given params.
-func newAuthenticatedRequest(t testing.TB, method, path string, body io.Reader) *http.Request {
+func newAuthenticatedRequest(t testing.TB, method, path string, body io.Reader, user, pass string) *http.Request {
 	req := newRequest(t, method, path, body)
-	req = req.WithContext(context.WithValue(req.Context(), httplib.ContextUserKey, "test"))
+	req.SetBasicAuth(user, pass)
 	req.Header.Add("Accept", resticAPIV2)
 	return req
 }
@@ -43,40 +41,51 @@ func TestResticPrivateRepositories(t *testing.T) {
 
 	// globally set private-repos mode & test user
 	prev := privateRepos
-	prevUser := httpflags.Opt.BasicUser
-	prevPassword := httpflags.Opt.BasicPass
+	prevUser := auth.Opt.BasicUser
+	prevPassword := auth.Opt.BasicPass
 	privateRepos = true
-	httpflags.Opt.BasicUser = "test"
-	httpflags.Opt.BasicPass = "password"
+	auth.Opt.BasicUser = "test"
+	auth.Opt.BasicPass = "password"
 	// reset when done
 	defer func() {
 		privateRepos = prev
-		httpflags.Opt.BasicUser = prevUser
-		httpflags.Opt.BasicPass = prevPassword
+		auth.Opt.BasicUser = prevUser
+		auth.Opt.BasicPass = prevPassword
 	}()
 
 	// make a new file system in the temp dir
 	f := cmd.NewFsSrc([]string{tempdir})
-	srv := NewServer(f, &httpflags.Opt)
+	srv := newServer(f)
+	router := chi.NewRouter()
+	srv.Bind(router)
 
 	// Requesting /test/ should allow access
 	reqs := []*http.Request{
-		newAuthenticatedRequest(t, "POST", "/test/?create=true", nil),
-		newAuthenticatedRequest(t, "POST", "/test/config", strings.NewReader("foobar test config")),
-		newAuthenticatedRequest(t, "GET", "/test/config", nil),
+		newAuthenticatedRequest(t, "POST", "/test/?create=true", nil, auth.Opt.BasicUser, auth.Opt.BasicPass),
+		newAuthenticatedRequest(t, "POST", "/test/config", strings.NewReader("foobar test config"), auth.Opt.BasicUser, auth.Opt.BasicPass),
+		newAuthenticatedRequest(t, "GET", "/test/config", nil, auth.Opt.BasicUser, auth.Opt.BasicPass),
 	}
 	for _, req := range reqs {
-		checkRequest(t, srv.ServeHTTP, req, []wantFunc{wantCode(http.StatusOK)})
+		checkRequest(t, router.ServeHTTP, req, []wantFunc{wantCode(http.StatusOK)})
+	}
+
+	// Requesting with bad credentials should raise unauthorised errors
+	reqs = []*http.Request{
+		newRequest(t, "GET", "/test/config", nil),
+		newAuthenticatedRequest(t, "GET", "/test/config", nil, auth.Opt.BasicUser, ""),
+	}
+	for _, req := range reqs {
+		checkRequest(t, router.ServeHTTP, req, []wantFunc{wantCode(http.StatusUnauthorized)})
 	}
 
 	// Requesting everything else should raise forbidden errors
 	reqs = []*http.Request{
-		newAuthenticatedRequest(t, "GET", "/", nil),
-		newAuthenticatedRequest(t, "POST", "/other_user", nil),
-		newAuthenticatedRequest(t, "GET", "/other_user/config", nil),
+		newAuthenticatedRequest(t, "GET", "/", nil, auth.Opt.BasicUser, auth.Opt.BasicPass),
+		newAuthenticatedRequest(t, "POST", "/other_user", nil, auth.Opt.BasicUser, auth.Opt.BasicPass),
+		newAuthenticatedRequest(t, "GET", "/other_user/config", nil, auth.Opt.BasicUser, auth.Opt.BasicPass),
 	}
 	for _, req := range reqs {
-		checkRequest(t, srv.ServeHTTP, req, []wantFunc{wantCode(http.StatusForbidden)})
+		checkRequest(t, router.ServeHTTP, req, []wantFunc{wantCode(http.StatusForbidden)})
 	}
 
 }

--- a/cmd/serve/restic/restic_privaterepos_test.go
+++ b/cmd/serve/restic/restic_privaterepos_test.go
@@ -55,7 +55,7 @@ func TestResticPrivateRepositories(t *testing.T) {
 
 	// make a new file system in the temp dir
 	f := cmd.NewFsSrc([]string{tempdir})
-	srv := newServer(f)
+	srv := newService(f)
 	router := chi.NewRouter()
 	srv.Bind(router)
 

--- a/cmd/serve/restic/restic_test.go
+++ b/cmd/serve/restic/restic_test.go
@@ -1,4 +1,4 @@
-// Serve restic tests set up a server and run the integration tests
+// Serve restic tests set up a service and run the integration tests
 // for restic against it.
 
 package restic
@@ -24,7 +24,7 @@ const (
 	resticSource    = "../../../../../restic/restic"
 )
 
-// TestRestic runs the restic server then runs the unit tests for the
+// TestRestic runs the restic service then runs the unit tests for the
 // restic remote against it.
 func TestRestic(t *testing.T) {
 	_, err := os.Stat(resticSource)
@@ -44,8 +44,8 @@ func TestRestic(t *testing.T) {
 	err = fremote.Mkdir(context.Background(), "")
 	assert.NoError(t, err)
 
-	// Start the server
-	w := newServer(fremote)
+	// Start the service
+	w := newService(fremote)
 	l, err := net.Listen("tcp", opt.ListenAddr)
 	if err != nil {
 		t.Fatal(err.Error())

--- a/cmd/serve/restic/restic_utils_test.go
+++ b/cmd/serve/restic/restic_utils_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // declare a few helper functions
@@ -15,11 +14,10 @@ import (
 // wantFunc tests the HTTP response in res and marks the test as errored if something is incorrect.
 type wantFunc func(t testing.TB, res *httptest.ResponseRecorder)
 
-// newRequest returns a new HTTP request with the given params. On error, the
-// test is marked as failed.
+// newRequest returns a new HTTP request with the given params
 func newRequest(t testing.TB, method, path string, body io.Reader) *http.Request {
-	req, err := http.NewRequest(method, path, body)
-	require.NoError(t, err)
+	req := httptest.NewRequest(method, path, body)
+	req.Header.Add("Accept", resticAPIV2)
 	return req
 }
 

--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -86,10 +86,12 @@ var DefaultOpt = Options{
 
 // Server interface of http server
 type Server interface {
-	Router() chi.Router
-	Route(pattern string, fn func(r chi.Router)) chi.Router
 	Mount(pattern string, h http.Handler)
+	Route(pattern string, fn func(r chi.Router)) chi.Router
+	Router() chi.Router
+	Serve()
 	Shutdown() error
+	Wait()
 }
 
 type server struct {
@@ -210,6 +212,7 @@ func NewServer(listeners, tlsListeners []net.Listener, opt Options) (Server, err
 	return &server{addrs, tlsAddrs, listeners, tlsListeners, httpServer, router, wg, useSSL}, nil
 }
 
+// Serve attaches server to registered listeners
 func (s *server) Serve() {
 	serve := func(l net.Listener) {
 		defer s.closing.Done()


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

refactors restic service to use new lib/http library

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/pull/3842

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
