### PR TITLE
🧪 `fstest.Run`: add convenience methods to check local and remote fs with precision

### DIFF
--- a/backend/local/local_internal_test.go
+++ b/backend/local/local_internal_test.go
@@ -93,16 +93,16 @@ func TestSymlink(t *testing.T) {
 	file2d := fstest.NewItem("symlink.txt", "hello", modTime1)
 
 	// Check with no symlink flags
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t)
 
 	// Set fs into "-L" mode
 	f.opt.FollowSymlinks = true
 	f.opt.TranslateSymlinks = false
 	f.lstat = os.Stat
 
-	fstest.CheckItems(t, r.Flocal, file1, file2d)
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckLocalItems(t, file1, file2d)
+	r.CheckRemoteItems(t)
 
 	// Set fs into "-l" mode
 	f.opt.FollowSymlinks = false
@@ -111,7 +111,7 @@ func TestSymlink(t *testing.T) {
 
 	fstest.CheckListingWithPrecision(t, r.Flocal, []fstest.Item{file1, file2}, nil, fs.ModTimeNotSupported)
 	if haveLChtimes {
-		fstest.CheckItems(t, r.Flocal, file1, file2)
+		r.CheckLocalItems(t, file1, file2)
 	}
 
 	// Create a symlink
@@ -119,7 +119,7 @@ func TestSymlink(t *testing.T) {
 	file3 := r.WriteObjectTo(ctx, r.Flocal, "symlink2.txt"+linkSuffix, "file.txt", modTime3, false)
 	fstest.CheckListingWithPrecision(t, r.Flocal, []fstest.Item{file1, file2, file3}, nil, fs.ModTimeNotSupported)
 	if haveLChtimes {
-		fstest.CheckItems(t, r.Flocal, file1, file2, file3)
+		r.CheckLocalItems(t, file1, file2, file3)
 	}
 
 	// Check it got the correct contents

--- a/cmd/touch/touch_test.go
+++ b/cmd/touch/touch_test.go
@@ -77,7 +77,7 @@ func TestTouchUpdateTimestamp(t *testing.T) {
 	srcFileName := "a"
 	content := "aaa"
 	file1 := r.WriteObject(context.Background(), srcFileName, content, t1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	timeAsArgument = "121212"
 	err := Touch(context.Background(), r.Fremote, "a")
@@ -92,7 +92,7 @@ func TestTouchUpdateTimestampWithCFlag(t *testing.T) {
 	srcFileName := "a"
 	content := "aaa"
 	file1 := r.WriteObject(context.Background(), srcFileName, content, t1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	notCreateNewFile = true
 	timeAsArgument = "121212"

--- a/fs/operations/check_test.go
+++ b/fs/operations/check_test.go
@@ -99,8 +99,8 @@ func testCheck(t *testing.T, checkFunction func(ctx context.Context, opt *operat
 	}
 
 	file1 := r.WriteBoth(ctx, "rutabaga", "is tasty", t3)
-	fstest.CheckItems(t, r.Fremote, file1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckRemoteItems(t, file1)
+	r.CheckLocalItems(t, file1)
 	check(1, 0, 1, false, map[string]string{
 		"combined":     "= rutabaga\n",
 		"missingonsrc": "",
@@ -111,7 +111,7 @@ func testCheck(t *testing.T, checkFunction func(ctx context.Context, opt *operat
 	})
 
 	file2 := r.WriteFile("potato2", "------------------------------------------------------------", t1)
-	fstest.CheckItems(t, r.Flocal, file1, file2)
+	r.CheckLocalItems(t, file1, file2)
 	check(2, 1, 1, false, map[string]string{
 		"combined":     "+ potato2\n= rutabaga\n",
 		"missingonsrc": "",
@@ -122,7 +122,7 @@ func testCheck(t *testing.T, checkFunction func(ctx context.Context, opt *operat
 	})
 
 	file3 := r.WriteObject(ctx, "empty space", "-", t2)
-	fstest.CheckItems(t, r.Fremote, file1, file3)
+	r.CheckRemoteItems(t, file1, file3)
 	check(3, 2, 1, false, map[string]string{
 		"combined":     "- empty space\n+ potato2\n= rutabaga\n",
 		"missingonsrc": "empty space\n",
@@ -138,7 +138,7 @@ func testCheck(t *testing.T, checkFunction func(ctx context.Context, opt *operat
 	} else {
 		r.WriteObject(ctx, "potato2", "------------------------------------------------------------", t1)
 	}
-	fstest.CheckItems(t, r.Fremote, file1, file2r, file3)
+	r.CheckRemoteItems(t, file1, file2r, file3)
 	check(4, 1, 2, false, map[string]string{
 		"combined":     "- empty space\n= potato2\n= rutabaga\n",
 		"missingonsrc": "empty space\n",
@@ -150,7 +150,7 @@ func testCheck(t *testing.T, checkFunction func(ctx context.Context, opt *operat
 
 	file3r := file3
 	file3l := r.WriteFile("empty space", "DIFFER", t2)
-	fstest.CheckItems(t, r.Flocal, file1, file2, file3l)
+	r.CheckLocalItems(t, file1, file2, file3l)
 	check(5, 1, 3, false, map[string]string{
 		"combined":     "* empty space\n= potato2\n= rutabaga\n",
 		"missingonsrc": "",
@@ -161,7 +161,7 @@ func testCheck(t *testing.T, checkFunction func(ctx context.Context, opt *operat
 	})
 
 	file4 := r.WriteObject(ctx, "remotepotato", "------------------------------------------------------------", t1)
-	fstest.CheckItems(t, r.Fremote, file1, file2r, file3r, file4)
+	r.CheckRemoteItems(t, file1, file2r, file3r, file4)
 	check(6, 2, 3, false, map[string]string{
 		"combined":     "* empty space\n= potato2\n= rutabaga\n- remotepotato\n",
 		"missingonsrc": "remotepotato\n",
@@ -440,7 +440,7 @@ func testCheckSum(t *testing.T, download bool) {
 	fcsums := makeSums(operations.HashSums{
 		"banana": testDigest1,
 	})
-	fstest.CheckItems(t, r.Fremote, fcsums, file1)
+	r.CheckRemoteItems(t, fcsums, file1)
 	check(1, 1, 0, wantType{
 		"combined":     "= banana\n",
 		"missingonsrc": "",
@@ -454,7 +454,7 @@ func testCheckSum(t *testing.T, download bool) {
 	fcsums = makeSums(operations.HashSums{
 		"banana": testDigest1,
 	})
-	fstest.CheckItems(t, r.Fremote, fcsums, file1, file2)
+	r.CheckRemoteItems(t, fcsums, file1, file2)
 	check(2, 2, 1, wantType{
 		"combined":     "- potato\n= banana\n",
 		"missingonsrc": "potato\n",
@@ -468,7 +468,7 @@ func testCheckSum(t *testing.T, download bool) {
 		"banana": testDigest1,
 		"potato": testDigest2,
 	})
-	fstest.CheckItems(t, r.Fremote, fcsums, file1, file2)
+	r.CheckRemoteItems(t, fcsums, file1, file2)
 	check(3, 2, 0, wantType{
 		"combined":     "= potato\n= banana\n",
 		"missingonsrc": "",
@@ -482,7 +482,7 @@ func testCheckSum(t *testing.T, download bool) {
 		"banana": testDigest2,
 		"potato": testDigest2,
 	})
-	fstest.CheckItems(t, r.Fremote, fcsums, file1, file2)
+	r.CheckRemoteItems(t, fcsums, file1, file2)
 	check(4, 2, 1, wantType{
 		"combined":     "* banana\n= potato\n",
 		"missingonsrc": "",
@@ -497,7 +497,7 @@ func testCheckSum(t *testing.T, download bool) {
 		"potato": testDigest2,
 		"orange": testDigest2,
 	})
-	fstest.CheckItems(t, r.Fremote, fcsums, file1, file2)
+	r.CheckRemoteItems(t, fcsums, file1, file2)
 	check(5, 2, 1, wantType{
 		"combined":     "+ orange\n= potato\n= banana\n",
 		"missingonsrc": "",
@@ -512,7 +512,7 @@ func testCheckSum(t *testing.T, download bool) {
 		"potato": testDigest1,
 		"orange": testDigest2,
 	})
-	fstest.CheckItems(t, r.Fremote, fcsums, file1, file2)
+	r.CheckRemoteItems(t, fcsums, file1, file2)
 	check(6, 2, 2, wantType{
 		"combined":     "+ orange\n* potato\n= banana\n",
 		"missingonsrc": "",
@@ -529,7 +529,7 @@ func testCheckSum(t *testing.T, download bool) {
 		"banana": testDigest1Upper,
 		"potato": testDigest2Mixed,
 	})
-	fstest.CheckItems(t, r.Fremote, fcsums, file1, file2)
+	r.CheckRemoteItems(t, fcsums, file1, file2)
 	check(7, 2, 0, wantType{
 		"combined":     "= banana\n= potato\n",
 		"missingonsrc": "",

--- a/fs/operations/dedupe_test.go
+++ b/fs/operations/dedupe_test.go
@@ -57,7 +57,7 @@ func TestDeduplicateInteractive(t *testing.T) {
 	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateInteractive, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestDeduplicateSkip(t *testing.T) {
@@ -148,7 +148,7 @@ func TestDeduplicateNewest(t *testing.T) {
 	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateNewest, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file3)
+	r.CheckRemoteItems(t, file3)
 }
 
 func TestDeduplicateNewestByHash(t *testing.T) {
@@ -162,12 +162,12 @@ func TestDeduplicateNewestByHash(t *testing.T) {
 	file2 := r.WriteObject(context.Background(), "also/one", contents, t2)
 	file3 := r.WriteObject(context.Background(), "another", contents, t3)
 	file4 := r.WriteObject(context.Background(), "not-one", "stuff", t3)
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3, file4)
+	r.CheckRemoteItems(t, file1, file2, file3, file4)
 
 	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateNewest, true)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file3, file4)
+	r.CheckRemoteItems(t, file3, file4)
 }
 
 func TestDeduplicateOldest(t *testing.T) {
@@ -183,7 +183,7 @@ func TestDeduplicateOldest(t *testing.T) {
 	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateOldest, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestDeduplicateLargest(t *testing.T) {
@@ -199,7 +199,7 @@ func TestDeduplicateLargest(t *testing.T) {
 	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateLargest, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file3)
+	r.CheckRemoteItems(t, file3)
 }
 
 func TestDeduplicateSmallest(t *testing.T) {
@@ -215,7 +215,7 @@ func TestDeduplicateSmallest(t *testing.T) {
 	err := operations.Deduplicate(context.Background(), r.Fremote, operations.DeduplicateSmallest, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestDeduplicateRename(t *testing.T) {
@@ -281,7 +281,7 @@ func TestMergeDirs(t *testing.T) {
 
 	file2.Path = "dupe1/two.txt"
 	file3.Path = "dupe1/three.txt"
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
 
 	objs, dirs, err = walk.GetAll(context.Background(), r.Fremote, "", true, 1)
 	require.NoError(t, err)

--- a/fs/operations/listdirsorted_test.go
+++ b/fs/operations/listdirsorted_test.go
@@ -34,7 +34,7 @@ func TestListDirSorted(t *testing.T) {
 		r.WriteObject(context.Background(), "sub dir/ignore dir/should be ignored", "to ignore", t1),
 		r.WriteObject(context.Background(), "sub dir/sub sub dir/hello world3", "hello world", t1),
 	}
-	fstest.CheckItems(t, r.Fremote, files...)
+	r.CheckRemoteItems(t, files...)
 	var items fs.DirEntries
 	var err error
 

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -41,7 +41,7 @@ func TestListJSON(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "file1", "file1", t1)
 	file2 := r.WriteBoth(ctx, "sub/file2", "sub/file2", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 	precision := fs.GetModifyWindow(ctx, r.Fremote)
 
 	for _, test := range []struct {
@@ -236,7 +236,7 @@ func TestStatJSON(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "file1", "file1", t1)
 	file2 := r.WriteBoth(ctx, "sub/file2", "sub/file2", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 	precision := fs.GetModifyWindow(ctx, r.Fremote)
 
 	for _, test := range []struct {

--- a/fs/operations/multithread_test.go
+++ b/fs/operations/multithread_test.go
@@ -125,8 +125,8 @@ func TestMultithreadCopy(t *testing.T) {
 			contents := random.String(test.size)
 			t1 := fstest.Time("2001-02-03T04:05:06.499999999Z")
 			file1 := r.WriteObject(ctx, "file1", contents, t1)
-			fstest.CheckItems(t, r.Fremote, file1)
-			fstest.CheckItems(t, r.Flocal)
+			r.CheckRemoteItems(t, file1)
+			r.CheckLocalItems(t)
 
 			src, err := r.Fremote.NewObject(ctx, "file1")
 			require.NoError(t, err)

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -80,7 +80,7 @@ func TestLsd(t *testing.T) {
 	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "sub dir/hello world", "hello world", t1)
 
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	var buf bytes.Buffer
 	err := operations.ListDir(ctx, r.Fremote, &buf)
@@ -96,7 +96,7 @@ func TestLs(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	var buf bytes.Buffer
 	err := operations.List(ctx, r.Fremote, &buf)
@@ -114,7 +114,7 @@ func TestLsWithFilesFrom(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	// Set the --files-from equivalent
 	f, err := filter.NewFilter(nil)
@@ -146,7 +146,7 @@ func TestLsLong(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	var buf bytes.Buffer
 	err := operations.ListLong(ctx, r.Fremote, &buf)
@@ -189,7 +189,7 @@ func TestHashSums(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	hashes := r.Fremote.Hashes()
 
@@ -350,7 +350,7 @@ func TestCount(t *testing.T) {
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 	file3 := r.WriteBoth(ctx, "sub dir/potato3", "hello", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
 
 	// Check the MaxDepth too
 	ci.MaxDepth = 1
@@ -372,11 +372,11 @@ func TestDelete(t *testing.T) {
 	file1 := r.WriteObject(ctx, "small", "1234567890", t2)                                                                                           // 10 bytes
 	file2 := r.WriteObject(ctx, "medium", "------------------------------------------------------------", t1)                                        // 60 bytes
 	file3 := r.WriteObject(ctx, "large", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1) // 100 bytes
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
 
 	err = operations.Delete(ctx, r.Fremote)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Fremote, file3)
+	r.CheckRemoteItems(t, file3)
 }
 
 func TestRetry(t *testing.T) {
@@ -413,7 +413,7 @@ func TestCat(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "file1", "ABCDEFGHIJ", t1)
 	file2 := r.WriteBoth(ctx, "file2", "012345678", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	for _, test := range []struct {
 		offset int64
@@ -678,7 +678,7 @@ func TestCopyURL(t *testing.T) {
 	file1 := r.WriteFile("file1", contents, t1)
 	file2 := r.WriteFile("file2", contents, t1)
 	r.Mkdir(ctx, r.Fremote)
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckRemoteItems(t)
 
 	// check when reading from regular HTTP server
 	status := 0
@@ -773,28 +773,28 @@ func TestMoveFile(t *testing.T) {
 	defer r.Finalise()
 
 	file1 := r.WriteFile("file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	file2 := file1
 	file2.Path = "sub/file2"
 
 	err := operations.MoveFile(ctx, r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file2)
 
 	r.WriteFile("file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	err = operations.MoveFile(ctx, r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file2)
 
 	err = operations.MoveFile(ctx, r.Fremote, r.Fremote, file2.Path, file2.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file2)
 }
 
 func TestMoveFileWithIgnoreExisting(t *testing.T) {
@@ -803,24 +803,24 @@ func TestMoveFileWithIgnoreExisting(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 	file1 := r.WriteFile("file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	ci.IgnoreExisting = true
 
 	err := operations.MoveFile(ctx, r.Fremote, r.Flocal, file1.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file1)
 
 	// Recreate file with updated content
 	file1b := r.WriteFile("file1", "file1 modified", t2)
-	fstest.CheckItems(t, r.Flocal, file1b)
+	r.CheckLocalItems(t, file1b)
 
 	// Ensure modified file did not transfer and was not deleted
 	err = operations.MoveFile(ctx, r.Fremote, r.Flocal, file1.Path, file1b.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1b)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1b)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestCaseInsensitiveMoveFile(t *testing.T) {
@@ -832,31 +832,31 @@ func TestCaseInsensitiveMoveFile(t *testing.T) {
 	}
 
 	file1 := r.WriteFile("file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	file2 := file1
 	file2.Path = "sub/file2"
 
 	err := operations.MoveFile(ctx, r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file2)
 
 	r.WriteFile("file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	err = operations.MoveFile(ctx, r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file2)
 
 	file2Capitalized := file2
 	file2Capitalized.Path = "sub/File2"
 
 	err = operations.MoveFile(ctx, r.Fremote, r.Fremote, file2Capitalized.Path, file2.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file2Capitalized)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file2Capitalized)
 }
 
 func TestMoveFileBackupDir(t *testing.T) {
@@ -871,16 +871,16 @@ func TestMoveFileBackupDir(t *testing.T) {
 	ci.BackupDir = r.FremoteName + "/backup"
 
 	file1 := r.WriteFile("dst/file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	file1old := r.WriteObject(ctx, "dst/file1", "file1 contents old", t1)
-	fstest.CheckItems(t, r.Fremote, file1old)
+	r.CheckRemoteItems(t, file1old)
 
 	err := operations.MoveFile(ctx, r.Fremote, r.Flocal, file1.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal)
+	r.CheckLocalItems(t)
 	file1old.Path = "backup/dst/file1"
-	fstest.CheckItems(t, r.Fremote, file1old, file1)
+	r.CheckRemoteItems(t, file1old, file1)
 }
 
 func TestCopyFile(t *testing.T) {
@@ -889,25 +889,25 @@ func TestCopyFile(t *testing.T) {
 	defer r.Finalise()
 
 	file1 := r.WriteFile("file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	file2 := file1
 	file2.Path = "sub/file2"
 
 	err := operations.CopyFile(ctx, r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
 
 	err = operations.CopyFile(ctx, r.Fremote, r.Flocal, file2.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
 
 	err = operations.CopyFile(ctx, r.Fremote, r.Fremote, file2.Path, file2.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
 }
 
 func TestCopyFileBackupDir(t *testing.T) {
@@ -922,16 +922,16 @@ func TestCopyFileBackupDir(t *testing.T) {
 	ci.BackupDir = r.FremoteName + "/backup"
 
 	file1 := r.WriteFile("dst/file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	file1old := r.WriteObject(ctx, "dst/file1", "file1 contents old", t1)
-	fstest.CheckItems(t, r.Fremote, file1old)
+	r.CheckRemoteItems(t, file1old)
 
 	err := operations.CopyFile(ctx, r.Fremote, r.Flocal, file1.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 	file1old.Path = "backup/dst/file1"
-	fstest.CheckItems(t, r.Fremote, file1old, file1)
+	r.CheckRemoteItems(t, file1old, file1)
 }
 
 // Test with CompareDest set
@@ -947,7 +947,7 @@ func TestCopyFileCompareDest(t *testing.T) {
 
 	// check empty dest, empty compare
 	file1 := r.WriteFile("one", "one", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file1.Path, file1.Path)
 	require.NoError(t, err)
@@ -955,12 +955,12 @@ func TestCopyFileCompareDest(t *testing.T) {
 	file1dst := file1
 	file1dst.Path = "dst/one"
 
-	fstest.CheckItems(t, r.Fremote, file1dst)
+	r.CheckRemoteItems(t, file1dst)
 
 	// check old dest, empty compare
 	file1b := r.WriteFile("one", "onet2", t2)
-	fstest.CheckItems(t, r.Fremote, file1dst)
-	fstest.CheckItems(t, r.Flocal, file1b)
+	r.CheckRemoteItems(t, file1dst)
+	r.CheckLocalItems(t, file1b)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file1b.Path, file1b.Path)
 	require.NoError(t, err)
@@ -968,41 +968,41 @@ func TestCopyFileCompareDest(t *testing.T) {
 	file1bdst := file1b
 	file1bdst.Path = "dst/one"
 
-	fstest.CheckItems(t, r.Fremote, file1bdst)
+	r.CheckRemoteItems(t, file1bdst)
 
 	// check old dest, new compare
 	file3 := r.WriteObject(ctx, "dst/one", "one", t1)
 	file2 := r.WriteObject(ctx, "CompareDest/one", "onet2", t2)
 	file1c := r.WriteFile("one", "onet2", t2)
-	fstest.CheckItems(t, r.Fremote, file2, file3)
-	fstest.CheckItems(t, r.Flocal, file1c)
+	r.CheckRemoteItems(t, file2, file3)
+	r.CheckLocalItems(t, file1c)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file1c.Path, file1c.Path)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file2, file3)
+	r.CheckRemoteItems(t, file2, file3)
 
 	// check empty dest, new compare
 	file4 := r.WriteObject(ctx, "CompareDest/two", "two", t2)
 	file5 := r.WriteFile("two", "two", t2)
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
-	fstest.CheckItems(t, r.Flocal, file1c, file5)
+	r.CheckRemoteItems(t, file2, file3, file4)
+	r.CheckLocalItems(t, file1c, file5)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file5.Path, file5.Path)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
+	r.CheckRemoteItems(t, file2, file3, file4)
 
 	// check new dest, new compare
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file5.Path, file5.Path)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
+	r.CheckRemoteItems(t, file2, file3, file4)
 
 	// check empty dest, old compare
 	file5b := r.WriteFile("two", "twot3", t3)
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
-	fstest.CheckItems(t, r.Flocal, file1c, file5b)
+	r.CheckRemoteItems(t, file2, file3, file4)
+	r.CheckLocalItems(t, file1c, file5b)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file5b.Path, file5b.Path)
 	require.NoError(t, err)
@@ -1010,7 +1010,7 @@ func TestCopyFileCompareDest(t *testing.T) {
 	file5bdst := file5b
 	file5bdst.Path = "dst/two"
 
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4, file5bdst)
+	r.CheckRemoteItems(t, file2, file3, file4, file5bdst)
 }
 
 // Test with CopyDest set
@@ -1031,7 +1031,7 @@ func TestCopyFileCopyDest(t *testing.T) {
 
 	// check empty dest, empty copy
 	file1 := r.WriteFile("one", "one", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file1.Path, file1.Path)
 	require.NoError(t, err)
@@ -1039,12 +1039,12 @@ func TestCopyFileCopyDest(t *testing.T) {
 	file1dst := file1
 	file1dst.Path = "dst/one"
 
-	fstest.CheckItems(t, r.Fremote, file1dst)
+	r.CheckRemoteItems(t, file1dst)
 
 	// check old dest, empty copy
 	file1b := r.WriteFile("one", "onet2", t2)
-	fstest.CheckItems(t, r.Fremote, file1dst)
-	fstest.CheckItems(t, r.Flocal, file1b)
+	r.CheckRemoteItems(t, file1dst)
+	r.CheckLocalItems(t, file1b)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file1b.Path, file1b.Path)
 	require.NoError(t, err)
@@ -1052,7 +1052,7 @@ func TestCopyFileCopyDest(t *testing.T) {
 	file1bdst := file1b
 	file1bdst.Path = "dst/one"
 
-	fstest.CheckItems(t, r.Fremote, file1bdst)
+	r.CheckRemoteItems(t, file1bdst)
 
 	// check old dest, new copy, backup-dir
 
@@ -1061,8 +1061,8 @@ func TestCopyFileCopyDest(t *testing.T) {
 	file3 := r.WriteObject(ctx, "dst/one", "one", t1)
 	file2 := r.WriteObject(ctx, "CopyDest/one", "onet2", t2)
 	file1c := r.WriteFile("one", "onet2", t2)
-	fstest.CheckItems(t, r.Fremote, file2, file3)
-	fstest.CheckItems(t, r.Flocal, file1c)
+	r.CheckRemoteItems(t, file2, file3)
+	r.CheckLocalItems(t, file1c)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file1c.Path, file1c.Path)
 	require.NoError(t, err)
@@ -1071,14 +1071,14 @@ func TestCopyFileCopyDest(t *testing.T) {
 	file2dst.Path = "dst/one"
 	file3.Path = "BackupDir/one"
 
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3)
+	r.CheckRemoteItems(t, file2, file2dst, file3)
 	ci.BackupDir = ""
 
 	// check empty dest, new copy
 	file4 := r.WriteObject(ctx, "CopyDest/two", "two", t2)
 	file5 := r.WriteFile("two", "two", t2)
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4)
-	fstest.CheckItems(t, r.Flocal, file1c, file5)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4)
+	r.CheckLocalItems(t, file1c, file5)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file5.Path, file5.Path)
 	require.NoError(t, err)
@@ -1086,19 +1086,19 @@ func TestCopyFileCopyDest(t *testing.T) {
 	file4dst := file4
 	file4dst.Path = "dst/two"
 
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4, file4dst)
 
 	// check new dest, new copy
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file5.Path, file5.Path)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4, file4dst)
 
 	// check empty dest, old copy
 	file6 := r.WriteObject(ctx, "CopyDest/three", "three", t2)
 	file7 := r.WriteFile("three", "threet3", t3)
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst, file6)
-	fstest.CheckItems(t, r.Flocal, file1c, file5, file7)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4, file4dst, file6)
+	r.CheckLocalItems(t, file1c, file5, file7)
 
 	err = operations.CopyFile(ctx, fdst, r.Flocal, file7.Path, file7.Path)
 	require.NoError(t, err)
@@ -1106,7 +1106,7 @@ func TestCopyFileCopyDest(t *testing.T) {
 	file7dst := file7
 	file7dst.Path = "dst/three"
 
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst, file6, file7dst)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4, file4dst, file6, file7dst)
 }
 
 // testFsInfo is for unit testing fs.Info
@@ -1468,7 +1468,7 @@ func TestRcat(t *testing.T) {
 
 		file1 := fstest.NewItem(path1, data1, t1)
 		file2 := fstest.NewItem(path2, data2, t2)
-		fstest.CheckItems(t, r.Fremote, file1, file2)
+		r.CheckRemoteItems(t, file1, file2)
 	}
 
 	for i := 0; i < 4; i++ {
@@ -1504,7 +1504,7 @@ func TestRcatSize(t *testing.T) {
 	assert.Equal(t, file2.Path, obj.Remote())
 
 	// Check files exist
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 }
 
 func TestCopyFileMaxTransfer(t *testing.T) {
@@ -1535,8 +1535,8 @@ func TestCopyFileMaxTransfer(t *testing.T) {
 	accounting.Stats(ctx).ResetCounters()
 	err = operations.CopyFile(ctx, r.Fremote, r.Flocal, file1.Path, file1.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1, file2, file3, file4)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1, file2, file3, file4)
+	r.CheckRemoteItems(t, file1)
 
 	// file2: show a large file does not get transferred
 	accounting.Stats(ctx).ResetCounters()
@@ -1544,8 +1544,8 @@ func TestCopyFileMaxTransfer(t *testing.T) {
 	require.NotNil(t, err, "Did not get expected max transfer limit error")
 	assert.Contains(t, err.Error(), "Max transfer limit reached")
 	assert.True(t, fserrors.IsFatalError(err), fmt.Sprintf("Not fatal error: %v: %#v:", err, err))
-	fstest.CheckItems(t, r.Flocal, file1, file2, file3, file4)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1, file2, file3, file4)
+	r.CheckRemoteItems(t, file1)
 
 	// Cutoff mode: Cautious
 	ci.CutoffMode = fs.CutoffModeCautious
@@ -1556,8 +1556,8 @@ func TestCopyFileMaxTransfer(t *testing.T) {
 	require.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Max transfer limit reached")
 	assert.True(t, fserrors.IsNoRetryError(err))
-	fstest.CheckItems(t, r.Flocal, file1, file2, file3, file4)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1, file2, file3, file4)
+	r.CheckRemoteItems(t, file1)
 
 	if strings.HasPrefix(r.Fremote.Name(), "TestChunker") {
 		t.Log("skipping remainder of test for chunker as it involves multiple transfers")
@@ -1571,8 +1571,8 @@ func TestCopyFileMaxTransfer(t *testing.T) {
 	accounting.Stats(ctx).ResetCounters()
 	err = operations.CopyFile(ctx, r.Fremote, r.Flocal, file4.Path, file4.Path)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1, file2, file3, file4)
-	fstest.CheckItems(t, r.Fremote, file1, file4)
+	r.CheckLocalItems(t, file1, file2, file3, file4)
+	r.CheckRemoteItems(t, file1, file4)
 }
 
 func TestTouchDir(t *testing.T) {
@@ -1587,7 +1587,7 @@ func TestTouchDir(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 	file3 := r.WriteBoth(ctx, "sub dir/potato3", "hello", t2)
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
 
 	timeValue := time.Date(2010, 9, 8, 7, 6, 5, 4, time.UTC)
 	err := operations.TouchDir(ctx, r.Fremote, timeValue, true)
@@ -1599,6 +1599,6 @@ func TestTouchDir(t *testing.T) {
 		file1.ModTime = timeValue
 		file2.ModTime = timeValue
 		file3.ModTime = timeValue
-		fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+		r.CheckRemoteItems(t, file1, file2, file3)
 	}
 }

--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -75,8 +75,8 @@ func TestRcCopyfile(t *testing.T) {
 	defer r.Finalise()
 	file1 := r.WriteFile("file1", "file1 contents", t1)
 	r.Mkdir(context.Background(), r.Fremote)
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t)
 
 	in := rc.Params{
 		"srcFs":     r.LocalName,
@@ -88,9 +88,9 @@ func TestRcCopyfile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 	file1.Path = "file1-renamed"
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 // operations/copyurl: Copy the URL to the object
@@ -100,7 +100,7 @@ func TestRcCopyurl(t *testing.T) {
 	contents := "file1 contents\n"
 	file1 := r.WriteFile("file1", contents, t1)
 	r.Mkdir(context.Background(), r.Fremote)
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckRemoteItems(t)
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, err := w.Write([]byte(contents))
@@ -164,7 +164,7 @@ func TestRcDelete(t *testing.T) {
 	file1 := r.WriteObject(context.Background(), "small", "1234567890", t2)                                                                                           // 10 bytes
 	file2 := r.WriteObject(context.Background(), "medium", "------------------------------------------------------------", t1)                                        // 60 bytes
 	file3 := r.WriteObject(context.Background(), "large", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1) // 100 bytes
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
 
 	in := rc.Params{
 		"fs": r.FremoteName,
@@ -173,7 +173,7 @@ func TestRcDelete(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckRemoteItems(t)
 }
 
 // operations/deletefile: Remove the single file pointed to
@@ -183,7 +183,7 @@ func TestRcDeletefile(t *testing.T) {
 
 	file1 := r.WriteObject(context.Background(), "small", "1234567890", t2)                                                    // 10 bytes
 	file2 := r.WriteObject(context.Background(), "medium", "------------------------------------------------------------", t1) // 60 bytes
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	in := rc.Params{
 		"fs":     r.FremoteName,
@@ -193,7 +193,7 @@ func TestRcDeletefile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckRemoteItems(t, file2)
 }
 
 // operations/list: List the given remote and path in JSON format.
@@ -204,7 +204,7 @@ func TestRcList(t *testing.T) {
 	file1 := r.WriteObject(context.Background(), "a", "a", t1)
 	file2 := r.WriteObject(context.Background(), "subdir/b", "bb", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	in := rc.Params{
 		"fs":     r.FremoteName,
@@ -268,7 +268,7 @@ func TestRcStat(t *testing.T) {
 
 	file1 := r.WriteObject(context.Background(), "subdir/a", "a", t1)
 
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	fetch := func(t *testing.T, remotePath string) *operations.ListJSONItem {
 		in := rc.Params{
@@ -340,8 +340,8 @@ func TestRcMovefile(t *testing.T) {
 	defer r.Finalise()
 	file1 := r.WriteFile("file1", "file1 contents", t1)
 	r.Mkdir(context.Background(), r.Fremote)
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t)
 
 	in := rc.Params{
 		"srcFs":     r.LocalName,
@@ -353,9 +353,9 @@ func TestRcMovefile(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
-	fstest.CheckItems(t, r.Flocal)
+	r.CheckLocalItems(t)
 	file1.Path = "file1-renamed"
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 // operations/purge: Remove a directory or container and all of its contents
@@ -443,7 +443,7 @@ func TestRcSize(t *testing.T) {
 	file1 := r.WriteObject(context.Background(), "small", "1234567890", t2)                                                           // 10 bytes
 	file2 := r.WriteObject(context.Background(), "subdir/medium", "------------------------------------------------------------", t1) // 60 bytes
 	file3 := r.WriteObject(context.Background(), "subdir/subsubdir/large", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1)  // 50 bytes
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
 
 	in := rc.Params{
 		"fs": r.FremoteName,

--- a/fs/sync/rc_test.go
+++ b/fs/sync/rc_test.go
@@ -33,8 +33,8 @@ func TestRcCopy(t *testing.T) {
 	file2 := r.WriteFile("subdir/file2", "file2 contents", t2)
 	file3 := r.WriteObject(context.Background(), "subdir/subsubdir/file3", "file3 contents", t3)
 
-	fstest.CheckItems(t, r.Flocal, file1, file2)
-	fstest.CheckItems(t, r.Fremote, file1, file3)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1, file3)
 
 	in := rc.Params{
 		"srcFs": r.LocalName,
@@ -44,8 +44,8 @@ func TestRcCopy(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
-	fstest.CheckItems(t, r.Flocal, file1, file2)
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1, file2, file3)
 }
 
 // sync/move: move a directory from source remote to destination remote
@@ -58,8 +58,8 @@ func TestRcMove(t *testing.T) {
 	file2 := r.WriteFile("subdir/file2", "file2 contents", t2)
 	file3 := r.WriteObject(context.Background(), "subdir/subsubdir/file3", "file3 contents", t3)
 
-	fstest.CheckItems(t, r.Flocal, file1, file2)
-	fstest.CheckItems(t, r.Fremote, file1, file3)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1, file3)
 
 	in := rc.Params{
 		"srcFs": r.LocalName,
@@ -69,8 +69,8 @@ func TestRcMove(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file1, file2, file3)
 }
 
 // sync/sync: sync a directory from source remote to destination remote
@@ -83,8 +83,8 @@ func TestRcSync(t *testing.T) {
 	file2 := r.WriteFile("subdir/file2", "file2 contents", t2)
 	file3 := r.WriteObject(context.Background(), "subdir/subsubdir/file3", "file3 contents", t3)
 
-	fstest.CheckItems(t, r.Flocal, file1, file2)
-	fstest.CheckItems(t, r.Fremote, file1, file3)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1, file3)
 
 	in := rc.Params{
 		"srcFs": r.LocalName,
@@ -94,6 +94,6 @@ func TestRcSync(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params(nil), out)
 
-	fstest.CheckItems(t, r.Flocal, file1, file2)
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 }

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -49,8 +49,8 @@ func TestCopyWithDryRun(t *testing.T) {
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t)
 }
 
 // Now without dry run
@@ -64,8 +64,8 @@ func TestCopy(t *testing.T) {
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestCopyMissingDirectory(t *testing.T) {
@@ -97,8 +97,8 @@ func TestCopyNoTraverse(t *testing.T) {
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 // Now with --check-first
@@ -115,8 +115,8 @@ func TestCopyCheckFirst(t *testing.T) {
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 // Now with --no-traverse
@@ -134,8 +134,8 @@ func TestSyncNoTraverse(t *testing.T) {
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 // Test copy with depth
@@ -153,8 +153,8 @@ func TestCopyWithDepth(t *testing.T) {
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1, file2)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file2)
 }
 
 // Test copy with files from
@@ -180,8 +180,8 @@ func testCopyWithFilesFrom(t *testing.T, noTraverse bool) {
 	err = CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1, file2)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1)
 }
 func TestCopyWithFilesFrom(t *testing.T)              { testCopyWithFilesFrom(t, false) }
 func TestCopyWithFilesFromAndNoTraverse(t *testing.T) { testCopyWithFilesFrom(t, true) }
@@ -199,9 +199,8 @@ func TestCopyEmptyDirectories(t *testing.T) {
 	err = CopyDir(ctx, r.Fremote, r.Flocal, true)
 	require.NoError(t, err)
 
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file1,
 		},
@@ -209,7 +208,6 @@ func TestCopyEmptyDirectories(t *testing.T) {
 			"sub dir",
 			"sub dir2",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 }
 
@@ -226,9 +224,8 @@ func TestMoveEmptyDirectories(t *testing.T) {
 	err = MoveDir(ctx, r.Fremote, r.Flocal, false, true)
 	require.NoError(t, err)
 
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file1,
 		},
@@ -236,7 +233,6 @@ func TestMoveEmptyDirectories(t *testing.T) {
 			"sub dir",
 			"sub dir2",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 }
 
@@ -253,9 +249,8 @@ func TestSyncEmptyDirectories(t *testing.T) {
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
 	require.NoError(t, err)
 
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file1,
 		},
@@ -263,7 +258,6 @@ func TestSyncEmptyDirectories(t *testing.T) {
 			"sub dir",
 			"sub dir2",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 }
 
@@ -273,7 +267,7 @@ func TestServerSideCopy(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "sub dir/hello world", "hello world", t1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	FremoteCopy, _, finaliseCopy, err := fstest.RandomRemote()
 	require.NoError(t, err)
@@ -293,8 +287,8 @@ func TestCopyAfterDelete(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "sub dir/hello world", "hello world", t1)
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file1)
 
 	err := operations.Mkdir(ctx, r.Flocal, "")
 	require.NoError(t, err)
@@ -302,8 +296,8 @@ func TestCopyAfterDelete(t *testing.T) {
 	err = CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t)
+	r.CheckRemoteItems(t, file1)
 }
 
 // Check the copy downloading a file
@@ -312,13 +306,13 @@ func TestCopyRedownload(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "sub dir/hello world", "hello world", t1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	err := CopyDir(ctx, r.Flocal, r.Fremote, false)
 	require.NoError(t, err)
 
 	// Test with combined precision of local and remote as we copied it there and back
-	fstest.CheckListingWithPrecision(t, r.Flocal, []fstest.Item{file1}, nil, fs.GetModifyWindow(ctx, r.Flocal, r.Fremote))
+	r.CheckLocalListing(t, []fstest.Item{file1}, nil)
 }
 
 // Create a file and sync it. Change the last modified date and resync.
@@ -332,7 +326,7 @@ func TestSyncBasedOnCheckSum(t *testing.T) {
 	ci.CheckSum = true
 
 	file1 := r.WriteFile("check sum", "-", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
@@ -340,11 +334,11 @@ func TestSyncBasedOnCheckSum(t *testing.T) {
 
 	// We should have transferred exactly one file.
 	assert.Equal(t, toyFileTransfers(r), accounting.GlobalStats().GetTransfers())
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	// Change last modified date only
 	file2 := r.WriteFile("check sum", "-", t2)
-	fstest.CheckItems(t, r.Flocal, file2)
+	r.CheckLocalItems(t, file2)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
@@ -352,8 +346,8 @@ func TestSyncBasedOnCheckSum(t *testing.T) {
 
 	// We should have transferred no files
 	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
-	fstest.CheckItems(t, r.Flocal, file2)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file2)
+	r.CheckRemoteItems(t, file1)
 }
 
 // Create a file and sync it. Change the last modified date and the
@@ -367,7 +361,7 @@ func TestSyncSizeOnly(t *testing.T) {
 	ci.SizeOnly = true
 
 	file1 := r.WriteFile("sizeonly", "potato", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
@@ -375,11 +369,11 @@ func TestSyncSizeOnly(t *testing.T) {
 
 	// We should have transferred exactly one file.
 	assert.Equal(t, toyFileTransfers(r), accounting.GlobalStats().GetTransfers())
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	// Update mtime, md5sum but not length of file
 	file2 := r.WriteFile("sizeonly", "POTATO", t2)
-	fstest.CheckItems(t, r.Flocal, file2)
+	r.CheckLocalItems(t, file2)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
@@ -387,8 +381,8 @@ func TestSyncSizeOnly(t *testing.T) {
 
 	// We should have transferred no files
 	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
-	fstest.CheckItems(t, r.Flocal, file2)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file2)
+	r.CheckRemoteItems(t, file1)
 }
 
 // Create a file and sync it. Keep the last modified date but change
@@ -402,7 +396,7 @@ func TestSyncIgnoreSize(t *testing.T) {
 	ci.IgnoreSize = true
 
 	file1 := r.WriteFile("ignore-size", "contents", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
@@ -410,11 +404,11 @@ func TestSyncIgnoreSize(t *testing.T) {
 
 	// We should have transferred exactly one file.
 	assert.Equal(t, toyFileTransfers(r), accounting.GlobalStats().GetTransfers())
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	// Update size but not date of file
 	file2 := r.WriteFile("ignore-size", "longer contents but same date", t1)
-	fstest.CheckItems(t, r.Flocal, file2)
+	r.CheckLocalItems(t, file2)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
@@ -422,8 +416,8 @@ func TestSyncIgnoreSize(t *testing.T) {
 
 	// We should have transferred no files
 	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
-	fstest.CheckItems(t, r.Flocal, file2)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file2)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestSyncIgnoreTimes(t *testing.T) {
@@ -432,7 +426,7 @@ func TestSyncIgnoreTimes(t *testing.T) {
 	r := fstest.NewRun(t)
 	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "existing", "potato", t1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
@@ -452,8 +446,8 @@ func TestSyncIgnoreTimes(t *testing.T) {
 	// files were identical.
 	assert.Equal(t, toyFileTransfers(r), accounting.GlobalStats().GetTransfers())
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestSyncIgnoreExisting(t *testing.T) {
@@ -468,8 +462,8 @@ func TestSyncIgnoreExisting(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file1)
 
 	// Change everything
 	r.WriteFile("existing", "newpotatoes", t2)
@@ -477,7 +471,7 @@ func TestSyncIgnoreExisting(t *testing.T) {
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	// Items should not change
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestSyncIgnoreErrors(t *testing.T) {
@@ -491,9 +485,8 @@ func TestSyncIgnoreErrors(t *testing.T) {
 	file3 := r.WriteBoth(ctx, "c/non empty space", "AhHa!", t2)
 	require.NoError(t, operations.Mkdir(ctx, r.Fremote, "d"))
 
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		[]fstest.Item{
 			file1,
 			file3,
@@ -502,11 +495,9 @@ func TestSyncIgnoreErrors(t *testing.T) {
 			"a",
 			"c",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file2,
 			file3,
@@ -516,16 +507,14 @@ func TestSyncIgnoreErrors(t *testing.T) {
 			"c",
 			"d",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 
 	accounting.GlobalStats().ResetCounters()
 	_ = fs.CountError(errors.New("boom"))
 	assert.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
 
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		[]fstest.Item{
 			file1,
 			file3,
@@ -534,11 +523,9 @@ func TestSyncIgnoreErrors(t *testing.T) {
 			"a",
 			"c",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file1,
 			file3,
@@ -547,7 +534,6 @@ func TestSyncIgnoreErrors(t *testing.T) {
 			"a",
 			"c",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 }
 
@@ -559,8 +545,8 @@ func TestSyncAfterChangingModtimeOnly(t *testing.T) {
 	file1 := r.WriteFile("empty space", "-", t2)
 	file2 := r.WriteObject(ctx, "empty space", "-", t1)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
 
 	ci.DryRun = true
 
@@ -568,8 +554,8 @@ func TestSyncAfterChangingModtimeOnly(t *testing.T) {
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
 
 	ci.DryRun = false
 
@@ -577,8 +563,8 @@ func TestSyncAfterChangingModtimeOnly(t *testing.T) {
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestSyncAfterChangingModtimeOnlyWithNoUpdateModTime(t *testing.T) {
@@ -597,15 +583,15 @@ func TestSyncAfterChangingModtimeOnlyWithNoUpdateModTime(t *testing.T) {
 	file1 := r.WriteFile("empty space", "-", t2)
 	file2 := r.WriteObject(ctx, "empty space", "-", t1)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
 }
 
 func TestSyncDoesntUpdateModtime(t *testing.T) {
@@ -619,15 +605,15 @@ func TestSyncDoesntUpdateModtime(t *testing.T) {
 	file1 := r.WriteFile("foo", "foo", t2)
 	file2 := r.WriteObject(ctx, "foo", "bar", t1)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file1)
 
 	// We should have transferred exactly one file, not set the mod time
 	assert.Equal(t, toyFileTransfers(r), accounting.GlobalStats().GetTransfers())
@@ -640,14 +626,14 @@ func TestSyncAfterAddingAFile(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "empty space", "-", t2)
 	file2 := r.WriteFile("potato", "------------------------------------------------------------", t3)
 
-	fstest.CheckItems(t, r.Flocal, file1, file2)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1, file2)
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 }
 
 func TestSyncAfterChangingFilesSizeOnly(t *testing.T) {
@@ -656,14 +642,14 @@ func TestSyncAfterChangingFilesSizeOnly(t *testing.T) {
 	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "potato", "------------------------------------------------------------", t3)
 	file2 := r.WriteFile("potato", "smaller but same date", t3)
-	fstest.CheckItems(t, r.Fremote, file1)
-	fstest.CheckItems(t, r.Flocal, file2)
+	r.CheckRemoteItems(t, file1)
+	r.CheckLocalItems(t, file2)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file2)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file2)
+	r.CheckRemoteItems(t, file2)
 }
 
 // Sync after changing a file's contents, changing modtime but length
@@ -680,14 +666,14 @@ func TestSyncAfterChangingContentsOnly(t *testing.T) {
 		file1 = r.WriteObject(ctx, "potato", "smaller but same date", t3)
 	}
 	file2 := r.WriteFile("potato", "SMALLER BUT SAME DATE", t2)
-	fstest.CheckItems(t, r.Fremote, file1)
-	fstest.CheckItems(t, r.Flocal, file2)
+	r.CheckRemoteItems(t, file1)
+	r.CheckLocalItems(t, file2)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file2)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file2)
+	r.CheckRemoteItems(t, file2)
 }
 
 // Sync after removing a file and adding a file --dry-run
@@ -706,8 +692,8 @@ func TestSyncAfterRemovingAFileAndAddingAFileDryRun(t *testing.T) {
 	ci.DryRun = false
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Flocal, file3, file1)
-	fstest.CheckItems(t, r.Fremote, file3, file2)
+	r.CheckLocalItems(t, file3, file1)
+	r.CheckRemoteItems(t, file3, file2)
 }
 
 // Sync after removing a file and adding a file
@@ -717,14 +703,14 @@ func testSyncAfterRemovingAFileAndAddingAFile(ctx context.Context, t *testing.T)
 	file1 := r.WriteFile("potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteObject(ctx, "potato", "SMALLER BUT SAME DATE", t2)
 	file3 := r.WriteBoth(ctx, "empty space", "-", t2)
-	fstest.CheckItems(t, r.Fremote, file2, file3)
-	fstest.CheckItems(t, r.Flocal, file1, file3)
+	r.CheckRemoteItems(t, file2, file3)
+	r.CheckLocalItems(t, file1, file3)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1, file3)
-	fstest.CheckItems(t, r.Fremote, file1, file3)
+	r.CheckLocalItems(t, file1, file3)
+	r.CheckRemoteItems(t, file1, file3)
 }
 
 func TestSyncAfterRemovingAFileAndAddingAFile(t *testing.T) {
@@ -741,9 +727,8 @@ func testSyncAfterRemovingAFileAndAddingAFileSubDir(ctx context.Context, t *test
 	require.NoError(t, operations.Mkdir(ctx, r.Fremote, "d"))
 	require.NoError(t, operations.Mkdir(ctx, r.Fremote, "d/e"))
 
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		[]fstest.Item{
 			file1,
 			file3,
@@ -752,11 +737,9 @@ func testSyncAfterRemovingAFileAndAddingAFileSubDir(ctx context.Context, t *test
 			"a",
 			"c",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file2,
 			file3,
@@ -767,16 +750,14 @@ func testSyncAfterRemovingAFileAndAddingAFileSubDir(ctx context.Context, t *test
 			"d",
 			"d/e",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		[]fstest.Item{
 			file1,
 			file3,
@@ -785,11 +766,9 @@ func testSyncAfterRemovingAFileAndAddingAFileSubDir(ctx context.Context, t *test
 			"a",
 			"c",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file1,
 			file3,
@@ -798,7 +777,6 @@ func testSyncAfterRemovingAFileAndAddingAFileSubDir(ctx context.Context, t *test
 			"a",
 			"c",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 }
 
@@ -816,9 +794,8 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 	file3 := r.WriteBoth(ctx, "c/non empty space", "AhHa!", t2)
 	require.NoError(t, operations.Mkdir(ctx, r.Fremote, "d"))
 
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		[]fstest.Item{
 			file1,
 			file3,
@@ -827,11 +804,9 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 			"a",
 			"c",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file2,
 			file3,
@@ -841,7 +816,6 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 			"c",
 			"d",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 
 	accounting.GlobalStats().ResetCounters()
@@ -849,9 +823,8 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	assert.Equal(t, fs.ErrorNotDeleting, err)
 
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		[]fstest.Item{
 			file1,
 			file3,
@@ -860,11 +833,9 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 			"a",
 			"c",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file1,
 			file2,
@@ -876,7 +847,6 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 			"c",
 			"d",
 		},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 }
 
@@ -918,15 +888,15 @@ func TestCopyDeleteBefore(t *testing.T) {
 
 	file1 := r.WriteObject(ctx, "potato", "hopefully not deleted", t1)
 	file2 := r.WriteFile("potato2", "hopefully copied in", t1)
-	fstest.CheckItems(t, r.Fremote, file1)
-	fstest.CheckItems(t, r.Flocal, file2)
+	r.CheckRemoteItems(t, file1)
+	r.CheckLocalItems(t, file2)
 
 	accounting.GlobalStats().ResetCounters()
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2)
-	fstest.CheckItems(t, r.Flocal, file2)
+	r.CheckRemoteItems(t, file1, file2)
+	r.CheckLocalItems(t, file2)
 }
 
 // Test with exclude
@@ -937,8 +907,8 @@ func TestSyncWithExclude(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 	file3 := r.WriteFile("enormous", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1) // 100 bytes
-	fstest.CheckItems(t, r.Fremote, file1, file2)
-	fstest.CheckItems(t, r.Flocal, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2)
+	r.CheckLocalItems(t, file1, file2, file3)
 
 	fi, err := filter.NewFilter(nil)
 	require.NoError(t, err)
@@ -948,14 +918,14 @@ func TestSyncWithExclude(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Fremote, file2, file1)
+	r.CheckRemoteItems(t, file2, file1)
 
 	// Now sync the other way round and check enormous doesn't get
 	// deleted as it is excluded from the sync
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, r.Flocal, r.Fremote, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file2, file1, file3)
+	r.CheckLocalItems(t, file2, file1, file3)
 }
 
 // Test with exclude and delete excluded
@@ -966,8 +936,8 @@ func TestSyncWithExcludeAndDeleteExcluded(t *testing.T) {
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1) // 60 bytes
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 	file3 := r.WriteBoth(ctx, "enormous", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1) // 100 bytes
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
-	fstest.CheckItems(t, r.Flocal, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
+	r.CheckLocalItems(t, file1, file2, file3)
 
 	fi, err := filter.NewFilter(nil)
 	require.NoError(t, err)
@@ -978,14 +948,14 @@ func TestSyncWithExcludeAndDeleteExcluded(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckRemoteItems(t, file2)
 
 	// Check sync the other way round to make sure enormous gets
 	// deleted even though it is excluded
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, r.Flocal, r.Fremote, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file2)
+	r.CheckLocalItems(t, file2)
 }
 
 // Test with UpdateOlder set
@@ -1004,19 +974,19 @@ func TestSyncWithUpdateOlder(t *testing.T) {
 	threeF := r.WriteFile("three", "three", t2)
 	fourF := r.WriteFile("four", "four", t2)
 	fiveF := r.WriteFile("five", "five", t2)
-	fstest.CheckItems(t, r.Flocal, oneF, twoF, threeF, fourF, fiveF)
+	r.CheckLocalItems(t, oneF, twoF, threeF, fourF, fiveF)
 	oneO := r.WriteObject(ctx, "one", "ONE", t2)
 	twoO := r.WriteObject(ctx, "two", "TWO", t2)
 	threeO := r.WriteObject(ctx, "three", "THREE", t2plus)
 	fourO := r.WriteObject(ctx, "four", "FOURFOUR", t2minus)
-	fstest.CheckItems(t, r.Fremote, oneO, twoO, threeO, fourO)
+	r.CheckRemoteItems(t, oneO, twoO, threeO, fourO)
 
 	ci.UpdateOlder = true
 	ci.ModifyWindow = fs.ModTimeNotSupported
 
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Fremote, oneO, twoF, threeO, fourF, fiveF)
+	r.CheckRemoteItems(t, oneO, twoF, threeO, fourF, fiveF)
 
 	if r.Fremote.Hashes().Count() == 0 {
 		t.Logf("Skip test with --checksum as no hashes supported")
@@ -1028,7 +998,7 @@ func TestSyncWithUpdateOlder(t *testing.T) {
 
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Fremote, oneO, twoF, threeF, fourF, fiveF)
+	r.CheckRemoteItems(t, oneO, twoF, threeF, fourF, fiveF)
 }
 
 // Test with a max transfer duration
@@ -1093,8 +1063,8 @@ func TestSyncWithTrackRenames(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
 
-	fstest.CheckItems(t, r.Fremote, f1, f2)
-	fstest.CheckItems(t, r.Flocal, f1, f2)
+	r.CheckRemoteItems(t, f1, f2)
+	r.CheckLocalItems(t, f1, f2)
 
 	// Now rename locally.
 	f2 = r.RenameFile(f2, "yaml")
@@ -1102,7 +1072,7 @@ func TestSyncWithTrackRenames(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
 
-	fstest.CheckItems(t, r.Fremote, f1, f2)
+	r.CheckRemoteItems(t, f1, f2)
 
 	// Check we renamed something if we should have
 	if canTrackRenames {
@@ -1162,8 +1132,8 @@ func TestSyncWithTrackRenamesStrategyModtime(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
 
-	fstest.CheckItems(t, r.Fremote, f1, f2)
-	fstest.CheckItems(t, r.Flocal, f1, f2)
+	r.CheckRemoteItems(t, f1, f2)
+	r.CheckLocalItems(t, f1, f2)
 
 	// Now rename locally.
 	f2 = r.RenameFile(f2, "yaml")
@@ -1171,7 +1141,7 @@ func TestSyncWithTrackRenamesStrategyModtime(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
 
-	fstest.CheckItems(t, r.Fremote, f1, f2)
+	r.CheckRemoteItems(t, f1, f2)
 
 	// Check we renamed something if we should have
 	if canTrackRenames {
@@ -1198,8 +1168,8 @@ func TestSyncWithTrackRenamesStrategyLeaf(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
 
-	fstest.CheckItems(t, r.Fremote, f1, f2)
-	fstest.CheckItems(t, r.Flocal, f1, f2)
+	r.CheckRemoteItems(t, f1, f2)
+	r.CheckLocalItems(t, f1, f2)
 
 	// Now rename locally.
 	f2 = r.RenameFile(f2, "yam")
@@ -1207,7 +1177,7 @@ func TestSyncWithTrackRenamesStrategyLeaf(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
 
-	fstest.CheckItems(t, r.Fremote, f1, f2)
+	r.CheckRemoteItems(t, f1, f2)
 
 	// Check we renamed something if we should have
 	if canTrackRenames {
@@ -1240,7 +1210,7 @@ func testServerSideMove(ctx context.Context, t *testing.T, r *fstest.Run, withFi
 		require.NoError(t, err)
 	}
 
-	fstest.CheckItems(t, r.Fremote, file2, file1, file3u)
+	r.CheckRemoteItems(t, file2, file1, file3u)
 
 	t.Logf("Server side move (if possible) %v -> %v", r.Fremote, FremoteMove)
 
@@ -1255,13 +1225,13 @@ func testServerSideMove(ctx context.Context, t *testing.T, r *fstest.Run, withFi
 	require.NoError(t, err)
 
 	if withFilter {
-		fstest.CheckItems(t, r.Fremote, file2)
+		r.CheckRemoteItems(t, file2)
 	} else {
-		fstest.CheckItems(t, r.Fremote)
+		r.CheckRemoteItems(t)
 	}
 
 	if testDeleteEmptyDirs {
-		fstest.CheckListingWithPrecision(t, r.Fremote, nil, []string{}, fs.GetModifyWindow(ctx, r.Fremote))
+		r.CheckRemoteListing(t, nil, []string{})
 	}
 
 	fstest.CheckItems(t, FremoteMove, file2, file1, file3u)
@@ -1307,14 +1277,12 @@ func TestMoveWithDeleteEmptySrcDirs(t *testing.T) {
 	err := MoveDir(ctx, r.Fremote, r.Flocal, true, false)
 	require.NoError(t, err)
 
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		nil,
 		[]string{},
-		fs.GetModifyWindow(ctx, r.Flocal),
 	)
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 }
 
 func TestMoveWithoutDeleteEmptySrcDirs(t *testing.T) {
@@ -1328,18 +1296,16 @@ func TestMoveWithoutDeleteEmptySrcDirs(t *testing.T) {
 	err := MoveDir(ctx, r.Fremote, r.Flocal, false, false)
 	require.NoError(t, err)
 
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		nil,
 		[]string{
 			"sub dir",
 			"nested",
 			"nested/sub dir",
 		},
-		fs.GetModifyWindow(ctx, r.Flocal),
 	)
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 }
 
 func TestMoveWithIgnoreExisting(t *testing.T) {
@@ -1355,22 +1321,18 @@ func TestMoveWithIgnoreExisting(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	err := MoveDir(ctx, r.Fremote, r.Flocal, false, false)
 	require.NoError(t, err)
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		[]fstest.Item{},
 		[]string{},
-		fs.GetModifyWindow(ctx, r.Flocal),
 	)
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file1,
 			file2,
 		},
 		[]string{},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 
 	// Recreate first file with modified content
@@ -1379,25 +1341,21 @@ func TestMoveWithIgnoreExisting(t *testing.T) {
 	err = MoveDir(ctx, r.Fremote, r.Flocal, false, false)
 	require.NoError(t, err)
 	// Source items should still exist in modified state
-	fstest.CheckListingWithPrecision(
+	r.CheckLocalListing(
 		t,
-		r.Flocal,
 		[]fstest.Item{
 			file1b,
 		},
 		[]string{},
-		fs.GetModifyWindow(ctx, r.Flocal),
 	)
 	// Dest items should not have changed
-	fstest.CheckListingWithPrecision(
+	r.CheckRemoteListing(
 		t,
-		r.Fremote,
 		[]fstest.Item{
 			file1,
 			file2,
 		},
 		[]string{},
-		fs.GetModifyWindow(ctx, r.Fremote),
 	)
 }
 
@@ -1446,7 +1404,7 @@ func TestServerSideMoveOverlap(t *testing.T) {
 	require.NoError(t, err)
 
 	file1 := r.WriteObject(ctx, "potato2", "------------------------------------------------------------", t1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	// Subdir move with no filters should return ErrorCantMoveOverlapping
 	err = MoveDir(ctx, FremoteMove, r.Fremote, false, false)
@@ -1498,7 +1456,7 @@ func TestSyncCompareDest(t *testing.T) {
 
 	// check empty dest, empty compare
 	file1 := r.WriteFile("one", "one", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
@@ -1507,12 +1465,12 @@ func TestSyncCompareDest(t *testing.T) {
 	file1dst := file1
 	file1dst.Path = "dst/one"
 
-	fstest.CheckItems(t, r.Fremote, file1dst)
+	r.CheckRemoteItems(t, file1dst)
 
 	// check old dest, empty compare
 	file1b := r.WriteFile("one", "onet2", t2)
-	fstest.CheckItems(t, r.Fremote, file1dst)
-	fstest.CheckItems(t, r.Flocal, file1b)
+	r.CheckRemoteItems(t, file1dst)
+	r.CheckLocalItems(t, file1b)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
@@ -1521,39 +1479,39 @@ func TestSyncCompareDest(t *testing.T) {
 	file1bdst := file1b
 	file1bdst.Path = "dst/one"
 
-	fstest.CheckItems(t, r.Fremote, file1bdst)
+	r.CheckRemoteItems(t, file1bdst)
 
 	// check old dest, new compare
 	file3 := r.WriteObject(ctx, "dst/one", "one", t1)
 	file2 := r.WriteObject(ctx, "CompareDest/one", "onet2", t2)
 	file1c := r.WriteFile("one", "onet2", t2)
-	fstest.CheckItems(t, r.Fremote, file2, file3)
-	fstest.CheckItems(t, r.Flocal, file1c)
+	r.CheckRemoteItems(t, file2, file3)
+	r.CheckLocalItems(t, file1c)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file2, file3)
+	r.CheckRemoteItems(t, file2, file3)
 
 	// check empty dest, new compare
 	file4 := r.WriteObject(ctx, "CompareDest/two", "two", t2)
 	file5 := r.WriteFile("two", "two", t2)
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
-	fstest.CheckItems(t, r.Flocal, file1c, file5)
+	r.CheckRemoteItems(t, file2, file3, file4)
+	r.CheckLocalItems(t, file1c, file5)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
+	r.CheckRemoteItems(t, file2, file3, file4)
 
 	// check new dest, new compare
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
+	r.CheckRemoteItems(t, file2, file3, file4)
 
 	// Work out if we actually have hashes for uploaded files
 	haveHash := false
@@ -1574,21 +1532,21 @@ func TestSyncCompareDest(t *testing.T) {
 	// always copied.
 	if haveHash {
 		file5b := r.WriteFile("two", "two", t3)
-		fstest.CheckItems(t, r.Flocal, file1c, file5b)
+		r.CheckLocalItems(t, file1c, file5b)
 
 		accounting.GlobalStats().ResetCounters()
 		err = Sync(ctx, fdst, r.Flocal, false)
 		require.NoError(t, err)
 
-		fstest.CheckItems(t, r.Fremote, file2, file3, file4)
+		r.CheckRemoteItems(t, file2, file3, file4)
 	} else {
 		t.Log("No hash on uploaded file so skipping compare timestamp test")
 	}
 
 	// check empty dest, old compare
 	file5c := r.WriteFile("two", "twot3", t3)
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
-	fstest.CheckItems(t, r.Flocal, file1c, file5c)
+	r.CheckRemoteItems(t, file2, file3, file4)
+	r.CheckLocalItems(t, file1c, file5c)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
@@ -1597,7 +1555,7 @@ func TestSyncCompareDest(t *testing.T) {
 	file5cdst := file5c
 	file5cdst.Path = "dst/two"
 
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4, file5cdst)
+	r.CheckRemoteItems(t, file2, file3, file4, file5cdst)
 }
 
 // Test with multiple CompareDest
@@ -1606,6 +1564,7 @@ func TestSyncMultipleCompareDest(t *testing.T) {
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
 	defer r.Finalise()
+	precision := fs.GetModifyWindow(ctx, r.Fremote, r.Flocal)
 
 	ci.CompareDest = []string{r.FremoteName + "/pre-dest1", r.FremoteName + "/pre-dest2"}
 
@@ -1613,11 +1572,11 @@ func TestSyncMultipleCompareDest(t *testing.T) {
 	fsrc1 := r.WriteFile("1", "1", t1)
 	fsrc2 := r.WriteFile("2", "2", t1)
 	fsrc3 := r.WriteFile("3", "3", t1)
-	fstest.CheckItems(t, r.Flocal, fsrc1, fsrc2, fsrc3)
+	r.CheckLocalItems(t, fsrc1, fsrc2, fsrc3)
 
 	fdest1 := r.WriteObject(ctx, "pre-dest1/1", "1", t1)
 	fdest2 := r.WriteObject(ctx, "pre-dest2/2", "2", t1)
-	fstest.CheckItems(t, r.Fremote, fdest1, fdest2)
+	r.CheckRemoteItems(t, fdest1, fdest2)
 
 	accounting.GlobalStats().ResetCounters()
 	fdst, err := fs.NewFs(ctx, r.FremoteName+"/dest")
@@ -1627,8 +1586,8 @@ func TestSyncMultipleCompareDest(t *testing.T) {
 	fdest3 := fsrc3
 	fdest3.Path = "dest/3"
 
-	fstest.CheckItems(t, fdst, fsrc3)
-	fstest.CheckItems(t, r.Fremote, fdest1, fdest2, fdest3)
+	fstest.CheckItemsWithPrecision(t, fdst, precision, fsrc3)
+	r.CheckRemoteItems(t, fdest1, fdest2, fdest3)
 }
 
 // Test with CopyDest set
@@ -1649,7 +1608,7 @@ func TestSyncCopyDest(t *testing.T) {
 
 	// check empty dest, empty copy
 	file1 := r.WriteFile("one", "one", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
@@ -1658,12 +1617,12 @@ func TestSyncCopyDest(t *testing.T) {
 	file1dst := file1
 	file1dst.Path = "dst/one"
 
-	fstest.CheckItems(t, r.Fremote, file1dst)
+	r.CheckRemoteItems(t, file1dst)
 
 	// check old dest, empty copy
 	file1b := r.WriteFile("one", "onet2", t2)
-	fstest.CheckItems(t, r.Fremote, file1dst)
-	fstest.CheckItems(t, r.Flocal, file1b)
+	r.CheckRemoteItems(t, file1dst)
+	r.CheckLocalItems(t, file1b)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
@@ -1672,7 +1631,7 @@ func TestSyncCopyDest(t *testing.T) {
 	file1bdst := file1b
 	file1bdst.Path = "dst/one"
 
-	fstest.CheckItems(t, r.Fremote, file1bdst)
+	r.CheckRemoteItems(t, file1bdst)
 
 	// check old dest, new copy, backup-dir
 
@@ -1681,8 +1640,8 @@ func TestSyncCopyDest(t *testing.T) {
 	file3 := r.WriteObject(ctx, "dst/one", "one", t1)
 	file2 := r.WriteObject(ctx, "CopyDest/one", "onet2", t2)
 	file1c := r.WriteFile("one", "onet2", t2)
-	fstest.CheckItems(t, r.Fremote, file2, file3)
-	fstest.CheckItems(t, r.Flocal, file1c)
+	r.CheckRemoteItems(t, file2, file3)
+	r.CheckLocalItems(t, file1c)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
@@ -1692,14 +1651,14 @@ func TestSyncCopyDest(t *testing.T) {
 	file2dst.Path = "dst/one"
 	file3.Path = "BackupDir/one"
 
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3)
+	r.CheckRemoteItems(t, file2, file2dst, file3)
 	ci.BackupDir = ""
 
 	// check empty dest, new copy
 	file4 := r.WriteObject(ctx, "CopyDest/two", "two", t2)
 	file5 := r.WriteFile("two", "two", t2)
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4)
-	fstest.CheckItems(t, r.Flocal, file1c, file5)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4)
+	r.CheckLocalItems(t, file1c, file5)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
@@ -1708,20 +1667,20 @@ func TestSyncCopyDest(t *testing.T) {
 	file4dst := file4
 	file4dst.Path = "dst/two"
 
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4, file4dst)
 
 	// check new dest, new copy
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4, file4dst)
 
 	// check empty dest, old copy
 	file6 := r.WriteObject(ctx, "CopyDest/three", "three", t2)
 	file7 := r.WriteFile("three", "threet3", t3)
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst, file6)
-	fstest.CheckItems(t, r.Flocal, file1c, file5, file7)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4, file4dst, file6)
+	r.CheckLocalItems(t, file1c, file5, file7)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
@@ -1730,7 +1689,7 @@ func TestSyncCopyDest(t *testing.T) {
 	file7dst := file7
 	file7dst.Path = "dst/three"
 
-	fstest.CheckItems(t, r.Fremote, file2, file2dst, file3, file4, file4dst, file6, file7dst)
+	r.CheckRemoteItems(t, file2, file2dst, file3, file4, file4dst, file6, file7dst)
 }
 
 // Test with BackupDir set
@@ -1770,8 +1729,8 @@ func testSyncBackupDir(t *testing.T, backupDir string, suffix string, suffixKeep
 	file2a := r.WriteFile("two", "two", t1)
 	file1a := r.WriteFile("one", "oneA", t2)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
-	fstest.CheckItems(t, r.Flocal, file1a, file2a)
+	r.CheckRemoteItems(t, file1, file2, file3)
+	r.CheckLocalItems(t, file1a, file2a)
 
 	fdst, err := fs.NewFs(ctx, r.FremoteName+"/dst")
 	require.NoError(t, err)
@@ -1791,13 +1750,13 @@ func testSyncBackupDir(t *testing.T, backupDir string, suffix string, suffixKeep
 		file3.Path = backupDir + "three.txt" + suffix
 	}
 
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3, file1a)
+	r.CheckRemoteItems(t, file1, file2, file3, file1a)
 
 	// Now check what happens if we do it again
 	// Restore a different three and update one in the source
 	file3a := r.WriteObject(ctx, "dst/three.txt", "threeA", t2)
 	file1b := r.WriteFile("one", "oneBB", t3)
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3, file1a, file3a)
+	r.CheckRemoteItems(t, file1, file2, file3, file1a, file3a)
 
 	// This should delete three and overwrite one again, checking
 	// the files got overwritten correctly in backup-dir
@@ -1816,7 +1775,7 @@ func testSyncBackupDir(t *testing.T, backupDir string, suffix string, suffixKeep
 		file3a.Path = backupDir + "three.txt" + suffix
 	}
 
-	fstest.CheckItems(t, r.Fremote, file1b, file2, file3a, file1a)
+	r.CheckRemoteItems(t, file1b, file2, file3a, file1a)
 }
 func TestSyncBackupDir(t *testing.T) {
 	testSyncBackupDir(t, "backup", "", false)
@@ -1855,8 +1814,8 @@ func testSyncSuffix(t *testing.T, suffix string, suffixKeepExtension bool) {
 	file1a := r.WriteFile("one", "oneA", t2)
 	file3a := r.WriteFile("three.txt", "threeA", t1)
 
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
-	fstest.CheckItems(t, r.Flocal, file1a, file2a, file3a)
+	r.CheckRemoteItems(t, file1, file2, file3)
+	r.CheckLocalItems(t, file1a, file2a, file3a)
 
 	fdst, err := fs.NewFs(ctx, r.FremoteName+"/dst")
 	require.NoError(t, err)
@@ -1881,13 +1840,13 @@ func testSyncSuffix(t *testing.T, suffix string, suffixKeepExtension bool) {
 	}
 	file3a.Path = "dst/three.txt"
 
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3, file1a, file3a)
+	r.CheckRemoteItems(t, file1, file2, file3, file1a, file3a)
 
 	// Now check what happens if we do it again
 	// Restore a different three and update one in the source
 	file3b := r.WriteFile("three.txt", "threeBDifferentSize", t3)
 	file1b := r.WriteFile("one", "oneBB", t3)
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3, file1a, file3a)
+	r.CheckRemoteItems(t, file1, file2, file3, file1a, file3a)
 
 	// This should delete three and overwrite one again, checking
 	// the files got overwritten correctly in backup-dir
@@ -1911,7 +1870,7 @@ func testSyncSuffix(t *testing.T, suffix string, suffixKeepExtension bool) {
 	}
 	file3b.Path = "dst/three.txt"
 
-	fstest.CheckItems(t, r.Fremote, file1b, file3b, file2, file3a, file1a)
+	r.CheckRemoteItems(t, file1b, file3b, file2, file3a, file1a)
 }
 func TestSyncSuffix(t *testing.T)              { testSyncSuffix(t, ".bak", false) }
 func TestSyncSuffixKeepExtension(t *testing.T) { testSyncSuffix(t, "-2019-01-01", true) }
@@ -1933,10 +1892,10 @@ func TestSyncUTFNorm(t *testing.T) {
 	assert.Equal(t, norm.NFC.String(Encoding1), norm.NFC.String(Encoding2))
 
 	file1 := r.WriteFile(Encoding1, "This is a test", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 
 	file2 := r.WriteObject(ctx, Encoding2, "This is a old test", t2)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckRemoteItems(t, file2)
 
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
@@ -1945,9 +1904,9 @@ func TestSyncUTFNorm(t *testing.T) {
 	// We should have transferred exactly one file, but kept the
 	// normalized state of the file.
 	assert.Equal(t, toyFileTransfers(r), accounting.GlobalStats().GetTransfers())
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 	file1.Path = file2.Path
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 // Test --immutable
@@ -1961,27 +1920,27 @@ func TestSyncImmutable(t *testing.T) {
 
 	// Create file on source
 	file1 := r.WriteFile("existing", "potato", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t)
 
 	// Should succeed
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file1)
 
 	// Modify file data and timestamp on source
 	file2 := r.WriteFile("existing", "tomatoes", t2)
-	fstest.CheckItems(t, r.Flocal, file2)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file2)
+	r.CheckRemoteItems(t, file1)
 
 	// Should fail with ErrorImmutableModified and not modify local or remote files
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	assert.EqualError(t, err, fs.ErrorImmutableModified.Error())
-	fstest.CheckItems(t, r.Flocal, file2)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckLocalItems(t, file2)
+	r.CheckRemoteItems(t, file1)
 }
 
 // Test --ignore-case-sync
@@ -2000,16 +1959,16 @@ func TestSyncIgnoreCase(t *testing.T) {
 
 	// Create files with different filename casing
 	file1 := r.WriteFile("existing", "potato", t1)
-	fstest.CheckItems(t, r.Flocal, file1)
+	r.CheckLocalItems(t, file1)
 	file2 := r.WriteObject(ctx, "EXISTING", "potato", t1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckRemoteItems(t, file2)
 
 	// Should not copy files that are differently-cased but otherwise identical
 	accounting.GlobalStats().ResetCounters()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	fstest.CheckItems(t, r.Flocal, file1)
-	fstest.CheckItems(t, r.Fremote, file2)
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
 }
 
 // Test that aborting on --max-transfer works
@@ -2034,8 +1993,8 @@ func TestMaxTransfer(t *testing.T) {
 		file1 := r.WriteFile("file1", string(make([]byte, 5*1024)), t1)
 		file2 := r.WriteFile("file2", string(make([]byte, 2*1024)), t1)
 		file3 := r.WriteFile("file3", string(make([]byte, 3*1024)), t1)
-		fstest.CheckItems(t, r.Flocal, file1, file2, file3)
-		fstest.CheckItems(t, r.Fremote)
+		r.CheckLocalItems(t, file1, file2, file3)
+		r.CheckRemoteItems(t)
 
 		accounting.GlobalStats().ResetCounters()
 
@@ -2088,7 +2047,7 @@ func testSyncConcurrent(t *testing.T, subtest string) {
 		}
 	}
 
-	fstest.CheckItems(t, r.Fremote, itemsBefore...)
+	r.CheckRemoteItems(t, itemsBefore...)
 	stats.ResetErrors()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	if errors.Is(err, fs.ErrorCantUploadEmptyFiles) {
@@ -2096,7 +2055,7 @@ func testSyncConcurrent(t *testing.T, subtest string) {
 	}
 	assert.NoError(t, err, "Sync must not return a error")
 	assert.False(t, stats.Errored(), "Low level errors must not have happened")
-	fstest.CheckItems(t, r.Fremote, itemsAfter...)
+	r.CheckRemoteItems(t, itemsAfter...)
 }
 
 func TestSyncConcurrentDelete(t *testing.T) {

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -345,6 +345,12 @@ func CheckListing(t *testing.T, f fs.Fs, items []Item) {
 	CheckListingWithPrecision(t, f, items, nil, precision)
 }
 
+// CheckItemsWithPrecision checks the fs with the specified precision
+// to see if it has the expected items.
+func CheckItemsWithPrecision(t *testing.T, f fs.Fs, precision time.Duration, items ...Item) {
+	CheckListingWithPrecision(t, f, items, nil, precision)
+}
+
 // CheckItems checks the fs to see if it has only the items passed in
 // using a precision of fs.Config.ModifyWindow
 func CheckItems(t *testing.T, f fs.Fs, items ...Item) {

--- a/vfs/dir_handle_test.go
+++ b/vfs/dir_handle_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/rclone/rclone/fstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,7 +44,7 @@ func TestDirHandleReaddir(t *testing.T) {
 	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2- contents", t2)
 	file3 := r.WriteObject(context.Background(), "dir/subdir/file3", "file3-- contents", t3)
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
 
 	node, err := vfs.Stat("dir")
 	require.NoError(t, err)

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -19,7 +19,7 @@ func dirCreate(t *testing.T) (r *fstest.Run, vfs *VFS, dir *Dir, item fstest.Ite
 	r, vfs, cleanup = newTestVFS(t)
 
 	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	node, err := vfs.Stat("dir")
 	require.NoError(t, err)
@@ -145,7 +145,7 @@ func TestDirWalk(t *testing.T) {
 	defer cleanup()
 
 	file2 := r.WriteObject(context.Background(), "fil/a/b/c", "super long file", t1)
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	root, err := vfs.Root()
 	require.NoError(t, err)
@@ -259,7 +259,7 @@ func TestDirReadDirAll(t *testing.T) {
 	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2- contents", t2)
 	file3 := r.WriteObject(context.Background(), "dir/subdir/file3", "file3-- contents", t3)
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
 
 	node, err := vfs.Stat("dir")
 	require.NoError(t, err)

--- a/vfs/file_test.go
+++ b/vfs/file_test.go
@@ -24,7 +24,7 @@ func fileCreate(t *testing.T, mode vfscommon.CacheMode) (r *fstest.Run, vfs *VFS
 	r, vfs, cleanup = newTestVFSOpt(t, &opt)
 
 	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	node, err := vfs.Stat("dir/file1")
 	require.NoError(t, err)
@@ -137,7 +137,7 @@ func testFileSetModTime(t *testing.T, cacheMode vfscommon.CacheMode, open bool, 
 	}
 
 	file1 = fstest.NewItem(file1.Path, contents, t2)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	vfs.Opt.ReadOnly = true
 	err = file.SetModTime(t2)
@@ -255,7 +255,7 @@ func TestFileRemove(t *testing.T) {
 	err := file.Remove()
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckRemoteItems(t)
 
 	vfs.Opt.ReadOnly = true
 	err = file.Remove()
@@ -269,7 +269,7 @@ func TestFileRemoveAll(t *testing.T) {
 	err := file.RemoveAll()
 	require.NoError(t, err)
 
-	fstest.CheckItems(t, r.Fremote)
+	r.CheckRemoteItems(t)
 
 	vfs.Opt.ReadOnly = true
 	err = file.RemoveAll()
@@ -340,14 +340,14 @@ func testFileRename(t *testing.T, mode vfscommon.CacheMode, inCache bool, forceC
 	dir := file.Dir()
 
 	// start with "dir/file1"
-	fstest.CheckItems(t, r.Fremote, item)
+	r.CheckRemoteItems(t, item)
 
 	// rename file to "newLeaf"
 	err = dir.Rename("file1", "newLeaf", rootDir)
 	require.NoError(t, err)
 
 	item.Path = "newLeaf"
-	fstest.CheckItems(t, r.Fremote, item)
+	r.CheckRemoteItems(t, item)
 
 	// check file in cache
 	if inCache {
@@ -363,7 +363,7 @@ func testFileRename(t *testing.T, mode vfscommon.CacheMode, inCache bool, forceC
 	require.NoError(t, err)
 
 	item.Path = "dir/file1"
-	fstest.CheckItems(t, r.Fremote, item)
+	r.CheckRemoteItems(t, item)
 
 	// check file in cache
 	if inCache {

--- a/vfs/read_test.go
+++ b/vfs/read_test.go
@@ -16,7 +16,7 @@ func readHandleCreate(t *testing.T) (r *fstest.Run, vfs *VFS, fh *ReadFileHandle
 	r, vfs, cleanup = newTestVFS(t)
 
 	file1 := r.WriteObject(context.Background(), "dir/file1", "0123456789abcdef", t1)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	h, err := vfs.OpenFile("dir/file1", os.O_RDONLY, 0777)
 	require.NoError(t, err)

--- a/vfs/read_write_test.go
+++ b/vfs/read_write_test.go
@@ -38,7 +38,7 @@ func rwHandleCreateFlags(t *testing.T, create bool, filename string, flags int) 
 
 	if create {
 		file1 := r.WriteObject(context.Background(), filename, "0123456789abcdef", t1)
-		fstest.CheckItems(t, r.Fremote, file1)
+		r.CheckRemoteItems(t, file1)
 	}
 
 	h, err := vfs.OpenFile(filename, flags, 0777)
@@ -690,7 +690,7 @@ func TestRWFileModTimeWithOpenWriters(t *testing.T) {
 
 	file1 := fstest.NewItem("file1", "hi", mtime)
 	vfs.WaitForWriters(waitForWritersDelay)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 }
 
 func TestRWCacheRename(t *testing.T) {

--- a/vfs/vfs_case_test.go
+++ b/vfs/vfs_case_test.go
@@ -23,7 +23,7 @@ func TestCaseSensitivity(t *testing.T) {
 	ctx := context.Background()
 	file1 := r.WriteObject(ctx, "FiLeA", "data1", t1)
 	file2 := r.WriteObject(ctx, "FiLeB", "data2", t2)
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	// Create file3 with name differing from file2 name only by case.
 	// On a case-Sensitive remote this will be a separate file.
@@ -65,7 +65,7 @@ func TestCaseSensitivity(t *testing.T) {
 	}
 
 	// Continue with test as the underlying remote is fully case-Sensitive.
-	fstest.CheckItems(t, r.Fremote, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
 
 	// See how VFS handles case-INsensitive flag
 	assertFileDataVFS(t, vfsCI, "FiLeA", "data1")

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -194,7 +194,7 @@ func TestVFSStat(t *testing.T) {
 
 	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	node, err := vfs.Stat("file1")
 	require.NoError(t, err)
@@ -230,7 +230,7 @@ func TestVFSStatParent(t *testing.T) {
 
 	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	node, leaf, err := vfs.StatParent("file1")
 	require.NoError(t, err)
@@ -263,7 +263,7 @@ func TestVFSOpenFile(t *testing.T) {
 
 	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
-	fstest.CheckItems(t, r.Fremote, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
 
 	fd, err := vfs.OpenFile("file1", os.O_RDONLY, 0777)
 	require.NoError(t, err)
@@ -302,17 +302,17 @@ func TestVFSRename(t *testing.T) {
 	}
 
 	file1 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	err := vfs.Rename("dir/file2", "dir/file1")
 	require.NoError(t, err)
 	file1.Path = "dir/file1"
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	err = vfs.Rename("dir/file1", "file0")
 	require.NoError(t, err)
 	file1.Path = "file0"
-	fstest.CheckItems(t, r.Fremote, file1)
+	r.CheckRemoteItems(t, file1)
 
 	err = vfs.Rename("not found/file0", "file0")
 	assert.Equal(t, os.ErrNotExist, err)


### PR DESCRIPTION
#### What is the purpose of this change?

Previously only the fs being checked on gets passed to `GetModifyWindow()`. However, in most tests, the test files are generated in the local fs and transferred to the remote fs. So the local fs time precision has to be taken into account. On Windows, the local fs has a time precision of 100ns. Checking remote items uploaded from local fs on Windows also requires a modify window of 100ns.

With the changes in this PR applied, integration tests against Google Cloud Storage remotes can now pass on Windows.

#### Was the change discussed in an issue or in the forum before?

As discussed in #5347.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
