### PR TITLE
some improvement about documentation related to --disable

### DIFF
--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -37,7 +37,7 @@ These flags are available for every command.
       --delete-before                        When synchronizing, delete files on destination before transferring
       --delete-during                        When synchronizing, delete files during transfer
       --delete-excluded                      Delete files on dest excluded from sync
-      --disable string                       Disable a comma separated list of features.  Use help to see a list.
+      --disable string                       Disable a comma separated list of features.  Use --disable help to see a list.
   -n, --dry-run                              Do a trial run with no permanent changes
       --dscp string                          Set DSCP value to connections. Can be value or names, eg. CS1, LE, DF, AF21.
       --dump DumpFlags                       List of items to dump from: headers,bodies,requests,responses,auth,filters,goroutines,openfiles

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -90,7 +90,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.Float64VarP(flagSet, &ci.TPSLimit, "tpslimit", "", ci.TPSLimit, "Limit HTTP transactions per second to this.")
 	flags.IntVarP(flagSet, &ci.TPSLimitBurst, "tpslimit-burst", "", ci.TPSLimitBurst, "Max burst of transactions for --tpslimit.")
 	flags.StringVarP(flagSet, &bindAddr, "bind", "", "", "Local address to bind to for outgoing connections, IPv4, IPv6 or name.")
-	flags.StringVarP(flagSet, &disableFeatures, "disable", "", "", "Disable a comma separated list of features.  Use help to see a list.")
+	flags.StringVarP(flagSet, &disableFeatures, "disable", "", "", "Disable a comma separated list of features.  Use --disable help to see a list.")
 	flags.StringVarP(flagSet, &ci.UserAgent, "user-agent", "", ci.UserAgent, "Set the user-agent to a specified string. The default is rclone/ version")
 	flags.BoolVarP(flagSet, &ci.Immutable, "immutable", "", ci.Immutable, "Do not modify files. Fail if existing files have been modified.")
 	flags.BoolVarP(flagSet, &ci.AutoConfirm, "auto-confirm", "", ci.AutoConfirm, "If enabled, do not request console confirmation.")


### PR DESCRIPTION

#### What is the purpose of this change?

A few days ago (on forum), I explain how difficult it was to the --disable syntax : https://forum.rclone.org/t/looking-for-advice-for-remote-crypt-chunker/23924

So, today I'm submitting a small change.
I hope that next time I will be looking for that syntax, it will be easier to me (an maybe others)

Is it acceptable to replace ? : Disable a comma separated list of features.  Use help to see a list.
                             by : Disable a comma separated list of features.  Use --disable help to see a list.

#### Was the change discussed in an issue or in the forum before?

no

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
