### PR TITLE
feat: Add ResumableUpload interface

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1847,7 +1847,7 @@ func (f *Fs) ListR(ctx context.Context, dir string, callback fs.ListRCallback) (
 
 	// Send the entry to the caller, queueing any directories as new jobs
 	cb := func(entry fs.DirEntry) error {
-		if d, isDir := entry.(*fs.Dir); isDir {
+		if d, isDir := entry.(fs.Dir); isDir {
 			job := listREntry{actualID(d.ID()), d.Remote()}
 			sendJob(job)
 		}

--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -669,8 +669,8 @@ func (f *Fs) findSharedFolder(ctx context.Context, name string) (id string, err 
 		return "", err
 	}
 	for _, entry := range entries {
-		if entry.(*fs.Dir).Remote() == name {
-			return entry.(*fs.Dir).ID(), nil
+		if entry.(fs.Dir).Remote() == name {
+			return entry.(fs.Dir).ID(), nil
 		}
 	}
 	return "", fs.ErrorDirNotFound

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -24,6 +25,7 @@ import (
 	"github.com/rclone/rclone/fs/config/configstruct"
 	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/hash"
+	"github.com/rclone/rclone/fs/resumable"
 	"github.com/rclone/rclone/lib/encoder"
 	"github.com/rclone/rclone/lib/file"
 	"github.com/rclone/rclone/lib/readers"
@@ -1275,6 +1277,81 @@ func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.Wr
 	return out, nil
 }
 
+const uploadDir = ".%!%uploads%!%/"   // TODO make configurable
+const uploadLifetime = time.Hour * 24 // TODO make configurable
+
+// Concat implements fs.Concatenator interface
+func (f *Fs) Concat(ctx context.Context, fragments fs.Objects, remote string) (fs.Object, error) {
+	var totalSize int64 = 0
+	modTime := fragments[0].ModTime(ctx)
+	fragmentReaders := make([]io.Reader, len(fragments))
+
+	defer func() {
+		// Close open fragmentReaders
+		for _, reader := range fragmentReaders {
+			if reader, ok := reader.(io.ReadCloser); ok {
+				_ = reader.Close()
+			}
+		}
+	}()
+
+	// Aggregate fragment properties and fragment readers
+	for i, fragment := range fragments {
+		totalSize += fragment.Size()
+		fmodTime := fragment.ModTime(ctx)
+		if modTime.Before(fmodTime) {
+			// Use most recent modification time
+			modTime = fmodTime
+		}
+		reader, err := fragment.Open(ctx)
+		if err != nil {
+			return nil, err
+		}
+		fragmentReaders[i] = reader
+	}
+
+	// Create temporary Object to act as unified src
+	src := &Object{
+		fs:      f, // TODO does it matter if fragments fs != f?
+		remote:  remote,
+		size:    totalSize,
+		modTime: modTime,
+	}
+
+	return f.Put(ctx, io.MultiReader(fragmentReaders...), src)
+}
+
+// ResumableUpload implements fs.ResumableUploader interface
+func (f *Fs) ResumableUpload(ctx context.Context, remoteURL string) (fs.Uploader, string, error) {
+	parsedPath, err := url.Parse(remoteURL)
+	if err != nil {
+		return nil, remoteURL, err
+	}
+	dir := path.Join(uploadDir, parsedPath.Path)
+	err = f.Mkdir(ctx, dir)
+	if err != nil {
+		return nil, remoteURL, err
+	}
+
+	// Update mtime of all folders in path for cleanup
+	now := time.Now()
+	current := uploadDir
+	for _, d := range strings.Split(parsedPath.Path, "/") {
+		current = path.Join(current, d)
+		_ = os.Chtimes(f.localPath(current), now, now)
+	}
+
+	return resumable.NewConcatUploader(parsedPath.Path, dir, f, ctx), remoteURL, err
+}
+
+func (f *Fs) ResumableCleanup(ctx context.Context) error {
+	entries, err := f.List(ctx, uploadDir)
+	if err != nil {
+		return err
+	}
+	return resumable.CleanUploads(ctx, f, entries, uploadLifetime)
+}
+
 // setMetadata sets the file info from the os.FileInfo passed in
 func (o *Object) setMetadata(info os.FileInfo) {
 	// if not checking updated then don't update the stat
@@ -1343,12 +1420,14 @@ func cleanRootPath(s string, noUNC bool, enc encoder.MultiEncoder) string {
 
 // Check the interfaces are satisfied
 var (
+	_ fs.Commander      = &Fs{}
+	_ fs.Concatenator   = &Fs{}
+	_ fs.DirMover       = &Fs{}
 	_ fs.Fs             = &Fs{}
+	_ fs.Mover          = &Fs{}
+	_ fs.OpenWriterAter = &Fs{}
 	_ fs.Purger         = &Fs{}
 	_ fs.PutStreamer    = &Fs{}
-	_ fs.Mover          = &Fs{}
-	_ fs.DirMover       = &Fs{}
-	_ fs.Commander      = &Fs{}
-	_ fs.OpenWriterAter = &Fs{}
+	_ fs.ResumableUploader = &Fs{}
 	_ fs.Object         = &Object{}
 )

--- a/backend/s3/concat.go
+++ b/backend/s3/concat.go
@@ -1,0 +1,266 @@
+package s3
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"path"
+	"strconv"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/operations"
+)
+
+const uploadDir = ".%!%uploads%!%"    // TODO make configurable
+const uploadLifetime = time.Hour * 24 // TODO make configurable
+
+func (f *Fs) uploadFragment(ctx context.Context, fragment fs.Object, bucket, bucketPath string, partNumber int64, uploadID *string) (*s3.CompletedPart, error) {
+	return f.uploadFragmentRange(ctx, fragment, bucket, bucketPath, partNumber, uploadID, 0, 0)
+}
+
+func (f *Fs) uploadFragmentRange(ctx context.Context, fragment fs.Object, bucket, bucketPath string, partNumber int64, uploadID *string, start, end uint64) (*s3.CompletedPart, error) {
+	// TODO If fragment can be directly transferred between backends, stage the object in the .%!%uploads%!% folder on the target backend (use f.Copy())
+	if operations.Same(fragment.Fs(), f) { // If fragment is on same backend, just pass a reference
+		var sourceRange *string = nil
+		if start != 0 || end != 0 {
+			if start != 0 && end == 0 {
+				end = uint64(fragment.Size()) - 1
+			}
+			tmp := fmt.Sprintf("bytes=%d-%d", start, end)
+			sourceRange = &tmp
+		}
+		part, err := f.c.UploadPartCopy(&s3.UploadPartCopyInput{
+			Bucket:          aws.String(bucket),
+			CopySource:      aws.String(fragment.Remote()),
+			CopySourceRange: sourceRange,
+			Key:             aws.String(bucketPath),
+			PartNumber:      aws.Int64(partNumber),
+			UploadId:        uploadID,
+		})
+		if err != nil {
+			return nil, err
+		}
+		return &s3.CompletedPart{ETag: part.CopyPartResult.ETag, PartNumber: aws.Int64(partNumber)}, nil
+	} else { // else stream data from fragment backend
+		body, err := fragment.Open(ctx)
+		if err != nil {
+			return nil, err
+		}
+		if start != 0 {
+			_, err := io.CopyN(ioutil.Discard, body, int64(start))
+			if err != nil {
+				return nil, err
+			}
+		}
+		stream := body.(io.Reader)
+		if end != 0 {
+			stream = io.LimitReader(body, int64(end-start))
+		}
+		part, err := f.c.UploadPart(&s3.UploadPartInput{
+			Bucket:     aws.String(bucket),
+			Body:       aws.ReadSeekCloser(stream),
+			Key:        aws.String(bucketPath),
+			PartNumber: aws.Int64(partNumber),
+			UploadId:   uploadID,
+		})
+		err = body.Close()
+		if err != nil {
+			return nil, err
+		}
+		return &s3.CompletedPart{ETag: part.ETag, PartNumber: aws.Int64(partNumber)}, nil
+	}
+}
+
+func (f *Fs) Concat(ctx context.Context, fragments fs.Objects, remote string) (fs.Object, error) {
+	if len(fragments) == 0 {
+		return nil, errors.New("no fragments to concatenate")
+	}
+	if len(fragments) == 1 {
+		return fragments[0], nil
+	}
+
+	// Keep track of intermediate fragments
+	tmpFragments := make(fs.Objects, len(fragments))
+	tmpFragmentCount := uint64(0)
+	defer func() { // defer runs LIFO and this will be executed after completing the upload below
+		// Clean up temporary fragments
+		for i := uint64(0); i < tmpFragmentCount; i++ {
+			_ = tmpFragments[i].Remove(ctx)
+		}
+	}()
+
+	if maxUploadParts > 0 {
+		fragLen := uint64(len(fragments))
+		if fragLen > maxUploadParts {
+			// Handle more than maxUploadParts
+			bucket, bucketPath, err := f.makeUploadBucket(ctx)
+			if err != nil {
+				return nil, err
+			}
+			for fragLen > maxUploadParts {
+				manyFragments := fragments
+				chunks := fragLen / maxUploadParts
+				remainder := fragLen % maxUploadParts
+				fragments = make(fs.Objects, chunks+remainder)
+				for i := uint64(0); i < chunks; i++ {
+					cat := path.Join(bucket, bucketPath, remote, "concat_"+strconv.FormatUint(i, 10))
+					toMerge := manyFragments[i*maxUploadParts : (i+1)*maxUploadParts]
+					fragments[i], err = f.Concat(ctx, toMerge, cat)
+					tmpFragments[tmpFragmentCount] = fragments[i]
+					tmpFragmentCount++
+					if err != nil {
+						return nil, err
+					}
+				}
+				copy(fragments[chunks:], manyFragments[fragLen-remainder:])
+				fragLen = uint64(len(fragments))
+			}
+		}
+	}
+
+	o := &Object{
+		fs:     f,
+		remote: remote,
+	}
+	result := o
+	bucket, bucketPath := o.split()
+	err := o.fs.makeBucket(ctx, bucket)
+	if err != nil {
+		return nil, err
+	}
+
+	expires := time.Now().Add(uploadLifetime)
+	upload, err := f.c.CreateMultipartUpload(&s3.CreateMultipartUploadInput{
+		Bucket:  aws.String(bucket),
+		Key:     aws.String(bucketPath),
+		Expires: &expires,
+	})
+	if err != nil {
+		return nil, err
+	}
+	parts := make([]*s3.CompletedPart, len(fragments))
+	partCount := int64(0)
+	defer func() {
+		// Complete or abort upload
+		if err == nil && partCount > 0 {
+			_, err = f.c.CompleteMultipartUpload(&s3.CompleteMultipartUploadInput{
+				Bucket: aws.String(bucket),
+				Key:    aws.String(bucketPath),
+				MultipartUpload: &s3.CompletedMultipartUpload{
+					Parts: parts[:partCount],
+				},
+				UploadId: upload.UploadId,
+			})
+		} else {
+			_, _ = f.c.AbortMultipartUpload(&s3.AbortMultipartUploadInput{
+				Bucket:   aws.String(bucket),
+				Key:      aws.String(bucketPath),
+				UploadId: upload.UploadId,
+			})
+		}
+	}()
+
+	for i := 0; i < len(fragments); i++ {
+		missing := int64(minChunkSize) - fragments[i].Size()
+		if minChunkSize > 0 && missing > 0 {
+			// Handle fragments less than minChunkSize
+			if i == 0 { // if first part too small
+				// Stream chunks until big enough
+				readClosers := make([]io.ReadCloser, 0)
+				for ; missing > 0 && i < len(fragments); i++ {
+					readCloser, err := fragments[i].Open(ctx)
+					if err != nil {
+						break
+					}
+					if fragments[i].Size() > int64(minChunkSize)+missing { // should always be false for i == 0
+						// steal range from next to avoid streaming entire next fragment
+						readClosers = append(readClosers, io.LimitReader(readCloser, missing).(io.ReadCloser))
+
+						parts[partCount+1], err = f.uploadFragmentRange(ctx, fragments[i], bucket, bucketPath, partCount+1, upload.UploadId, uint64(missing), 0)
+						// partCount will be incremented below
+						if err != nil {
+							break
+						}
+					} else {
+						readClosers = append(readClosers, readCloser)
+					}
+					missing -= fragments[i].Size()
+				}
+
+				if missing > 0 {
+					err = errors.New("total concatenated size is smaller than minimum")
+				}
+
+				if err == nil {
+					// Convert to []io.Reader
+					readers := make([]io.Reader, len(readClosers)+1)
+					for j, reader := range readClosers {
+						readers[j] = reader
+					}
+					part, e := f.c.UploadPart(&s3.UploadPartInput{
+						Bucket:     aws.String(bucket),
+						Body:       aws.ReadSeekCloser(io.MultiReader(readers...)),
+						Key:        aws.String(bucketPath),
+						PartNumber: aws.Int64(partCount),
+						UploadId:   upload.UploadId,
+					})
+					err = e
+					if part != nil {
+						parts[partCount] = &s3.CompletedPart{ETag: part.ETag, PartNumber: aws.Int64(partCount)}
+						partCount++
+						if parts[partCount] != nil {
+							// Catch up partCount if a range from the next fragment was taken
+							partCount++
+						}
+					}
+				}
+
+				// Close all streams
+				for _, reader := range readClosers {
+					e := reader.Close()
+					if err != nil { // Continue closing but preserve error. Hopefully it is the same error if multiple.
+						err = e
+					}
+				}
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				// Exploit last part no minimum
+				cat := path.Join(bucket, bucketPath, remote, "merge_"+strconv.Itoa(i))
+				toMerge := fs.Objects{fragments[i], fragments[i+1]}
+				tmpFragment, err := f.Concat(ctx, toMerge, cat)
+				if err != nil {
+					return nil, err
+				}
+				tmpFragments[tmpFragmentCount] = tmpFragment
+				tmpFragmentCount++
+				part, err := f.c.UploadPartCopy(&s3.UploadPartCopyInput{
+					Bucket:     aws.String(bucket),
+					CopySource: aws.String(tmpFragment.Remote()),
+					Key:        aws.String(bucketPath),
+					PartNumber: aws.Int64(partCount),
+					UploadId:   upload.UploadId,
+				})
+				if err != nil {
+					return nil, err
+				}
+				parts[partCount] = &s3.CompletedPart{ETag: part.CopyPartResult.ETag, PartNumber: aws.Int64(partCount)}
+				partCount++
+				i++ // Two fragments consumed, increment an extra time
+			}
+		} else {
+			parts[partCount], err = f.uploadFragment(ctx, fragments[i], bucket, bucketPath, int64(partCount), upload.UploadId)
+			partCount++
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	return result, nil
+}

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -932,6 +932,27 @@ func (ft *Features) WrapsFs(f Fs, w Fs) *Features {
 	return ft
 }
 
+// Uploader describes a resumable upload
+type Uploader interface {
+	io.WriteCloser
+	Pos() (int64, bool)  // position we have got to in the upload
+	Size() (int64, bool) // final size of the upload
+	SetSize(int64) error // Set the final size of the upload, must be called before Pos() == Size(). Calling multiple times has undefined behavior.
+	Abort() error        // abort the upload
+	Expires() time.Time  // the time the upload expires or nil if never
+}
+
+// ResumableUploader describes how to start or resume a resumable upload
+type ResumableUploader interface {
+	ResumableUpload(ctx context.Context, path string) (uploader Uploader, newPath string, err error) // Start or continue an existing upload to path. path is a uri encoded remote path that can include a RFC3986 query string
+	ResumableCleanup(ctx context.Context) error                                                      // Clean up expired incomplete uploads
+}
+
+// Concatenator is an optional interface for Fs
+type Concatenator interface {
+	Concat(ctx context.Context, fragments Objects, remote string) (Object, error) // Concatenate to remote path
+}
+
 // Purger is an optional interfaces for Fs
 type Purger interface {
 	// Purge all files in the directory specified

--- a/fs/resumable/concatreader.go
+++ b/fs/resumable/concatreader.go
@@ -1,0 +1,55 @@
+package resumable
+
+import (
+	"context"
+	"io"
+
+	"github.com/rclone/rclone/fs"
+)
+
+type concatReader struct {
+	objects fs.Objects
+	reader  io.ReadCloser
+	index   int
+	ctx     context.Context
+}
+
+// NewConcatReader returns an io.ReadCloser that streams the concatenated content of the provided objects
+// This is very similar to the functionality of the cat POSIX tool.
+func NewConcatReader(ctx context.Context, objects fs.Objects) io.ReadCloser {
+	return &concatReader{
+		objects: objects,
+		reader:  nil,
+		index:   0,
+		ctx:     ctx,
+	}
+}
+
+// Read implements io.ReadCloser
+func (c *concatReader) Read(p []byte) (n int, err error) {
+	if c.reader == nil {
+		if c.index >= len(c.objects) {
+			return 0, io.EOF
+		}
+		c.reader, err = c.objects[c.index].Open(c.ctx)
+		if err != nil {
+			return
+		}
+	}
+	n, err = c.reader.Read(p)
+	if err == io.EOF {
+		c.index++
+		err = c.reader.Close()
+		c.reader = nil
+	}
+	return
+}
+
+// Close implements io.ReadCloser
+func (c *concatReader) Close() (err error) {
+	if c.reader != nil {
+		err = c.reader.Close()
+		c.reader = nil
+	}
+	return
+}

--- a/fs/resumable/concatuploader.go
+++ b/fs/resumable/concatuploader.go
@@ -20,7 +20,7 @@ type ConcatenatorFs interface {
 
 // NewConcatUploader returns an fs.Uploader that is able to receive upload chunks which are then concatenated upon completion
 func NewConcatUploader(remote, uploadDir string, f ConcatenatorFs, ctx context.Context) fs.Uploader {
-	self := &concatUploader{fragmentUploader{nil, remote, uploadDir, f, ctx, []io.Reader{}, 0, -1}, f}
+	self := &concatUploader{fragmentUploader{nil, remote, uploadDir, f, ctx, []io.Reader{}, 0, -1, 0, nil}, f}
 	self.self = self
 	return self
 }

--- a/fs/resumable/concatuploader.go
+++ b/fs/resumable/concatuploader.go
@@ -1,0 +1,37 @@
+package resumable
+
+import (
+	"context"
+	"io"
+
+	"github.com/rclone/rclone/fs"
+)
+
+type concatUploader struct {
+	fragmentUploader
+	fs ConcatenatorFs
+}
+
+// ConcatenatorFs represents a fs.Fs that implements the fs.Concatenator interface
+type ConcatenatorFs interface {
+	fs.Fs
+	fs.Concatenator
+}
+
+// NewConcatUploader returns an fs.Uploader that is able to receive upload chunks which are then concatenated upon completion
+func NewConcatUploader(remote, uploadDir string, f ConcatenatorFs, ctx context.Context) fs.Uploader {
+	self := &concatUploader{fragmentUploader{nil, remote, uploadDir, f, ctx, []io.Reader{}, 0, -1}, f}
+	self.self = self
+	return self
+}
+
+func (u *concatUploader) finish(fragments fs.Objects) error {
+	_, err := u.fs.Concat(u.ctx, fragments, u.remote)
+	return err
+}
+
+// Check interfaces
+var (
+	_ FragmentUploader = (*concatUploader)(nil)
+	_ fs.Uploader      = (*concatUploader)(nil)
+)

--- a/fs/resumable/fallbackuploader.go
+++ b/fs/resumable/fallbackuploader.go
@@ -1,0 +1,174 @@
+package resumable
+
+import (
+	"context"
+	"io"
+	"path"
+	"strconv"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/lib/errors"
+)
+
+type fallbackUploader struct {
+	fragmentUploader
+	fallbackUploadDir     string
+	fallbackFs            fs.Fs
+	minSize, maxFragments int64
+	partialFallback       bool // partialFallback is manipulated to force flush(), uploadDirContents(), and binPath() to use parent implementation
+}
+
+// NewFallbackUploader returns an fs.Uploader that stages upload chunks to an alternate fs.Fs while uploading. Upon completion
+// the chunks are concatenated and streamed to the target fs.Fs
+func NewFallbackUploader(remote, uploadDir, fallbackUploadDir string, fs_, fallbackFs fs.Fs, ctx context.Context, minSize, maxFragments int64) fs.Uploader {
+	_, concatable := fs_.(ConcatenatorFs)
+	self := &fallbackUploader{
+		fragmentUploader{
+			nil,
+			remote,
+			uploadDir,
+			fs_,
+			ctx,
+			[]io.Reader{},
+			0,
+			-1,
+		},
+		fallbackUploadDir,
+		fallbackFs,
+		minSize,
+		maxFragments,
+		concatable,
+	}
+	self.self = self
+	return self
+}
+
+func (f *fallbackUploader) uploadDirContents() (entries fs.DirEntries, fs fs.Fs, err error) {
+	if f.partialFallback {
+		fs = f.fallbackFs
+		entries, err = fs.List(f.ctx, f.fallbackUploadDir)
+		return
+	} else {
+		return f.fragmentUploader.uploadDirContents()
+	}
+}
+
+func (f *fallbackUploader) Pos() (pos int64, ok bool) {
+	if f.partialFallback {
+		var fallbackPos int64
+		fallbackPos, ok = f.fragmentUploader.Pos()
+		if !ok {
+			return
+		}
+		f.partialFallback = false
+		pos, ok = f.fragmentUploader.Pos()
+		f.partialFallback = true
+		if pos < fallbackPos {
+			pos = fallbackPos
+		}
+		return
+	} else {
+		return f.fragmentUploader.Pos()
+	}
+}
+
+func (f *fallbackUploader) getSizeObject() (fs.Object, error) {
+	if f.partialFallback {
+		return f.fragmentUploader.getSizeObject()
+	} else {
+		return f.fallbackFs.NewObject(f.ctx, path.Join(f.fallbackUploadDir, "size"))
+	}
+}
+
+func (f *fallbackUploader) putSizeObject(data io.Reader, src *uploadSrcObjectInfo) error {
+	if f.partialFallback {
+		return f.fragmentUploader.putSizeObject(data, src)
+	} else {
+		src.remote = path.Join(f.fallbackUploadDir, "size")
+		_, err := f.fallbackFs.Put(f.ctx, data, src)
+		return err
+	}
+}
+
+func (f *fallbackUploader) binPath(bin uint64) string {
+	if f.partialFallback {
+		return f.fragmentUploader.binPath(bin)
+	} else {
+		return path.Join(f.fallbackUploadDir, strconv.FormatUint(bin, 10))
+	}
+}
+
+func (f *fallbackUploader) flush() (bool, error) {
+	if f.partialFallback {
+		defer func() { f.partialFallback = true }()
+		totalFragments := int64(-1)
+		if f.maxFragments > 0 {
+			totalFragments = 0
+			for _, f.partialFallback = range []bool{true, false} { // Total for fallback and main
+				lastDir, _, dirIndex, err := f.lastDir()
+				if err != nil {
+					return false, err
+				}
+				if dirIndex > 0 {
+					totalFragments += (int64(dirIndex) - 1) * MaxFolderCount
+				}
+				totalFragments += lastDir.Items()
+			}
+		}
+		f.partialFallback = false
+		lastFragmentSize := int64(0)
+		if f.minSize > 0 {
+			// Check to make sure the last fragment size on the fallback is big enough to eventually upload otherwise provide fallback with enough contiguous data
+			frag, err := f.lastFragment()
+			if err != nil {
+				return false, err
+			}
+			lastFragmentSize = frag.object.Size()
+		}
+		f.partialFallback = (f.pendingLen >= f.minSize && lastFragmentSize >= f.minSize) && totalFragments < f.maxFragments
+	}
+	return f.fragmentUploader.flush() // the fs that is written to is determined by f.partialFallback
+}
+
+func (f *fallbackUploader) finish(fragments fs.Objects) error {
+	if f.partialFallback {
+		catFs, ok := f.fs.(ConcatenatorFs)
+		if !ok {
+			panic("initial interface check in NewFallbackUploader() for ConcatenatorFs falsely returned true") // Seriously, if this ever gets hit, something went very very wrong
+		}
+		_, err := catFs.Concat(f.ctx, fragments, f.remote)
+		return err
+	}
+
+	// Target Fs doesn't support concat, stream everything
+	size, ok := f.Size()
+	if !ok {
+		return errors.New("finish() called before SetSize() or value can't be recovered")
+	}
+
+	readCloser := NewConcatReader(f.ctx, fragments)
+	defer readCloser.Close()
+
+	_, err := f.fs.Put(f.ctx, readCloser, &uploadSrcObjectInfo{
+		remote: f.remote,
+		size:   size,
+	})
+	return err
+}
+
+func (f *fallbackUploader) Abort() error {
+	err := operations.Purge(f.ctx, f.fallbackFs, f.fallbackUploadDir)
+	if err != nil {
+		_ = f.fragmentUploader.Abort()
+	} else {
+		return f.fragmentUploader.Abort()
+	}
+	return err
+}
+
+// Check interfaces
+var (
+	_ FragmentUploader = (*fallbackUploader)(nil)
+	_ fs.Uploader      = (*fallbackUploader)(nil)
+)

--- a/fs/resumable/fallbackuploader.go
+++ b/fs/resumable/fallbackuploader.go
@@ -33,6 +33,8 @@ func NewFallbackUploader(remote, uploadDir, fallbackUploadDir string, fs_, fallb
 			[]io.Reader{},
 			0,
 			-1,
+			0,
+			nil,
 		},
 		fallbackUploadDir,
 		fallbackFs,

--- a/fs/resumable/fragmentuploader.go
+++ b/fs/resumable/fragmentuploader.go
@@ -1,0 +1,313 @@
+package resumable
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/fspath"
+	"github.com/rclone/rclone/fs/operations"
+)
+
+const MaxFolderCount = 10000 // Some filesystems will struggle or fail if a folder contains more than 10000 files
+
+type FragmentUploader interface {
+	fs.Uploader
+	flush() (bool, error)
+	finish(fs.Objects) error
+	binPath(uint64) string
+	lastDir() (fs.Directory, fs.Fs, uint64, error)
+	uploadDirContents() (fs.DirEntries, fs.Fs, error)
+	getSizeObject() (fs.Object, error)
+	putSizeObject(io.Reader, *uploadSrcObjectInfo) error
+	getAllFragments(fs.Fs, string) ([]*fragment, error)
+	lastFragment() (*fragment, error)
+}
+
+// CleanUploads recursively deletes any entries that have expired
+func CleanUploads(ctx context.Context, f fs.Fs, entries fs.DirEntries, uploadLifetime time.Duration) (err error) {
+	// Recursively delete the upload dir
+	entries.ForDir(func(dir fs.Directory) {
+		// Do not recurse if mTime of parent is expired
+		if dir.ModTime(ctx).Add(uploadLifetime).Before(time.Now()) {
+			e := operations.Purge(ctx, f, dir.Remote())
+			if e != nil {
+				err = e
+			}
+			return
+		}
+		subentries, e := f.List(ctx, dir.Remote())
+		if e != nil {
+			err = e
+			return
+		}
+		e = CleanUploads(ctx, f, subentries, uploadLifetime)
+		if e != nil {
+			err = e
+		}
+	})
+	return
+}
+
+// fragmentUploader abstract base class for other uploaders in this package
+// Extending classes need to provide the finish() method
+type fragmentUploader struct {
+	self       FragmentUploader
+	remote     string
+	uploadDir  string
+	fs         fs.Fs
+	ctx        context.Context
+	pending    []io.Reader
+	pendingLen int64
+	size       int64
+}
+
+type fragment struct {
+	start  int64
+	object fs.Object
+}
+
+func (f *fragmentUploader) Write(p []byte) (n int, err error) {
+	n = len(p)
+	if n == 0 {
+		return
+	}
+	f.pending = append(f.pending, bytes.NewReader(p))
+	f.pendingLen += int64(n)
+	if f.pendingLen >= 2^24 { // 16Mb chunks TODO make configurable
+		err = f.self.Close()
+	}
+	return
+}
+
+func (f *fragmentUploader) uploadDirContents() (entries fs.DirEntries, fs_ fs.Fs, err error) {
+	fs_ = f.fs
+	entries, err = f.fs.List(f.ctx, f.uploadDir)
+	return
+}
+
+func (f *fragmentUploader) lastDir() (fs.Directory, fs.Fs, uint64, error) {
+	var dirIndex uint64
+	entries, fs_, err := f.self.uploadDirContents()
+	if err != nil {
+		return nil, fs_, dirIndex, err
+	}
+	var lastDir fs.Directory
+	entries.ForDir(func(dir fs.Directory) {
+		i, e := strconv.ParseUint(dir.ID(), 10, 64) // TODO .ID() is likely not the correct function to call
+		if e != nil {
+			return
+		}
+		if lastDir == nil || dirIndex < i {
+			lastDir = dir
+			dirIndex = i
+		}
+	})
+	return lastDir, fs_, dirIndex, err
+}
+
+func (f *fragmentUploader) lastFragment() (*fragment, error) {
+	// Get largest file name across all subdirectories in upload dir
+	lastDir, s, _, err := f.self.lastDir()
+	if lastDir == nil || err != nil {
+		return nil, err
+	}
+	entries, err := s.List(f.ctx, lastDir.Remote())
+	if err != nil {
+		return nil, err
+	}
+	pos := int64(-1)
+	var frag *fragment
+	entries.ForObject(func(o fs.Object) {
+		if _, name, err := fspath.Split(o.Remote()); err == nil && name != "" && name[0] != '.' {
+			if start, err := strconv.ParseInt(name, 10, 64); err == nil && pos < (start+o.Size()) {
+				pos = start + o.Size()
+				frag = &fragment{
+					start:  start,
+					object: o,
+				}
+			}
+		}
+	})
+	if pos == -1 {
+		return nil, nil // If no entries found then assume at start
+	}
+	return frag, nil
+}
+
+func (f *fragmentUploader) Pos() (int64, bool) {
+	lastFrag, err := f.self.lastFragment()
+	if lastFrag == nil {
+		return 0, err != nil
+	}
+	return lastFrag.start + lastFrag.object.Size(), true
+}
+
+func (f *fragmentUploader) getSizeObject() (fs.Object, error) {
+	return f.fs.NewObject(f.ctx, path.Join(f.uploadDir, "size"))
+}
+
+func (f *fragmentUploader) Size() (size int64, ok bool) {
+	// Look for and read a file in the upload dir called 'size' that stores the total size of the upload in utf-8 encoded text
+	if f.size > -1 {
+		return f.size, true
+	}
+	ok = false
+	sizeObject, err := f.self.getSizeObject()
+	if err != nil {
+		return
+	}
+	handle, err := sizeObject.Open(f.ctx)
+	if err != nil {
+		return
+	}
+	data := make([]byte, 20)
+	length, err := handle.Read(data)
+	if length == 0 || err != nil {
+		return
+	}
+	size, err = strconv.ParseInt(string(data[:length]), 10, 64)
+	ok = err != nil
+	if ok {
+		f.size = size
+	}
+	return
+}
+
+func (f *fragmentUploader) putSizeObject(data io.Reader, src *uploadSrcObjectInfo) error {
+	_, err := f.fs.Put(f.ctx, data, src)
+	return err
+}
+
+func (f *fragmentUploader) SetSize(size int64) error {
+	if size > 1 {
+		return errors.New("size must be at least 1")
+	}
+	sizeStr := strconv.FormatInt(size, 10)
+	// Create temporary Object
+	src := &uploadSrcObjectInfo{
+		remote: path.Join(f.uploadDir, "size"),
+		size:   int64(len(sizeStr)),
+	}
+	err := f.self.putSizeObject(bytes.NewReader([]byte(sizeStr)), src)
+	f.size = size
+	return err
+}
+
+func (f *fragmentUploader) getAllFragments(fs_ fs.Fs, uploadDir string) ([]*fragment, error) {
+	entries, err := fs_.List(f.ctx, uploadDir)
+	if err != nil {
+		return nil, err
+	}
+
+	var count int64 = 0
+	entries.ForDir(func(dir fs.Directory) {
+		count += dir.Items() // TODO guarantee items() returns >= 0
+	})
+
+	fragments := make([]*fragment, count)
+	var fragI int64 = 0
+	entries.ForDir(func(dir fs.Directory) {
+		subentries, err := fs_.List(f.ctx, dir.Remote())
+		if err != nil {
+			return
+		}
+		subentries.ForObject(func(o fs.Object) {
+			i, e := strconv.ParseInt(o.Remote(), 10, 64)
+			if e == nil {
+				fragments[fragI] = &fragment{i, o}
+				fragI++
+			}
+		})
+	})
+	if fragI != count {
+		err = errors.New("unexpected number of fragments")
+	}
+
+	sort.Slice(fragments, func(i, j int) bool {
+		return fragments[i].start < fragments[j].start
+	})
+
+	return fragments, err
+}
+
+func (f *fragmentUploader) binPath(bin uint64) string {
+	return path.Join(f.uploadDir, strconv.FormatUint(bin, 10))
+}
+
+func (f *fragmentUploader) flush() (bool, error) {
+	pos, ok := f.self.Pos()
+	if !ok {
+		return false, errors.New("failed to determine current upload position")
+	}
+
+	// Limit folders to 10000 fragments
+	lastDir, fs_, dirIndex, err := f.self.lastDir()
+	if err != nil {
+		return false, err
+	}
+
+	var uploadDir string
+	if lastDir == nil || lastDir.Items() >= MaxFolderCount {
+		uploadDir = f.self.binPath(dirIndex + 1)
+	} else {
+		uploadDir = lastDir.Remote()
+	}
+
+	src := &uploadSrcObjectInfo{
+		remote: path.Join(uploadDir, strconv.FormatInt(pos, 10)),
+		size:   f.pendingLen,
+	}
+	_, err = fs_.Put(f.ctx, io.MultiReader(f.pending...), src)
+	pos += f.pendingLen
+	if err != nil {
+		return false, err
+	}
+	size, ok := f.Size()
+	return ok && size == pos, nil
+}
+
+func (f *fragmentUploader) Close() error {
+	finished, err := f.self.flush()
+	if err == nil && finished {
+		// Finalize upload
+		fragments, e := f.self.getAllFragments(f.fs, f.uploadDir)
+		if e != nil {
+			return e
+		}
+
+		// Validate upload complete and unpack objects
+		files := make(fs.Objects, len(fragments))
+		for i := range fragments {
+			if fragments[i].start+fragments[i].object.Size() != fragments[i+1].start {
+				return errors.New(fmt.Sprintf("missing upload fragment between %d and %d", fragments[i].start+fragments[i].object.Size(), fragments[i+1].start))
+			}
+			files[i] = fragments[i].object
+		}
+		err = f.self.finish(files)
+		_ = f.self.Abort()
+	}
+	f.pending = []io.Reader{}
+	f.pendingLen = 0
+	return err
+}
+
+func (f *fragmentUploader) Abort() error {
+	return operations.Purge(f.ctx, f.fs, f.uploadDir)
+}
+
+func (f *fragmentUploader) Expires() time.Time {
+	return time.Date(9999, time.January, 1, 0, 0, 0, 0, time.UTC) // TODO modTime + configured expiry
+}
+
+// Check interfaces
+var (
+	_ fs.Uploader = (*fragmentUploader)(nil)
+)

--- a/fs/resumable/resumable.go
+++ b/fs/resumable/resumable.go
@@ -1,0 +1,79 @@
+package resumable
+
+import (
+	"context"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/hash"
+)
+
+// uploadSrcInfo stub fs.Info for uploadSrcObjectInfo
+type uploadSrcInfo struct {
+}
+
+func (u *uploadSrcInfo) Name() string {
+	return "Upload"
+}
+
+func (u *uploadSrcInfo) Root() string {
+	return ""
+}
+
+func (u *uploadSrcInfo) String() string {
+	return "Upload from non addressable source"
+}
+
+func (u *uploadSrcInfo) Precision() time.Duration {
+	return time.Second
+}
+
+func (u *uploadSrcInfo) Hashes() hash.Set {
+	return 0
+}
+
+func (u *uploadSrcInfo) Features() *fs.Features {
+	return nil
+}
+
+// uploadSrcObjectInfo stub fs.ObjectInfo implementation that only provides the upload size and remote
+type uploadSrcObjectInfo struct {
+	size   int64
+	remote string
+}
+
+func (u *uploadSrcObjectInfo) String() string {
+	if u == nil {
+		return "<nil>"
+	}
+	return u.remote
+}
+
+func (u *uploadSrcObjectInfo) Remote() string {
+	return u.remote
+}
+
+func (u *uploadSrcObjectInfo) ModTime(context.Context) time.Time {
+	return time.Now()
+}
+
+func (u *uploadSrcObjectInfo) Size() int64 {
+	return u.size
+}
+
+func (u *uploadSrcObjectInfo) Fs() fs.Info {
+	return &uploadSrcInfo{}
+}
+
+func (u *uploadSrcObjectInfo) Hash(ctx context.Context, ty hash.Type) (string, error) {
+	return "", nil
+}
+
+func (u *uploadSrcObjectInfo) Storable() bool {
+	return false
+}
+
+var (
+	_ fs.ObjectInfo = (*uploadSrcObjectInfo)(nil)
+	_ fs.Info       = (*uploadSrcInfo)(nil)
+)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This adds an interface for fs to implement resumable uploads. This includes generic uploaders that do not require a backend to implement the resumable interface to benefit from the functionality.

This was split out of the [TUS http uploader PR](https://github.com/rclone/rclone/pull/3850) to reduce its size

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/http-upload-contribution/13271/69

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
