### PR TITLE
config: support hyphen in remote name from environment variable

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -319,8 +319,9 @@ Will get their own names
 
 ### Valid remote names
 
- - Remote names may only contain 0-9, A-Z ,a-z ,_ , - and space.
- - Remote names may not start with -.
+Remote names are case sensitive, and must adhere to the following rules:
+ - May only contain `0`-`9`, `A`-`Z`, `a`-`z`, `_`, `-` and space.
+ - May not start with `-` or space.
 
 Quoting and the shell
 ---------------------
@@ -2159,7 +2160,7 @@ file (using unix ways of setting environment variables):
 $ export RCLONE_CONFIG_MYS3_TYPE=s3
 $ export RCLONE_CONFIG_MYS3_ACCESS_KEY_ID=XXX
 $ export RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY=XXX
-$ rclone lsd MYS3:
+$ rclone lsd mys3:
           -1 2016-09-21 12:54:21        -1 my-bucket
 $ rclone listremotes | grep mys3
 mys3:
@@ -2167,6 +2168,20 @@ mys3:
 
 Note that if you want to create a remote using environment variables
 you must create the `..._TYPE` variable as above.
+
+Note that the name of a remote created using environment variable is
+case insensitive, in contrast to regular remotes stored in config
+file as documented [above](#valid-remote-names).
+You must write the name in uppercase in the environment variable, but
+as seen from example above it will be listed and can be accessed in
+lowercase, while you can also refer to the same remote in uppercase:
+```
+$ rclone lsd mys3:
+          -1 2016-09-21 12:54:21        -1 my-bucket
+$ rclone lsd MYS3:
+          -1 2016-09-21 12:54:21        -1 my-bucket
+```
+
 
 Note that you can only set the options of the immediate backend, 
 so RCLONE_CONFIG_MYS3CRYPT_ACCESS_KEY_ID has no effect, if myS3Crypt is 

--- a/fs/config.go
+++ b/fs/config.go
@@ -237,11 +237,11 @@ func AddConfig(ctx context.Context) (context.Context, *ConfigInfo) {
 	return newCtx, cCopy
 }
 
-// ConfigToEnv converts a config section and name, e.g. ("myremote",
+// ConfigToEnv converts a config section and name, e.g. ("my-remote",
 // "ignore-size") into an environment name
-// "RCLONE_CONFIG_MYREMOTE_IGNORE_SIZE"
+// "RCLONE_CONFIG_MY-REMOTE_IGNORE_SIZE"
 func ConfigToEnv(section, name string) string {
-	return "RCLONE_CONFIG_" + strings.ToUpper(strings.Replace(section+"_"+name, "-", "_", -1))
+	return "RCLONE_CONFIG_" + strings.ToUpper(section+"_"+strings.Replace(name, "-", "_", -1))
 }
 
 // OptionToEnv converts an option name, e.g. "ignore-size" into an


### PR DESCRIPTION

Note:
- Beta build here: https://beta.rclone.org/branch/remote-name-env/

#### What is the purpose of this change?

Valid remote names according to (existing) [docs](https://rclone.org/docs/#valid-remote-names):

> Remote names may only contain 0-9, A-Z ,a-z ,_ , - and space.
> Remote names may not start with -.

I will add the following:
- May not start with space (any leading/trailing spaces will be trimmed off automatically).
- Case sensitive.

That is the general case. But creating remotes using environment variables (RCLONE_CONFIG_..._TYPE) currently has additional, undocumented, limitations:
1) May not contain -.
2) Case insensitive.

This PR aims at removing the additional limitation 1) imposed on remote names from environment variables: Make rclone properly support hypen in remote names when creating remote using environment variable (RCLONE_CONFIG_..._TYPE).

*Limitation 2, case sensitivity, is discussed in https://github.com/rclone/rclone/pull/5603, with some initial work/experimentation. Currently it is closed because it will take a bit of effort to get the overview, and I'm not really sure it will end up in a robust and consistent solution...*

In previous version rclone would replace any `-` with `_` when considering environment variables. Probably because use of `-` is inconvenient, possibly even impossible in some systems/shells. By changing this we will leave it up to user, and their shells etc, if they want to use hypens in remote names and live with the consequences.. The reason to change it is that the implicit transformation leads to inconsistencies:
- The `rclone listremotes` command would list remote names as given by `^RCLONE_CONFIG_(.*?)_TYPE=.*$`, transformed to lowercase but otherwise as is. This means if you were to use `-` in the name, it would be shown.
   ```
	SET RCLONE_CONFIG_REMOTE-X_TYPE=local
	SET RCLONE_CONFIG_REMOTE_X_TYPE=local
	rclone listremotes --config NUL
	remote-x:
	remote_x:
   ```
- But when accessing a remote, a remote from environment variable with `-` in the name cannot be used:
   ```
	SET RCLONE_CONFIG_REMOTE-X_TYPE=local
	rclone listremotes --config NUL
	remote-x:
	rclone lsd remote-x: --config NUL
	Failed to create file system for "remote-x:": didn't find section in config file
	rclone lsd remote_x:
	Failed to create file system for "remote-x:": didn't find section in config file
   ```
- On the other hand, accessing a remote created from environment variable with `_` in name can also be accessed with `-`:
   ```
	SET RCLONE_CONFIG_REMOTE_X_TYPE=local
	rclone listremotes --config NUL
	remote_x:	
	rclone lsd remote-x: --config NUL
	          -1 2021-09-16 13:37:48        -1 rclone
	rclone lsd remote_x: --config NUL
	          -1 2021-09-16 13:37:48        -1 rclone
   ```
- With rclone config, you can create two remotes in your config file:
   ```
	rclone config create remote-x local
	rclone listremotes
	remote-x:
	rclone config create remote_x local
	rclone listremotes
	remote-x:
	remote_x:
   ```
  If both are FTP remotes, you can set the following environment variable to override the username be used `RCLONE_CONFIG_REMOTE_X_USER=otheruser`, but it will be considered by both remotes!

#### Build notes

Note to self:
- PR from branch on fork
  (https://github.com/albertony/rclone/tree/remote_name_env)
- Pushed the branch also to upstream to get beta build, renamed from remote_name_env to remote-name-env to be valid in semver
  (https://github.com/rclone/rclone/tree/remote-name-env)
- Beta builds here: https://beta.rclone.org/branch/remote-name-env/

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/problem-with-parsing-of-environment-variables/26528

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
