### PR TITLE
docs: cleanup header levels

### DIFF
--- a/docs/content/authors.md
+++ b/docs/content/authors.md
@@ -3,6 +3,8 @@ title: "Authors"
 description: "Rclone Authors and Contributors"
 ---
 
+# Authors and contributors
+
 Authors
 -------
 

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -3,6 +3,15 @@ title: "Documentation"
 description: "Rclone Usage"
 ---
 
+# Usage
+
+Rclone is a command line program to manage files on cloud storage.
+After [download](/downloads/) and [install](/install), continue
+here to learn how to use it: Initial [configuration](#configure),
+what the [basic syntax](#basic-syntax) looks like, describes the
+various [subcommands](#subcommands), the various [options](#options),
+and more.
+
 Configure
 ---------
 
@@ -62,7 +71,7 @@ See the following for detailed instructions for
   * [Zoho WorkDrive](/zoho/)
   * [The local filesystem](/local/)
 
-Usage
+Basic syntax
 -----
 
 Rclone syncs a directory tree from one storage system to another.

--- a/docs/content/downloads.md
+++ b/docs/content/downloads.md
@@ -4,8 +4,13 @@ description: "Download rclone binaries for your OS."
 type: page
 ---
 
-Rclone Download {{< version >}}
-=====================
+# Downloads
+
+Rclone is single executable (`rclone`, or `rclone.exe` on Windows) that you can
+simply download as a zip archive and extract into a location of your choosing.
+See the [install](https://rclone.org/install/) documentation for more details.
+
+## Release {{< version >}}
 
 | Arch-OS | Windows | macOS | Linux | .deb | .rpm | FreeBSD | NetBSD | OpenBSD | Plan9 | Solaris |
 |:-------:|:-------:|:-----:|:-----:|:----:|:----:|:-------:|:------:|:-------:|:-----:|:-------:|
@@ -32,8 +37,7 @@ For beta installation, run:
 Note that this script checks the version of rclone installed first and
 won't re-download if not needed.
 
-Beta releases
-=============
+## Beta releases
 
 [Beta releases](https://beta.rclone.org) are generated from each commit
 to master.  Note these are named like
@@ -70,8 +74,7 @@ Note that [rclone.org](https://rclone.org/) is only updated on
 releases - to see the documentation for the latest beta go to
 [tip.rclone.org](https://tip.rclone.org/).
 
-Downloads for scripting
-=======================
+## Downloads for scripting
 
 If you would like to download the current version (maybe from a
 script) from a URL which doesn't change then you can use these links.
@@ -86,7 +89,6 @@ script) from a URL which doesn't change then you can use these links.
 | MIPS - Big Endian | - | - | {{< cdownload linux mips >}} | {{< cdownload linux mips deb >}} | {{< cdownload linux mips rpm >}} | - | - | - | - | - |
 | MIPS - Little Endian | - | - | {{< cdownload linux mipsle >}} | {{< cdownload linux mipsle deb >}} | {{< cdownload linux mipsle rpm >}} | - | - | - | - | - |
 
-Older Downloads
-==============
+## Older Downloads
 
 Older downloads can be found [here](https://downloads.rclone.org/).

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -3,8 +3,7 @@ title: "FAQ"
 description: "Rclone Frequently Asked Questions"
 ---
 
-Frequently Asked Questions
---------------------------
+# Frequently Asked Questions
 
 ### Do all cloud storage systems support all rclone commands ###
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -16,7 +16,7 @@ Rclone is a Go program and comes as a single binary file.
 
 See below for some expanded Linux / macOS instructions.
 
-See the [Usage section](/docs/#usage) of the docs for how to use rclone, or
+See the [usage](/docs/) docs for how to use rclone, or
 run `rclone -h`.
 
 Already installed rclone can be easily updated to the latest version
@@ -228,7 +228,7 @@ Instructions
           - rclone
 ```
 
-# Autostart #
+## Autostart
 
 After installing and configuring rclone, as described above, you are ready to use rclone
 as an interactive command line utility. If your goal is to perform *periodic* operations,
@@ -244,14 +244,14 @@ different operating systems.
 NOTE: Before setting up autorun it is highly recommended that you have tested your command
 manually from a Command Prompt first.
 
-## Autostart on Windows ##
+### Autostart on Windows
 
 The most relevant alternatives for autostart on Windows are:
 - Run at user log on using the Startup folder
 - Run at user log on, at system startup or at schedule using Task Scheduler
 - Run at system startup using Windows service
 
-### Running in background
+#### Running in background
 
 Rclone is a console application, so if not starting from an existing Command Prompt,
 e.g. when starting rclone.exe from a shortcut, it will open a Command Prompt window.
@@ -267,7 +267,7 @@ Example command to run a sync in background:
 c:\rclone\rclone.exe sync c:\files remote:/files --no-console --log-file c:\rclone\logs\sync_files.txt
 ```
 
-### User account
+#### User account
 
 As mentioned in the [mount](https://rclone.org/commands/rclone_move/) documentation,
 mounted drives created as Administrator are not visible to other accounts, not even the
@@ -286,7 +286,7 @@ the [PsExec](https://docs.microsoft.com/en-us/sysinternals/downloads/psexec)
 utility from Microsoft's Sysinternals suite, which takes option `-s` to
 execute commands as the `SYSTEM` user.
 
-### Start from Startup folder ###
+#### Start from Startup folder ###
 
 To quickly execute an rclone command you can simply create a standard
 Windows Explorer shortcut for the complete rclone command you want to run. If you
@@ -301,7 +301,7 @@ functionality to set it to run as different user, or to set conditions or
 actions on certain events. Setting up a scheduled task as described below
 will often give you better results.
 
-### Start from Task Scheduler ###
+#### Start from Task Scheduler ###
 
 Task Scheduler is an administrative tool built into Windows, and it can be used to
 configure rclone to be started automatically in a highly configurable way, e.g.
@@ -311,12 +311,12 @@ be available to all users it can run as the `SYSTEM` user.
 For technical information, see
 https://docs.microsoft.com/windows/win32/taskschd/task-scheduler-start-page.
 
-### Run as service ###
+#### Run as service ###
 
 For running rclone at system startup, you can create a Windows service that executes
 your rclone command, as an alternative to scheduled task configured to run at startup.
 
-#### Mount command built-in service integration ####
+##### Mount command built-in service integration ####
 
 For mount commands, Rclone has a built-in Windows service integration via the third party
 WinFsp library it uses. Registering as a regular Windows service easy, as you just have to
@@ -338,7 +338,7 @@ Windows standard methods for managing network drives. This is currently not
 officially supported by Rclone, but with WinFsp version 2019.3 B2 / v1.5B2 or later
 it should be possible through path rewriting as described [here](https://github.com/rclone/rclone/issues/3340).
 
-#### Third party service integration ####
+##### Third party service integration ####
 
 To Windows service running any rclone command, the excellent third party utility
 [NSSM](http://nssm.cc), the "Non-Sucking Service Manager", can be used.
@@ -358,9 +358,9 @@ settings, without having go through manual steps in a GUI. One thing to note is 
 by default it does not restart the service on error, one have to explicit enable this
 in the configuration file (via the "onfailure" parameter).
 
-## Autostart on Linux
+### Autostart on Linux
 
-### Start as a service
+#### Start as a service
 
 To always run rclone in background, relevant for mount commands etc,
 you can use systemd to set up rclone as a system or user service. Running as a
@@ -368,6 +368,6 @@ system service ensures that it is run at startup even if the user it is running 
 has no active session. Running rclone as a user service ensures that it only
 starts after the configured user has logged into the system.
 
-### Run periodically from cron
+#### Run periodically from cron
 
 To run a periodic command, such as a copy/sync, you can set up a cron job.

--- a/docs/content/licence.md
+++ b/docs/content/licence.md
@@ -3,8 +3,7 @@ title: "Licence"
 description: "Rclone Licence"
 ---
 
-License
--------
+# License
 
 This is free software under the terms of MIT the license (check the
 COPYING file included with the source code).


### PR DESCRIPTION
#### What is the purpose of this change?

Some cleanup in the usage, install and download docs. Mainly related to headers.

Ensure each page starts with a level 1 header (`# header`), and then only use level 2 or higher for sections below. E.g. existing install doc uses header level 1 for "Autostart", above [Autostart on Windows](https://rclone.org/install/#autostart-on-windows), but then this does not get a anchor on hover-over and also is not listed in the contents box to the right. And existing downloads doc have several level 1 headers but only one level 2 header, and then only the level 2 header "Script download and install" is shown in the contents box to the right.

The [usage](https://rclone.org/docs/) docs started with level 2 header called "Configure". So for consistency I introduced a level 1 header with the page name, "Usage", and *tried* to come up with something short to write there to avoid having an empty level 1 header followed only by a level 2 header.
Edit: I see that existing Changelog and Privacy Policy pages does have an empty level 1 header followed by a level 2 header. It does not look too bad, so I can just do the same in Usage. One thing is that the usage site is at the /docs url, so feels like som sort of main/entry point for documentation. So I tried to write a short, generic intro to rclone doc. But open for suggestions to do this differently.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~I have added tests for all changes in this PR if appropriate.~
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
