### PR TITLE
ftp: fix deadlock after failed update when concurrency=1

### DIFF
--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -1062,8 +1062,9 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	}
 	if err != nil {
 		_ = c.Quit() // toss this connection to avoid sync errors
-		remove()
+		// recycle connection in advance to let remove() find free token
 		o.fs.putFtpConnection(nil, err)
+		remove()
 		return errors.Wrap(err, "update stor")
 	}
 	o.fs.putFtpConnection(&c, nil)


### PR DESCRIPTION
#### What is the purpose of this change?

Our users complained many times that rclone FTP client manifests random problems with completing a file upload.

As my investigations have shown, the bug triggers because [jlaffaye/ftp does not properly nudge](https://github.com/jlaffaye/ftp/blob/5d41901190670f202a4aafb39c81d72e2e42bd8d/ftp.go#L721) the [fshttp anti-hanging timer](https://github.com/rclone/rclone/blob/v1.56.0/fs/fshttp/dialer.go#L85) on command channel after a file upload. I have a [working fix](https://github.com/ivandeex/rclone/releases) for [jlaffaye/ftp](https://github.com/ivandeex/ftp/commit/08390f8cbaa60e98bb1687989752e31feaf8b416) and [backend/ftp](https://github.com/ivandeex/rclone/commit/f70e98d1595feadf6d52ade6e9565aec3ed77aa3) which I will submit **later**.

This pull request solves a second-stage bug triggered by the above bug which can be fixed **solely** in rclone. Frequently when users reported the above bug we recommended them to simplify their FTP client settings, in particular set `--ftp-concurrency=1`. When the FTP backend's [upload routine](https://github.com/rclone/rclone/blob/v1.56.0/backend/ftp/ftp.go#L1063) encounters a error, it will remove the failed file. The removal needs another connection but due to low concurrency setting it will wait for [connection token](https://github.com/rclone/rclone/blob/v1.56.0/backend/ftp/ftp.go#L317) forever.

This patch modifies the upload routine so that after error it will _first_ release the failed connection and _then_ remove the failed file and thus avoid the deadlock.
Due to presence of another bug I will include a [relevant unit test](https://github.com/ivandeex/rclone/commit/f70e98d1595feadf6d52ade6e9565aec3ed77aa3#diff-67452ac6849fa36379c4aa76d2d528fd2dbe411ac03493522a63e59ea03a8c40R84) with a dedicated pull request #5596, not here. I just hope that the change looks self-evident. @ncw ??

#### Was the change discussed in an issue or in the forum before?

- https://forum.rclone.org/t/rclone-copy-to-ftp-rclone-sends-a-quit-and-never-ends-itself/24046/10
- #5596 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate (see **manual test** below)
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
