### PR TITLE
config: allow dot in remote names

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -332,7 +332,7 @@ Will get their own names
 ### Valid remote names
 
 Remote names are case sensitive, and must adhere to the following rules:
- - May only contain `0`-`9`, `A`-`Z`, `a`-`z`, `_`, `-` and space.
+ - May only contain `0`-`9`, `A`-`Z`, `a`-`z`, `_`, `-`, `.` and space.
  - May not start with `-` or space.
 
 Quoting and the shell

--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -13,12 +13,12 @@ import (
 )
 
 const (
-	configNameRe = `[\w_ -]+`
+	configNameRe = `[\w_. -]+`
 	remoteNameRe = `^(:?` + configNameRe + `)`
 )
 
 var (
-	errInvalidCharacters = errors.New("config name contains invalid characters - may only contain `0-9`, `A-Z`, `a-z`, `_`, `-` and space")
+	errInvalidCharacters = errors.New("config name contains invalid characters - may only contain `0-9`, `A-Z`, `a-z`, `_`, `-`, `.` and space")
 	errCantBeEmpty       = errors.New("can't use empty string as a path")
 	errCantStartWithDash = errors.New("config name starts with `-`")
 	errBadConfigParam    = errors.New("config parameters may only contain `0-9`, `A-Z`, `a-z` and `_`")

--- a/fs/fspath/path_test.go
+++ b/fs/fspath/path_test.go
@@ -35,6 +35,9 @@ func TestCheckConfigName(t *testing.T) {
 		{"-remote", errCantStartWithDash},
 		{"r-emote-", nil},
 		{"_rem_ote_", nil},
+		{".", nil},
+		{"..", nil},
+		{".r.e.m.o.t.e.", nil},
 	} {
 		got := CheckConfigName(test.in)
 		assert.Equal(t, test.want, got, test.in)
@@ -49,6 +52,9 @@ func TestCheckRemoteName(t *testing.T) {
 		{":remote:", nil},
 		{":s3:", nil},
 		{"remote:", nil},
+		{".:", nil},
+		{"..:", nil},
+		{".r.e.m.o.t.e.:", nil},
 		{"", errInvalidCharacters},
 		{"rem:ote", errInvalidCharacters},
 		{"rem:ote:", errInvalidCharacters},
@@ -160,6 +166,27 @@ func TestParse(t *testing.T) {
 				Path:         "path/to/file",
 			},
 		}, {
+			in: ".:",
+			wantParsed: Parsed{
+				ConfigString: ".",
+				Name:         ".",
+				Path:         "",
+			},
+		}, {
+			in: "..:",
+			wantParsed: Parsed{
+				ConfigString: "..",
+				Name:         "..",
+				Path:         "",
+			},
+		}, {
+			in: ".:colon.txt",
+			wantParsed: Parsed{
+				ConfigString: ".",
+				Name:         ".",
+				Path:         "colon.txt",
+			},
+		}, {
 			in: "remote:path/to/file",
 			wantParsed: Parsed{
 				ConfigString: "remote",
@@ -177,7 +204,14 @@ func TestParse(t *testing.T) {
 				Path:         "/path/to/file",
 			},
 		}, {
-			in:      "rem.ote:/path/to/file",
+			in: "rem.ote:/path/to/file",
+			wantParsed: Parsed{
+				ConfigString: "rem.ote",
+				Name:         "rem.ote",
+				Path:         "/path/to/file",
+			},
+		}, {
+			in:      "rem#ote:/path/to/file",
 			wantErr: errInvalidCharacters,
 		}, {
 			in: ":backend:/path/to/file",
@@ -216,6 +250,20 @@ func TestParse(t *testing.T) {
 			wantParsed: Parsed{
 				Name: "",
 				Path: `\path\to\file`,
+			},
+			noWin: true,
+		}, {
+			in: `.`,
+			wantParsed: Parsed{
+				Name: "",
+				Path: `.`,
+			},
+			noWin: true,
+		}, {
+			in: `..`,
+			wantParsed: Parsed{
+				Name: "",
+				Path: `..`,
 			},
 			noWin: true,
 		}, {
@@ -388,7 +436,12 @@ func TestSplitFs(t *testing.T) {
 		{"remote:/potato", "remote:", "/potato", nil},
 		{"remote:/potato/potato", "remote:", "/potato/potato", nil},
 		{"remote:potato/sausage", "remote:", "potato/sausage", nil},
-		{"rem.ote:potato/sausage", "", "", errInvalidCharacters},
+		{"rem.ote:potato/sausage", "rem.ote:", "potato/sausage", nil},
+
+		{".:", ".:", "", nil},
+		{"..:", "..:", "", nil},
+		{".:potato/sausage", ".:", "potato/sausage", nil},
+		{"..:potato/sausage", "..:", "potato/sausage", nil},
 
 		{":remote:", ":remote:", "", nil},
 		{":remote:potato", ":remote:", "potato", nil},
@@ -397,6 +450,11 @@ func TestSplitFs(t *testing.T) {
 		{":remote:/potato/potato", ":remote:", "/potato/potato", nil},
 		{":remote:potato/sausage", ":remote:", "potato/sausage", nil},
 		{":rem[ote:potato/sausage", "", "", errInvalidCharacters},
+
+		{":.:", ":.:", "", nil},
+		{":..:", ":..:", "", nil},
+		{":.:potato/sausage", ":.:", "potato/sausage", nil},
+		{":..:potato/sausage", ":..:", "potato/sausage", nil},
 
 		{"/", "", "/", nil},
 		{"/root", "", "/root", nil},
@@ -429,7 +487,12 @@ func TestSplit(t *testing.T) {
 		{"remote:/potato", "remote:/", "potato", nil},
 		{"remote:/potato/potato", "remote:/potato/", "potato", nil},
 		{"remote:potato/sausage", "remote:potato/", "sausage", nil},
-		{"rem.ote:potato/sausage", "", "", errInvalidCharacters},
+		{"rem.ote:potato/sausage", "rem.ote:potato/", "sausage", nil},
+
+		{".:", ".:", "", nil},
+		{"..:", "..:", "", nil},
+		{".:potato/sausage", ".:potato/", "sausage", nil},
+		{"..:potato/sausage", "..:potato/", "sausage", nil},
 
 		{":remote:", ":remote:", "", nil},
 		{":remote:potato", ":remote:", "potato", nil},
@@ -438,6 +501,11 @@ func TestSplit(t *testing.T) {
 		{":remote:/potato/potato", ":remote:/potato/", "potato", nil},
 		{":remote:potato/sausage", ":remote:potato/", "sausage", nil},
 		{":rem[ote:potato/sausage", "", "", errInvalidCharacters},
+
+		{":.:", ":.:", "", nil},
+		{":..:", ":..:", "", nil},
+		{":.:potato/sausage", ":.:potato/", "sausage", nil},
+		{":..:potato/sausage", ":..:potato/", "sausage", nil},
 
 		{"/", "/", "", nil},
 		{"/root", "/", "root", nil},

--- a/fs/fspath/path_test.go
+++ b/fs/fspath/path_test.go
@@ -221,6 +221,13 @@ func TestParse(t *testing.T) {
 				Path:         "/path/to/file",
 			},
 		}, {
+			in: ":back.end:/path/to/file",
+			wantParsed: Parsed{
+				ConfigString: ":back.end",
+				Name:         ":back.end",
+				Path:         "/path/to/file",
+			},
+		}, {
 			in:      ":bac*kend:/path/to/file",
 			wantErr: errInvalidCharacters,
 		}, {
@@ -449,6 +456,7 @@ func TestSplitFs(t *testing.T) {
 		{":remote:/potato", ":remote:", "/potato", nil},
 		{":remote:/potato/potato", ":remote:", "/potato/potato", nil},
 		{":remote:potato/sausage", ":remote:", "potato/sausage", nil},
+		{":rem.ote:potato/sausage", ":rem.ote:", "potato/sausage", nil},
 		{":rem[ote:potato/sausage", "", "", errInvalidCharacters},
 
 		{":.:", ":.:", "", nil},
@@ -500,6 +508,7 @@ func TestSplit(t *testing.T) {
 		{":remote:/potato", ":remote:/", "potato", nil},
 		{":remote:/potato/potato", ":remote:/potato/", "potato", nil},
 		{":remote:potato/sausage", ":remote:potato/", "sausage", nil},
+		{":rem.ote:potato/sausage", ":rem.ote:potato/", "sausage", nil},
 		{":rem[ote:potato/sausage", "", "", errInvalidCharacters},
 
 		{":.:", ":.:", "", nil},


### PR DESCRIPTION
#### What is the purpose of this change?

Add `.` as legal character in remote names. :bomb:

Beta build here:
- https://beta.rclone.org/branch/remote-name-dot/

Note to self:
<sub><sup>- PR from branch on fork</sup></sub>
<sub><sup>  (https://github.com/albertony/rclone/tree/remote_name_dot)</sup></sub>
<sub><sup>- Pushed the branch also to upstream to get beta build, renamed from remote_name_dot to remote-name-dot to be valid in semver</sup></sub>
<sub><sup>  (https://github.com/rclone/rclone/tree/remote-name-dot)</sup></sub>


#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/problem-with-parsing-of-environment-variables/26528/10

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
