### PR TITLE
Docs: Add notes about leading path separators and unc paths

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -163,7 +163,7 @@ The syntax of the paths passed to the rclone command are as follows.
 This refers to the local file system.
 
 On Windows `\` may be used instead of `/` in local paths **only**,
-non local paths must use `/`. See [local filesystem](https://rclone.org/local/#windows-paths)
+non local paths must use `/`. See [local filesystem](https://rclone.org/local/#paths-on-windows)
 documentation for more about Windows-specific paths.
 
 These paths needn't start with a leading `/` - if they don't then they

--- a/docs/content/local.md
+++ b/docs/content/local.md
@@ -114,9 +114,9 @@ as they can't be converted to UTF-16.
 ### Paths on Windows ###
 
 On Windows there are many ways of specifying a path to a file system resource.
-Both absolute paths like `C:\path\to\wherever`, and relative paths like
-`..\wherever` can be used, and path separator can be either
-`\` (as in `C:\path\to\wherever`) or `/` (as in `C:/path/to/wherever`).
+Local paths can be absolute, like `C:\path\to\wherever`, or relative,
+like `..\wherever`. Network paths in UNC format, `\\server\share`, are also supported.
+Path separator can be either `\` (as in `C:\path\to\wherever`) or `/` (as in `C:/path/to/wherever`).
 Length of these paths are limited to 259 characters for files and 247
 characters for directories, but there is an alternative extended-length
 path format increasing the limit to (approximately) 32,767 characters.


### PR DESCRIPTION
#### What is the purpose of this change?

1. Mention that network/unc paths are supported in local filesystem on windows
2. Mention that additional leading path separators are ignored
   - This is the case from the linked forum thread.
   - Are we sure that this is how it is working? From my testing and code inspection it seems to be true.
   - Are we confident this is how we want it to be, so that it is correct to document it - which avoids uncertainty as in the forum question? Or is it more of a coincidence that should be left undocumented?
3. Fixes a wrong link

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/leading-slash-in-source-dest-paths/24005

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~I have added tests for all changes in this PR if appropriate.~
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
