### PR TITLE
config: fix handling of default, exclusive and required properties of multiple-choice options

### DIFF
--- a/backend/fichier/fichier.go
+++ b/backend/fichier/fichier.go
@@ -42,18 +42,15 @@ func init() {
 		}, {
 			Help:     "If you want to download a shared folder, add this parameter.",
 			Name:     "shared_folder",
-			Required: false,
 			Advanced: true,
 		}, {
 			Help:       "If you want to download a shared file that is password protected, add this parameter.",
 			Name:       "file_password",
-			Required:   false,
 			Advanced:   true,
 			IsPassword: true,
 		}, {
 			Help:       "If you want to list the files in a shared folder that is password protected, add this parameter.",
 			Name:       "folder_password",
-			Required:   false,
 			Advanced:   true,
 			IsPassword: true,
 		}, {

--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -51,11 +51,13 @@ func init() {
 			Help:     "FTP host to connect to.\n\nE.g. \"ftp.example.com\".",
 			Required: true,
 		}, {
-			Name: "user",
-			Help: "FTP username, leave blank for current username, " + currentUser + ".",
+			Name:    "user",
+			Help:    "FTP username.",
+			Default: currentUser,
 		}, {
-			Name: "port",
-			Help: "FTP port, leave blank to use default (21).",
+			Name:    "port",
+			Help:    "FTP port number.",
+			Default: 21,
 		}, {
 			Name:       "pass",
 			Help:       "FTP password.",

--- a/backend/hdfs/hdfs.go
+++ b/backend/hdfs/hdfs.go
@@ -22,9 +22,8 @@ func init() {
 			Help:     "Hadoop name node and port.\n\nE.g. \"namenode:8020\" to connect to host namenode at port 8020.",
 			Required: true,
 		}, {
-			Name:     "username",
-			Help:     "Hadoop user name.",
-			Required: false,
+			Name: "username",
+			Help: "Hadoop user name.",
 			Examples: []fs.OptionExample{{
 				Value: "root",
 				Help:  "Connect to hdfs as root.",
@@ -36,7 +35,6 @@ func init() {
 Enables KERBEROS authentication. Specifies the Service Principal Name
 (SERVICE/FQDN) for the namenode. E.g. \"hdfs/namenode.hadoop.docker\"
 for namenode running as service 'hdfs' with FQDN 'namenode.hadoop.docker'.`,
-			Required: false,
 			Advanced: true,
 		}, {
 			Name: "data_transfer_protection",
@@ -46,7 +44,6 @@ Specifies whether or not authentication, data signature integrity
 checks, and wire encryption is required when communicating the the
 datanodes. Possible values are 'authentication', 'integrity' and
 'privacy'. Used only with KERBEROS enabled.`,
-			Required: false,
 			Examples: []fs.OptionExample{{
 				Value: "privacy",
 				Help:  "Ensure authentication, integrity and encryption enabled.",

--- a/backend/koofr/koofr.go
+++ b/backend/koofr/koofr.go
@@ -39,7 +39,6 @@ func init() {
 		}, {
 			Name:     "mountid",
 			Help:     "Mount ID of the mount to use.\n\nIf omitted, the primary mount is used.",
-			Required: false,
 			Default:  "",
 			Advanced: true,
 		}, {

--- a/backend/koofr/koofr.go
+++ b/backend/koofr/koofr.go
@@ -34,18 +34,15 @@ func init() {
 			Name:     "endpoint",
 			Help:     "The Koofr API endpoint to use.",
 			Default:  "https://app.koofr.net",
-			Required: true,
 			Advanced: true,
 		}, {
 			Name:     "mountid",
 			Help:     "Mount ID of the mount to use.\n\nIf omitted, the primary mount is used.",
-			Default:  "",
 			Advanced: true,
 		}, {
 			Name:     "setmtime",
 			Help:     "Does the backend support setting modification time.\n\nSet this to false if you use a mount ID that points to a Dropbox or Amazon Drive backend.",
 			Default:  true,
-			Required: true,
 			Advanced: true,
 		}, {
 			Name:     "user",

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -59,11 +59,13 @@ func init() {
 			Help:     "SSH host to connect to.\n\nE.g. \"example.com\".",
 			Required: true,
 		}, {
-			Name: "user",
-			Help: "SSH username, leave blank for current username, " + currentUser + ".",
+			Name:    "user",
+			Help:    "SSH username.",
+			Default: currentUser,
 		}, {
-			Name: "port",
-			Help: "SSH port, leave blank to use default (22).",
+			Name:    "port",
+			Help:    "SSH port number.",
+			Default: 22,
 		}, {
 			Name:       "pass",
 			Help:       "SSH password, leave blank to use ssh-agent.",

--- a/backend/tardigrade/fs.go
+++ b/backend/tardigrade/fs.go
@@ -99,13 +99,11 @@ func init() {
 			{
 				Name:     "access_grant",
 				Help:     "Access grant.",
-				Required: false,
 				Provider: "existing",
 			},
 			{
 				Name:     "satellite_address",
 				Help:     "Satellite address.\n\nCustom satellite address should match the format: `<nodeid>@<address>:<port>`.",
-				Required: false,
 				Provider: newProvider,
 				Default:  "us-central-1.tardigrade.io",
 				Examples: []fs.OptionExample{{
@@ -123,13 +121,11 @@ func init() {
 			{
 				Name:     "api_key",
 				Help:     "API key.",
-				Required: false,
 				Provider: newProvider,
 			},
 			{
 				Name:     "passphrase",
 				Help:     "Encryption passphrase.\n\nTo access existing objects enter passphrase used for uploading.",
-				Required: false,
 				Provider: newProvider,
 			},
 		},

--- a/backend/tardigrade/fs.go
+++ b/backend/tardigrade/fs.go
@@ -84,10 +84,9 @@ func init() {
 		},
 		Options: []fs.Option{
 			{
-				Name:     fs.ConfigProvider,
-				Help:     "Choose an authentication method.",
-				Required: true,
-				Default:  existingProvider,
+				Name:    fs.ConfigProvider,
+				Help:    "Choose an authentication method.",
+				Default: existingProvider,
 				Examples: []fs.OptionExample{{
 					Value: "existing",
 					Help:  "Use an existing access grant.",

--- a/backend/union/union.go
+++ b/backend/union/union.go
@@ -33,25 +33,21 @@ func init() {
 			Help:     "List of space separated upstreams.\n\nCan be 'upstreama:test/dir upstreamb:', '\"upstreama:test/space:ro dir\" upstreamb:', etc.",
 			Required: true,
 		}, {
-			Name:     "action_policy",
-			Help:     "Policy to choose upstream on ACTION category.",
-			Required: true,
-			Default:  "epall",
+			Name:    "action_policy",
+			Help:    "Policy to choose upstream on ACTION category.",
+			Default: "epall",
 		}, {
-			Name:     "create_policy",
-			Help:     "Policy to choose upstream on CREATE category.",
-			Required: true,
-			Default:  "epmfs",
+			Name:    "create_policy",
+			Help:    "Policy to choose upstream on CREATE category.",
+			Default: "epmfs",
 		}, {
-			Name:     "search_policy",
-			Help:     "Policy to choose upstream on SEARCH category.",
-			Required: true,
-			Default:  "ff",
+			Name:    "search_policy",
+			Help:    "Policy to choose upstream on SEARCH category.",
+			Default: "ff",
 		}, {
-			Name:     "cache_time",
-			Help:     "Cache time of usage and free space (in seconds).\n\nThis option is only useful when a path preserving policy is used.",
-			Required: true,
-			Default:  120,
+			Name:    "cache_time",
+			Help:    "Cache time of usage and free space (in seconds).\n\nThis option is only useful when a path preserving policy is used.",
+			Default: 120,
 		}},
 	}
 	fs.Register(fsi)

--- a/docs/content/alias.md
+++ b/docs/content/alias.md
@@ -33,7 +33,7 @@ First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/amazonclouddrive.md
+++ b/docs/content/amazonclouddrive.md
@@ -53,7 +53,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 r) Rename remote
 c) Copy remote

--- a/docs/content/azureblob.md
+++ b/docs/content/azureblob.md
@@ -19,7 +19,7 @@ configuration.  For a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/b2.md
+++ b/docs/content/b2.md
@@ -23,7 +23,7 @@ recommended method. See below for further details on generating and using
 an Application Key.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 q) Quit config
 n/q> n

--- a/docs/content/box.md
+++ b/docs/content/box.md
@@ -22,7 +22,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/cache.md
+++ b/docs/content/cache.md
@@ -34,7 +34,7 @@ Here is an example of how to make a remote called `test-cache`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 r) Rename remote
 c) Copy remote

--- a/docs/content/chunker.md
+++ b/docs/content/chunker.md
@@ -25,7 +25,7 @@ Now configure `chunker` using `rclone config`. We will call this one `overlay`
 to separate it from the `remote` itself.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -86,7 +86,7 @@ configure a dedicated path for encrypted content, and access it
 exclusively through a crypt remote.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -22,7 +22,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 r) Rename remote
 c) Copy remote

--- a/docs/content/fichier.md
+++ b/docs/content/fichier.md
@@ -25,7 +25,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/filefabric.md
+++ b/docs/content/filefabric.md
@@ -23,7 +23,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -339,7 +339,7 @@ and may be set in the config file.
       --ftp-idle-timeout Duration                    Max time before closing idle connections (default 1m0s)
       --ftp-no-check-certificate                     Do not verify the TLS certificate of the server
       --ftp-pass string                              FTP password (obscured)
-      --ftp-port string                              FTP port, leave blank to use default (21)
+      --ftp-port string                              FTP port number (default 21)
       --ftp-shut-timeout Duration                    Maximum time to wait for data connection closing status (default 1m0s)
       --ftp-tls                                      Use Implicit FTPS (FTP over TLS)
       --ftp-tls-cache-size int                       Size of TLS session cache for all control and data connections (default 32)
@@ -528,7 +528,7 @@ and may be set in the config file.
       --sftp-md5sum-command string                   The command used to read md5 hashes
       --sftp-pass string                             SSH password, leave blank to use ssh-agent (obscured)
       --sftp-path-override string                    Override path used by SSH connection
-      --sftp-port string                             SSH port, leave blank to use default (22)
+      --sftp-port string                             SSH port number (default 22)
       --sftp-pubkey-file string                      Optional path to public key file
       --sftp-server-command string                   Specifies the path or command to run a sftp server on the remote host
       --sftp-set-modtime                             Set the modified time on the remote if set (default true)

--- a/docs/content/ftp.md
+++ b/docs/content/ftp.md
@@ -51,11 +51,11 @@ Choose a number from below, or type in your own value
  1 / Connect to ftp.example.com
    \ "ftp.example.com"
 host> ftp.example.com
-FTP username, leave blank for current username, $USER
-Enter a string value. Press Enter for the default ("").
+FTP username
+Enter a string value. Press Enter for the default ("$USER").
 user> 
-FTP port, leave blank to use default (21)
-Enter a string value. Press Enter for the default ("").
+FTP port number
+Enter a signed integer. Press Enter for the default (21).
 port> 
 FTP password
 y) Yes type in my own password

--- a/docs/content/ftp.md
+++ b/docs/content/ftp.md
@@ -27,7 +27,7 @@ For an anonymous FTP server, use `anonymous` as username and your email
 address as password.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 r) Rename remote
 c) Copy remote

--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -26,7 +26,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/hasher.md
+++ b/docs/content/hasher.md
@@ -28,7 +28,7 @@ Now proceed to interactive or manual configuration.
 
 Run `rclone config`:
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/hdfs.md
+++ b/docs/content/hdfs.md
@@ -19,7 +19,7 @@ Here is an example of how to make a remote called `remote`. First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/http.md
+++ b/docs/content/http.md
@@ -24,7 +24,7 @@ run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/jottacloud.md
+++ b/docs/content/jottacloud.md
@@ -62,7 +62,7 @@ Here is an example of how to make a remote called `remote` with the default setu
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/koofr.md
+++ b/docs/content/koofr.md
@@ -23,7 +23,7 @@ Here is an example of how to make a remote called `koofr`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/mailru.md
+++ b/docs/content/mailru.md
@@ -32,7 +32,7 @@ account and choose a tariff, then run
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/mega.md
+++ b/docs/content/mega.md
@@ -27,7 +27,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/memory.md
+++ b/docs/content/memory.md
@@ -18,7 +18,7 @@ You can configure it as a remote like this with `rclone config` too if
 you want to:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/pcloud.md
+++ b/docs/content/pcloud.md
@@ -21,7 +21,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/premiumizeme.md
+++ b/docs/content/premiumizeme.md
@@ -21,7 +21,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/putio.md
+++ b/docs/content/putio.md
@@ -23,7 +23,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/qingstor.md
+++ b/docs/content/qingstor.md
@@ -17,7 +17,7 @@ Here is an example of making an QingStor configuration.  First run
 This will guide you through an interactive setup process.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 r) Rename remote
 c) Copy remote

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -57,7 +57,7 @@ First run
 This will guide you through an interactive setup process.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config
@@ -2116,7 +2116,7 @@ To configure access to IBM COS S3, follow the steps below:
 1. Run rclone config and select n for a new remote.
 ```
 	2018/02/14 14:13:11 NOTICE: Config file "C:\\Users\\a\\.config\\rclone\\rclone.conf" not found - using defaults
-	No remotes found - make a new one
+	No remotes found, make a new one?
 	n) New remote
 	s) Set configuration password
 	q) Quit config
@@ -2429,7 +2429,7 @@ Wasabi provides an S3 interface which can be configured for use with
 rclone like this.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 n/s> n
@@ -2541,7 +2541,7 @@ configuration.  First run:
 This will guide you through an interactive setup process.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config
@@ -2651,7 +2651,7 @@ To configure access to Tencent COS, follow the steps below:
 
 ```
 rclone config
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/seafile.md
+++ b/docs/content/seafile.md
@@ -29,7 +29,7 @@ This will guide you through an interactive setup process. To authenticate
 you will need the URL of your server, your email (or username) and your password.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config
@@ -118,7 +118,7 @@ excess files in the library.
 Here's an example of a configuration in library mode with a user that has the two-factor authentication enabled. Your 2FA code will be asked at the end of the configuration, and will attempt to authenticate you:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -38,7 +38,7 @@ Here is an example of making an SFTP configuration.  First run
 This will guide you through an interactive setup process.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -56,9 +56,11 @@ Choose a number from below, or type in your own value
  1 / Connect to example.com
    \ "example.com"
 host> example.com
-SSH username, leave blank for current username, $USER
+SSH username
+Enter a string value. Press Enter for the default ("$USER").
 user> sftpuser
-SSH port, leave blank to use default (22)
+SSH port number
+Enter a signed integer. Press Enter for the default (22).
 port>
 SSH password, leave blank to use ssh-agent.
 y) Yes type in my own password

--- a/docs/content/sharefile.md
+++ b/docs/content/sharefile.md
@@ -20,7 +20,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/sia.md
+++ b/docs/content/sia.md
@@ -64,7 +64,7 @@ First, run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/sugarsync.md
+++ b/docs/content/sugarsync.md
@@ -21,7 +21,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/swift.md
+++ b/docs/content/swift.md
@@ -26,7 +26,7 @@ Here is an example of making a swift configuration.  First run
 This will guide you through an interactive setup process.
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/tardigrade.md
+++ b/docs/content/tardigrade.md
@@ -25,7 +25,7 @@ This will guide you through an interactive setup process:
 ### Setup with access grant
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config
@@ -67,7 +67,7 @@ y/e/d> y
 ### Setup with API key and passphrase
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/union.md
+++ b/docs/content/union.md
@@ -34,7 +34,7 @@ First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -22,7 +22,7 @@ Here is an example of how to make a remote called `remote`.  First run:
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 q) Quit config

--- a/docs/content/yandex.md
+++ b/docs/content/yandex.md
@@ -16,7 +16,7 @@ Here is an example of making a yandex configuration.  First run
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 n/s> n

--- a/docs/content/zoho.md
+++ b/docs/content/zoho.md
@@ -16,7 +16,7 @@ Here is an example of making a zoho configuration.  First run
 This will guide you through an interactive setup process:
 
 ```
-No remotes found - make a new one
+No remotes found, make a new one?
 n) New remote
 s) Set configuration password
 n/s> n

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -51,7 +51,7 @@ const (
 	ConfigEncoding = "encoding"
 
 	// ConfigEncodingHelp is the help for ConfigEncoding
-	ConfigEncodingHelp = "This sets the encoding for the backend.\n\nSee the [encoding section in the overview](/overview/#encoding) for more info."
+	ConfigEncodingHelp = "The encoding for the backend.\n\nSee the [encoding section in the overview](/overview/#encoding) for more info."
 
 	// ConfigAuthorize indicates that we just want "rclone authorize"
 	ConfigAuthorize = "config_authorize"

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -570,9 +570,10 @@ func JSONListProviders() error {
 // fsOption returns an Option describing the possible remotes
 func fsOption() *fs.Option {
 	o := &fs.Option{
-		Name:    "Storage",
-		Help:    "Type of storage to configure.",
-		Default: "",
+		Name:     "Storage",
+		Help:     "Type of storage to configure.",
+		Default:  "",
+		Required: true,
 	}
 	for _, item := range fs.Registry {
 		example := fs.OptionExample{

--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -200,13 +200,17 @@ func Enter(what string, kind string, defaultValue string, required bool) string 
 }
 
 // ChoosePassword asks the user for a password
-func ChoosePassword(required bool) string {
+func ChoosePassword(defaultValue string, required bool) string {
 	fmt.Printf("Choose an alternative below.")
-	actions := []string{"yYes type in my own password", "gGenerate random password"}
+	actions := []string{"yYes, type in my own password", "gGenerate random password"}
 	defaultAction := -1
-	if !required {
+	if defaultValue != "" {
 		defaultAction = len(actions)
-		actions = append(actions, "nNo leave this optional password blank")
+		actions = append(actions, "nNo, keep existing")
+		fmt.Printf(" Press Enter for the default (%s).", string(actions[defaultAction][0]))
+	} else if !required {
+		defaultAction = len(actions)
+		actions = append(actions, "nNo, leave this optional password blank")
 		fmt.Printf(" Press Enter for the default (%s).", string(actions[defaultAction][0]))
 	}
 	fmt.Println()
@@ -232,7 +236,7 @@ func ChoosePassword(required bool) string {
 			}
 		}
 	case 'n':
-		return ""
+		return defaultValue
 	default:
 		fs.Errorf(nil, "Bad choice %c", i)
 	}
@@ -412,8 +416,15 @@ func ChooseOption(o *fs.Option, name string) string {
 		fmt.Println(help)
 	}
 
+	var defaultValue string
+	if o.Default == nil {
+		defaultValue = ""
+	} else {
+		defaultValue = fmt.Sprint(o.Default)
+	}
+
 	if o.IsPassword {
-		return ChoosePassword(o.Required)
+		return ChoosePassword(defaultValue, o.Required)
 	}
 
 	what := fmt.Sprintf("%T value", o.Default)
@@ -430,13 +441,6 @@ func ChooseOption(o *fs.Option, name string) string {
 		what = "unsigned integer"
 	}
 	var in string
-	var defaultValue string
-	if o.Default == nil {
-		defaultValue = ""
-	} else {
-		defaultValue = fmt.Sprint(o.Default)
-	}
-
 	for {
 		if len(o.Examples) > 0 {
 			var values []string

--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -611,7 +611,7 @@ func EditConfig(ctx context.Context) (err error) {
 			ShowRemotes()
 			fmt.Printf("\n")
 		} else {
-			fmt.Printf("No remotes found - make a new one\n")
+			fmt.Printf("No remotes found, make a new one?\n")
 			// take 2nd item and last 2 items of menu list
 			what = append(what[1:2], what[len(what)-2:]...)
 		}

--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -101,10 +101,12 @@ func Choose(what string, kind string, choices, help []string, defaultValue strin
 		valueDescription = "your own"
 	}
 	fmt.Printf("Choose a number from below, or type in %s %s.\n", valueDescription, kind)
-	if !required || defaultValue != "" {
-		// Empty input is allowed if not required is set, or if
-		// required is set but there is a default value to use.
-		fmt.Printf("Press Enter for the default (%q).\n", defaultValue)
+	// Empty input is allowed if not required is set, or if
+	// required is set but there is a default value to use.
+	if defaultValue != "" {
+		fmt.Printf("Press Enter for the default (%s).\n", defaultValue)
+	} else if !required {
+		fmt.Printf("Press Enter to leave empty.\n")
 	}
 	attributes := []string{terminal.HiRedFg, terminal.HiGreenFg}
 	for i, text := range choices {
@@ -113,7 +115,7 @@ func Choose(what string, kind string, choices, help []string, defaultValue strin
 			parts := strings.Split(help[i], "\n")
 			lines = append(lines, parts...)
 		}
-		lines = append(lines, fmt.Sprintf("%q", text))
+		lines = append(lines, fmt.Sprintf("(%s)", text))
 		pos := i + 1
 		terminal.WriteString(attributes[i%len(attributes)])
 		if len(lines) == 1 {
@@ -179,12 +181,15 @@ func Choose(what string, kind string, choices, help []string, defaultValue strin
 
 // Enter prompts for an input value of a specified type
 func Enter(what string, kind string, defaultValue string, required bool) string {
-	if !required || defaultValue != "" {
-		// Empty input is allowed if not required is set, or if
-		// required is set but there is a default value to use.
-		fmt.Printf("Enter a %s. Press Enter for the default (%q).\n", kind, defaultValue)
+	// Empty input is allowed if not required is set, or if
+	// required is set but there is a default value to use.
+	fmt.Printf("Enter a %s.", kind)
+	if defaultValue != "" {
+		fmt.Printf(" Press Enter for the default (%s).\n", defaultValue)
+	} else if !required {
+		fmt.Println(" Press Enter to leave empty.")
 	} else {
-		fmt.Printf("Enter a %s.\n", kind)
+		fmt.Println()
 	}
 	for {
 		fmt.Printf("%s> ", what)
@@ -427,18 +432,22 @@ func ChooseOption(o *fs.Option, name string) string {
 		return ChoosePassword(defaultValue, o.Required)
 	}
 
-	what := fmt.Sprintf("%T value", o.Default)
-	switch o.Default.(type) {
-	case bool:
-		what = "boolean value (true or false)"
-	case fs.SizeSuffix:
-		what = "size with suffix K,M,G,T"
-	case fs.Duration:
-		what = "duration s,m,h,d,w,M,y"
-	case int, int8, int16, int32, int64:
-		what = "signed integer"
-	case uint, byte, uint16, uint32, uint64:
-		what = "unsigned integer"
+	what := "value"
+	if o.Default != "" {
+		switch o.Default.(type) {
+		case bool:
+			what = "boolean value (true or false)"
+		case fs.SizeSuffix:
+			what = "size with suffix K,M,G,T"
+		case fs.Duration:
+			what = "duration s,m,h,d,w,M,y"
+		case int, int8, int16, int32, int64:
+			what = "signed integer"
+		case uint, byte, uint16, uint32, uint64:
+			what = "unsigned integer"
+		default:
+			what = fmt.Sprintf("%T value", o.Default)
+		}
 	}
 	var in string
 	for {

--- a/fs/registry.go
+++ b/fs/registry.go
@@ -125,20 +125,29 @@ const (
 // Option is describes an option for the config wizard
 //
 // This also describes command line options and environment variables
+//
+// To create a multiple-choice option, specify the possible values
+// in the Examples property. Whether the option's value is required
+// to be one of these depends on other properties:
+// - Default is to allow any value, either from specified examples,
+//   or any other value. To restrict exclusively to the specified
+//   examples, also set Exclusive=true.
+// - If empty string should not be allowed then set Required=true,
+//   and do not set Default.
 type Option struct {
 	Name       string           // name of the option in snake_case
-	Help       string           // Help, the first line only is used for the command line help
-	Provider   string           // Set to filter on provider
-	Default    interface{}      // default value, nil => ""
+	Help       string           // help, start with a single sentence on a single line that will be extracted for command line help
+	Provider   string           // set to filter on provider
+	Default    interface{}      // default value, nil => "", if set (and not to nil or "") then Required does nothing
 	Value      interface{}      // value to be set by flags
-	Examples   OptionExamples   `json:",omitempty"` // config examples
+	Examples   OptionExamples   `json:",omitempty"` // predefined values that can be selected from list (multiple-choice option)
 	ShortOpt   string           // the short option for this if required
 	Hide       OptionVisibility // set this to hide the config from the configurator or the command line
-	Required   bool             // this option is required
+	Required   bool             // this option is required, meaning value cannot be empty unless there is a default
 	IsPassword bool             // set if the option is a password
 	NoPrefix   bool             // set if the option for this should not use the backend prefix
 	Advanced   bool             // set if this is an advanced config option
-	Exclusive  bool             // set if the answer can only be one of the examples
+	Exclusive  bool             // set if the answer can only be one of the examples (empty string allowed unless Required or Default is set)
 }
 
 // BaseOption is an alias for Option used internally


### PR DESCRIPTION
#### What is the purpose of this change?

Main purpose of this PR is to fix/improve the handling of `Default`, `Exclusive` and `Required` properties of multiple-choice options. Does also include some additional improvements around the config ui, fixes and nitpicks discovered during development, such as default value prompting (not only for multiple-choice), required password editing, several prompting/spelling tweaks etc.

**Fix handling of default, exclusive and required properties**

Previously an empty input (just pressing enter) was only allowed for multiple-choice options that did not have the Exclusive property set. Here is an example session with an exclusive multiple-choice option:
```
Option config_type.
Authentication type
Enter a string value. Press Enter for the default ("standard").
Choose a number from below, or type in an existing value.
   / Standard authentication.
 1 | Use this if you're a normal Jottacloud user.
   \ "standard"
   / Legacy authentication.
 2 | This is only required for certain whitelabel versions of Jottacloud and not recommended for normal users.
   \ "legacy"
   / Telia Cloud authentication.
 3 | Use this if you are using Telia Cloud.
   \ "telia"
config_type>
config_type>
config_type>
```

With this change the existing `Required` property is introduced into the multiple choice handling, so that one can have `Exclusive` and `Required` options where only a value from the list is allowed, and one can have `Exclusive` but not `Required` options where an empty value is accepted but any non-empty value must still be matching an item from the list. And, as before, a multiple choice that is neither `Exclusive` nor `Required`, where any input is accepted.

Some notes about `Required`:
- The `Required` property means the option must have a value, but it can be explicitely set or it can be an implicit default.
- This means that when there is a default value, that is not an empty string, then setting `Required: true` makes no difference.
- When there is no default value, setting `Required: true` means user have to supply a value, cannot simply press Enter.
- This interpretation did not change with this PR, that was how it was done for free-text input already, but the same logic was introduced for multiple-choice inputs as well.

Note that there are several combinations of properties that will achieve the same: `Exclusive` and `Required` boolean properties set true or false, `Default` value set or not set (nil, treated as empty string), and in addition one can have empty string (`""`) as an entry in the multiple-choice list. Not something that is directly intentional, but more of a consequence, backwards compat etc. The way to achieve the different behavior can be summarized:
- If only values from the specified list should be allowed: `Exclusive=true && Required=true && Default=""`
   - "Exclusive and Required, with no Default"
- If empty string and values from specified list should be allowed: `Exclusive=true && (Required=false || Default!="")`
   - "Exclusive, and not Required or a Default"
- If anything but empty string should be allowed: `Exclusive=false && Required=true && Default==""`
   - "Required, but not Exclusive and no Default"
- If anything should be allowed: `Exclusive=false && Required=false`
   - "Not Required and not Exclusive"

In other words, the recommended approach is: For multiple-choice option do specify `Examples`, and then:
- The default behavior is to allow any value, either from specified examples, or any other value. To restrict exclusively to the specified examples, set `Exclusive=true`.
- If empty string should not be allowed then set `Required=true`, and do not set `Default` (leave it at `nil`).

**Press Enter for the default**

A related issue is the misleading description `Press Enter for the default ("")`, as can be seen from example above. This is also an issue for regular free-text (non-multiple-choice) input, e.g.:
```
FTP host to connect to
Enter a string value. Press Enter for the default ("").
Choose a number from below, or type in your own value
 1 / Connect to ftp.example.com
   \ "ftp.example.com"
host>
This value is required and it has no default.
Enter a string value. Press Enter for the default ("").
Choose a number from below, or type in your own value
 1 / Connect to ftp.example.com
   \ "ftp.example.com"
host>
```
This was also fixed, now the message `Press Enter for the default ("standard").` will only be shown when this is actually allowed.

**Quoting of values in prompt**

Previously the default and multiple choice values were always shown in quotes. For strictly numeric values, e.g. port number, this instinctively seemed wrong (at least with the `FTP port, leave blank to use default (21)` case, described later). So I tried a quick change in the code code to only quote values that are string types. E.g. instead of:
```
Enter a string value. Press Enter for the default ("standard").
Enter a signed integer. Press Enter for the default ("21").
```
Then:
```
Enter a string value. Press Enter for the default ("standard").
Enter a signed integer. Press Enter for the default (21).
```
But then there are other types of values which are not strings, but not simple value types either:
```
Enter a size with suffix K,M,G,T. Press Enter for the default (10Mi).
Enter a boolean value (true or false). Press Enter for the default (false).
Enter a encoder.MultiEncoder value. Press Enter for the default (Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,Del,Ctl,InvalidUtf8,Dot).
```

And that made me think: The input that user enters in the config ui is not programming language / go syntax. When entering string the user should not surround it by quotes. So just as a number input is `21` a string input is also just `this is a string`.

The code that is printing default value is converting it to a string and then using the format verb `%q`, which prints it *safely escaped with Go syntax*. This means surrounded by quotes, but also that `\` is escaped to `\\`, `"` to `\"` etc. This is different from the actual input the user should enter.

Example where rclone is printing default value with `%q`, an option where default is current username with domain prefix:
- When default value is printed with `%q` it is escaped like this:
  ```
  Enter a string value. Press Enter for the default ("domain\\user").
  ```
- But if a user then were to enter his own value in the same format:
  ```
  user>domain\\otheruser
  ```
  Then it would be stored in the config file as `domain\\otheruser`, and when read back this will be escaped into string `"domain\\\\otheruser"`. This can be observed if editing the config, then the default will be the value from config,
  again formatted with `%q`:
  ```
  Press Enter for the default ("domain\\\\otheruser").
  ```

The same thing is true for multiple-choice options, where rclone is printing the "example" values with `%q`:
  ```
  Username
  Choose a number from below, or type in your own string value.
  Press Enter for the default ("").
   1 / Current user
     \ "domain\\user"
   2 / This is "me", yes it is
     | More text here
     \ "mini \"me\" is me"
  ```

An improvement could be to print the string values with `%s` or `%v` instead of `%q`:
  ```
  Enter a string value. Press Enter for the default (some standard value).
  ```
Another variant is to manually add quotes around, `fmt.Sprintf("\"%s\"", v)` to get
quotes without escaping:
  ```
  Enter a string value. Press Enter for the default ("some standard value").
  ```
But then if the original value contains escaped quotes, although not very likely, this will look wrong:
  ```
  Enter a string value. Press Enter for the default ("some "quoted" value").
  ```
So I'm thinking it is best just to print the value without quotes or anything: Everything between `(` and `)` is exactly as the user would have to write it! ...Although same thing here if original value contains parens as well, but parens within parens maybe does not look *that* wrong as with quotes within quotes? Regardless, the main purpose with no quoting and just parens, is it looks a bit cleaner, to avoid confusion with regards to if values containing spaces must be quoted or not, less targeted at programmers and more at end-users.. I don't know. Thats the idea, at least.. :)

But then for non-required options without a default value, the current version prompts:
```
Press Enter for the default ("").
```
With the change above this would look worse:
```
Press Enter for the default ().
```
But can easily consider this in code, so that this case is instead shown as:
```
Press Enter to leave empty.
```

(not sure if it should say "to leave empty", or "to skip" or "not set" or something like that instead?)

But then when it comes to how multiple-choice are prompted, the option value for each choice are in a section together with the help text today, and not separated in the same way as the default values described above. Currently:
```
   2 / This is "me", yes it is
     | More text here
     \ "this \"me\" is not really me"
```
But perhaps we can just do the same here - plain string (content), and add parenthesis to separate from help text:
```
   2 / This is "me", yes it is
     | More text here
     \ (this "me" is not really me)
```

That is what I have done, so the "look" will be a bit different - notice the values in parenthesis:

```
Type of storage to configure.
Choose a number from below, or type in your own string value.
 1 / 1Fichier
   \ (fichier)
 2 / Alias for an existing remote
   \ (alias)
 3 / Amazon Drive
   \ (amazon cloud drive)
Storage>

Host to connect to
Choose a number from below, or type in your own string value.
 1 / Connect to ftp.example.com
   \ (ftp.example.com)
host>

Username
Press Enter for the default (domain\user).
user>

Port
Press Enter for the default (21).
port>

Username2
Choose a number from below, or type in your own string value.
Press Enter to leave empty.
 1 / Current user
   \ (domain\user)
   / This is "me", yes it is
 2 | Here we go with more text
   \ (this "me" is not really me)
 3 / This is an empty choice
   \ ()
user2>
```

(The choice 3 in the last example still shows an empty `()`. This is a very special case where the multiple choice list have an explicit entry with value empty string. Rarely used, and is a bit confusing compared to the Default, Required etc discussed above, but I have seen it. Left it just printing `()` for now, have not come up with a better option yet).

**Fixed edit of required password**

Another related issue is in the process of editing existing remotes, where there is a password. The editing process was changed in v1.56 from a separate edit workflow:
```
Value "port" = "2222"
Edit? (y/n)>
y) Yes
n) No (default)
```
..into making edit being more like the initial create - just with existing values as default. This lead to a regression for required password inputs, as reported here: https://forum.rclone.org/t/v1-56-beta-i-have-to-re-enter-the-password-when-editing-the-remote/26437. Fixed this by making password input handle the `Default` property of options, in addition to `Required`, the same way as other option types. When editing the existing value will be the default value, and user gets the additional choice `n` to keep existing/default in addition to `y` and `g`:
```
FTP password
y) Yes, type in my own password
g) Generate random password
n) No, keep existing (default)
```
PS: The changes in the edit process introduced in v1.56 came with the following commits:
   https://github.com/rclone/rclone/commit/296ceadda61b82fe47e22e71ca85d01b00dc7c67#diff-d43e96d17fe826ebacb1c626935c1ced77f6c508a47cd7fa19832eb724c473c2
   https://github.com/rclone/rclone/commit/77cda6773ca6d46d95e7e63f0d6b2be93ce81af3#diff-d43e96d17fe826ebacb1c626935c1ced77f6c508a47cd7fa19832eb724c473c2

**Additional improvements to config ui prompts:**

- Moved the code for input of the three types, free-text, password and multiple-choice, into separate functions, and made their prompting a bit mot tailor-made.
- Improved "title" for multiple-choice options, especially the ones without default:
    ```
    Enter a string value.
    Choose a number from below, or type in an existing value
    ```
    Now:
    ```
    Choose a number from below, or type in an existing string value.
    ```
- Improved feedback on wrong input: Print message such as `This value is required and it has no default.` and then a new "prompt" such as `my_option>`, also for multiple-choice options (consistent for all option types):
    ```
    Choose a number from below, or type in your own string value.
     1 / Rclone should act on behalf of a user.
       \ "user"
     2 / Rclone should act on behalf of a service account.
       \ "enterprise"
    my_option>
    This value is required and it has no default.
    my_option>
    This value is required and it has no default.
    my_option>
    ```
    Previously it would, depending on error, whether free-text input or multiple-choice etc, either just repeat the prompt as in the initial example at the top or repeat the entire "question" with description (and choices) as the second example with ftp host input.
- Made ftp and ssh port and username option default values explicit, using `Default` property.
  - This avoids a prompt that would be repetative and confusing.
  - When creating a ftp remote you get this question:
  ```
  FTP port, leave blank to use default (21)
  Enter a string value. Press Enter for the default ("").
  port>
  ```
  If explicitely entering a port number, e.g. 2222, then when later editing the remote you get this question:
  ```
  FTP port, leave blank to use default (21)
  Enter a string value. Press Enter for the default ("2222").
  port>
  ```
  (as mentioned above I've removed the quoting around the "2222" value so with this change it would show `Press Enter for the 
  default (2222).`)

  So default is 21, "", 2222, or what??

  The explanation is that the help text of the ftp port option is defined as:
  ```
  Help: "FTP port, leave blank to use default (21)",
  ```
  So the "leave blank to use default (21)" was actually "hard-coded" in the help text. The ftp backend implementation will connect to port 21 when nothing else is specified - this is an *implicit* default. The option definition did not actually have a `Default` parameter, meaning it is `nil`. When the config ui prompts for this option during creation it will therefore add the description `Press Enter for the default ("").` When editing an existing remote, where the ftp option has a value explicitely set (e.g. 2222), then the existing value will be the option's `Default` parameter and therefore the prompt changes to `Press Enter for the default ("2222").`.
  
  Fixed by setting the `Default` property of the option, and removing the description of default from help text.
  
  Similar for username, where it would show:
   ```
  FTP username, leave blank for current username, DOMAIN\user
  Enter a string value. Press Enter for the default ("").
  user>
  ```
  But now instead:
  ```
  FTP username
  Press Enter for the default (DOMAIN\user).
  user>
  ```
- Includes some initial commits with minor cleanup done to make the main refactoring easier, but these did not end up being important for the solution (I can remove them if this is preferred):
  - Removed explicit setting of defaults `Required: false` and `Default: ""`
  - Removed setting `Required: true` when there is a `Default` value set.

**NOTE: Some issues and imperfections noticed but not fixed**

- The datatype of options are decided by the type of the `Default` property, but if there is no default then the type is always referred to as string (`Enter a string value`), even if it naturally is an integer (like a port number).
   - We could have introduced a new property `Type` that defines the value type expected, e.g. "bool" or "string". If this is not  specified we could check `Default` as before (backwards compat.).
- When editing an existing remote that has set an explicit value for an option that has an implicit default, it is not possible to "clear" the value and get back to the implicit default. E.g. for ftp port number: Ftp backend will use port 21 if none is specified. Say an existing remote has this set to 2122. When editing this remote, to be able to use the default value 21 one have to explicit set it:
  ```
  FTP port, leave blank to use default (21)
  Enter a signed integer. Press Enter for the default (2122).
  port>
  ```  
  Empty input here (just pressing enter) will keep existing value 2122.
- The question to edit advanced config is repeated when done with all advanced options, but could be intentional?
  ```
  Edit advanced config?
  y) Yes
  n) No (default)
  y/n>
  ```
- Multiple choice options cannot take an integer as value! Any input entered by user that is convertible to integer will be treated as a number referencing the choice number. So if there are two choices then entering `2` will pick the second choice. Entering `999` will not pick any, but will be treated as a invalid choice because it there are no choices with that number. So if one had a multiple-choice option for configuring a port number, e.g. predefined values `1) 80`, `2) 8080`, `3) 8088`, but the option not being `Exclusive`, then entering 1, 2 or 3 would pick the corresponding predefined value, but entering 8 or 80 or 8888, would not be allowed, although that is supposed to be a way for the user to enter a custom port number.

**TODO: Remaining**

Update references to the interactive config prompts in documentation, to match the changes. Especially the example config session shown in most backend md docs.

#### Was the change discussed in an issue or in the forum before?

Fixes #5549
Fixes #5562

Also fixes an issue reported in forum: https://forum.rclone.org/t/v1-56-beta-i-have-to-re-enter-the-password-when-editing-the-remote/26437

**Also related to #5538, should probably merge that first (if accepted) and then fix up a few conflicts before merging this one.**

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
