### PR TITLE
googleDrive: add direct link support for link cmd

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -55,6 +55,7 @@ import (
 const (
 	rcloneClientID              = "202264815644.apps.googleusercontent.com"
 	rcloneEncryptedClientSecret = "eX8GpZTVx3vxMWVkuuBdDWmAUE6rGhTwVrvG9GhllYccSdj2-mvHVg"
+	rcloneAPIKey                = "AIzaSyB7Qf0eRsyvLZoCMtYnHMc1U5CjvX0pEdQ" // FIXME Should use APIKey of rcloneDev
 	driveFolderType             = "application/vnd.google-apps.folder"
 	shortcutMimeType            = "application/vnd.google-apps.shortcut"
 	shortcutMimeTypeDangling    = "application/vnd.google-apps.shortcut.dangling" // synthetic mime type for internal use
@@ -2575,10 +2576,12 @@ func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object,
 
 // PublicLink adds a "readable by anyone with link" permission on the given file or folder.
 func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, unlink bool) (link string, err error) {
+	isFolder := false
 	id, err := f.dirCache.FindDir(ctx, remote, false)
 	if err == nil {
 		fs.Debugf(f, "attempting to share directory '%s'", remote)
 		id = shortcutID(id)
+		isFolder = true
 	} else {
 		fs.Debugf(f, "attempting to share single file '%s'", remote)
 		o, err := f.NewObject(ctx, remote)
@@ -2606,7 +2609,16 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 	if err != nil {
 		return "", err
 	}
-	return fmt.Sprintf("https://drive.google.com/open?id=%s", id), nil
+
+	// Convert share link to direct download link if target is not a folder
+	if isFolder {
+		fs.Debugf(nil, "Can't convert share link for folder to direct link - returning the link as is")
+		return fmt.Sprintf("https://drive.google.com/open?id=%s", id), nil
+	}
+
+	// Do not use "https://drive.google.com/uc?id={id}&export=download" method because of the 100 MB file size limit.
+	// The current "https://www.googleapis.com/drive/v3/..." method will rename the downloaded file to {id}.{suffix}
+	return fmt.Sprintf("https://www.googleapis.com/drive/v3/files/%s?alt=media&key=%s", id, rcloneAPIKey), nil
 }
 
 // DirMove moves src, srcRemote to this remote at dstRemote


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Make `rclone link googleDrive` return direct download link.
Share link of file will be converted to direct link, but folder won't, since google drive also manages folder download in a different and intransparent way.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/5381

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~
- [ ] ~~I have added documentation for the changes if appropriate.~~
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
