### PR TITLE
Removed ambiguity from copy command docs

### DIFF
--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -23,12 +23,12 @@ func init() {
 
 var commandDefinition = &cobra.Command{
 	Use:   "copy source:path dest:path",
-	Short: `Copy files from source to dest, skipping already copied.`,
+	Short: `Copy files from source to dest, skipping identical files.`,
 	// Note: "|" will be replaced by backticks below
 	Long: strings.ReplaceAll(`
-Copy the source to the destination.  Doesn't transfer
-unchanged files, testing by size and modification time or
-MD5SUM.  Doesn't delete files from the destination.
+Copy the source to the destination.  Does not transfer files that are
+identical on source and destination, testing by size and modification
+time or MD5SUM.  Doesn't delete files from the destination.
 
 Note that it is always the contents of the directory that is synced,
 not the directory so when source:path is a directory, it's the

--- a/cmd/copyto/copyto.go
+++ b/cmd/copyto/copyto.go
@@ -15,7 +15,7 @@ func init() {
 
 var commandDefinition = &cobra.Command{
 	Use:   "copyto source:path dest:path",
-	Short: `Copy files from source to dest, skipping already copied.`,
+	Short: `Copy files from source to dest, skipping identical files.`,
 	Long: `
 If source:path is a file or directory then it copies it to a file or
 directory named dest:path.
@@ -39,9 +39,9 @@ This will:
         copy it to dst, overwriting existing files if they exist
         see copy command for full details
 
-This doesn't transfer unchanged files, testing by size and
-modification time or MD5SUM.  It doesn't delete files from the
-destination.
+This doesn't transfer files that are identical on src and dst, testing
+by size and modification time or MD5SUM.  It doesn't delete files from
+the destination.
 
 **Note**: Use the ` + "`-P`" + `/` + "`--progress`" + ` flag to view real-time transfer statistics
 `,

--- a/cmd/moveto/moveto.go
+++ b/cmd/moveto/moveto.go
@@ -39,9 +39,9 @@ This will:
         move it to dst, overwriting existing files if they exist
         see move command for full details
 
-This doesn't transfer unchanged files, testing by size and
-modification time or MD5SUM.  src will be deleted on successful
-transfer.
+This doesn't transfer files that are identical on src and dst, testing
+by size and modification time or MD5SUM.  src will be deleted on
+successful transfer.
 
 **Important**: Since this can cause data loss, test first with the
 ` + "`--dry-run` or the `--interactive`/`-i`" + ` flag.

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -25,10 +25,10 @@ var commandDefinition = &cobra.Command{
 	Short: `Make source and dest identical, modifying destination only.`,
 	Long: `
 Sync the source to the destination, changing the destination
-only.  Doesn't transfer unchanged files, testing by size and
-modification time or MD5SUM.  Destination is updated to match
-source, including deleting files if necessary (except duplicate
-objects, see below).
+only.  Doesn't transfer files that are identical on source and
+destination, testing by size and modification time or MD5SUM.
+Destination is updated to match source, including deleting files
+if necessary (except duplicate objects, see below).
 
 **Important**: Since this can cause data loss, test first with the
 ` + "`--dry-run` or the `--interactive`/`-i`" + ` flag.


### PR DESCRIPTION
Switched from talking about "unchanged" files to "identical" files.

I found out the hard way that the rclone copy will overwrite newer files.
Looking at posts in the rclone forum, this is a common experience.

The docs for copy have referred to "unchanged" files.
This is ambiguous because it intuitively introduces a sense
of chronology, but chronology is irrelevant.
Rclone only "cares" about difference, not change.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
