### PR TITLE
fs/operations: Don't update timestamps of files in --compare-dest

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -1408,7 +1408,9 @@ func compareDest(ctx context.Context, dst, src fs.Object, CompareDest fs.Fs) (No
 	default:
 		return false, err
 	}
-	if Equal(ctx, src, CompareDestFile) {
+	opt := defaultEqualOpt(ctx)
+	opt.updateModTime = false
+	if equal(ctx, src, CompareDestFile, opt) {
 		fs.Debugf(src, "Destination found in --compare-dest, skipping")
 		return true, nil
 	}

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1496,19 +1496,29 @@ func TestSyncCompareDest(t *testing.T) {
 
 	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
 
-	// check empty dest, old compare
-	file5b := r.WriteFile("two", "twot3", t3)
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
+	// check new dest, new compare, src timestamp differs
+	file5b := r.WriteFile("two", "two", t3)
 	fstest.CheckItems(t, r.Flocal, file1c, file5b)
 
 	accounting.GlobalStats().ResetCounters()
 	err = Sync(ctx, fdst, r.Flocal, false)
 	require.NoError(t, err)
 
-	file5bdst := file5b
-	file5bdst.Path = "dst/two"
+	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
 
-	fstest.CheckItems(t, r.Fremote, file2, file3, file4, file5bdst)
+	// check empty dest, old compare
+	file5c := r.WriteFile("two", "twot3", t3)
+	fstest.CheckItems(t, r.Fremote, file2, file3, file4)
+	fstest.CheckItems(t, r.Flocal, file1c, file5c)
+
+	accounting.GlobalStats().ResetCounters()
+	err = Sync(ctx, fdst, r.Flocal, false)
+	require.NoError(t, err)
+
+	file5cdst := file5c
+	file5cdst.Path = "dst/two"
+
+	fstest.CheckItems(t, r.Fremote, file2, file3, file4, file5cdst)
 }
 
 // Test with multiple CompareDest


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The [`--compare-dest`](https://rclone.org/docs/#compare-dest-dir) flag specifies a remote directory to compare files to when syncing.

Currently, if a file in the compare-dest is identical to a source file (same size and checksum), but its timestamp differs, the timestamp of the compare-dest file will be updated.

The documentation does not mention this behavior and it is likely an unintended side effect of how the checking is implemented.  I believe the compare-dest should be treated as an immutable reference point and should not be modified by the operation.

#### Was the change discussed in an issue or in the forum before?

No, as far as I know

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate. (N/A)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
