### PR TITLE
lib/http: add default 404 handler

### DIFF
--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -173,6 +173,9 @@ func NewServer(listeners, tlsListeners []net.Listener, opt Options) (Server, err
 	router.MethodNotAllowed(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
 	})
+	router.NotFound(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+	})
 
 	handler := router.(http.Handler)
 	if opt.BaseURL != "" {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Adds a default handler to the base router for the default server to serve a generic 404 message is no route is found

#### Was the change discussed in an issue or in the forum before?

This should have been included in https://github.com/rclone/rclone/pull/3842

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
