### PR TITLE
add --azureblob-no-head-object

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -235,7 +235,7 @@ This option controls how often unused buffers will be removed from the pool.`,
 			Advanced: true,
 		}, {
 			Name:     "no_head_object",
-			Help:     `If set, don't HEAD objects`,
+			Help:     `If set, don't HEAD objects. So, it will be faster when getting a lot of small files.`,
 			Default:  false,
 			Advanced: true,
 		}},

--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -235,7 +235,7 @@ This option controls how often unused buffers will be removed from the pool.`,
 			Advanced: true,
 		}, {
 			Name:     "no_head_object",
-			Help:     `If set, don't HEAD objects. So, it will be faster when getting a lot of small files.`,
+			Help:     `If set, do not do HEAD before GET when getting objects.`,
 			Default:  false,
 			Advanced: true,
 		}},

--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -233,6 +233,11 @@ This option controls how often unused buffers will be removed from the pool.`,
 				},
 			},
 			Advanced: true,
+		}, {
+			Name:     "no_head_object",
+			Help:     `If set, don't HEAD objects`,
+			Default:  false,
+			Advanced: true,
 		}},
 	})
 }
@@ -258,6 +263,7 @@ type Options struct {
 	MemoryPoolUseMmap    bool                 `config:"memory_pool_use_mmap"`
 	Enc                  encoder.MultiEncoder `config:"encoding"`
 	PublicAccess         string               `config:"public_access"`
+	NoHeadObject         bool                 `config:"no_head_object"`
 }
 
 // Fs represents a remote azure server
