### PR TITLE
docs: add a step for drive.md

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -1327,6 +1327,9 @@ you using a GSuite account and click "Create". (the default name is fine)
 8. It will show you a client ID and client secret.  Use these values
 in rclone config to add a new remote or edit an existing remote.
 
+9. Click "OAuth consent screen", then click "PUBLISH APP" button and 
+confirm, or add your account under "Test users".
+
 Be aware that, due to the "enhanced security" recently introduced by
 Google, you are theoretically expected to "submit your app for verification"
 and then wait a few weeks(!) for their response; in practice, you can go right


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
If the status of the added APP in Google APIs & Services is "testing", then "Authorization Error" will occur when `rclone config` try to get access to it. So the step I added may be necessary to get a gdrive client ID.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
Solutions for "Authorization Error" can be found in [this issue in googleapis](https://github.com/googleapis/google-api-php-client/issues/2001)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
