### PR TITLE
docs/config: remove use of backticks around words within a larger code block

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -196,7 +196,7 @@ Note that |bin/config.py| in the rclone source implements this protocol
 as a readable demonstration.
 `, "|", "`")
 var configCreateCommand = &cobra.Command{
-	Use:   "create `name` `type` [`key` `value`]*",
+	Use:   "create name type [key value]*",
 	Short: `Create a new remote with name, type and options.`,
 	Long: strings.ReplaceAll(`
 Create a new remote of |name| with |type| and options.  The options
@@ -259,7 +259,7 @@ func init() {
 }
 
 var configUpdateCommand = &cobra.Command{
-	Use:   "update `name` [`key` `value`]+",
+	Use:   "update name [key value]+",
 	Short: `Update options in an existing remote.`,
 	Long: strings.ReplaceAll(`
 Update an existing remote's options. The options should be passed in
@@ -289,8 +289,8 @@ require this add an extra parameter thus:
 }
 
 var configDeleteCommand = &cobra.Command{
-	Use:   "delete `name`",
-	Short: "Delete an existing remote `name`.",
+	Use:   "delete name",
+	Short: "Delete an existing remote.",
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(1, 1, command, args)
 		config.DeleteRemote(args[0])
@@ -298,7 +298,7 @@ var configDeleteCommand = &cobra.Command{
 }
 
 var configPasswordCommand = &cobra.Command{
-	Use:   "password `name` [`key` `value`]+",
+	Use:   "password name [key value]+",
 	Short: `Update password in an existing remote.`,
 	Long: strings.ReplaceAll(`
 Update an existing remote's password. The password


### PR DESCRIPTION
#### What is the purpose of this change?

Minor improvement in docs for rclone config subcommands, removing backticks that are intended for markdown code elements in strings that are inserted into larger code blocks.

Result is, instead of:

```
rclone config delete `name` [flags]
```

Then this:
```
rclone config delete name [flags]
```

Also removed `name` code element in short string of rclone config delete, as it makes it stick out in the docs at https://rclone.org/commands/, none of the other have this.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
