### PR TITLE
pcloud: add sha256 support - fixes #5496

### DIFF
--- a/backend/pcloud/pcloud.go
+++ b/backend/pcloud/pcloud.go
@@ -888,7 +888,7 @@ func (f *Fs) Hashes() hash.Set {
 	//
 	// https://forum.rclone.org/t/pcloud-to-local-no-hashes-in-common/19440
 	if f.opt.Hostname == "eapi.pcloud.com" {
-		return hash.Set(hash.SHA1)
+		return hash.Set(hash.SHA1 | hash.SHA256)
 	}
 	return hash.Set(hash.MD5 | hash.SHA1)
 }
@@ -937,7 +937,7 @@ func (o *Object) getHashes(ctx context.Context) (err error) {
 
 // Hash returns the SHA-1 of an object returning a lowercase hex string
 func (o *Object) Hash(ctx context.Context, t hash.Type) (string, error) {
-	if t != hash.MD5 && t != hash.SHA1 {
+	if t != hash.MD5 && t != hash.SHA1 && t != hash.SHA256 {
 		return "", hash.ErrUnsupported
 	}
 	if o.md5 == "" && o.sha1 == "" {

--- a/docs/content/commands/rclone_hashsum.md
+++ b/docs/content/commands/rclone_hashsum.md
@@ -29,6 +29,7 @@ Run without a hash to see the list of all supported hashes, e.g.
       * sha1
       * whirlpool
       * crc32
+      * sha256
       * dropbox
       * mailru
       * quickxor

--- a/docs/content/pcloud.md
+++ b/docs/content/pcloud.md
@@ -89,11 +89,8 @@ second.  These will be used to detect whether objects need syncing or
 not.  In order to set a Modification time pCloud requires the object
 be re-uploaded.
 
-pCloud supports MD5 and SHA1 type hashes in the US region but and SHA1
-only in the EU region, so you can use the `--checksum` flag.
-
-(Note that pCloud also support SHA256 in the EU region, but rclone
-does not have support for that yet.)
+pCloud supports MD5 and SHA1 hashes in the US region, and SHA1 and SHA256
+hashes in the EU region, so you can use the `--checksum` flag.
 
 #### Restricted filename characters
 

--- a/fs/hash/hash.go
+++ b/fs/hash/hash.go
@@ -3,6 +3,7 @@ package hash
 import (
 	"crypto/md5"
 	"crypto/sha1"
+	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
 	"hash"
@@ -71,6 +72,9 @@ var (
 
 	// CRC32 indicates CRC-32 support
 	CRC32 Type
+
+	// SHA256 indicates SHA-256 support
+	SHA256 Type
 )
 
 func init() {
@@ -78,6 +82,7 @@ func init() {
 	SHA1 = RegisterHash("sha1", "SHA-1", 40, sha1.New)
 	Whirlpool = RegisterHash("whirlpool", "Whirlpool", 128, whirlpool.New)
 	CRC32 = RegisterHash("crc32", "CRC-32", 8, func() hash.Hash { return crc32.NewIEEE() })
+	SHA256 = RegisterHash("sha256", "SHA-256", 64, sha256.New)
 }
 
 // Supported returns a set of all the supported hashes by

--- a/fs/hash/hash_test.go
+++ b/fs/hash/hash_test.go
@@ -75,6 +75,7 @@ var hashTestSet = []hashTest{
 			hash.SHA1:      "3ab6543c08a75f292a5ecedac87ec41642d12166",
 			hash.Whirlpool: "eddf52133d4566d763f716e853d6e4efbabd29e2c2e63f56747b1596172851d34c2df9944beb6640dbdbe3d9b4eb61180720a79e3d15baff31c91e43d63869a4",
 			hash.CRC32:     "a6041d7e",
+			hash.SHA256:    "c839e57675862af5c21bd0a15413c3ec579e0d5522dab600bc6c3489b05b8f54",
 		},
 	},
 	// Empty data set
@@ -85,6 +86,7 @@ var hashTestSet = []hashTest{
 			hash.SHA1:      "da39a3ee5e6b4b0d3255bfef95601890afd80709",
 			hash.Whirlpool: "19fa61d75522a4669b44e39c1d2e1726c530232130d407f89afee0964997f7a73e83be698b288febcf88e3e03c4f0757ea8964e59b63d93708b138cc42a66eb3",
 			hash.CRC32:     "00000000",
+			hash.SHA256:    "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
 		},
 	},
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Add SHA-256 hashing support for pcloud backend. Fixes #5496
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
Yes
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
