### PR TITLE
cryptcheck: agnostify src dst order

### DIFF
--- a/cmd/cryptcheck/cryptcheck.go
+++ b/cmd/cryptcheck/cryptcheck.go
@@ -57,11 +57,16 @@ After it has run it will log the status of the encryptedremote:.
 
 // cryptCheck checks the integrity of a crypted remote
 func cryptCheck(ctx context.Context, fdst, fsrc fs.Fs) error {
-	// Check to see fcrypt is a crypt
+	// Check to see fdst is crypted. If not, check fsrc.
 	fcrypt, ok := fdst.(*crypt.Fs)
 	if !ok {
-		return errors.Errorf("%s:%s is not a crypt remote", fdst.Name(), fdst.Root())
+		fcrypt, ok = fsrc.(*crypt.Fs)
+		if !ok {
+			return errors.Errorf("Both %s:%s and %s:%s are not crypt remote", fsrc.Name(), fsrc.Root(), fdst.Name(), fdst.Root())
+		}
+		fdst, fsrc = fsrc, fdst
 	}
+
 	// Find a hash to use
 	funderlying := fcrypt.UnWrap()
 	hashType := funderlying.Hashes().GetOne()

--- a/cmd/cryptcheck/cryptcheck.go
+++ b/cmd/cryptcheck/cryptcheck.go
@@ -64,6 +64,7 @@ func cryptCheck(ctx context.Context, fdst, fsrc fs.Fs) error {
 		if !ok {
 			return errors.Errorf("Both %s:%s and %s:%s are not crypt remote", fsrc.Name(), fsrc.Root(), fdst.Name(), fdst.Root())
 		}
+		fs.Infof(nil, "Dst %s:%s is not a crypt remote, switching src and dst", fdst.Name(), fdst.Root())
 		fdst, fsrc = fsrc, fdst
 	}
 

--- a/cmd/cryptcheck/cryptcheck.go
+++ b/cmd/cryptcheck/cryptcheck.go
@@ -62,9 +62,9 @@ func cryptCheck(ctx context.Context, fdst, fsrc fs.Fs) error {
 	if !ok {
 		fcrypt, ok = fsrc.(*crypt.Fs)
 		if !ok {
-			return errors.Errorf("Both %s:%s and %s:%s are not crypt remote", fsrc.Name(), fsrc.Root(), fdst.Name(), fdst.Root())
+			return errors.Errorf("Both %s:%s and %s:%s are not crypt remote", fdst.Name(), fdst.Root(), fsrc.Name(), fsrc.Root())
 		}
-		fs.Infof(nil, "Dst %s:%s is not a crypt remote, switching src and dst", fdst.Name(), fdst.Root())
+		fs.Logf(nil, "%s:%s is not a crypt remote, using %s:%s as dst", fdst.Name(), fdst.Root(), fsrc.Name(), fsrc.Root())
 		fdst, fsrc = fsrc, fdst
 	}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Make `rclone cryptcheck` being agnostic about src dst order.

So that both
`rclone cryptcheck [unencrypted local] [crypted remote]`
and
`rclone cryptcheck [crypted remote] [unencrypted local]`
work.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

close #5425

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~
- [ ] ~~I have added documentation for the changes if appropriate.~~
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
