### PR TITLE
Add a new statistic "skips" counting skipped transfers (already sync)

### DIFF
--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -366,6 +366,7 @@ func (sg *statsGroups) sum(ctx context.Context) *StatsInfo {
 			sum.deletes += stats.deletes
 			sum.deletedDirs += stats.deletedDirs
 			sum.renames += stats.renames
+			sum.skips += stats.skips
 			sum.checking.merge(stats.checking)
 			sum.transferring.merge(stats.transferring)
 			sum.inProgress.merge(stats.inProgress)

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -349,6 +349,8 @@ func (s *syncCopyMove) pairChecker(in *pipe, out *pipe, fraction int, wg *sync.W
 					}
 				}
 			} else {
+				// Transfer skipped
+				accounting.Stats(s.ctx).Skips(1)
 				// If moving need to delete the files we don't need to copy
 				if s.DoMove {
 					// Delete src if no error on copy


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

On copy, move, ... New statistic "skips" counting how many files are not transferred because they don't need to (same hash).

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/5541

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
