### PR TITLE
config: use unmodified name when creating remote from environment variable

### DIFF
--- a/cmdtest/environment_test.go
+++ b/cmdtest/environment_test.go
@@ -78,6 +78,59 @@ func TestEnvironmentVariables(t *testing.T) {
 		assert.Contains(t, out, "RCLONE_STATS=")
 	}
 
+	// Backend flags and remote name
+	// - The listremotes command includes names from environment variables,
+	//   the part between "RCLONE_CONFIG_" and "_TYPE", converted to lowercase.
+	// - When using using a remote created from env, e.g. with lsd command,
+	//   the name is case insensitive in contrast to remotes in config file
+	//   (fs.ConfigToEnv converts to uppercase before checking environment).
+	// - Previously using a remote created from env, e.g. with lsd command,
+	//   would not be possible for remotes with '-' in names, and remote names
+	//   with '_' could be referred to with both '-' and '_', because any '-'
+	//   were replaced with '_' before lookup.
+	// ===================================
+
+	env = "RCLONE_CONFIG_MY-LOCAL_TYPE=local"
+	out, err = rcloneEnv(env, "listremotes")
+	if assert.NoError(t, err) {
+		assert.Contains(t, out, "my-local:")
+	}
+	out, err = rcloneEnv(env, "lsl", "my-local:"+testFolder)
+	if assert.NoError(t, err) {
+		assert.Contains(t, out, "rclone.config")
+		assert.Contains(t, out, "file1.txt")
+		assert.Contains(t, out, "fileA1.txt")
+		assert.Contains(t, out, "fileAA1.txt")
+	}
+	out, err = rcloneEnv(env, "lsl", "mY-LoCaL:"+testFolder)
+	if assert.NoError(t, err) {
+		assert.Contains(t, out, "rclone.config")
+		assert.Contains(t, out, "file1.txt")
+		assert.Contains(t, out, "fileA1.txt")
+		assert.Contains(t, out, "fileAA1.txt")
+	}
+	out, err = rcloneEnv(env, "lsl", "my_local:"+testFolder)
+	if assert.Error(t, err) {
+		assert.Contains(t, out, "Failed to create file system")
+	}
+
+	env = "RCLONE_CONFIG_MY_LOCAL_TYPE=local"
+	out, err = rcloneEnv(env, "listremotes")
+	if assert.NoError(t, err) {
+		assert.Contains(t, out, "my_local:")
+	}
+	out, err = rcloneEnv(env, "lsl", "my_local:"+testFolder)
+	if assert.NoError(t, err) {
+		assert.Contains(t, out, "rclone.config")
+		assert.Contains(t, out, "file1.txt")
+		assert.Contains(t, out, "fileA1.txt")
+		assert.Contains(t, out, "fileAA1.txt")
+	}
+	out, err = rcloneEnv(env, "lsl", "my-local:"+testFolder)
+	if assert.Error(t, err) {
+		assert.Contains(t, out, "Failed to create file system")
+	}
+
 	// Backend flags and option precedence
 	// ===================================
 
