### PR TITLE
Run rclone as a mount helper program

### DIFF
--- a/cmd/mountlib/help.go
+++ b/cmd/mountlib/help.go
@@ -12,13 +12,22 @@ On Linux and OSX, you can either run mount in foreground mode or background (dae
 Mount runs in foreground mode by default, use the |--daemon| flag to specify background mode.
 You can only run mount in foreground mode on Windows.
 
+In background mode rclone acts as a generic Unix mount program: the main program
+starts, spawns a background rclone process to setup and maintain the mount, waits
+until success or timeout, kills the child process if mount fails, and immediately
+exits with appropriate return code.
+
 On Linux/macOS/FreeBSD start the mount like this, where |/path/to/local/mount|
 is an **empty** **existing** directory:
 
     rclone @ remote:path/to/files /path/to/local/mount
 
 On Windows you can start a mount in different ways. See [below](#mounting-modes-on-windows)
-for details. The following examples will mount to an automatically assigned drive,
+for details. If foreground mount is used interactively from a console window,
+rclone will serve the mount and occupy the console so another window should be
+used to work with the mount until rclone is interrupted e.g. by pressing Ctrl-C.
+
+The following examples will mount to an automatically assigned drive,
 to specific drive letter |X:|, to path |C:\path\parent\mount|
 (where parent directory or drive must exist, and mount must **not** exist,
 and is not supported when [mounting as a network drive](#mounting-modes-on-windows)), and
@@ -225,6 +234,13 @@ Hubic) do not support the concept of empty directories, so empty
 directories will have a tendency to disappear once they fall out of
 the directory cache.
 
+When mount is invoked on Unix with |--daemon|, the main rclone program
+will wait until the background mount is ready until timeout specified by
+the |--daemon-wait| flag. On Linux rclone will poll ProcFS to check status
+so the flag sets the **maximum time to wait**. On macOS/BSD the time to wait
+is constant and the check is performed only at the end of sleep so don't
+set it too high...
+
 Only supported on Linux, FreeBSD, OS X and Windows at the moment.
 
 ### rclone @ vs rclone sync/copy
@@ -280,4 +296,80 @@ to use Type=notify. In this case the service will enter the started state
 after the mountpoint has been successfully set up.
 Units having the rclone @ service specified as a requirement
 will see all files and folders immediately in this mode.
+
+Note that systemd runs mount units without any environment variables including
+|PATH| or |HOME|. This means that tilde (|~|) expansion will not work
+and you should provide |--config| and |--cache-dir| explicitly as absolute
+paths via rclone arguments. Since mounting requires the |fusermount| program,
+rclone will use the fallback PATH of |/bin:/usr/bin| in this scenario.
+Please ensure that |fusermount| is present on this PATH.
+
+### Rclone as Unix mount helper
+
+The core Unix program |/bin/mount| normally takes the |-t FSTYPE| argument
+then runs the |/sbin/mount.FSTYPE| helper program passing it mount options
+as |-o key=val,...| or |--opt=...|. Automount (classic or systemd) follows
+the suit.
+
+rclone by default expects GNU-style flags |--key val|. To run it as a
+mount helper you should symlink the rclone binary to |/sbin/mount.rclone|
+and optionally |/usr/bin/rclonefs|, e.g. |ln -s /usr/bin/rclone /sbin/mount.rclone|.
+
+Now you can run classic mounts like this:
+|||
+mount sftp1:subdir /mnt/data -t rclone -o vfs_cache_mode=writes,sftp_key_file=/path/to/pem
+|||
+
+or create systemd mount units:
+|||
+# /etc/systemd/system/mnt-data.mount
+[Unit]
+After=network-online.target
+[Mount]
+Type=rclone
+What=sftp1:subdir
+Where=/mnt/data
+Options=rw,allow_other,args2env,vfs-cache-mode=writes,config=/etc/rclone.conf,cache-dir=/var/rclone
+|||
+
+optionally augmented by systemd automount unit
+|||
+# /etc/systemd/system/mnt-data.automount
+[Unit]
+After=network-online.target
+Before=remote-fs.target
+[Automount]
+Where=/mnt/data
+TimeoutIdleSec=600
+[Install]
+WantedBy=multi-user.target
+|||
+
+or add in |/etc/fstab| a line like
+|||
+sftp1:subdir /mnt/data rclone rw,noauto,nofail,_netdev,x-systemd.automount,args2env,vfs_cache_mode=writes,config=/etc/rclone.conf,cache_dir=/var/cache/rclone 0 0
+|||
+
+or use classic Automountd.
+Remember to provide explicit |config=...,cache-dir=...| as mount units
+run without |HOME|.
+
+Rclone in the mount helper mode will split |-o| argument(s) by comma, replace |_|
+by |-| and prepend |--| to get the command-line flags. Options containing commas
+or spaces can be wrapped in single or double quotes. Any quotes inside outer quotes
+should be doubled.
+
+Mount option syntax includes a few extra options treated specially:
+
+- |env.NAME=VALUE| will set an environment variable for.
+  This helps with Automountd and Systemd.mount which don't allow to set custom
+  environment for mount helpers.
+  Typically you will use |env.HTTPS_PROXY=proxy.host:3128| or |env.HOME=/root|
+- |command=cmount| can be used to run any other command rather than default mount
+- |args2env| will pass mount options to the background mount helper via environment
+  variables instead of command line arguments. This allows to hide secrets from such
+  commands as |ps| or |pgrep|.
+- |vv...| will be transformed into appropriate |--verbose=N|
+- standard mount options like |x-systemd.automount|, |_netdev|, |nosuid| and alike
+  are intended only for Automountd so ignored by rclone
 `

--- a/docs/content/commands/rclone_mount.md
+++ b/docs/content/commands/rclone_mount.md
@@ -22,13 +22,22 @@ On Linux and macOS, you can either run mount in foreground mode or background (d
 Mount runs in foreground mode by default, use the `--daemon` flag to specify background mode.
 You can only run mount in foreground mode on Windows.
 
+In background mode rclone acts as a generic Unix mount program: the main program
+starts, spawns a background rclone process to setup and maintain the mount, waits
+until success or timeout, kills the child process if mount fails, and immediately
+exits with appropriate return code.
+
 On Linux/macOS/FreeBSD start the mount like this, where `/path/to/local/mount`
 is an **empty** **existing** directory:
 
     rclone mount remote:path/to/files /path/to/local/mount
 
 On Windows you can start a mount in different ways. See [below](#mounting-modes-on-windows)
-for details. The following examples will mount to an automatically assigned drive,
+for details. If foreground mount is used interactively from a console window,
+rclone will serve the mount and occupy the console so another window should be
+used to work with the mount until rclone is interrupted e.g. by pressing Ctrl-C.
+
+The following examples will mount to an automatically assigned drive,
 to specific drive letter `X:`, to path `C:\path\parent\mount`
 (where parent directory or drive must exist, and mount must **not** exist,
 and is not supported when [mounting as a network drive](#mounting-modes-on-windows)), and
@@ -238,6 +247,13 @@ Hubic) do not support the concept of empty directories, so empty
 directories will have a tendency to disappear once they fall out of
 the directory cache.
 
+When mount is invoked on Unix with `--daemon`, the main rclone program
+will wait until the background mount is ready until timeout specified by
+the `--daemon-wait` flag. On Linux rclone will poll ProcFS to check status
+so the flag sets the **maximum time to wait**. On macOS/BSD the time to wait
+is constant and the check is performed only at the end of sleep so don't
+set it too high...
+
 Only supported on Linux, FreeBSD, macOS and Windows at the moment.
 
 ## rclone mount vs rclone sync/copy
@@ -293,6 +309,82 @@ to use Type=notify. In this case the service will enter the started state
 after the mountpoint has been successfully set up.
 Units having the rclone mount service specified as a requirement
 will see all files and folders immediately in this mode.
+
+Note that systemd runs mount units without any environment variables including
+`PATH` or `HOME`. This means that tilde (`~`) expansion will not work
+and you should provide `--config` and `--cache-dir` explicitly as absolute
+paths via rclone arguments. Since mounting requires the `fusermount` program,
+rclone will use the fallback PATH of `/bin:/usr/bin` in this scenario.
+Please ensure that `fusermount` is present on this PATH.
+
+## Rclone as Unix mount helper
+
+The core Unix program `/bin/mount` normally takes the `-t FSTYPE` argument
+then runs the `/sbin/mount.FSTYPE` helper program passing it mount options
+as `-o key=val,...` or `--opt=...`. Automount (classic or systemd) follows
+the suit.
+
+rclone by default expects GNU-style flags `--key val`. To run it as a
+mount helper you should symlink the rclone binary to `/sbin/mount.rclone`
+and optionally `/usr/bin/rclonefs`, e.g. `ln -s /usr/bin/rclone /sbin/mount.rclone`.
+
+Now you can run classic mounts like this:
+```
+mount sftp1:subdir /mnt/data -t rclone -o vfs_cache_mode=writes,sftp_key_file=/path/to/pem
+```
+
+or create systemd mount units:
+```
+# /etc/systemd/system/mnt-data.mount
+[Unit]
+After=network-online.target
+[Mount]
+Type=rclone
+What=sftp1:subdir
+Where=/mnt/data
+Options=rw,allow_other,args2env,vfs-cache-mode=writes,config=/etc/rclone.conf,cache-dir=/var/rclone
+```
+
+optionally augmented by systemd automount unit
+```
+# /etc/systemd/system/mnt-data.automount
+[Unit]
+After=network-online.target
+Before=remote-fs.target
+[Automount]
+Where=/mnt/data
+TimeoutIdleSec=600
+[Install]
+WantedBy=multi-user.target
+```
+
+or add in `/etc/fstab` a line like
+```
+sftp1:subdir /mnt/data rclone rw,noauto,nofail,_netdev,x-systemd.automount,args2env,vfs_cache_mode=writes,config=/etc/rclone.conf,cache_dir=/var/cache/rclone 0 0
+```
+
+or use classic Automountd.
+Remember to provide explicit `config=...,cache-dir=...` as mount units
+run without `HOME`.
+
+Rclone in the mount helper mode will split `-o` argument(s) by comma, replace `_`
+by `-` and prepend `--` to get the command-line flags. Options containing commas
+or spaces can be wrapped in single or double quotes. Any quotes inside outer quotes
+should be doubled.
+
+Mount option syntax includes a few extra options treated specially:
+
+- `env.NAME=VALUE` will set an environment variable for.
+  This helps with Automountd and Systemd.mount which don't allow to set custom
+  environment for mount helpers.
+  Typically you will use `env.HTTPS_PROXY=proxy.host:3128` or `env.HOME=/root`
+- `command=cmount` can be used to run any other command rather than default mount
+- `args2env` will pass mount options to the background mount helper via environment
+  variables instead of command line arguments. This allows to hide secrets from such
+  commands as `ps` or `pgrep`.
+- `vv...` will be transformed into appropriate `--verbose=N`
+- standard mount options like `x-systemd.automount`, `_netdev`, `nosuid` and alike
+  are intended only for Automountd so ignored by rclone
 
 ## chunked reading
 
@@ -587,8 +679,9 @@ rclone mount remote:path /path/to/mountpoint [flags]
       --allow-root                             Allow access to root user. Not supported on Windows.
       --async-read                             Use asynchronous reads. Not supported on Windows. (default true)
       --attr-timeout duration                  Time for which file/directory attributes are cached. (default 1s)
-      --daemon                                 Run mount as a daemon (background mode). Not supported on Windows.
+      --daemon                                 Run mount in background and exit parent process. Not supported on Windows. As background output is suppressed, use --log-file with --log-format=pid,... to monitor.
       --daemon-timeout duration                Time limit for rclone to respond to kernel. Not supported on Windows.
+      --daemon-wait duration                   Time to wait for ready mount from daemon (maximum time on Linux, constant sleep time on OSX/BSD). Ignored on Windows. (default 1m0s)
       --debug-fuse                             Debug the FUSE internals - needs -v.
       --default-permissions                    Makes kernel enforce access control based on the file mode. Not supported on Windows.
       --dir-cache-time duration                Time to cache directory entries for. (default 5m0s)

--- a/fs/config.go
+++ b/fs/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -178,6 +179,11 @@ func NewConfig() *ConfigInfo {
 		}
 		if arg == "--log-level=DEBUG" || (arg == "--log-level" && len(os.Args) > argIndex+1 && os.Args[argIndex+1] == "DEBUG") {
 			c.LogLevel = LogLevelDebug
+		}
+		if strings.HasPrefix(arg, "--verbose=") {
+			if level, err := strconv.Atoi(arg[10:]); err == nil && level >= 2 {
+				c.LogLevel = LogLevelDebug
+			}
 		}
 	}
 	envValue, found := os.LookupEnv("RCLONE_LOG_LEVEL")

--- a/fs/mount_helper.go
+++ b/fs/mount_helper.go
@@ -1,0 +1,286 @@
+package fs
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/pkg/errors"
+)
+
+func init() {
+	// This block is run super-early, before configuration harness kick in
+	if IsMountHelper() {
+		if args, err := convertMountHelperArgs(os.Args); err == nil {
+			os.Args = args
+		} else {
+			log.Fatalf("Failed to parse command line: %v", err)
+		}
+	}
+}
+
+// PassDaemonArgsAsEnviron tells how CLI arguments are passed to the daemon
+// When false, arguments are passed as is, visible in the `ps` output.
+// When true, arguments are converted into environment variables (more secure).
+var PassDaemonArgsAsEnviron bool
+
+// Comma-separated list of mount options to ignore.
+// Leading and trailing commas are required.
+const helperIgnoredOpts = ",rw,_netdev,nofail,user,dev,nodev,suid,nosuid,exec,noexec,auto,noauto,"
+
+// Valid option name characters
+const helperValidOptChars = "-_0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+// Parser errors
+var (
+	errHelperBadOption    = errors.New("option names may only contain `0-9`, `A-Z`, `a-z`, `-` and `_`")
+	errHelperOptionName   = errors.New("option name can't start with `-` or `_`")
+	errHelperEmptyOption  = errors.New("option name can't be empty")
+	errHelperQuotedValue  = errors.New("unterminated quoted value")
+	errHelperAfterQuote   = errors.New("expecting `,` or another quote after a quote")
+	errHelperSyntax       = errors.New("syntax error in option string")
+	errHelperEmptyCommand = errors.New("command name can't be empty")
+	errHelperEnvSyntax    = errors.New("environment variable must have syntax env.NAME=[VALUE]")
+)
+
+// IsMountHelper returns true if rclone was invoked as mount helper:
+// as /sbin/mount.rlone (by /bin/mount)
+// or /usr/bin/rclonefs (by fusermount or directly)
+func IsMountHelper() bool {
+	if runtime.GOOS == "windows" {
+		return false
+	}
+	me := filepath.Base(os.Args[0])
+	return me == "mount.rclone" || me == "rclonefs"
+}
+
+// convertMountHelperArgs converts "-o" styled mount helper arguments
+// into usual rclone flags
+func convertMountHelperArgs(origArgs []string) ([]string, error) {
+	if IsDaemon() {
+		// The arguments have already been converted by the parent
+		return origArgs, nil
+	}
+
+	args := []string{}
+	command := "mount"
+	parseOpts := false
+	gotDaemon := false
+	gotVerbose := false
+	vCount := 0
+
+	for _, arg := range origArgs[1:] {
+		if !parseOpts {
+			switch arg {
+			case "-o", "--opt":
+				parseOpts = true
+			case "-v", "-vv", "-vvv", "-vvvv":
+				vCount += len(arg) - 1
+			case "-h", "--help":
+				args = append(args, "--help")
+			default:
+				if strings.HasPrefix(arg, "-") {
+					return nil, errors.Errorf("flag %q is not supported in mount mode", arg)
+				}
+				args = append(args, arg)
+			}
+			continue
+		}
+
+		opts, err := parseHelperOptionString(arg)
+		if err != nil {
+			return nil, err
+		}
+		parseOpts = false
+
+		for _, opt := range opts {
+			if strings.Contains(helperIgnoredOpts, ","+opt+",") || strings.HasPrefix(opt, "x-systemd") {
+				continue
+			}
+
+			param, value := opt, ""
+			if idx := strings.Index(opt, "="); idx != -1 {
+				param, value = opt[:idx], opt[idx+1:]
+			}
+
+			// Set environment variables
+			if strings.HasPrefix(param, "env.") {
+				if param = param[4:]; param == "" {
+					return nil, errHelperEnvSyntax
+				}
+				_ = os.Setenv(param, value)
+				continue
+			}
+
+			switch param {
+			// Change command to run
+			case "command":
+				if value == "" {
+					return nil, errHelperEmptyCommand
+				}
+				command = value
+				continue
+			// Flag StartDaemon to pass arguments as environment
+			case "args2env":
+				PassDaemonArgsAsEnviron = true
+				continue
+			// Handle verbosity options
+			case "v", "vv", "vvv", "vvvv":
+				vCount += len(param)
+				continue
+			case "verbose":
+				gotVerbose = true
+			// Don't add --daemon if it was explicitly included
+			case "daemon":
+				gotDaemon = true
+			// Alias for the standard mount option "ro"
+			case "ro":
+				param = "read-only"
+			}
+
+			arg = "--" + strings.ToLower(strings.ReplaceAll(param, "_", "-"))
+			if value != "" {
+				arg += "=" + value
+			}
+			args = append(args, arg)
+		}
+	}
+	if parseOpts {
+		return nil, errors.Errorf("dangling -o without argument")
+	}
+
+	if vCount > 0 && !gotVerbose {
+		args = append(args, fmt.Sprintf("--verbose=%d", vCount))
+	}
+	if strings.Contains(command, "mount") && !gotDaemon {
+		// Default to daemonized mount
+		args = append(args, "--daemon")
+	}
+	if len(args) > 0 && args[0] == command {
+		// Remove artefact of repeated conversion
+		args = args[1:]
+	}
+	prepend := []string{origArgs[0], command}
+	return append(prepend, args...), nil
+}
+
+// parseHelperOptionString deconstructs the -o value into slice of options
+// in a way similar to connection strings.
+// Example:
+//   param1=value,param2="qvalue",param3='item1,item2',param4="a ""b"" 'c'"
+// An error may be returned if the remote name has invalid characters
+// or the parameters are invalid or the path is empty.
+//
+// The algorithm was adapted from fspath.Parse with some modifications:
+// - allow `-` in option names
+// - handle special options `x-systemd.X` and `env.X`
+// - drop support for :backend: and /path
+func parseHelperOptionString(optString string) (opts []string, err error) {
+	if optString = strings.TrimSpace(optString); optString == "" {
+		return nil, nil
+	}
+	// States for parser
+	const (
+		stateParam = uint8(iota)
+		stateValue
+		stateQuotedValue
+		stateAfterQuote
+		stateDone
+	)
+	var (
+		state   = stateParam // current state of parser
+		i       int          // position in path
+		prev    int          // previous position in path
+		c       rune         // current rune under consideration
+		quote   rune         // kind of quote to end this quoted string
+		param   string       // current parameter value
+		doubled bool         // set if had doubled quotes
+	)
+	for i, c = range optString + "," {
+		switch state {
+		// Parses param= and param2=
+		case stateParam:
+			switch c {
+			case ',', '=':
+				param = optString[prev:i]
+				if len(param) == 0 {
+					return nil, errHelperEmptyOption
+				}
+				if param[0] == '-' || param[0] == '_' {
+					return nil, errHelperOptionName
+				}
+				prev = i + 1
+				if c == '=' {
+					state = stateValue
+					break
+				}
+				opts = append(opts, param)
+			case '.':
+				if pref := optString[prev:i]; pref != "env" && pref != "x-systemd" {
+					return nil, errHelperBadOption
+				}
+			default:
+				if !strings.ContainsRune(helperValidOptChars, c) {
+					return nil, errHelperBadOption
+				}
+			}
+		case stateValue:
+			switch c {
+			case '\'', '"':
+				if i == prev {
+					quote = c
+					prev = i + 1
+					doubled = false
+					state = stateQuotedValue
+				}
+			case ',':
+				value := optString[prev:i]
+				prev = i + 1
+				opts = append(opts, param+"="+value)
+				state = stateParam
+			}
+		case stateQuotedValue:
+			if c == quote {
+				state = stateAfterQuote
+			}
+		case stateAfterQuote:
+			switch c {
+			case ',':
+				value := optString[prev : i-1]
+				// replace any doubled quotes if there were any
+				if doubled {
+					value = strings.ReplaceAll(value, string(quote)+string(quote), string(quote))
+				}
+				prev = i + 1
+				opts = append(opts, param+"="+value)
+				state = stateParam
+			case quote:
+				// Here is a doubled quote to indicate a literal quote
+				state = stateQuotedValue
+				doubled = true
+			default:
+				return nil, errHelperAfterQuote
+			}
+		}
+	}
+
+	// Depending on which state we were in when we fell off the
+	// end of the state machine we can return a sensible error.
+	if state == stateParam && prev > len(optString) {
+		state = stateDone
+	}
+	switch state {
+	case stateQuotedValue:
+		return nil, errHelperQuotedValue
+	case stateAfterQuote:
+		return nil, errHelperAfterQuote
+	case stateDone:
+		break
+	default:
+		return nil, errHelperSyntax
+	}
+	return opts, nil
+}

--- a/fs/mount_helper_test.go
+++ b/fs/mount_helper_test.go
@@ -1,0 +1,53 @@
+package fs
+
+import (
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMountHelperArgs(t *testing.T) {
+	type testCase struct {
+		src []string
+		dst []string
+		env string
+		err string
+	}
+	normalCases := []testCase{{
+		src: []string{},
+		dst: []string{"mount", "--daemon"},
+	}, {
+		src: []string{"-o", `x-systemd.automount,vvv,env.HTTPS_PROXY="a b;c,d?EF",ro,rw,args2env`},
+		dst: []string{"mount", "--read-only", "--verbose=3", "--daemon"},
+		env: "HTTPS_PROXY=a b;c,d?EF",
+	}}
+
+	for _, tc := range normalCases {
+		exe := []string{"rclone"}
+		src := append(exe, tc.src...)
+		res, err := convertMountHelperArgs(src)
+
+		if tc.err != "" {
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.err)
+			continue
+		}
+
+		require.NoError(t, err)
+		require.Greater(t, len(res), 1)
+		assert.Equal(t, exe[0], res[0])
+		dst := res[1:]
+
+		//log.Printf("%q -> %q", tc.src, dst)
+		assert.Equal(t, tc.dst, dst)
+
+		if tc.env != "" {
+			idx := strings.Index(tc.env, "=")
+			name, value := tc.env[:idx], tc.env[idx+1:]
+			assert.Equal(t, value, os.Getenv(name))
+		}
+	}
+}


### PR DESCRIPTION
#### What is the purpose of this change?

This PR will make rclonefs wrappers moot!

The PRedecessor #5593 solve(d) most problems that prevented rclone from running the mount in background i.e. working _like a generic unix mount_ program (`sshfs`, `mount.glusterfs` and others can do it out of the box), namely:
- have the main process prepare for mounting,
- spawn a background process to handle the mount,
- wait a little until the mount success or timeout (kill the background process if mount failed)
- don't block, exit with status code

The last incompatibility left is the way mount arguments are passed.
The core `/bin/mount` program will (in the basic scenario) get the `-t FSTYPE` argument then run the `/sbin/mount.FSTYPE` helper program passing it mount options. Automountd and systemd generally follow the same logic...
But rclone expects GNU-styled flags like `--key val` while mount options are passed as `-o key=val,...` (or `--opt=...`)!
This patch fills the last gap.

### Usage

Please symlink the rclone binary to `/sbin/mount.rclone` (and optionally `/usr/bin/rclonefs`) and **just**
- run something like
```
mount sftp1:subdir /mnt/data -t rclone -o vfs_cache_mode=writes,sftp_key_file=/path/to/pem
```
- or create systemd mount units (provide explicit `config=...,cache-dir=...` as mounts run without `HOME` !)
```
# /etc/systemd/system/mnt-data.mount
[Unit]
After=network-online.target
[Mount]
Type=rclone
What=sftp1:subdir
Where=/mnt/data
Options=rw,allow_other,args2env,vfs-cache-mode=writes,config=/etc/rclone.conf,cache-dir=/var/rclone
```
- optionally augmented by systemd automount unit
```
# /etc/systemd/system/mnt-data.automount
[Unit]
After=network-online.target
Before=remote-fs.target
[Automount]
Where=/mnt/data
TimeoutIdleSec=600
[Install]
WantedBy=multi-user.target
```
- or add in `/etc/fstab` a line like
```
sftp1:subdir /mnt/data rclone rw,noauto,nofail,_netdev,x-systemd.automount,args2env,vfs_cache_mode=writes,config=/etc/rclone.conf,cache_dir=/var/cache/rclone 0 0
```
- or use classic `Automountd` !

P.S. There was a ticket #2805 requesting the new `rclone mount --idle=X` flag but now we can do it in a standard way making it mostly moot (except on windows)...

### Implementation

~~This patch introduces new slice `fs.Args` which is by default a copy of `os.Args` but can be rewritten if rclone executable was invoked as `mount.rclone` or `rclonefs`.~~
**UPDATE**
This patch rewrites `os.Args` inplace in an early **init()** block if rclone executable was invoked as `mount.rclone` or `rclonefs`.

We use `os.Args[0]` rather than `os.Executable` to detect the name since the latter might resolve symlink while we want it unresolved.

Mount helpers usually lack the `HOME` or `RCLONE_CONFIG` environment variables, so config setup code in `fs/config` will require `fs.Args` to find a correct (probably converted) `--config FILE` running **very early** (most probably called from init blocks). Consequently the command line transformer also runs **super early** in the `init` block of the core `fs` package and avoids using other packages to **prevent import loops**. Utility functions `IsDaemon` and `IsMountHelper` were put directly in `fs` for this very reason.

Basically the conversion splits `-o` argument(s) by comma, replaces `_` by `-` and prepends `--` to transform `-o` options into Cobra flags. Options containing commas or spaces can be wrapped in single or double quotes (any quotes inside outer quotes should be doubled). The parser algorithm is based on the _connection string parser_ with a few command-line specific modifications.

The option syntax additionally includes a few pseudo mount options treated specially:
- `env.NAME=VALUE` will set an environment variable for this rclone instance and its children.
   This helps with Automountd and Systemd.mount which don't let set custom environment for mount helpers.
   Typically you will use `env.HTTPS_PROXY=proxy.host:3128` or `env.HOME=/root`
- `command=cmount` can be used to run any other command rather than default `mount` in the helper mode 
- `args2env` will pass mount options to the daemonized mount helper via `RCLONE_X` environment variables instead of CLI flags. This allows to hide secrets from `ps` or `pgrep`.
- `-o vv...` will be transformed into `--verbose=N`, just for convenience
- `x-systemd.automount`, `_netdev`, `nosuid` and alike are intended for automountd or systemd and ignored by rclone

#### Was the change discussed in an issue or in the forum before?

Based on #5593 (this PR includes preliminary patch of #5593 expected to annihilate at merge time)
Fixes #992

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
