### PR TITLE
dialer: fix DSCP support and improve error handling

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -787,6 +787,8 @@ rclone copy --dscp LE from:/from to:/to
 ```
 would make the priority lower than usual internet flows.
 
+This option has no effect on Windows (see [golang/go#42728](https://github.com/golang/go/issues/42728)).
+
 ### -n, --dry-run ###
 
 Do a trial run with no permanent changes.  Use this to see what rclone


### PR DESCRIPTION
These patches fix #5293 and add more graceful error handling since failing to set socket options shouldn't cause the process to exit. 

I've tested:

* macOS IPv4: ✅ working
* macOS IPv6: ✅ working
* openSUSE Tumbleweed IPv4: ✅ working
* openSUSE Tumbleweed IPv6: ✅ working
* Windows 10 20H2 IPv4:  ⚠️ fails due to https://github.com/golang/go/issues/42728; handled by custom error handler (prints `WARNING: dialer: setting DSCP on Windows/IPv4 fails silently; see https://github.com/golang/go/issues/42728` and continues)
* Windows 10 20H2 IPv6:  ⚠️ fails due to lack of support in net/ipv6; handled by standard error handler (prints `WARNING: dialer: failed to set DSCP socket options: not implemented on windows/amd64` and continues)

If Go adds proper support for Windows, DSCP will work properly but will print a spurious warning on IPv4 (only) until the custom error handler is removed. I think this is preferable to having it fail silently as it would otherwise.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
