### PR TITLE
docs: clearify backend support for setting modtime only

### DIFF
--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -14,48 +14,48 @@ show through.
 
 Here is an overview of the major features of each cloud storage system.
 
-| Name                         | Hash        | ModTime | Case Insensitive | Duplicate Files | MIME Type |
-| ---------------------------- |:-----------:|:-------:|:----------------:|:---------------:|:---------:|
-| 1Fichier                     | Whirlpool   | -       | No               | Yes             | R         |
-| Akamai Netstorage            | MD5, SHA256 | R/W     | No               | No              | R         |
-| Amazon Drive                 | MD5         | -       | Yes              | No              | R         |
-| Amazon S3 (or S3 compatible) | MD5         | R/W     | No               | No              | R/W       |
-| Backblaze B2                 | SHA1        | R/W     | No               | No              | R/W       |
-| Box                          | SHA1        | R/W     | Yes              | No              | -         |
-| Citrix ShareFile             | MD5         | R/W     | Yes              | No              | -         |
-| Dropbox                      | DBHASH ¹    | R       | Yes              | No              | -         |
-| Enterprise File Fabric       | -           | R/W     | Yes              | No              | R/W       |
-| FTP                          | -           | R/W ¹⁰  | No               | No              | -         |
-| Google Cloud Storage         | MD5         | R/W     | No               | No              | R/W       |
-| Google Drive                 | MD5         | R/W     | No               | Yes             | R/W       |
-| Google Photos                | -           | -       | No               | Yes             | R         |
-| HDFS                         | -           | R/W     | No               | No              | -         |
-| HTTP                         | -           | R       | No               | No              | R         |
-| Hubic                        | MD5         | R/W     | No               | No              | R/W       |
-| Internet Archive             | MD5, SHA1, CRC32 | R/W | No              | No              | -         |
-| Jottacloud                   | MD5         | R/W     | Yes              | No              | R         |
-| Koofr                        | MD5         | -       | Yes              | No              | -         |
-| Mail.ru Cloud                | Mailru ⁶    | R/W     | Yes              | No              | -         |
-| Mega                         | -           | -       | No               | Yes             | -         |
-| Memory                       | MD5         | R/W     | No               | No              | -         |
-| Microsoft Azure Blob Storage | MD5         | R/W     | No               | No              | R/W       |
-| Microsoft OneDrive           | SHA1 ⁵      | R/W     | Yes              | No              | R         |
-| OpenDrive                    | MD5         | R/W     | Yes              | Partial ⁸       | -         |
-| OpenStack Swift              | MD5         | R/W     | No               | No              | R/W       |
-| pCloud                       | MD5, SHA1 ⁷ | R       | No               | No              | W         |
-| premiumize.me                | -           | -       | Yes              | No              | R         |
-| put.io                       | CRC-32      | R/W     | No               | Yes             | R         |
-| QingStor                     | MD5         | - ⁹     | No               | No              | R/W       |
-| Seafile                      | -           | -       | No               | No              | -         |
-| SFTP                         | MD5, SHA1 ² | R/W     | Depends          | No              | -         |
-| Sia                          | -           | -       | No               | No              | -         |
-| SugarSync                    | -           | -       | No               | No              | -         |
-| Storj                        | -           | R       | No               | No              | -         |
-| Uptobox                      | -           | -       | No               | Yes             | -         |
-| WebDAV                       | MD5, SHA1 ³ | R ⁴     | Depends          | No              | -         |
-| Yandex Disk                  | MD5         | R/W     | No               | No              | R         |
-| Zoho WorkDrive               | -           | -       | No               | No              | -         |
-| The local filesystem         | All         | R/W     | Depends          | No              | -         |
+| Name                         | Hash             | ModTime | Case Insensitive | Duplicate Files | MIME Type |
+| ---------------------------- |:----------------:|:-------:|:----------------:|:---------------:|:---------:|
+| 1Fichier                     | Whirlpool        | -       | No               | Yes             | R         |
+| Akamai Netstorage            | MD5, SHA256      | R/W     | No               | No              | R         |
+| Amazon Drive                 | MD5              | -       | Yes              | No              | R         |
+| Amazon S3 (or S3 compatible) | MD5              | R/W     | No               | No              | R/W       |
+| Backblaze B2                 | SHA1             | R/W     | No               | No              | R/W       |
+| Box                          | SHA1             | R/W     | Yes              | No              | -         |
+| Citrix ShareFile             | MD5              | R/W     | Yes              | No              | -         |
+| Dropbox                      | DBHASH ¹         | R       | Yes              | No              | -         |
+| Enterprise File Fabric       | -                | R/W     | Yes              | No              | R/W       |
+| FTP                          | -                | R/W ¹⁰  | No               | No              | -         |
+| Google Cloud Storage         | MD5              | R/W     | No               | No              | R/W       |
+| Google Drive                 | MD5              | R/W     | No               | Yes             | R/W       |
+| Google Photos                | -                | -       | No               | Yes             | R         |
+| HDFS                         | -                | R/W     | No               | No              | -         |
+| HTTP                         | -                | R       | No               | No              | R         |
+| Hubic                        | MD5              | R/W     | No               | No              | R/W       |
+| Internet Archive             | MD5, SHA1, CRC32 | R/W ¹¹  | No               | No              | -         |
+| Jottacloud                   | MD5              | R/W     | Yes              | No              | R         |
+| Koofr                        | MD5              | -       | Yes              | No              | -         |
+| Mail.ru Cloud                | Mailru ⁶         | R/W     | Yes              | No              | -         |
+| Mega                         | -                | -       | No               | Yes             | -         |
+| Memory                       | MD5              | R/W     | No               | No              | -         |
+| Microsoft Azure Blob Storage | MD5              | R/W     | No               | No              | R/W       |
+| Microsoft OneDrive           | SHA1 ⁵           | R/W     | Yes              | No              | R         |
+| OpenDrive                    | MD5              | R/W     | Yes              | Partial ⁸       | -         |
+| OpenStack Swift              | MD5              | R/W     | No               | No              | R/W       |
+| pCloud                       | MD5, SHA1 ⁷      | R       | No               | No              | W         |
+| premiumize.me                | -                | -       | Yes              | No              | R         |
+| put.io                       | CRC-32           | R/W     | No               | Yes             | R         |
+| QingStor                     | MD5              | - ⁹     | No               | No              | R/W       |
+| Seafile                      | -                | -       | No               | No              | -         |
+| SFTP                         | MD5, SHA1 ²      | R/W     | Depends          | No              | -         |
+| Sia                          | -                | -       | No               | No              | -         |
+| SugarSync                    | -                | -       | No               | No              | -         |
+| Storj                        | -                | R       | No               | No              | -         |
+| Uptobox                      | -                | -       | No               | Yes             | -         |
+| WebDAV                       | MD5, SHA1 ³      | R ⁴     | Depends          | No              | -         |
+| Yandex Disk                  | MD5              | R/W     | No               | No              | R         |
+| Zoho WorkDrive               | -                | -       | No               | No              | -         |
+| The local filesystem         | All              | R/W     | Depends          | No              | -         |
 
 ### Notes
 
