### PR TITLE
onedrive: Make link return direct download link

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -1523,12 +1523,10 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 			fs.Logf(f, cnvFailMsg)
 			return url, nil
 		}
-
 		enc := base64.StdEncoding.EncodeToString([]byte(url))
 		strings.ReplaceAll(enc, "/", "_")
 		strings.ReplaceAll(enc, "+", "-")
 		url = "https://api.onedrive.com/v1.0/shares/u!" + enc[:len(enc)-1] + "/root/content"
-
 	case driveTypeBusiness:
 		/*
 			Method: https://docs.microsoft.com/en-us/sharepoint/dev/spfx/shorter-share-link-format
@@ -1541,10 +1539,8 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 			fs.Logf(f, cnvFailMsg)
 			return url, nil
 		}
-
 		url = strings.Join(segments[:3], "/") + "/" + segments[5] + "/" + segments[6] +
 			"/_layouts/15/download.aspx?share=" + segments[7]
-
 	case driveTypeSharepoint:
 		/*
 			Method: Similar to driveTypeBusiness
@@ -1565,7 +1561,6 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 			fs.Logf(f, cnvFailMsg)
 			return url, nil
 		}
-
 		url = strings.Join(segments[:3], "/")
 		switch segments[4] {
 		case "s": // Site
@@ -1577,10 +1572,6 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 			fs.Logf(f, cnvFailMsg)
 		}
 		url += "/_layouts/15/download.aspx?share=" + segments[len(segments)-1]
-
-	default:
-		fs.Logf(f, cnvFailMsg)
-		return url, nil
 	}
 
 	return url, nil

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -1528,13 +1528,11 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 		enc = strings.ReplaceAll(enc, "=", "")
 		directURL = "https://api.onedrive.com/v1.0/shares/u!" + enc + "/root/content"
 	case driveTypeBusiness:
-
 		// Method: https://docs.microsoft.com/en-us/sharepoint/dev/spfx/shorter-share-link-format
 		// Example:
 		//   https://{tenant}-my.sharepoint.com/:t:/g/personal/{user_email}/{Opaque_String}
 		//   --convert to->
 		//   https://{tenant}-my.sharepoint.com/personal/{user_email}/_layouts/15/download.aspx?share={Opaque_String}
-
 		if len(segments) != 8 {
 			fs.Logf(f, cnvFailMsg)
 			return shareURL, nil
@@ -1555,7 +1553,6 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 		//   https://{tenant}-my.sharepoint.com/:t:/g/{Opaque_String}
 		//   --convert to->
 		//   https://{tenant}-my.sharepoint.com/_layouts/15/download.aspx?share={Opaque_String}
-
 		if len(segments) < 6 || len(segments) > 7 {
 			fs.Logf(f, cnvFailMsg)
 			return shareURL, nil

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -1528,13 +1528,13 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 		enc = strings.ReplaceAll(enc, "=", "")
 		directURL = "https://api.onedrive.com/v1.0/shares/u!" + enc + "/root/content"
 	case driveTypeBusiness:
-		/*
-			Method: https://docs.microsoft.com/en-us/sharepoint/dev/spfx/shorter-share-link-format
-			Example:
-				https://{tenant}-my.sharepoint.com/:t:/g/personal/{user_email}/{Opaque_String}
-				--convert to->
-				https://{tenant}-my.sharepoint.com/personal/{user_email}/_layouts/15/download.aspx?share={Opaque_String}
-		*/
+
+		// Method: https://docs.microsoft.com/en-us/sharepoint/dev/spfx/shorter-share-link-format
+		// Example:
+		//   https://{tenant}-my.sharepoint.com/:t:/g/personal/{user_email}/{Opaque_String}
+		//   --convert to->
+		//   https://{tenant}-my.sharepoint.com/personal/{user_email}/_layouts/15/download.aspx?share={Opaque_String}
+
 		if len(segments) != 8 {
 			fs.Logf(f, cnvFailMsg)
 			return shareURL, nil
@@ -1542,21 +1542,20 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 		directURL = strings.Join(segments[:3], "/") + "/" + segments[5] + "/" + segments[6] +
 			"/_layouts/15/download.aspx?share=" + segments[7]
 	case driveTypeSharepoint:
-		/*
-			Method: Similar to driveTypeBusiness
-			Example:
-				https://{tenant}-my.sharepoint.com/:t:/s/{site_name}/{Opaque_String}
-				--convert to->
-				https://{tenant}-my.sharepoint.com/sites/{site_name}/_layouts/15/download.aspx?share={Opaque_String}
+		// Method: Similar to driveTypeBusiness
+		// Example:
+		//   https://{tenant}-my.sharepoint.com/:t:/s/{site_name}/{Opaque_String}
+		//   --convert to->
+		//   https://{tenant}-my.sharepoint.com/sites/{site_name}/_layouts/15/download.aspx?share={Opaque_String}
+		//
+		//   https://{tenant}-my.sharepoint.com/:t:/t/{team_name}/{Opaque_String}
+		//   --convert to->
+		//   https://{tenant}-my.sharepoint.com/teams/{team_name}/_layouts/15/download.aspx?share={Opaque_String}
+		//
+		//   https://{tenant}-my.sharepoint.com/:t:/g/{Opaque_String}
+		//   --convert to->
+		//   https://{tenant}-my.sharepoint.com/_layouts/15/download.aspx?share={Opaque_String}
 
-				https://{tenant}-my.sharepoint.com/:t:/t/{team_name}/{Opaque_String}
-				--convert to->
-				https://{tenant}-my.sharepoint.com/teams/{team_name}/_layouts/15/download.aspx?share={Opaque_String}
-
-				https://{tenant}-my.sharepoint.com/:t:/g/{Opaque_String}
-				--convert to->
-				https://{tenant}-my.sharepoint.com/_layouts/15/download.aspx?share={Opaque_String}
-		*/
 		if len(segments) < 6 || len(segments) > 7 {
 			fs.Logf(f, cnvFailMsg)
 			return shareURL, nil

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -1557,19 +1557,19 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 			fs.Logf(f, cnvFailMsg)
 			return shareURL, nil
 		}
-		segType := ""
+		pathPrefix := ""
 		switch segments[4] {
 		case "s": // Site
-			segType = "/sites/" + segments[5]
+			pathPrefix = "/sites/" + segments[5]
 		case "t": // Team
-			segType = "/teams/" + segments[5]
+			pathPrefix = "/teams/" + segments[5]
 		case "g": // Root site
 		default:
 			fs.Logf(f, cnvFailMsg)
 			return shareURL, nil
 		}
 		directURL = fmt.Sprintf("https://%s%s/_layouts/15/download.aspx?share=%s",
-			segments[2], segType, segments[len(segments)-1])
+			segments[2], pathPrefix, segments[len(segments)-1])
 	}
 
 	return directURL, nil

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -1507,12 +1507,16 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 	shareURL := result.Link.WebURL
 
 	// Convert share link to direct download link if target is not a folder
-	cnvFailMsg := "Don't know how to convert share link to direct link - returning the link as is"
+	// Not attempting to do the conversion for regional versions, just to be safe
+	if f.opt.Region != regionGlobal {
+		return shareURL, nil
+	}
 	if info.Folder != nil {
 		fs.Debugf(nil, "Can't convert share link for folder to direct link - returning the link as is")
 		return shareURL, nil
 	}
 
+	cnvFailMsg := "Don't know how to convert share link to direct link - returning the link as is"
 	directURL := ""
 	segments := strings.Split(shareURL, "/")
 	switch f.driveType {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Make `rclone link onedrive` return direct download link.
Share link of file will be converted to direct link, but folder won't, since Onedrive manages folder download in a different and intransparent way.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/5381

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~
- [ ] ~~I have added documentation for the changes if appropriate.~~
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
