### PR TITLE
docs: fix incorrect syntax in config update example

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -274,7 +274,7 @@ you would do:
 If the remote uses OAuth the token will be updated, if you don't
 require this add an extra parameter thus:
 
-    rclone config update myremote swift env_auth=true config_refresh_token=false
+    rclone config update myremote env_auth=true config_refresh_token=false
 `, "|", "`") + configPasswordHelp,
 	RunE: func(command *cobra.Command, args []string) error {
 		cmd.CheckArgs(1, 256, command, args)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

There is an extra swift in example commands.

```
rclone config update myremote swift env_auth true
```

The correct command should be:

```
rclone config update myremote env_auth true
```

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/example-command-error-in-help-info-and-manpage/24729

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~I have added tests for all changes in this PR if appropriate.~
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
