### PR TITLE
vfstest: retry flakey tests using fstest/retesting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -186,6 +186,7 @@ jobs:
       - name: Run tests
         shell: bash
         run: |
+          export RCLONE_FLAKEY_RETRIES=2
           make quicktest
         if: matrix.quicktest
 

--- a/cmd/mount2/mount_test.go
+++ b/cmd/mount2/mount_test.go
@@ -12,5 +12,5 @@ import (
 
 func TestMount(t *testing.T) {
 	testy.SkipUnreliable(t)
-	vfstest.RunTests(t, false, mount)
+	vfstest.RetryTests(t, false, mount)
 }

--- a/fstest/retesting/retesting.go
+++ b/fstest/retesting/retesting.go
@@ -1,0 +1,281 @@
+// Package retesting retries flakey tests
+package retesting
+
+import (
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+const defaultFlakeyRetries = 0 // off by default
+
+// Globals
+var (
+	Debug         = false
+	FlakeyRetries = flag.Int("flakey-retries", getDefaultRetries(), "Number of flakey test retriesi (0 = no retries)")
+)
+
+func getDefaultRetries() int {
+	val, err := strconv.Atoi(os.Getenv("RCLONE_FLAKEY_RETRIES"))
+	if err != nil {
+		val = defaultFlakeyRetries
+	}
+	return val
+}
+
+// T is the interface representing the standard *testing.T
+// It allows to implement and use custom test drivers.
+//
+// In unit tests you can just pass a *testing.T struct.
+// testify/assert and testify/require accept it seamlessly.
+type T interface {
+	Cleanup(func())
+	// Deadline() (time.Time, bool) // go 1.15+
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Helper()
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+	Name() string
+	Parallel()
+	Run(name string, f func(t *testing.T)) bool
+	Skip(args ...interface{})
+	// Setenv(key, val string) // go 1.17+
+	SkipNow()
+	Skipf(format string, args ...interface{})
+	Skipped() bool
+	// TempDir() string // go 1.15+
+}
+
+// retrier mimics testing.T and retries failing tests
+type retrier struct {
+	mu       sync.RWMutex
+	name     string
+	t        T        // connected testing.T
+	parent   *retrier // parent flakey test
+	retryNum int
+	failNum  int
+	failMax  int
+	failed   bool
+	finished bool
+}
+
+// Run mimics testing.T.Run but runs subtest with retries.
+// retesting.Run(t, name, f) is similar to normal t.Run(name, f).
+// The core difference is in prototype of the callback func:
+// func(t retesting.T) vs func(t *testing.T).
+//
+// Subtest of *testing.T is called the "core" retriable test.
+// Only the core test will be retried after failures.
+//
+// Subtests of the core retriable test are not retried on their own.
+// They just propagate encountered failures to the core test
+// and get called again when the core test is retried.
+//
+// All failed test attempts are marked as skipped in go test.
+func Run(t T, name string, f func(t T)) bool {
+	t.Helper()
+	if r, ok := t.(*retrier); ok {
+		return r.runFlakeySubtest(name, f)
+	}
+	return runCoreFlakeyTest(t, name, f)
+}
+
+func runCoreFlakeyTest(t T, name string, f func(t T)) bool {
+	t.Helper()
+	r := &retrier{
+		name:    name,
+		failMax: *FlakeyRetries,
+	}
+	if r.failMax <= 0 {
+		r.failMax = 1
+	}
+
+	r.failed = true // so the loop starts
+	for r.failed && r.failNum < r.failMax {
+		r.failed = false
+		r.retryNum++
+		retryName := fmt.Sprintf("%s_%d", r.name, r.retryNum)
+		t.Run(retryName, func(tt *testing.T) {
+			r.t = tt
+			f(r)
+			if r.failed && r.failNum < r.failMax {
+				r.SkipNow() // mark ignored failures as skipped
+			}
+		})
+	}
+
+	return !r.failed
+}
+
+func (r *retrier) runFlakeySubtest(name string, f func(t T)) bool {
+	r.t.Helper()
+	if Debug {
+		log.Printf("retesting %s: spawn subtest %s", r.name, name)
+	}
+	wrapper := func(t *testing.T) {
+		rr := &retrier{
+			parent:  r,
+			t:       t,
+			name:    name,
+			failMax: r.failMax,
+		}
+		f(rr)
+		if rr.failed && rr.failNum < rr.failMax {
+			rr.SkipNow() // mark ignored failures as skipped
+		}
+	}
+	return r.t.Run(name, wrapper)
+}
+
+//
+// Overridden methods of retrier vs *testing.T
+//
+
+// Fail marks the function as having failed but continues execution.
+func (r *retrier) Fail() {
+	r.t.Helper()
+
+	if r.parent != nil {
+		r.parent.Fail() // propagate to parent retrier
+	}
+
+	r.mu.Lock()
+	r.failed = true
+	r.failNum++
+	failNum := r.failNum
+	r.mu.Unlock()
+
+	if failNum < r.failMax {
+		if Debug {
+			log.Printf("retesting %s: fail #%d ignored", r.name, failNum)
+		}
+		return // don't raise it to connected testing.T, just mark in r.failed
+	}
+
+	if Debug {
+		log.Printf("retesting %s: fail #%d raised", r.name, failNum)
+	}
+	r.t.Fail() // raise the failure
+}
+
+// FailNow marks the function as having failed and stops its execution.
+func (r *retrier) FailNow() {
+	r.Fail()
+	r.finished = true
+	r.t.SkipNow()
+}
+
+// Failed reports whether the function has failed.
+func (r *retrier) Failed() bool {
+	r.mu.RLock()
+	failed := r.failed
+	r.mu.RUnlock()
+	return failed
+}
+
+// Error is equivalent to Log followed by Fail.
+func (r *retrier) Error(args ...interface{}) {
+	r.t.Helper()
+	r.Log(args...)
+	r.Fail()
+}
+
+// Errorf is equivalent to Logf followed by Fail.
+func (r *retrier) Errorf(format string, args ...interface{}) {
+	r.t.Helper()
+	r.Logf(format, args...)
+	r.Fail()
+}
+
+// Fatal is equivalent to Log followed by FailNow.
+func (r *retrier) Fatal(args ...interface{}) {
+	r.t.Helper()
+	r.Log(args...)
+	r.FailNow()
+}
+
+// Fatalf is equivalent to Logf followed by FailNow.
+func (r *retrier) Fatalf(format string, args ...interface{}) {
+	r.t.Helper()
+	r.Logf(format, args...)
+	r.FailNow()
+}
+
+//
+// Logging
+//
+
+// Log prints a message
+func (r *retrier) Log(args ...interface{}) {
+	r.t.Helper()
+	r.t.Log(args...)
+}
+
+// Logf prints a message
+func (r *retrier) Logf(format string, args ...interface{}) {
+	r.t.Helper()
+	r.t.Logf(format, args...)
+}
+
+//
+// Inherited methods of retrier vs *testing.T
+//
+
+// Cleanup (inherited)
+func (r *retrier) Cleanup(f func()) {
+	r.t.Helper()
+	r.t.Cleanup(f)
+}
+
+// Helper (inherited)
+func (r *retrier) Helper() {
+	r.t.Helper()
+}
+
+// Name (inherited)
+func (r *retrier) Name() string {
+	return r.t.Name()
+}
+
+// Parallel (inherited)
+func (r *retrier) Parallel() {
+	r.t.Parallel()
+}
+
+// Run (inherited)
+func (r *retrier) Run(name string, f func(t *testing.T)) bool {
+	r.t.Helper()
+	return r.t.Run(name, f)
+}
+
+// Skip (inherited)
+func (r *retrier) Skip(args ...interface{}) {
+	r.t.Helper()
+	r.t.Skip(args...)
+}
+
+// SkipNow (inherited)
+func (r *retrier) SkipNow() {
+	r.t.SkipNow()
+}
+
+// Skipf (inherited)
+func (r *retrier) Skipf(format string, args ...interface{}) {
+	r.t.Helper()
+	r.t.Skipf(format, args...)
+}
+
+// Skipped (inherited)
+func (r *retrier) Skipped() bool {
+	return r.t.Skipped()
+}

--- a/fstest/retesting/retesting_test.go
+++ b/fstest/retesting/retesting_test.go
@@ -1,0 +1,57 @@
+package retesting_test
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fstest/retesting"
+	"github.com/stretchr/testify/assert"
+)
+
+var savedRetries int
+
+func setRetries(newRetries int) {
+	savedRetries = *retesting.FlakeyRetries
+	*retesting.FlakeyRetries = newRetries
+}
+
+func restoreRetries() {
+	*retesting.FlakeyRetries = savedRetries
+}
+
+func TestRetriesOneDeep(t *testing.T) {
+	setRetries(2)
+	defer restoreRetries()
+
+	boyCount := 0
+
+	retesting.Run(t, "boy", func(t retesting.T) {
+		boyCount++
+		pass := boyCount > 1 // fail at #1 then pass at #2
+		t.Logf("boy run #%d - %v pass", boyCount, pass)
+		assert.True(t, pass)
+	})
+
+	assert.Equal(t, 2, boyCount, "boy must retry 2 times")
+}
+
+func TestRetriesTwoDeep(t *testing.T) {
+	setRetries(2)
+	defer restoreRetries()
+
+	dadCount := 0
+	sonCount := 0
+
+	retesting.Run(t, "dad", func(t retesting.T) {
+		dadCount++
+		t.Logf("dad run #%d", dadCount)
+		retesting.Run(t, "son", func(t retesting.T) {
+			sonCount++
+			pass := sonCount > 1 // fail at #1 then pass at #2
+			t.Logf("son run #%d - %v pass", sonCount, pass)
+			assert.True(t, pass)
+		})
+	})
+
+	assert.Equal(t, 2, dadCount, "dad must retry 2 times")
+	assert.Equal(t, 2, sonCount, "son must retry 2 times")
+}

--- a/vfs/vfstest/dir.go
+++ b/vfs/vfstest/dir.go
@@ -2,16 +2,16 @@ package vfstest
 
 import (
 	"context"
-	"testing"
 	"time"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fstest/retesting"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestDirLs checks out listing
-func TestDirLs(t *testing.T) {
+func TestDirLs(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.checkDir(t, "")
@@ -28,7 +28,7 @@ func TestDirLs(t *testing.T) {
 }
 
 // TestDirCreateAndRemoveDir tests creating and removing a directory
-func TestDirCreateAndRemoveDir(t *testing.T) {
+func TestDirCreateAndRemoveDir(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.mkdir(t, "dir")
@@ -47,7 +47,7 @@ func TestDirCreateAndRemoveDir(t *testing.T) {
 }
 
 // TestDirCreateAndRemoveFile tests creating and removing a file
-func TestDirCreateAndRemoveFile(t *testing.T) {
+func TestDirCreateAndRemoveFile(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.mkdir(t, "dir")
@@ -67,7 +67,7 @@ func TestDirCreateAndRemoveFile(t *testing.T) {
 }
 
 // TestDirRenameFile tests renaming a file
-func TestDirRenameFile(t *testing.T) {
+func TestDirRenameFile(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.mkdir(t, "dir")
@@ -95,7 +95,7 @@ func TestDirRenameFile(t *testing.T) {
 }
 
 // TestDirRenameEmptyDir tests renaming and empty directory
-func TestDirRenameEmptyDir(t *testing.T) {
+func TestDirRenameEmptyDir(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.mkdir(t, "dir")
@@ -116,7 +116,7 @@ func TestDirRenameEmptyDir(t *testing.T) {
 }
 
 // TestDirRenameFullDir tests renaming a full directory
-func TestDirRenameFullDir(t *testing.T) {
+func TestDirRenameFullDir(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.mkdir(t, "dir")
@@ -139,7 +139,7 @@ func TestDirRenameFullDir(t *testing.T) {
 }
 
 // TestDirModTime tests mod times
-func TestDirModTime(t *testing.T) {
+func TestDirModTime(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.mkdir(t, "dir")
@@ -157,7 +157,7 @@ func TestDirModTime(t *testing.T) {
 }
 
 // TestDirCacheFlush tests flushing the dir cache
-func TestDirCacheFlush(t *testing.T) {
+func TestDirCacheFlush(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.checkDir(t, "")
@@ -197,7 +197,7 @@ func TestDirCacheFlush(t *testing.T) {
 }
 
 // TestDirCacheFlushOnDirRename tests flushing the dir cache on rename
-func TestDirCacheFlushOnDirRename(t *testing.T) {
+func TestDirCacheFlushOnDirRename(t retesting.T) {
 	run.skipIfNoFUSE(t)
 	run.mkdir(t, "dir")
 	run.createFile(t, "dir/file", "1")

--- a/vfs/vfstest/edge_cases.go
+++ b/vfs/vfstest/edge_cases.go
@@ -2,14 +2,14 @@ package vfstest
 
 import (
 	"runtime"
-	"testing"
 
+	"github.com/rclone/rclone/fstest/retesting"
 	"github.com/stretchr/testify/require"
 )
 
 // TestTouchAndDelete checks that writing a zero byte file and immediately
 // deleting it is not racy. See https://github.com/rclone/rclone/issues/1181
-func TestTouchAndDelete(t *testing.T) {
+func TestTouchAndDelete(t retesting.T) {
 	run.skipIfNoFUSE(t)
 	run.checkDir(t, "")
 
@@ -21,7 +21,7 @@ func TestTouchAndDelete(t *testing.T) {
 
 // TestRenameOpenHandle checks that a file with open writers is successfully
 // renamed after all writers close. See https://github.com/rclone/rclone/issues/2130
-func TestRenameOpenHandle(t *testing.T) {
+func TestRenameOpenHandle(t retesting.T) {
 	run.skipIfNoFUSE(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows")

--- a/vfs/vfstest/file.go
+++ b/vfs/vfstest/file.go
@@ -3,16 +3,16 @@ package vfstest
 import (
 	"os"
 	"runtime"
-	"testing"
 	"time"
 
+	"github.com/rclone/rclone/fstest/retesting"
 	"github.com/rclone/rclone/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestFileModTime tests mod times on files
-func TestFileModTime(t *testing.T) {
+func TestFileModTime(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.createFile(t, "file", "123")
@@ -41,7 +41,7 @@ func osAppend(name string) (vfs.OsFiler, error) {
 }
 
 // TestFileModTimeWithOpenWriters tests mod time on open files
-func TestFileModTimeWithOpenWriters(t *testing.T) {
+func TestFileModTimeWithOpenWriters(t retesting.T) {
 	run.skipIfNoFUSE(t)
 	if runtime.GOOS == "windows" {
 		t.Skip("Skipping test on Windows")

--- a/vfs/vfstest/read.go
+++ b/vfs/vfstest/read.go
@@ -3,13 +3,13 @@ package vfstest
 import (
 	"io"
 	"io/ioutil"
-	"testing"
 
+	"github.com/rclone/rclone/fstest/retesting"
 	"github.com/stretchr/testify/assert"
 )
 
 // TestReadByByte reads by byte including don't read any bytes
-func TestReadByByte(t *testing.T) {
+func TestReadByByte(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	var data = []byte("hellohello")
@@ -34,7 +34,7 @@ func TestReadByByte(t *testing.T) {
 }
 
 // TestReadChecksum checks the checksum reading is working
-func TestReadChecksum(t *testing.T) {
+func TestReadChecksum(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	// create file big enough so we exceed any single FUSE read
@@ -75,7 +75,7 @@ func TestReadChecksum(t *testing.T) {
 }
 
 // TestReadSeek test seeking
-func TestReadSeek(t *testing.T) {
+func TestReadSeek(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	var data = []byte("helloHELLO")

--- a/vfs/vfstest/read_non_unix.go
+++ b/vfs/vfstest/read_non_unix.go
@@ -5,10 +5,11 @@ package vfstest
 
 import (
 	"runtime"
-	"testing"
+
+	"github.com/rclone/rclone/fstest/retesting"
 )
 
 // TestReadFileDoubleClose tests double close on read
-func TestReadFileDoubleClose(t *testing.T) {
+func TestReadFileDoubleClose(t retesting.T) {
 	t.Skip("not supported on " + runtime.GOOS)
 }

--- a/vfs/vfstest/read_unix.go
+++ b/vfs/vfstest/read_unix.go
@@ -5,13 +5,13 @@ package vfstest
 
 import (
 	"syscall"
-	"testing"
 
+	"github.com/rclone/rclone/fstest/retesting"
 	"github.com/stretchr/testify/assert"
 )
 
 // TestReadFileDoubleClose tests double close on read
-func TestReadFileDoubleClose(t *testing.T) {
+func TestReadFileDoubleClose(t retesting.T) {
 	run.skipIfVFS(t)
 	run.skipIfNoFUSE(t)
 

--- a/vfs/vfstest/write.go
+++ b/vfs/vfstest/write.go
@@ -3,15 +3,15 @@ package vfstest
 import (
 	"os"
 	"runtime"
-	"testing"
 
+	"github.com/rclone/rclone/fstest/retesting"
 	"github.com/rclone/rclone/vfs/vfscommon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 // TestWriteFileNoWrite tests writing a file with no write()'s to it
-func TestWriteFileNoWrite(t *testing.T) {
+func TestWriteFileNoWrite(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	fd, err := osCreate(run.path("testnowrite"))
@@ -28,7 +28,7 @@ func TestWriteFileNoWrite(t *testing.T) {
 }
 
 // FIXMETestWriteOpenFileInDirListing tests open file in directory listing
-func FIXMETestWriteOpenFileInDirListing(t *testing.T) {
+func FIXMETestWriteOpenFileInDirListing(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	fd, err := osCreate(run.path("testnowrite"))
@@ -45,7 +45,7 @@ func FIXMETestWriteOpenFileInDirListing(t *testing.T) {
 }
 
 // TestWriteFileWrite tests writing a file and reading it back
-func TestWriteFileWrite(t *testing.T) {
+func TestWriteFileWrite(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.createFile(t, "testwrite", "data")
@@ -56,7 +56,7 @@ func TestWriteFileWrite(t *testing.T) {
 }
 
 // TestWriteFileOverwrite tests overwriting a file
-func TestWriteFileOverwrite(t *testing.T) {
+func TestWriteFileOverwrite(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	run.createFile(t, "testwrite", "data")
@@ -70,7 +70,7 @@ func TestWriteFileOverwrite(t *testing.T) {
 // TestWriteFileFsync tests Fsync
 //
 // NB the code for this is in file.go rather than write.go
-func TestWriteFileFsync(t *testing.T) {
+func TestWriteFileFsync(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	filepath := run.path("to be synced")
@@ -87,7 +87,7 @@ func TestWriteFileFsync(t *testing.T) {
 }
 
 // TestWriteFileDup tests behavior of mmap() in Python by using dup() on a file handle
-func TestWriteFileDup(t *testing.T) {
+func TestWriteFileDup(t retesting.T) {
 	run.skipIfVFS(t)
 	run.skipIfNoFUSE(t)
 
@@ -133,7 +133,7 @@ func TestWriteFileDup(t *testing.T) {
 }
 
 // TestWriteFileAppend tests that O_APPEND works on cache backends >= writes
-func TestWriteFileAppend(t *testing.T) {
+func TestWriteFileAppend(t retesting.T) {
 	run.skipIfNoFUSE(t)
 
 	if run.vfs.Opt.CacheMode < vfscommon.CacheModeWrites {

--- a/vfs/vfstest/write_non_unix.go
+++ b/vfs/vfstest/write_non_unix.go
@@ -5,13 +5,13 @@ package vfstest
 
 import (
 	"runtime"
-	"testing"
 
+	"github.com/rclone/rclone/fstest/retesting"
 	"golang.org/x/sys/windows"
 )
 
 // TestWriteFileDoubleClose tests double close on write
-func TestWriteFileDoubleClose(t *testing.T) {
+func TestWriteFileDoubleClose(t retesting.T) {
 	t.Skip("not supported on " + runtime.GOOS)
 }
 

--- a/vfs/vfstest/write_unix.go
+++ b/vfs/vfstest/write_unix.go
@@ -5,15 +5,15 @@ package vfstest
 
 import (
 	"runtime"
-	"testing"
 
+	"github.com/rclone/rclone/fstest/retesting"
 	"github.com/rclone/rclone/vfs/vfscommon"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/sys/unix"
 )
 
 // TestWriteFileDoubleClose tests double close on write
-func TestWriteFileDoubleClose(t *testing.T) {
+func TestWriteFileDoubleClose(t retesting.T) {
 	run.skipIfVFS(t)
 	run.skipIfNoFUSE(t)
 	if runtime.GOOS == "darwin" {


### PR DESCRIPTION
#### What is the purpose of this change?

> The mount tests lock my machine up quite regularly which is super boring and we don't run them on the CI for the same reason.

We actually run `mount`, `mount2` and `cmount` tests on the CI and they regularly but sporadically fail.

Now, we've got the commit https://github.com/rclone/rclone/commit/6a9ef27b0919fed17c3865a395afec97a6ed53d3. It disables a mount test failing on windows/386.
Now we've got the CI/CD test for this very commit. It fails for go 1.15 on **Linux**. Failing test name? `mount2`!
Now me tells ya. Yours is boring. Mee is musta. Don't mess on Mancunians. Get the ~~punch~~patch.

This patch provides a wrapper for `*testing.T` in "github.com/rclone/rclone/fstest/retesting".
Rewrite your test in 4 easy steps:
- replace `t *testing.T` with `t retesting.T`
- replace `t.Run(name,f)` with `retesting.Run(t,name,f)`
- rename core test function `TestName(t *testing.T)` into `testName(t retesting.T)`
- add wrapper under original name `func TestName(t *testing.T) { retesting.Run(t, "TestName", testName) }`

Set environment variable `export RCLONE_FLAKEY_RETRIES=999`, run `go test .`
Enjoy.

**When your tests get stable, just set RCLONE_FLAKEY_RETRIES=0 and test as usual.**

If Google wanted you to develop custom test drivers, they would make `testing.T` an interface, but they didn't.
It's a `struct` with private fields. You cannot instantiate it. You cannot wrap it. All functions in `testing` want only it.
The author of https://github.com/stretchr/testify noticed this and made all his functions accept an interface.
This PR provides the interface so it plays transparently with testify/accept and testify/require.
Unfortunately we've got to do a number of replacements `*testing.T -> retesting.T`
I can't help it. Blame Google.

#### Was the change discussed in an issue or in the forum before?

[commit 6a9ef27b comments](https://github.com/rclone/rclone/commit/6a9ef27b0919fed17c3865a395afec97a6ed53d3#commitcomment-55235890)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
