### PR TITLE
docs/vfs: Merge duplicate chunked reading documentation from mount docs.

### DIFF
--- a/cmd/mountlib/help.go
+++ b/cmd/mountlib/help.go
@@ -283,20 +283,4 @@ to use Type=notify. In this case the service will enter the started state
 after the mountpoint has been successfully set up.
 Units having the rclone @ service specified as a requirement
 will see all files and folders immediately in this mode.
-
-### chunked reading
-
-|--vfs-read-chunk-size| will enable reading the source objects in parts.
-This can reduce the used download quota for some remotes by requesting only chunks
-from the remote that are actually read at the cost of an increased number of requests.
-
-When |--vfs-read-chunk-size-limit| is also specified and greater than
-|--vfs-read-chunk-size|, the chunk size for each open file will get doubled
-for each chunk read, until the specified value is reached. A value of |-1| will disable
-the limit and the chunk size will grow indefinitely.
-
-With |--vfs-read-chunk-size 100M| and |--vfs-read-chunk-size-limit 0|
-the following parts will be downloaded: 0-100M, 100M-200M, 200M-300M, 300M-400M and so on.
-When |--vfs-read-chunk-size-limit 500M| is specified, the result would be
-0-100M, 100M-300M, 300M-700M, 700M-1200M, 1200M-1700M and so on.
 `

--- a/vfs/help.go
+++ b/vfs/help.go
@@ -100,8 +100,8 @@ The higher the cache mode the more compatible rclone becomes at the
 cost of using disk space.
 
 Note that files are written back to the remote only when they are
-closed and if they haven't been accessed for --vfs-write-back
-second. If rclone is quit or dies with files that haven't been
+closed and if they haven't been accessed for !--vfs-write-back!
+seconds. If rclone is quit or dies with files that haven't been
 uploaded, these will be uploaded next time rclone is run with the same
 flags.
 
@@ -170,46 +170,61 @@ their full size in the cache, but they will be sparse files with only
 the data that has been downloaded present in them.
 
 This mode should support all normal file system operations and is
-otherwise identical to --vfs-cache-mode writes.
+otherwise identical to !--vfs-cache-mode! writes.
 
-When reading a file rclone will read --buffer-size plus
---vfs-read-ahead bytes ahead.  The --buffer-size is buffered in memory
-whereas the --vfs-read-ahead is buffered on disk.
+When reading a file rclone will read !--buffer-size! plus
+!--vfs-read-ahead! bytes ahead.  The !--buffer-size! is buffered in memory
+whereas the !--vfs-read-ahead! is buffered on disk.
 
-When using this mode it is recommended that --buffer-size is not set
-too big and --vfs-read-ahead is set large if required.
+When using this mode it is recommended that !--buffer-size! is not set
+too large and !--vfs-read-ahead! is set large if required.
 
 **IMPORTANT** not all file systems support sparse files. In particular
 FAT/exFAT do not. Rclone will perform very badly if the cache
 directory is on a filesystem which doesn't support sparse files and it
 will log an ERROR message if one is detected.
 
+### VFS Chunked Reading
+
+When rclone reads files from a remote it reads them in chunks. This
+means that rather than requesting the whole file rclone reads the
+chunk specified.  This can reduce the used download quota for some
+remotes by requesting only chunks from the remote that are actually
+read, at the cost of an increased number of requests.
+
+These flags control the chunking:
+
+    --vfs-read-chunk-size SizeSuffix        Read the source objects in chunks (default 128M)
+    --vfs-read-chunk-size-limit SizeSuffix  Max chunk doubling size (default off)
+
+Rclone will start reading a chunk of size !--vfs-read-chunk-size!,
+and then double the size for each read. When !--vfs-read-chunk-size-limit! is
+specified, and greater than !--vfs-read-chunk-size!, the chunk size for each
+open file will get doubled only until the specified value is reached. If the
+value is "off", which is the default, the limit is disabled and the chunk size
+will grow indefinitely.
+
+With !--vfs-read-chunk-size 100M! and !--vfs-read-chunk-size-limit 0!
+the following parts will be downloaded: 0-100M, 100M-200M, 200M-300M, 300M-400M and so on.
+When !--vfs-read-chunk-size-limit 500M! is specified, the result would be
+0-100M, 100M-300M, 300M-700M, 700M-1200M, 1200M-1700M and so on.
+
+Setting !--vfs-read-chunk-size! to !0! or "off" disables chunked reading.
+
 ### VFS Performance
 
 These flags may be used to enable/disable features of the VFS for
-performance or other reasons.
+performance or other reasons. See also the [chunked reading](#vfs-chunked-reading)
+feature.
 
-In particular S3 and Swift benefit hugely from the --no-modtime flag
-(or use --use-server-modtime for a slightly different effect) as each
+In particular S3 and Swift benefit hugely from the !--no-modtime! flag
+(or use !--use-server-modtime! for a slightly different effect) as each
 read of the modification time takes a transaction.
 
     --no-checksum     Don't compare checksums on up/download.
     --no-modtime      Don't read/write the modification time (can speed things up).
     --no-seek         Don't allow seeking in files.
     --read-only       Mount read-only.
-
-When rclone reads files from a remote it reads them in chunks. This
-means that rather than requesting the whole file rclone reads the
-chunk specified. This is advantageous because some cloud providers
-account for reads being all the data requested, not all the data
-delivered.
-
-Rclone will keep doubling the chunk size requested starting at
---vfs-read-chunk-size with a maximum of --vfs-read-chunk-size-limit
-unless it is set to "off" in which case there will be no limit.
-
-    --vfs-read-chunk-size SizeSuffix        Read the source objects in chunks. (default 128M)
-    --vfs-read-chunk-size-limit SizeSuffix  Max chunk doubling size (default "off")
 
 Sometimes rclone is delivered reads or writes out of order. Rather
 than seeking rclone will wait a short time for the in sequence read or
@@ -219,9 +234,9 @@ on disk cache file.
     --vfs-read-wait duration   Time to wait for in-sequence read before seeking. (default 20ms)
     --vfs-write-wait duration  Time to wait for in-sequence write before giving error. (default 1s)
 
-When using VFS write caching (--vfs-cache-mode with value writes or full),
-the global flag --transfers can be set to adjust the number of parallel uploads of
-modified files from cache (the related global flag --checkers have no effect on mount).
+When using VFS write caching (!--vfs-cache-mode! with value writes or full),
+the global flag !--transfers! can be set to adjust the number of parallel uploads of
+modified files from cache (the related global flag !--checkers! have no effect on mount).
 
     --transfers int  Number of file transfers to run in parallel. (default 4)
 
@@ -236,7 +251,7 @@ to create the file is preserved and available for programs to query.
 It is not allowed for two files in the same directory to differ only by case.
 
 Usually file systems on macOS are case-insensitive. It is possible to make macOS
-file systems case-sensitive but that is not the default
+file systems case-sensitive but that is not the default.
 
 The !--vfs-case-insensitive! mount flag controls how rclone handles these
 two cases. If its value is "false", rclone passes file names to the mounted


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Merging duplicate documentation of VFS chunked reading. It was previously described as part of the common VFS documentation, in the VFS Performance chapter, and in addition there was a separate chapter "chunked reading" in the mount specific documentation. Tried to merge them into a separate chapter in the common VFS documentation: VFS Chunked Reading.

Not sure about the meaning behind the following sentence previously in VFS Performance, if there is a detail relevant to keep:

> This is advantageous because some cloud providers account for reads being all the data requested, not all the data delivered.

I left that out, in favor of the following sentence from the chunked reading doc:

>  This can reduce the used download quota for some remotes by requesting only chunks from the remote that are actually read at the cost of an increased number of requests.

But maybe there is some nuance in the former that should be included?

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/documenation-issue-with-rclone-mount/26000

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~I have added tests for all changes in this PR if appropriate.~
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