@@ -89,6 +89,9 @@ mistake or an unsupported feature.
 ¹⁰ FTP supports modtimes for the major FTP servers, and also others
 if they advertised required protocol extensions. See [this](/ftp/#modified-time)
 for more details.
+
+¹¹ Internet Archive requires option `wait_archive` to be set to a non-zero value
+for full modtime support.
 
 ### Hash ###
 

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -16,46 +16,46 @@ Here is an overview of the major features of each cloud storage system.
 
 | Name                         | Hash        | ModTime | Case Insensitive | Duplicate Files | MIME Type |
 | ---------------------------- |:-----------:|:-------:|:----------------:|:---------------:|:---------:|
-| 1Fichier                     | Whirlpool   | No      | No               | Yes             | R         |
-| Akamai Netstorage            | MD5, SHA256 | Yes     | No               | No              | R         |
-| Amazon Drive                 | MD5         | No      | Yes              | No              | R         |
-| Amazon S3 (or S3 compatible) | MD5         | Yes     | No               | No              | R/W       |
-| Backblaze B2                 | SHA1        | Yes     | No               | No              | R/W       |
-| Box                          | SHA1        | Yes     | Yes              | No              | -         |
-| Citrix ShareFile             | MD5         | Yes     | Yes              | No              | -         |
-| Dropbox                      | DBHASH ¹    | Yes     | Yes              | No              | -         |
-| Enterprise File Fabric       | -           | Yes     | Yes              | No              | R/W       |
-| FTP                          | -           | No      | No               | No              | -         |
-| Google Cloud Storage         | MD5         | Yes     | No               | No              | R/W       |
-| Google Drive                 | MD5         | Yes     | No               | Yes             | R/W       |
-| Google Photos                | -           | No      | No               | Yes             | R         |
-| HDFS                         | -           | Yes     | No               | No              | -         |
-| HTTP                         | -           | No      | No               | No              | R         |
-| Hubic                        | MD5         | Yes     | No               | No              | R/W       |
-| Internet Archive             | MD5, SHA1, CRC32 | Yes | No              | No              | -         |
-| Jottacloud                   | MD5         | Yes     | Yes              | No              | R         |
-| Koofr                        | MD5         | No      | Yes              | No              | -         |
-| Mail.ru Cloud                | Mailru ⁶    | Yes     | Yes              | No              | -         |
-| Mega                         | -           | No      | No               | Yes             | -         |
-| Memory                       | MD5         | Yes     | No               | No              | -         |
-| Microsoft Azure Blob Storage | MD5         | Yes     | No               | No              | R/W       |
-| Microsoft OneDrive           | SHA1 ⁵      | Yes     | Yes              | No              | R         |
-| OpenDrive                    | MD5         | Yes     | Yes              | Partial ⁸       | -         |
-| OpenStack Swift              | MD5         | Yes     | No               | No              | R/W       |
-| pCloud                       | MD5, SHA1 ⁷ | Yes     | No               | No              | W         |
-| premiumize.me                | -           | No      | Yes              | No              | R         |
-| put.io                       | CRC-32      | Yes     | No               | Yes             | R         |
-| QingStor                     | MD5         | No      | No               | No              | R/W       |
-| Seafile                      | -           | No      | No               | No              | -         |
-| SFTP                         | MD5, SHA1 ² | Yes     | Depends          | No              | -         |
-| Sia                          | -           | No      | No               | No              | -         |
-| SugarSync                    | -           | No      | No               | No              | -         |
-| Storj                        | -           | Yes     | No               | No              | -         |
-| Uptobox                      | -           | No      | No               | Yes             | -         |
-| WebDAV                       | MD5, SHA1 ³ | Yes ⁴   | Depends          | No              | -         |
-| Yandex Disk                  | MD5         | Yes     | No               | No              | R         |
-| Zoho WorkDrive               | -           | No      | No               | No              | -         |
-| The local filesystem         | All         | Yes     | Depends          | No              | -         |
+| 1Fichier                     | Whirlpool   | R       | No               | Yes             | R         |
+| Akamai Netstorage            | MD5, SHA256 | R/W     | No               | No              | R         |
+| Amazon Drive                 | MD5         | R       | Yes              | No              | R         |
+| Amazon S3 (or S3 compatible) | MD5         | R/W     | No               | No              | R/W       |
+| Backblaze B2                 | SHA1        | R/W     | No               | No              | R/W       |
+| Box                          | SHA1        | R/W     | Yes              | No              | -         |
+| Citrix ShareFile             | MD5         | R/W     | Yes              | No              | -         |
+| Dropbox                      | DBHASH ¹    | R       | Yes              | No              | -         |
+| Enterprise File Fabric       | -           | R/W     | Yes              | No              | R/W       |
+| FTP                          | -           | R       | No               | No              | -         |
+| Google Cloud Storage         | MD5         | R/W     | No               | No              | R/W       |
+| Google Drive                 | MD5         | R/W     | No               | Yes             | R/W       |
+| Google Photos                | -           | R       | No               | Yes             | R         |
+| HDFS                         | -           | R/W     | No               | No              | -         |
+| HTTP                         | -           | R       | No               | No              | R         |
+| Hubic                        | MD5         | R/W     | No               | No              | R/W       |
+| Internet Archive             | MD5, SHA1, CRC32 | R/W | No              | No              | -         |
+| Jottacloud                   | MD5         | R/W     | Yes              | No              | R         |
+| Koofr                        | MD5         | R       | Yes              | No              | -         |
+| Mail.ru Cloud                | Mailru ⁶    | R/W     | Yes              | No              | -         |
+| Mega                         | -           | R       | No               | Yes             | -         |
+| Memory                       | MD5         | R/W     | No               | No              | -         |
+| Microsoft Azure Blob Storage | MD5         | R/W     | No               | No              | R/W       |
+| Microsoft OneDrive           | SHA1 ⁵      | R/W     | Yes              | No              | R         |
+| OpenDrive                    | MD5         | R/W     | Yes              | Partial ⁸       | -         |
+| OpenStack Swift              | MD5         | R/W     | No               | No              | R/W       |
+| pCloud                       | MD5, SHA1 ⁷ | R       | No               | No              | W         |
+| premiumize.me                | -           | R       | Yes              | No              | R         |
+| put.io                       | CRC-32      | R/W     | No               | Yes             | R         |
+| QingStor                     | MD5         | R ⁹     | No               | No              | R/W       |
+| Seafile                      | -           | R       | No               | No              | -         |
+| SFTP                         | MD5, SHA1 ² | R/W     | Depends          | No              | -         |
+| Sia                          | -           | -       | No               | No              | -         |
+| SugarSync                    | -           | R       | No               | No              | -         |
+| Storj                        | -           | R       | No               | No              | -         |
+| Uptobox                      | -           | -       | No               | Yes             | -         |
+| WebDAV                       | MD5, SHA1 ³ | R ⁴     | Depends          | No              | -         |
+| Yandex Disk                  | MD5         | R/W     | No               | No              | R         |
+| Zoho WorkDrive               | -           | R       | No               | No              | -         |
+| The local filesystem         | All         | R/W     | Depends          | No              | -         |
 
 ### Notes
 
@@ -84,6 +84,8 @@ storage platform has been determined to allow duplicate files, and it
 is possible to create them with `rclone`.  It may be that this is a
 mistake or an unsupported feature.
 
+⁹ QingStor does not support SetModTime for objects bigger than 5 GiB.
+
 ### Hash ###
 
 The cloud storage system supports various hash types of the objects.
@@ -96,13 +98,26 @@ systems they must support a common hash type.
 
 ### ModTime ###
 
-The cloud storage system supports setting modification times on
-objects.  If it does then this enables a using the modification times
-as part of the sync.  If not then only the size will be checked by
-default, though the MD5SUM can be checked with the `--checksum` flag.
+Allmost all cloud storage systems support storing modification times
+on objects, at least some kind of timestamp that are set on upload.
+If it does then this enables using them as part of the sync.
+If not, only the size will be checked by default, though the
+file hash can be checked with the `--checksum` flag.
 
-All cloud storage systems support some kind of date on the object and
-these will be set when transferring from the cloud storage system.
+Storage systems with an `R`, for read-only, in the ModTime colum,
+means the it keeps modification times on objects, and updates them when
+uploading objects, but it does not support changing only the
+modification time (`SetModTime` operation) without re-uploading,
+possibly also deleting existing first. Some operations in rclone,
+such as `copy` and `sync` commands, will automatically check for
+`SetModTime` support and re-upload if necessary to keep the modification
+times in sync. Other commands will not work without `SetModTime` support,
+e.g. `touch` command on an existing file will fail, and changes to
+modification time only on a files in a `mount` will be silently ignored.
+
+Storage systems with `R/W`, for read/write, in the ModTime column, means
+they do support modtime-only operations. An `-` means it does not
+provide any usable modification time at all.
 
 ### Case Insensitive ###
 

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -25,7 +25,7 @@ Here is an overview of the major features of each cloud storage system.
 | Citrix ShareFile             | MD5         | R/W     | Yes              | No              | -         |
 | Dropbox                      | DBHASH ¹    | R       | Yes              | No              | -         |
 | Enterprise File Fabric       | -           | R/W     | Yes              | No              | R/W       |
-| FTP                          | -           | -       | No               | No              | -         |
+| FTP                          | -           | R/W ¹⁰  | No               | No              | -         |
 | Google Cloud Storage         | MD5         | R/W     | No               | No              | R/W       |
 | Google Drive                 | MD5         | R/W     | No               | Yes             | R/W       |
 | Google Photos                | -           | -       | No               | Yes             | R         |
@@ -85,6 +85,10 @@ is possible to create them with `rclone`.  It may be that this is a
 mistake or an unsupported feature.
 
 ⁹ QingStor does not support SetModTime for objects bigger than 5 GiB.
+
+¹⁰ FTP supports modtimes for the major FTP servers, and also others
+if they advertised required protocol extensions. See [this](/ftp/#modified-time)
+for more details.
 
 ### Hash ###
 


### PR DESCRIPTION
#### What is the purpose of this change?

It is confusing for users to know what "ModTime" support in a backend really means.

This change documents backends that support storing and reading modtimes (`ModTime`), at least some kind of usable timestamp, but does not support changing the modtime-only (`SetModTime`). Marking these with `Partial` in the `ModTime` column features table. 

Existing version seemed to have a mix of `Yes` and `No` for backends supporting `ModTime` but not `SetModTime` (I guess it is confusing for developers too - and I'm including me here).

The following are set to Partial, because `ModTime` is implemented, but `SetModTime` returns `ErrorCantSetModTime` or `ErrorCantSetModTimeWithoutDelete`:
```
1Fichier: No -> Partial
Amazon Drive: No -> Partial
Dropbox: Yes -> Partial
FTP: No -> Partial
Google Photos: No -> Partial
HTTP: No -> Partial
Koofr: No -> Partial
Mega: No -> Partial
pCloud: Yes -> Partial
premiumize.me: No -> Partial
Seafile: No -> Partial
Sugarsync: No -> Partial
Tardigrade: Yes -> Partial
WebDAV: Yes -> Partial **Note: Supports modtimes when used with Owncloud and Nextcloud only**
Zoho WorkDrive: No -> Partial
```

Other changes:
```
QingStor: No -> Yes **Note: SetModTime is unsupported for objects bigger than 5GiB**
```

The only one left with a big fat `No` is Uptobox. Its implementation of ModTime just returns `time.Now()`.
- If it hadn't been for this we could have renamed the column to "SetModTime" and only used Yes/No values.

I removed the following sentence from docs, couldn't quite grasp what this meant in relation to the other things described:

> All cloud storage systems support some kind of date on the object and
> these will be set when transferring from the cloud storage system.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/1066

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] ~I have added tests for all changes in this PR if appropriate.~
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
