### PR TITLE
test: skip mount2 test on CI runners

### DIFF
--- a/cmd/mount2/mount_test.go
+++ b/cmd/mount2/mount_test.go
@@ -5,9 +5,11 @@ package mount2
 import (
 	"testing"
 
+	"github.com/rclone/rclone/fstest/testy"
 	"github.com/rclone/rclone/vfs/vfstest"
 )
 
 func TestMount(t *testing.T) {
+	testy.SkipUnreliable(t)
 	vfstest.RunTests(t, false, mount)
 }


### PR DESCRIPTION
#### What is the purpose of this change?

This PR contains a single commit spun off #5550 

Really skip `mount2` ~~and cmount~~ test on single-CPU runners to prevent sporadic lockups.

#### Was the change discussed in an issue or in the forum before?

Discussed in https://github.com/rclone/rclone/pull/5550#issuecomment-903684789 and [commit 6a9ef27b comments](https://github.com/rclone/rclone/commit/6a9ef27b0919fed17c3865a395afec97a6ed53d3#commitcomment-55235890)

cc @ncw

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
