### PR TITLE
cmd/mount: remind that --fast-list does nothing on a mount

### DIFF
--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -1,6 +1,7 @@
 package mountlib
 
 import (
+	"context"
 	"log"
 	"os"
 	"path/filepath"
@@ -127,6 +128,10 @@ func NewMountCommand(commandName string, hidden bool, mount MountFn) *cobra.Comm
 		Long:   strings.ReplaceAll(strings.ReplaceAll(mountHelp, "|", "`"), "@", commandName) + vfs.Help,
 		Run: func(command *cobra.Command, args []string) {
 			cmd.CheckArgs(2, 2, command, args)
+
+			if fs.GetConfig(context.Background()).UseListR {
+				fs.Logf(nil, "--fast-list does nothing on a mount")
+			}
 
 			if Opt.Daemon {
 				config.PassConfigKeyForDaemonization = true


### PR DESCRIPTION
#### What is the purpose of this change?

Our support personnel regularly remind our users that `--fast-list does nothing on a mount`.
This patch automates the job.

#### Was the change discussed in an issue or in the forum before?

- https://forum.rclone.org/t/infinite-loop-with-plex-media-server-and-data-on-rclone/25683/10
- https://forum.rclone.org/t/dropped-my-cache-remote-and-now-seeing-visual-artifacts/25922/2
- https://forum.rclone.org/t/vfs-cache-issues-with-union-chunker-google-drive/25848/2
- https://forum.rclone.org/t/does-multi-thread-streams-work-for-dropbox-business/25795/4
- many more...

@animosity22 @ncw 
Please review

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
