### PR TITLE
mountlib: restore daemon mode after #5415

### DIFF
--- a/cmd/serve/docker/volume.go
+++ b/cmd/serve/docker/volume.go
@@ -270,7 +270,7 @@ func (vol *Volume) mount(id string) error {
 		return errors.New("volume filesystem is not ready")
 	}
 
-	if err := vol.mnt.Mount(); err != nil {
+	if _, err := vol.mnt.Mount(); err != nil {
 		return err
 	}
 	vol.mnt.MountedOn = time.Now()


### PR DESCRIPTION
#### What is the purpose of this change?

After mountlib refactoring by #5415 `mount --daemon` waits for mount thread instead of returning immediately.

This patch fixes it.

~~Additionally it moves remaining helper functions from `mount.go` to `utils.go` (I forgot to move them in #5415 !).~~
**UPDATE 2021-07-26** I removed refactoring from this PR leaving only the fix.

#### Was the change discussed in an issue or in the forum before?

Fixes #5472

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
