### PR TITLE
dropbox: improve the "own App IP" instructions

### DIFF
--- a/docs/content/dropbox.md
+++ b/docs/content/dropbox.md
@@ -367,6 +367,8 @@ to be the same account as the Dropbox you want to access)
 
 5. Click the button `Create App`
 
-5. Fill `Redirect URIs` as `http://localhost:53682/`
+6. Switch to the `Permissions` tab. Enable at least the following permissions: `account_info.read`, `files.metadata.write`, `files.content.write`, `files.content.read`, `sharing.write`. The `files.metadata.read` and `sharing.read` checkboxes will be marked too. Click `Submit`
 
-6. Find the `App key` and `App secret` Use these values in rclone config to add a new remote or edit an existing remote.
+7. Switch to the `Settings` tab. Fill `OAuth2 - Redirect URIs` as `http://localhost:53682/`
+
+8. Find the `App key` and `App secret` values on the `Settings` tab. Use these values in rclone config to add a new remote or edit an existing remote. The `App key` setting corresponds to `client_id` in rclone config, the `App secret` corresponds to `client_secret`


### PR DESCRIPTION
#### What is the purpose of this change?

Instructions in https://rclone.org/dropbox/#get-your-own-dropbox-app-id are a little incomplete. I had to guess a few extra details to make things work. This patch adds missing parts.

#### Was the change discussed in an issue or in the forum before?

Fixes #5242

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
