### PR TITLE
rc: fix speed does not update in core/stats

### DIFF
--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -375,6 +375,9 @@ func (sg *statsGroups) sum(ctx context.Context) *StatsInfo {
 			sum.startedTransfers = append(sum.startedTransfers, stats.startedTransfers...)
 			sum.oldDuration += stats.oldDuration
 			sum.oldTimeRanges = append(sum.oldTimeRanges, stats.oldTimeRanges...)
+			stats.average.mu.Lock()
+			sum.average.speed += stats.average.speed
+			stats.average.mu.Unlock()
 		}
 		stats.mu.RUnlock()
 	}

--- a/fs/accounting/stats_groups_test.go
+++ b/fs/accounting/stats_groups_test.go
@@ -62,6 +62,7 @@ func TestStatsGroupOperations(t *testing.T) {
 		assert.Equal(t, stats1.bytes+stats2.bytes, sum.bytes)
 		assert.Equal(t, stats1.errors+stats2.errors, sum.errors)
 		assert.Equal(t, stats1.oldDuration+stats2.oldDuration, sum.oldDuration)
+		assert.Equal(t, stats1.average.speed+stats2.average.speed, sum.average.speed)
 		// dict can iterate in either order
 		a := timeRanges{stats1.oldTimeRanges[0], stats2.oldTimeRanges[0]}
 		b := timeRanges{stats2.oldTimeRanges[0], stats1.oldTimeRanges[0]}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The `speed` in core/stats does not change the speed which is returned by the global stats using sum.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

No. 

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
