### PR TITLE
docs: add faq section explaining why rclone changes fullwidth characters in file names

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -211,38 +211,20 @@ directory with thousands or millions of files in.  Rclone has to load
 this entirely into memory as rclone objects.  Each rclone object takes
 0.5k-1k of memory.
 
-### Rclone changes fullwidth characters in file names
+### Rclone changes fullwidth Unicode punctuation marks in file names
 
-On a Windows system, you have a file with name `C：Backup.txt`,
-where `：` is the Unicode fullwidth colon symbol, and use rclone to
-copy this to your Google Drive with rclone. Then you will notice that
-it in Google Drive it has been renamed to `C:Backup.txt`, where `:` is
-the regular (halfwidth) colon.
+For example: On a Windows system, you have a file with name `Test：1.jpg`,
+where `：` is the Unicode fullwidth colon symbol. When using rclone
+to copy this to your Google Drive, you will notice that the file
+gets renamed to `Test:1.jpg`, where `:` is the regular (halfwidth) colon.
 
-The reason for such unexpected renames is the way rclone handles
-different [restricted filenames](/overview/#restricted-filenames)
-on different cloud storage systems. It tries to avoid ambiguous file
-names as much and allow moving files between many cloud storage systems
+The reason for such renames is the way rclone handles different
+[restricted filenames](/overview/#restricted-filenames) on different
+cloud storage systems. It tries to avoid ambiguous file names as
+much and allow moving files between many cloud storage systems
 transparently, by replacing invalid characters with similar looking
 Unicode characters when transferring to one storage system, and replacing
 back again when transferring to a different storage system where the
-original characters are supported.
-
-You will see this process working as intended in an example which is
-opposite of the one above: If you upload a file named `C:Backup.txt`
-from a Linux system (where such a filename is valid), into your
-Google Drive (where it is also valid) using the official client,
-or Web GUI, but not rclone. Then if you later copy this file to
-your Windows computer with rclone, you will notice that in your
-local disk it will get name `C：Backup.txt`. But this may also
-become an issue, if you already had a *different* file
-originally named `C：Backup.txt` in your Windows system.
-
-Its impossible to handle all cases like these correctly in all
-situations, but by customizing the [encoding option](/overview/#encoding),
-changing the set of characters that rclone should convert,
-you should be able to make it work correct in your situation.
-See [this](/overview/#encoding-example-windows) example.
-
-Windows was used as an example of a file system with many restricted
-characters, and Google drive a storage system with few.
+original characters are supported. When the same Unicode characters
+are intentionally used in file names, this replacement strategy leads
+to unwanted renames. Read more [here](/overview/#restricted-filenames-caveats).

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -210,3 +210,39 @@ The most common cause of rclone using lots of memory is a single
 directory with thousands or millions of files in.  Rclone has to load
 this entirely into memory as rclone objects.  Each rclone object takes
 0.5k-1k of memory.
+
+### Rclone changes fullwidth characters in file names
+
+On a Windows system, you have a file with name `C：Backup.txt`,
+where `：` is the Unicode fullwidth colon symbol, and use rclone to
+copy this to your Google Drive with rclone. Then you will notice that
+it in Google Drive it has been renamed to `C:Backup.txt`, where `:` is
+the regular (halfwidth) colon.
+
+The reason for such unexpected renames is the way rclone handles
+different [restricted filenames](/overview/#restricted-filenames)
+on different cloud storage systems. It tries to avoid ambiguous file
+names as much and allow moving files between many cloud storage systems
+transparently, by replacing invalid characters with similar looking
+Unicode characters when transferring to one storage system, and replacing
+back again when transferring to a different storage system where the
+original characters are supported.
+
+You will see this process working as intended in an example which is
+opposite of the one above: If you upload a file named `C:Backup.txt`
+from a Linux system (where such a filename is valid), into your
+Google Drive (where it is also valid) using the official client,
+or Web GUI, but not rclone. Then if you later copy this file to
+your Windows computer with rclone, you will notice that in your
+local disk it will get name `C：Backup.txt`. But this may also
+become an issue, if you already had a *different* file
+originally named `C：Backup.txt` in your Windows system.
+
+Its impossible to handle all cases like these correctly in all
+situations, but by customizing the [encoding option](/overview/#encoding),
+changing the set of characters that rclone should convert,
+you should be able to make it work correct in your situation.
+See [this](/overview/#encoding-example-windows) example.
+
+Windows was used as an example of a file system with many restricted
+characters, and Google drive a storage system with few.

--- a/docs/content/local.md
+++ b/docs/content/local.md
@@ -44,6 +44,10 @@ Local file system at .: Replacing invalid UTF-8 characters in "gro\xdf"
 
 #### Restricted characters
 
+With the local backend, restrictions on the characters that are usable in
+file or directory names depend on the operating system. To check what
+rclone will replace by default on your system, run `rclone help flags local-encoding`.
+
 On non Windows platforms the following characters are replaced when
 handling file names.
 


### PR DESCRIPTION
#### What is the purpose of this change?

Title says it all.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/cannot-correctly-handle-filenames-with-u-ff1a-full-width-colon/26698

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~I have added tests for all changes in this PR if appropriate.~
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
