### PR TITLE
librclone: add FreeString function

### DIFF
--- a/librclone/librclone.go
+++ b/librclone/librclone.go
@@ -20,12 +20,15 @@
 package main
 
 /*
+#include <stdlib.h>
+
 struct RcloneRPCResult {
 	char*	Output;
 	int	Status;
 };
 */
 import "C"
+import "unsafe"
 
 import (
 	"github.com/rclone/rclone/librclone/librclone"
@@ -77,6 +80,12 @@ func RcloneRPC(method *C.char, input *C.char) (result C.struct_RcloneRPCResult) 
 	result.Output = C.CString(output)
 	result.Status = C.int(status)
 	return result
+}
+
+// Use this to free the string returned by RcloneRPC
+//export FreeString
+func FreeString(str *C.char) {
+	C.free(unsafe.Pointer(str))
 }
 
 // do nothing here - necessary for building into a C library


### PR DESCRIPTION
to free the string pointer returned by RcloneRPC function; it can be useful for languages that lack built-in ways to free malloc'ed memory (such as .NET).

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Some languages (e.g. C#) cannot appropriately free the memory allocated by `RcloneRPC` function using built-in API.
To allow these languages to consume librclone we can add a function that exposes `C.free` which [is used to free](https://stackoverflow.com/a/47192786/5491216) the pointer created by `C.CString` and returned to the caller from `RcloneRPC`.


<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
