### PR TITLE
docs: incorrect token type in Yandex docs

### DIFF
--- a/docs/content/yandex.md
+++ b/docs/content/yandex.md
@@ -46,7 +46,7 @@ Got code
 [remote]
 client_id =
 client_secret =
-token = {"access_token":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","token_type":"bearer","expiry":"2016-12-29T12:27:11.362788025Z"}
+token = {"access_token":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx","token_type":"OAuth","expiry":"2016-12-29T12:27:11.362788025Z"}
 --------------------
 y) Yes this is OK
 e) Edit this remote


### PR DESCRIPTION
https://forum.rclone.org/t/yandex-documentation/24445/2

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Potential incorrect documentation for Yandex token

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/yandex-documentation/24445/2

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
