### PR TITLE
vfs: avoid unnecessary subdir in cache path

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -1419,7 +1419,7 @@ func NewFs(ctx context.Context, path string) (Fs, error) {
 		extraConfig := overridden.String()
 		//Debugf(nil, "detected overriden config %q", extraConfig)
 		md5sumBinary := md5.Sum([]byte(extraConfig))
-		suffix := base64.RawStdEncoding.EncodeToString(md5sumBinary[:])
+		suffix := base64.RawURLEncoding.EncodeToString(md5sumBinary[:])
 		// 5 characters length is 5*6 = 30 bits of base64
 		const maxLength = 5
 		if len(suffix) > maxLength {


### PR DESCRIPTION
#### What is the purpose of this change?

Avoid sometimes creating additional subdirectory in cache folder. It may happen as a result of "detected overridden config - adding ... suffix to name", where the suffix is base64 encoded MD5, when the encoded suffix happens to include the `/` character - which is in the base64 "alphabet".

Edit: Is backwards compatibility an issue here? That there may be an existing cache directory `cache`\\`path`\\`{Db`\\`Y9}` with content, and after this change rclone will not find the existing cache and begin with a new cache directory `cache`\\`path`\\`{Db_Y9}`? And then, any changes still in the old cache that has not been written back to remote will be lost? 🤔 

#### Was the change discussed in an issue or in the forum before?

Fixes #5316

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
