### PR TITLE
seafile: fix 2fa state machine

### DIFF
--- a/backend/seafile/seafile_internal_test.go
+++ b/backend/seafile/seafile_internal_test.go
@@ -1,10 +1,15 @@
 package seafile
 
 import (
+	"context"
 	"path"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type pathData struct {
@@ -19,77 +24,77 @@ type pathData struct {
 // from a mix of configuration data and path command line argument
 func TestSplitPath(t *testing.T) {
 	testData := []pathData{
-		pathData{
+		{
 			configLibrary:   "",
 			configRoot:      "",
 			argumentPath:    "",
 			expectedLibrary: "",
 			expectedPath:    "",
 		},
-		pathData{
+		{
 			configLibrary:   "",
 			configRoot:      "",
 			argumentPath:    "Library",
 			expectedLibrary: "Library",
 			expectedPath:    "",
 		},
-		pathData{
+		{
 			configLibrary:   "",
 			configRoot:      "",
 			argumentPath:    path.Join("Library", "path", "to", "file"),
 			expectedLibrary: "Library",
 			expectedPath:    path.Join("path", "to", "file"),
 		},
-		pathData{
+		{
 			configLibrary:   "Library",
 			configRoot:      "",
 			argumentPath:    "",
 			expectedLibrary: "Library",
 			expectedPath:    "",
 		},
-		pathData{
+		{
 			configLibrary:   "Library",
 			configRoot:      "",
 			argumentPath:    "path",
 			expectedLibrary: "Library",
 			expectedPath:    "path",
 		},
-		pathData{
+		{
 			configLibrary:   "Library",
 			configRoot:      "",
 			argumentPath:    path.Join("path", "to", "file"),
 			expectedLibrary: "Library",
 			expectedPath:    path.Join("path", "to", "file"),
 		},
-		pathData{
+		{
 			configLibrary:   "Library",
 			configRoot:      "root",
 			argumentPath:    "",
 			expectedLibrary: "Library",
 			expectedPath:    "root",
 		},
-		pathData{
+		{
 			configLibrary:   "Library",
 			configRoot:      path.Join("root", "path"),
 			argumentPath:    "",
 			expectedLibrary: "Library",
 			expectedPath:    path.Join("root", "path"),
 		},
-		pathData{
+		{
 			configLibrary:   "Library",
 			configRoot:      "root",
 			argumentPath:    "path",
 			expectedLibrary: "Library",
 			expectedPath:    path.Join("root", "path"),
 		},
-		pathData{
+		{
 			configLibrary:   "Library",
 			configRoot:      "root",
 			argumentPath:    path.Join("path", "to", "file"),
 			expectedLibrary: "Library",
 			expectedPath:    path.Join("root", "path", "to", "file"),
 		},
-		pathData{
+		{
 			configLibrary:   "Library",
 			configRoot:      path.Join("root", "path"),
 			argumentPath:    path.Join("subpath", "to", "file"),
@@ -119,5 +124,100 @@ func TestSplitPathIntoSlice(t *testing.T) {
 	for input, expected := range testData {
 		output := splitPath(input)
 		assert.Equal(t, expected, output)
+	}
+}
+
+func Test2FAStateMachine(t *testing.T) {
+	fixtures := []struct {
+		name               string
+		mapper             configmap.Mapper
+		input              fs.ConfigIn
+		expectState        string
+		expectErrorMessage string
+		expectResult       string
+		expectFail         bool
+	}{
+		{
+			name:       "no url",
+			mapper:     configmap.Simple{},
+			input:      fs.ConfigIn{State: ""},
+			expectFail: true,
+		},
+		{
+			name:       "2fa not set",
+			mapper:     configmap.Simple{"url": "http://localhost/"},
+			input:      fs.ConfigIn{State: ""},
+			expectFail: true,
+		},
+		{
+			name:       "unknown state",
+			mapper:     configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username"},
+			input:      fs.ConfigIn{State: "unknown"},
+			expectFail: true,
+		},
+		{
+			name:        "no password in config",
+			mapper:      configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username"},
+			input:       fs.ConfigIn{State: ""},
+			expectState: "password",
+		},
+		{
+			name:        "config ready for 2fa token",
+			mapper:      configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username", "pass": obscure.MustObscure("password")},
+			input:       fs.ConfigIn{State: ""},
+			expectState: "2fa",
+		},
+		{
+			name:               "password not entered",
+			mapper:             configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username"},
+			input:              fs.ConfigIn{State: "password"},
+			expectState:        "",
+			expectErrorMessage: "Password can't be blank",
+		},
+		{
+			name:        "password entered",
+			mapper:      configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username"},
+			input:       fs.ConfigIn{State: "password", Result: "password"},
+			expectState: "2fa",
+		},
+		{
+			name:        "ask for a 2fa code",
+			mapper:      configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username"},
+			input:       fs.ConfigIn{State: "2fa"},
+			expectState: "2fa_do",
+		},
+		{
+			name:               "no 2fa code entered",
+			mapper:             configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username"},
+			input:              fs.ConfigIn{State: "2fa_do"},
+			expectState:        "2fa", // ask for a code again
+			expectErrorMessage: "2FA codes can't be blank",
+		},
+		{
+			name:        "2fa error and retry",
+			mapper:      configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username"},
+			input:       fs.ConfigIn{State: "2fa_error", Result: "true"},
+			expectState: "2fa", // ask for a code again
+		},
+		{
+			name:       "2fa error and fail",
+			mapper:     configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username"},
+			input:      fs.ConfigIn{State: "2fa_error"},
+			expectFail: true,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		t.Run(fixture.name, func(t *testing.T) {
+			output, err := Config(context.Background(), "test", fixture.mapper, fixture.input)
+			if fixture.expectFail {
+				require.Error(t, err)
+				t.Log(err)
+				return
+			}
+			assert.Equal(t, fixture.expectState, output.State)
+			assert.Equal(t, fixture.expectErrorMessage, output.Error)
+			assert.Equal(t, fixture.expectResult, output.Result)
+		})
 	}
 }


### PR DESCRIPTION


#### What is the purpose of this change?

rclone 1.56 introduced a defect where you cannot create a new seafile remote with 2FA activated:

- this PR should fix the defect
- added unit tests for the seafile 2fa state machine


#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/config-seafile-with-2fa-password-cant-be-blank/26541

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
