### PR TITLE
Terminate with non-zero status after receiving signal

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -37,6 +37,7 @@ import (
 	"github.com/rclone/rclone/fs/rc/rcserver"
 	"github.com/rclone/rclone/lib/atexit"
 	"github.com/rclone/rclone/lib/buildinfo"
+	"github.com/rclone/rclone/lib/exitcode"
 	"github.com/rclone/rclone/lib/random"
 	"github.com/rclone/rclone/lib/terminal"
 	"github.com/spf13/cobra"
@@ -58,19 +59,6 @@ var (
 	errorUncategorized      = errors.New("uncategorized error")
 	errorNotEnoughArguments = errors.New("not enough arguments")
 	errorTooManyArguments   = errors.New("too many arguments")
-)
-
-const (
-	exitCodeSuccess = iota
-	exitCodeUsageError
-	exitCodeUncategorizedError
-	exitCodeDirNotFound
-	exitCodeFileNotFound
-	exitCodeRetryError
-	exitCodeNoRetryError
-	exitCodeFatalError
-	exitCodeTransferExceeded
-	exitCodeNoFilesTransferred
 )
 
 // ShowVersion prints the version to stdout
@@ -484,31 +472,31 @@ func resolveExitCode(err error) {
 	if err == nil {
 		if ci.ErrorOnNoTransfer {
 			if accounting.GlobalStats().GetTransfers() == 0 {
-				os.Exit(exitCodeNoFilesTransferred)
+				os.Exit(exitcode.NoFilesTransferred)
 			}
 		}
-		os.Exit(exitCodeSuccess)
+		os.Exit(exitcode.Success)
 	}
 
 	_, unwrapped := fserrors.Cause(err)
 
 	switch {
 	case unwrapped == fs.ErrorDirNotFound:
-		os.Exit(exitCodeDirNotFound)
+		os.Exit(exitcode.DirNotFound)
 	case unwrapped == fs.ErrorObjectNotFound:
-		os.Exit(exitCodeFileNotFound)
+		os.Exit(exitcode.FileNotFound)
 	case unwrapped == errorUncategorized:
-		os.Exit(exitCodeUncategorizedError)
+		os.Exit(exitcode.UncategorizedError)
 	case unwrapped == accounting.ErrorMaxTransferLimitReached:
-		os.Exit(exitCodeTransferExceeded)
+		os.Exit(exitcode.TransferExceeded)
 	case fserrors.ShouldRetry(err):
-		os.Exit(exitCodeRetryError)
+		os.Exit(exitcode.RetryError)
 	case fserrors.IsNoRetryError(err):
-		os.Exit(exitCodeNoRetryError)
+		os.Exit(exitcode.NoRetryError)
 	case fserrors.IsFatalError(err):
-		os.Exit(exitCodeFatalError)
+		os.Exit(exitcode.FatalError)
 	default:
-		os.Exit(exitCodeUsageError)
+		os.Exit(exitcode.UsageError)
 	}
 }
 

--- a/lib/atexit/atexit.go
+++ b/lib/atexit/atexit.go
@@ -51,7 +51,7 @@ func Register(fn func()) FnHandle {
 			fs.Infof(nil, "Signal received: %s", sig)
 			Run()
 			fs.Infof(nil, "Exiting...")
-			os.Exit(0)
+			os.Exit(exitCode(sig))
 		}()
 	})
 

--- a/lib/atexit/atexit_other.go
+++ b/lib/atexit/atexit_other.go
@@ -4,6 +4,12 @@ package atexit
 
 import (
 	"os"
+
+	"github.com/rclone/rclone/lib/exitcode"
 )
 
 var exitSignals = []os.Signal{os.Interrupt}
+
+func exitCode(_ os.Signal) int {
+	return exitcode.UncategorizedError
+}

--- a/lib/atexit/atexit_test.go
+++ b/lib/atexit/atexit_test.go
@@ -1,0 +1,41 @@
+package atexit
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/rclone/rclone/lib/exitcode"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeSignal struct{}
+
+func (*fakeSignal) String() string {
+	return "fake"
+}
+
+func (*fakeSignal) Signal() {
+}
+
+var _ os.Signal = (*fakeSignal)(nil)
+
+func TestExitCode(t *testing.T) {
+	switch runtime.GOOS {
+	case "windows", "plan9":
+		for _, i := range []os.Signal{
+			os.Interrupt,
+			os.Kill,
+		} {
+			assert.Equal(t, exitCode(i), exitcode.UncategorizedError)
+		}
+
+	default:
+		// SIGINT (2) and SIGKILL (9) are portable numbers specified by POSIX.
+		assert.Equal(t, exitCode(os.Interrupt), 128+2)
+		assert.Equal(t, exitCode(os.Kill), 128+9)
+	}
+
+	// Never a real signal
+	assert.Equal(t, exitCode(&fakeSignal{}), exitcode.UncategorizedError)
+}

--- a/lib/atexit/atexit_unix.go
+++ b/lib/atexit/atexit_unix.go
@@ -5,6 +5,20 @@ package atexit
 import (
 	"os"
 	"syscall"
+
+	"github.com/rclone/rclone/lib/exitcode"
 )
 
 var exitSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM} // Not syscall.SIGQUIT as we want the default behaviour
+
+// exitCode calculates the exit code for the given signal. Many Unix programs
+// exit with 128+signum if they handle signals. Most shell also implement the
+// same convention if a program is terminated by an uncaught and/or fatal
+// signal.
+func exitCode(sig os.Signal) int {
+	if real, ok := sig.(syscall.Signal); ok && int(real) > 0 {
+		return 128 + int(real)
+	}
+
+	return exitcode.UncategorizedError
+}

--- a/lib/exitcode/exitcode.go
+++ b/lib/exitcode/exitcode.go
@@ -1,0 +1,25 @@
+// Package exitcode exports rclone's exit status numbers.
+package exitcode
+
+const (
+	// Success is returned when rclone finished without error.
+	Success = iota
+	// UsageError is returned when there was a syntax or usage error in the arguments.
+	UsageError
+	// UncategorizedError is returned for any error not categorised otherwise.
+	UncategorizedError
+	// DirNotFound is returned when a source or destination directory is not found.
+	DirNotFound
+	// FileNotFound is returned when a source or destination file is not found.
+	FileNotFound
+	// RetryError is returned for temporary errors during operations which may be retried.
+	RetryError
+	// NoRetryError is returned for errors from operations which can't/shouldn't be retried.
+	NoRetryError
+	// FatalError is returned for errors one or more retries won't resolve.
+	FatalError
+	// TransferExceeded is returned when network I/O exceeded the quota.
+	TransferExceeded
+	// NoFilesTransferred everything succeeded, but no transfer was made.
+	NoFilesTransferred
+)


### PR DESCRIPTION
With this change fatal signals handled by the `atexit` package causea non-zero exit code. On Unix systems it's `128 + int(signum)` while
on other systems, such as Windows, it's always 2 ("error not otherwise
categorised").

Resolves #5437.