@@ -756,7 +762,7 @@ func (f *Fs) newObjectWithInfo(remote string, info *azblob.BlobItemInternal) (fs
 		if err != nil {
 			return nil, err
 		}
-	} else {
+	} else if !o.fs.opt.NoHeadObject {
 		err := o.readMetaData() // reads info and headers, returning an error
 		if err != nil {
 			return nil, err
@@ -1366,6 +1372,24 @@ func (o *Object) decodeMetaDataFromPropertiesResponse(info *azblob.BlobGetProper
 	return nil
 }
 
+func (o *Object) decodeMetaDataFromDownloadResponse(info *azblob.DownloadResponse) (err error) {
+	metadata := info.NewMetadata()
+	size := info.ContentLength()
+	if isDirectoryMarker(size, metadata, o.remote) {
+		return fs.ErrorNotAFile
+	}
+	// NOTE - Client library always returns MD5 as base64 decoded string, Object needs to maintain
+	// this as base64 encoded string.
+	o.md5 = base64.StdEncoding.EncodeToString(info.ContentMD5())
+	o.mimeType = info.ContentType()
+	o.size = size
+	o.modTime = info.LastModified()
+	o.accessTier = o.AccessTier()
+	o.setMetadata(metadata)
+
+	return nil
+}
+
 func (o *Object) decodeMetaDataFromBlob(info *azblob.BlobItemInternal) (err error) {
 	metadata := info.Metadata
 	size := *info.Properties.ContentLength
@@ -1495,6 +1519,10 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to open for download")
+	}
+	err = o.decodeMetaDataFromDownloadResponse(downloadResponse)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to decode metadata for download")
 	}
 	in = downloadResponse.Body(azblob.RetryReaderOptions{})
 	return in, nil

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1247,7 +1247,7 @@ very small even with this flag.
 			Advanced: true,
 		}, {
 			Name:     "no_head_object",
-			Help:     `If set, don't HEAD objects`,
+			Help:     `If set, don't HEAD objects. So, it will be faster when getting a lot of small files.`,
 			Default:  false,
 			Advanced: true,
 		}, {

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1247,7 +1247,7 @@ very small even with this flag.
 			Advanced: true,
 		}, {
 			Name:     "no_head_object",
-			Help:     `If set, don't HEAD objects. So, it will be faster when getting a lot of small files.`,
+			Help:     `If set, do not do HEAD before GET when getting objects.`,
 			Default:  false,
 			Advanced: true,
 		}, {


### PR DESCRIPTION
Could you add --azureblob-no-head-object to reduce HTTP Head?

The results are as follows:

################################
Before add --azureblob-no-head-object
################################

2021/07/26 14:23:29 DEBUG : rclone: Version "v1.56.0-beta.5589.da36ce08e" starting with parameters ["rclone" "--no-traverse" "--checksum" "--dump" "headers" "--log-level" "DEBUG" "copy" "azure:noyoritest/a.txt" "c.txt"]
2021/07/26 14:23:29 DEBUG : Creating backend with remote "azure:noyoritest/a.txt"
2021/07/26 14:23:29 DEBUG : Using config file from "/home/noyori/.config/rclone/rclone.conf"
2021/07/26 14:23:29 DEBUG : You have specified to dump information. Please be noted that the Accept-Encoding as shown may not be correct in the request and the response may not show Content-Encoding if the go standard libraries auto gzip encoding was in effect. In this case the body of the request will be gunzipped before showing it.
2021/07/26 14:23:29 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/07/26 14:23:29 DEBUG : HTTP REQUEST (req 0xc00065f100)
2021/07/26 14:23:29 DEBUG : HEAD /noyoritest/a.txt?timeout=31536001 HTTP/1.1
Host: noyoritest.blob.core.windows.net
User-Agent: rclone/v1.56.0-beta.5589.da36ce08e
Authorization: XXXX
X-Ms-Client-Request-Id: 44742ae8-f82d-499b-7135-88003d7d76a4
X-Ms-Version: 2020-04-08
x-ms-date: Mon, 26 Jul 2021 05:23:29 GMT

2021/07/26 14:23:29 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/07/26 14:23:29 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/07/26 14:23:29 DEBUG : HTTP RESPONSE (req 0xc00065f100)
2021/07/26 14:23:29 DEBUG : HTTP/1.1 200 OK
Content-Length: 1
Accept-Ranges: bytes
Content-Md5: kutf/uauL+w61xx3dTFXjw==
Content-Type: text/plain
Date: Mon, 26 Jul 2021 05:23:29 GMT
Etag: "0x8D94B47C510FB98"
Last-Modified: Tue, 20 Jul 2021 06:29:47 GMT
Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
X-Ms-Access-Tier: Hot
X-Ms-Access-Tier-Inferred: true
X-Ms-Blob-Type: BlockBlob
X-Ms-Client-Request-Id: 44742ae8-f82d-499b-7135-88003d7d76a4
X-Ms-Creation-Time: Tue, 20 Jul 2021 06:29:47 GMT
X-Ms-Lease-State: available
X-Ms-Lease-Status: unlocked
X-Ms-Request-Id: 2a017cb2-c01e-000e-02de-813acb000000
X-Ms-Server-Encrypted: true
X-Ms-Version: 2020-04-08

2021/07/26 14:23:29 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/07/26 14:23:29 DEBUG : fs cache: adding new entry for parent of "azure:noyoritest/a.txt", "azure:noyoritest"
2021/07/26 14:23:29 DEBUG : Creating backend with remote "c.txt"
2021/07/26 14:23:29 DEBUG : fs cache: renaming cache item "c.txt" to be canonical "/home/noyori/go/rclone/c.txt"
2021/07/26 14:23:29 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/07/26 14:23:29 DEBUG : HTTP REQUEST (req 0xc00003e100)
2021/07/26 14:23:29 DEBUG : HEAD /noyoritest/a.txt?timeout=31536001 HTTP/1.1
Host: noyoritest.blob.core.windows.net
User-Agent: rclone/v1.56.0-beta.5589.da36ce08e
Authorization: XXXX
X-Ms-Client-Request-Id: 197fcd7f-e4f3-4f57-61c1-a3f710e7291d
X-Ms-Version: 2020-04-08
x-ms-date: Mon, 26 Jul 2021 05:23:29 GMT

2021/07/26 14:23:29 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/07/26 14:23:29 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/07/26 14:23:29 DEBUG : HTTP RESPONSE (req 0xc00003e100)
2021/07/26 14:23:29 DEBUG : HTTP/1.1 200 OK
Content-Length: 1
Accept-Ranges: bytes
Content-Md5: kutf/uauL+w61xx3dTFXjw==
Content-Type: text/plain
Date: Mon, 26 Jul 2021 05:23:29 GMT
Etag: "0x8D94B47C510FB98"
Last-Modified: Tue, 20 Jul 2021 06:29:47 GMT
Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
X-Ms-Access-Tier: Hot
X-Ms-Access-Tier-Inferred: true
X-Ms-Blob-Type: BlockBlob
X-Ms-Client-Request-Id: 197fcd7f-e4f3-4f57-61c1-a3f710e7291d
X-Ms-Creation-Time: Tue, 20 Jul 2021 06:29:47 GMT
X-Ms-Lease-State: available
X-Ms-Lease-Status: unlocked
X-Ms-Request-Id: 2a017ce9-c01e-000e-34de-813acb000000
X-Ms-Server-Encrypted: true
X-Ms-Version: 2020-04-08

2021/07/26 14:23:29 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/07/26 14:23:29 DEBUG : a.txt: Need to transfer - File not found at Destination
2021/07/26 14:23:29 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/07/26 14:23:29 DEBUG : HTTP REQUEST (req 0xc00039ed00)
2021/07/26 14:23:29 DEBUG : GET /noyoritest/a.txt?timeout=31536001 HTTP/1.1
Host: noyoritest.blob.core.windows.net
User-Agent: rclone/v1.56.0-beta.5589.da36ce08e
Authorization: XXXX
X-Ms-Client-Request-Id: 966c7c9f-23e9-4389-7fc1-d12f62864006
X-Ms-Version: 2020-04-08
x-ms-date: Mon, 26 Jul 2021 05:23:29 GMT
Accept-Encoding: gzip

2021/07/26 14:23:29 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/07/26 14:23:29 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/07/26 14:23:29 DEBUG : HTTP RESPONSE (req 0xc00039ed00)
2021/07/26 14:23:29 DEBUG : HTTP/1.1 200 OK
Content-Length: 1
Accept-Ranges: bytes
Content-Md5: kutf/uauL+w61xx3dTFXjw==
Content-Type: text/plain
Date: Mon, 26 Jul 2021 05:23:29 GMT
Etag: "0x8D94B47C510FB98"
Last-Modified: Tue, 20 Jul 2021 06:29:47 GMT
Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
X-Ms-Blob-Type: BlockBlob
X-Ms-Client-Request-Id: 966c7c9f-23e9-4389-7fc1-d12f62864006
X-Ms-Creation-Time: Tue, 20 Jul 2021 06:29:47 GMT
X-Ms-Lease-State: available
X-Ms-Lease-Status: unlocked
X-Ms-Request-Id: 2a017d1d-c01e-000e-66de-813acb000000
X-Ms-Server-Encrypted: true
X-Ms-Version: 2020-04-08

2021/07/26 14:23:29 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/07/26 14:23:29 DEBUG : a.txt: md5 = 92eb5ffee6ae2fec3ad71c777531578f OK
2021/07/26 14:23:29 INFO  : a.txt: Copied (new)
2021/07/26 14:23:29 INFO  : 
Transferred:   	          1 / 1 Byte, 100%, 0 Byte/s, ETA -
Transferred:            1 / 1, 100%
Elapsed time:         0.5s

2021/07/26 14:23:29 DEBUG : 5 go routines active




################################
After add --azureblob-no-head-object
################################

2021/07/26 14:23:02 DEBUG : rclone: Version "v1.56.0-beta.5589.da36ce08e" starting with parameters ["rclone" "--azureblob-no-head-object" "--no-traverse" "--checksum" "--dump" "headers" "--log-level" "DEBUG" "copy" "azure:noyoritest/a.txt" "c.txt"]
2021/07/26 14:23:02 DEBUG : Creating backend with remote "azure:noyoritest/a.txt"
2021/07/26 14:23:02 DEBUG : Using config file from "/home/noyori/.config/rclone/rclone.conf"
2021/07/26 14:23:02 DEBUG : azure: detected overridden config - adding "{EVwtF}" suffix to name
2021/07/26 14:23:02 DEBUG : You have specified to dump information. Please be noted that the Accept-Encoding as shown may not be correct in the request and the response may not show Content-Encoding if the go standard libraries auto gzip encoding was in effect. In this case the body of the request will be gunzipped before showing it.
2021/07/26 14:23:02 DEBUG : fs cache: adding new entry for parent of "azure:noyoritest/a.txt", "azure{EVwtF}:noyoritest"
2021/07/26 14:23:02 DEBUG : Creating backend with remote "c.txt"
2021/07/26 14:23:02 DEBUG : fs cache: renaming cache item "c.txt" to be canonical "/home/noyori/go/rclone/c.txt"
2021/07/26 14:23:02 DEBUG : a.txt: Need to transfer - File not found at Destination
2021/07/26 14:23:02 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/07/26 14:23:02 DEBUG : HTTP REQUEST (req 0xc00003f000)
2021/07/26 14:23:02 DEBUG : GET /noyoritest/a.txt?timeout=31536001 HTTP/1.1
Host: noyoritest.blob.core.windows.net
User-Agent: rclone/v1.56.0-beta.5589.da36ce08e
Authorization: XXXX
X-Ms-Client-Request-Id: f3a4ead1-38d3-4c45-5a55-1ef74ee94517
X-Ms-Version: 2020-04-08
x-ms-date: Mon, 26 Jul 2021 05:23:02 GMT
Accept-Encoding: gzip

2021/07/26 14:23:02 DEBUG : >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
2021/07/26 14:23:03 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/07/26 14:23:03 DEBUG : HTTP RESPONSE (req 0xc00003f000)
2021/07/26 14:23:03 DEBUG : HTTP/1.1 200 OK
Content-Length: 1
Accept-Ranges: bytes
Content-Md5: kutf/uauL+w61xx3dTFXjw==
Content-Type: text/plain
Date: Mon, 26 Jul 2021 05:23:02 GMT
Etag: "0x8D94B47C510FB98"
Last-Modified: Tue, 20 Jul 2021 06:29:47 GMT
Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0
X-Ms-Blob-Type: BlockBlob
X-Ms-Client-Request-Id: f3a4ead1-38d3-4c45-5a55-1ef74ee94517
X-Ms-Creation-Time: Tue, 20 Jul 2021 06:29:47 GMT
X-Ms-Lease-State: available
X-Ms-Lease-Status: unlocked
X-Ms-Request-Id: 293b6e08-301e-00b1-6bde-812ebd000000
X-Ms-Server-Encrypted: true
X-Ms-Version: 2020-04-08

2021/07/26 14:23:03 DEBUG : <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<
2021/07/26 14:23:03 DEBUG : a.txt: md5 = 92eb5ffee6ae2fec3ad71c777531578f OK
2021/07/26 14:23:03 INFO  : a.txt: Copied (new)
2021/07/26 14:23:03 INFO  : 
Transferred:   	          1 / 1 Byte, 100%, 0 Byte/s, ETA -
Transferred:            1 / 1, 100%
Elapsed time:         0.6s

2021/07/26 14:23:03 DEBUG : 6 go routines active



#########
Best regards