### PR TITLE
googlephotos: Use encoder for album names

### DIFF
--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -20,6 +20,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/rclone/rclone/backend/googlephotos/api"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/configstruct"
 	"github.com/rclone/rclone/fs/config/obscure"
@@ -28,6 +29,7 @@ import (
 	"github.com/rclone/rclone/fs/fshttp"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/log"
+	"github.com/rclone/rclone/lib/encoder"
 	"github.com/rclone/rclone/lib/oauthutil"
 	"github.com/rclone/rclone/lib/pacer"
 	"github.com/rclone/rclone/lib/rest"
@@ -149,16 +151,24 @@ listings and transferred.
 Without this flag, archived media will not be visible in directory
 listings and won't be transferred.`,
 			Advanced: true,
+		}, {
+			Name:     config.ConfigEncoding,
+			Help:     config.ConfigEncodingHelp,
+			Advanced: true,
+			Default: (encoder.Base |
+				encoder.EncodeCrLf |
+				encoder.EncodeInvalidUtf8),
 		}}...),
 	})
 }
 
 // Options defines the configuration for this backend
 type Options struct {
-	ReadOnly        bool `config:"read_only"`
-	ReadSize        bool `config:"read_size"`
-	StartYear       int  `config:"start_year"`
-	IncludeArchived bool `config:"include_archived"`
+	ReadOnly        bool                 `config:"read_only"`
+	ReadSize        bool                 `config:"read_size"`
+	StartYear       int                  `config:"start_year"`
+	IncludeArchived bool                 `config:"include_archived"`
+	Enc             encoder.MultiEncoder `config:"encoding"`
 }
 
 // Fs represents a remote storage server
@@ -496,7 +506,9 @@ func (f *Fs) listAlbums(ctx context.Context, shared bool) (all *albums, err erro
 			lastID = newAlbums[len(newAlbums)-1].ID
 		}
 		for i := range newAlbums {
-			all.add(&newAlbums[i])
+			anAlbum := newAlbums[i]
+			anAlbum.Title = f.opt.Enc.FromStandardPath(anAlbum.Title)
+			all.add(&anAlbum)
 		}
 		if result.NextPageToken == "" {
 			break


### PR DESCRIPTION
#### What is the purpose of this change?

This fixes the problem of album names containing \n which caused problems as local directories could not be created during sync.

#### Was the change discussed in an issue or in the forum before?

Yes: https://forum.rclone.org/t/google-photos-sync-failed-for-multi-lined-album-names/25589

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)


#### Manual Testing
Please note the diff is intentionally redacted - it show cases the two primary differences in album names due to this change.
```
$ rclone_new lsf -Fp --csv gphotos:shared-album &> rclone_new_2021-08-15_shared-album_lsf.txt
$ rclone lsf -Fp --csv gphotos:shared-album &> rclone_2021-08-15_shared-album_lsf.txt
$ diff rclone_2021-08-15_shared-album_lsf.txt rclone_new_2021-08-15_shared-album_lsf.txt
88c88
< "2018 US Trip - San Francisco, Seattle/"
---
> "2018 US Trip - San Francisco, Seattle／Kirkland, New York/"
164,166c164
< "California Citrus State Historic Park
< 
<  29 Dec 2019/"
---
> California Citrus State Historic Park␊␊ 29 Dec 2019/
$
```