### PR TITLE
Add precision debug line to local fs

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -601,6 +601,9 @@ func (f *Fs) Precision() (precision time.Duration) {
 	f.precisionOk.Do(func() {
 		f.precision = f.readPrecision()
 	})
+
+	fs.Debugf(f, "precision detected: %v", f.precision)
+
 	return f.precision
 }
 


### PR DESCRIPTION
#### What is the purpose of this change?

Add a single debug line to help debugging local fs precision issues.

The final line looks like this:
```
2021/09/07 20:11:13 DEBUG : Local file system at /Volumes/Blue/temp: precision detected: 1ns
```

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/bug-without-modify-window-1s-sync-to-always-copies-all-files/26394/22

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