@@ -86,8 +139,8 @@ func TestEnvironmentVariables(t *testing.T) {
 	// and skip_links=false on all levels with lower precedence
 	//
 	// Reference: https://rclone.org/docs/#precedence
-
 	// Create a symlink in test data
+	env = ""
 	err = os.Symlink(testdataPath+"/folderA", testdataPath+"/symlinkA")
 	if runtime.GOOS == "windows" {
 		errNote := "The policy settings on Windows often prohibit the creation of symlinks due to security issues.\n"

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -319,8 +319,9 @@ Will get their own names
 
 ### Valid remote names
 
- - Remote names may only contain 0-9, A-Z ,a-z ,_ , - and space.
- - Remote names may not start with -.
+Remote names are case sensitive, and must adhere to the following rules:
+ - May only contain `0`-`9`, `A`-`Z`, `a`-`z`, `_`, `-` and space.
+ - May not start with `-` or space.
 
 Quoting and the shell
 ---------------------

--- a/docs/content/docs.md.bak
+++ b/docs/content/docs.md.bak
@@ -2149,9 +2149,9 @@ You can set defaults for values in the config file on an individual
 remote basis. The names of the config items are documented in the page
 for each backend.
 
-To find the name of the environment variable, you need to take
+To find the name of the environment variable, you need to set, take
 `RCLONE_CONFIG_` + name of remote + `_` + name of config file option
-in uppercase.
+and make it all uppercase.
 
 For example, to configure an S3 remote named `MYS3:` without a config
 file (using unix ways of setting environment variables):
@@ -2162,16 +2162,16 @@ $ export RCLONE_CONFIG_MYS3_ACCESS_KEY_ID=XXX
 $ export RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY=XXX
 $ rclone lsd MYS3:
           -1 2016-09-21 12:54:21        -1 my-bucket
-$ rclone listremotes | grep MYS3
-MYS3:
+$ rclone listremotes | grep mys3
+mys3:
 ```
 
 Note that if you want to create a remote using environment variables
 you must create the `..._TYPE` variable as above.
 
-Note that you can only set the options of the immediate backend,
-so RCLONE_CONFIG_MYS3CRYPT_ACCESS_KEY_ID has no effect, if MYS3CRYPT is
-a crypt remote based on an S3 remote. However RCLONE_S3_ACCESS_KEY_ID will
+Note that you can only set the options of the immediate backend, 
+so RCLONE_CONFIG_MYS3CRYPT_ACCESS_KEY_ID has no effect, if MYS3CRYPT is 
+a crypt remote based on an S3 remote. However RCLONE_S3_ACCESS_KEY_ID will 
 set the access key of all remotes using S3, including MYS3CRYPT.
 
 Note also that now rclone has [connection strings](#connection-strings),

--- a/fs/config.go
+++ b/fs/config.go
@@ -237,11 +237,11 @@ func AddConfig(ctx context.Context) (context.Context, *ConfigInfo) {
 	return newCtx, cCopy
 }
 
-// ConfigToEnv converts a config section and name, e.g. ("my-remote",
+// ConfigToEnv converts a config section and name, e.g. ("My-Remote",
 // "ignore-size") into an environment name
-// "RCLONE_CONFIG_MY-REMOTE_IGNORE_SIZE"
+// "RCLONE_CONFIG_My-Remote_IGNORE_SIZE"
 func ConfigToEnv(section, name string) string {
-	return "RCLONE_CONFIG_" + strings.ToUpper(section + "_" + strings.Replace(name, "-", "_", -1))
+	return "RCLONE_CONFIG_" + section + "_" + strings.ToUpper(strings.Replace(name, "-", "_", -1))
 }
 
 // OptionToEnv converts an option name, e.g. "ignore-size" into an

--- a/fs/config.go
+++ b/fs/config.go
@@ -237,11 +237,11 @@ func AddConfig(ctx context.Context) (context.Context, *ConfigInfo) {
 	return newCtx, cCopy
 }
 
-// ConfigToEnv converts a config section and name, e.g. ("myremote",
+// ConfigToEnv converts a config section and name, e.g. ("my-remote",
 // "ignore-size") into an environment name
-// "RCLONE_CONFIG_MYREMOTE_IGNORE_SIZE"
+// "RCLONE_CONFIG_MY-REMOTE_IGNORE_SIZE"
 func ConfigToEnv(section, name string) string {
-	return "RCLONE_CONFIG_" + strings.ToUpper(strings.Replace(section+"_"+name, "-", "_", -1))
+	return "RCLONE_CONFIG_" + strings.ToUpper(section + "_" + strings.Replace(name, "-", "_", -1))
 }
 
 // OptionToEnv converts an option name, e.g. "ignore-size" into an

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -633,7 +633,7 @@ func FileSections() []string {
 	for _, item := range os.Environ() {
 		matches := matchEnv.FindStringSubmatch(item)
 		if len(matches) == 2 {
-			sections = append(sections, strings.ToLower(matches[1]))
+			sections = append(sections, matches[1])
 		}
 	}
 	return sections

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -300,7 +300,7 @@ func TestOptionEnvVarName(t *testing.T) {
 func TestOptionGetters(t *testing.T) {
 	// Set up env vars
 	envVars := [][2]string{
-		{"RCLONE_CONFIG_LOCAL_POTATO_PIE", "yes"},
+		{"RCLONE_CONFIG_local_POTATO_PIE", "yes"},
 		{"RCLONE_COPY_LINKS", "TRUE"},
 		{"RCLONE_LOCAL_NOUNC", "NOUNC"},
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

Valid remote names according to (existing) [docs](https://rclone.org/docs/#valid-remote-names):

> Remote names may only contain 0-9, A-Z ,a-z ,_ , - and space.
> Remote names may not start with -.

I will add the following:
- May not start with space.
- Case sensitive.

That is the general case. But creating remotes using environment variables (RCLONE_CONFIG_..._TYPE) currently has additional, undocumented, limitations
- Case insensitive.
- May not contain -.

This PR aims at removing the additional limitation imposed on remote names from environment variables, make rclone use the unmodified remote name.

**NOTE:** Still a draft and experimenting! Not sure the casing part will work, on Windows, probably not! May have to revert that and document something about limitations instead. But I think the `-` vs `_` changes can be kept? Also a bit controversial, I know, and needs more testing!

**1. Hyphen**

This change adds support for hypen in remote names when creating remote using environment variable (RCLONE_CONFIG_..._TYPE).

In previous version rclone would replace any `-` with `_` when considering environment variables. Probably because use of `-` is inconvenient, possibly even impossible in some systems/shells. By changing this we will leave it up to user, and their shells etc, if they want to use hypens in remote names and live with the consequences.. The reason to change it is that the implicit transformation leads to inconsistencies:
- The `rclone listremotes` command would list remote names as given by `^RCLONE_CONFIG_(.*?)_TYPE=.*$`, transformed to lowercase but otherwise as is. This means if you were to use `-` in the name, it would be shown.
   ```
	SET RCLONE_CONFIG_REMOTE-X_TYPE=local
	SET RCLONE_CONFIG_REMOTE_X_TYPE=local
	rclone listremotes --config NUL
	remote-x:
	remote_x:
   ```
- But when accessing a remote, a remote from environment variable with `-` in the name cannot be used:
   ```
	SET RCLONE_CONFIG_REMOTE-X_TYPE=local
	rclone listremotes --config NUL
	remote-x:
	rclone lsd remote-x: --config NUL
	Failed to create file system for "remote-x:": didn't find section in config file
	rclone lsd remote_x:
	Failed to create file system for "remote-x:": didn't find section in config file
   ```
- On the other hand, accessing a remote created from environment variable with `_` in name can also be accessed with `-`:
   ```
	SET RCLONE_CONFIG_REMOTE_X_TYPE=local
	rclone listremotes --config NUL
	remote_x:	
	rclone lsd remote-x: --config NUL
	          -1 2021-09-16 13:37:48        -1 rclone
	rclone lsd remote_x: --config NUL
	          -1 2021-09-16 13:37:48        -1 rclone
   ```
- With rclone config, you can create two remotes in your config file:
   ```
	rclone config create remote-x local
	rclone listremotes
	remote-x:
	rclone config create remote_x local
	rclone listremotes
	remote-x:
	remote_x:
   ```
  If both are FTP remotes, you can set the following environment variable to override the username be used `RCLONE_CONFIG_REMOTE_X_USER=otheruser`, but it will be considered by both remotes!


**2. Case sensitivity**

In general, rclone treats remote names case sensitive. You can create one remote called "myremote" and a different called "MYREMOTE". They will both be listed with `rclone listremotes`, and `rclone lsd myremote:` and `rclone lsd MYREMOTE:` accesses the correct remotes.

This is not the case when creating creating remote using environment variable (RCLONE_CONFIG_..._TYPE). In this case environment variables are assumed to be all uppercase, including remote name. So when looking for a remote in environment the uppercase name is used. Rclone will show the name in lowercase with `listremotes`.

Environment variable case sensitivity:
- Windows:
	- Partly case sensitive.      
	- Name of variables keep the casing used when first setting a value.
	    - In golang os.Environ will list all environment variables with actual casing.
	- Lookup is case insensitive.
	    - In golang os.LookupEnv and os.Getenv will return value of variable using case insensitive matching of name.
	- Convention is to use all uppercase.
	- Example:
		```
		SET UPPERlower=123
		echo %UPPERLOWER%
		123
		echo %upperlower%
		123
		set upperlower
		UPPERlower=123
		```
- Linux:
	- Case sensitive, but convention is to use all uppercase.
	- Example:
		```
		UPPERlower=123
		echo $UPPERlower
		123
		echo $upperlower

		upperlower=234
		echo $upperlower
		234
		echo $UPPERlower
		123
		```

To be able to be case sensitive on Windows, existing use of os.LookupEnv with remote name would have to use os.Environ instead, but it returns as list of all environment variables so may want to cache the result? Seems the unix version of os.Environ does caching, but not the Windows version - it calls the win api GetEnvironmentStrings and converts the returned strings to golang strings on each call.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/problem-with-parsing-of-environment-variables/26528

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
