### PR TITLE
docs/jottacloud: update description of whitelabel services

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ Rclone *("rsync for cloud storage")* is a command line program to sync files and
   * Dropbox [:page_facing_up:](https://rclone.org/dropbox/)
   * Enterprise File Fabric [:page_facing_up:](https://rclone.org/filefabric/)
   * FTP [:page_facing_up:](https://rclone.org/ftp/)
-  * GetSky [:page_facing_up:](https://rclone.org/jottacloud/)
   * Google Cloud Storage [:page_facing_up:](https://rclone.org/googlecloudstorage/)
   * Google Drive [:page_facing_up:](https://rclone.org/drive/)
   * Google Photos [:page_facing_up:](https://rclone.org/googlephotos/)

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -38,7 +38,7 @@ See the following for detailed instructions for
   * [HDFS](/hdfs/)
   * [HTTP](/http/)
   * [Hubic](/hubic/)
-  * [Jottacloud / GetSky.no](/jottacloud/)
+  * [Jottacloud](/jottacloud/)
   * [Koofr](/koofr/)
   * [Mail.ru Cloud](/mailru/)
   * [Mega](/mega/)

--- a/docs/content/jottacloud.md
+++ b/docs/content/jottacloud.md
@@ -5,10 +5,23 @@ description: "Rclone docs for Jottacloud"
 
 # {{< icon "fa fa-cloud" >}} Jottacloud
 
-Jottacloud is a cloud storage service provider from a Norwegian company, using its own datacenters in Norway.
+Jottacloud is a cloud storage service provider from a Norwegian company, using its own datacenters
+in Norway. In addition to the official service at [jottacloud.com](https://www.jottacloud.com/),
+it also provides white-label solutions to different companies, such as:
+* Telia
+  * Telia Cloud (cloud.telia.se)
+  * Telia Sky (sky.telia.no)
+* Tele2
+  * Tele2 Cloud (mittcloud.tele2.se)
+* Elkjøp (with subsidiaries):
+  * Elkjøp Cloud (cloud.elkjop.no)
+  * Elgiganten Sweden (cloud.elgiganten.se)
+  * Elgiganten Denmark (cloud.elgiganten.dk)
+  * Giganti Cloud  (cloud.gigantti.fi)
+  * ELKO Clouud (cloud.elko.is)
 
-In addition to the official service at [jottacloud.com](https://www.jottacloud.com/), there are
-also several whitelabel versions which should work with this backend.
+Most of the white-label versions are supported by this backend, although may require different
+authentication setup - described below.
 
 Paths are specified as `remote:path`
 
@@ -25,7 +38,7 @@ Note that the web interface may refer to this token as a JottaCli token.
 
 ### Legacy Setup
 
-If you are using one of the whitelabel versions (Elgiganten, Com Hem Cloud) you may not have the option
+If you are using one of the whitelabel versions (e.g. from Elkjøp or Tele2) you may not have the option
 to generate a CLI token. In this case you'll have to use the legacy authentication. To to this select
 yes when the setup asks for legacy authentication and enter your username and password.
 The rest of the setup is identical to the default setup.


### PR DESCRIPTION
#### What is the purpose of this change?

Fix mentions of obsolete whitelabel services in docs:
- `Com Hem Cloud` is now `Tele2 Cloud` (the company Com Hem was discontinued as a brand as of April 2021, after being merged into Tele2 in 2018–2019).
- `Get Sky` is now `Telia Sky` (my previous Get Sky account was rebranded to Telia Sky mid 2020, Telia company bought the Get company some time before that so if not all accounts are rebranded I guess they will be soon).

Added list of known whitelabel services to Jottacloud docs:
- Not 100% decided if we should do this, maintain such an unpublished list in rclone docs.
- The reason to include it is that many (most?) users of such services may not know that it is a Jottacloud based service, and that they can use rclone with Jottacloud backend to access it.
- So, I guess my suggestion is to include it. What do you think?


#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
