### PR TITLE
s3: add specific provider for Storj Shared gateways

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -19,6 +19,7 @@ The S3 backend can be used with a number of different providers:
 {{< provider name="Scaleway" home="https://www.scaleway.com/en/object-storage/" config="/s3/#scaleway" >}}
 {{< provider name="SeaweedFS" home="https://github.com/chrislusf/seaweedfs/" config="/s3/#seaweedfs" >}}
 {{< provider name="StackPath" home="https://www.stackpath.com/products/object-storage/" config="/s3/#stackpath" >}}
+{{< provider name="Storj" home="https://storj.io/" config="/s3/#storj" >}}
 {{< provider name="Tencent Cloud Object Storage (COS)" home="https://intl.cloud.tencent.com/product/cos" config="/s3/#tencent-cos" >}}
 {{< provider name="Wasabi" home="https://wasabi.com/" config="/s3/#wasabi" end="true" >}}
 {{< /provider_list >}}
@@ -2821,6 +2822,83 @@ For Netease NOS configure as per the configurator `rclone config`
 setting the provider `Netease`.  This will automatically set
 `force_path_style = false` which is necessary for it to run properly.
 
+### Storj
+
+Storj is a decentralized cloud storage which can be used through its
+native protocol or an S3 compatible gateway.
+
+The S3 compatible gateway is configured using `rclone config` with a
+type of `s3` and with a provider name of `Storj`. Here is an example
+run of the configurator.
+
+```
+Type of storage to configure.
+Storage> s3
+Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars).
+Only applies if access_key_id and secret_access_key is blank.
+Choose a number from below, or type in your own boolean value (true or false).
+Press Enter for the default (false).
+ 1 / Enter AWS credentials in the next step.
+   \ (false)
+ 2 / Get AWS credentials from the environment (env vars or IAM).
+   \ (true)
+env_auth> 1
+Option access_key_id.
+AWS Access Key ID.
+Leave blank for anonymous access or runtime credentials.
+Enter a value. Press Enter to leave empty.
+access_key_id> XXXX (as shown when creating the access grant)
+Option secret_access_key.
+AWS Secret Access Key (password).
+Leave blank for anonymous access or runtime credentials.
+Enter a value. Press Enter to leave empty.
+secret_access_key> XXXX (as shown when creating the access grant)
+Option endpoint.
+Endpoint of the Shared Gateway.
+Choose a number from below, or type in your own value.
+Press Enter to leave empty.
+ 1 / EU1 Shared Gateway
+   \ (gateway.eu1.storjshare.io)
+ 2 / US1 Shared Gateway
+   \ (gateway.us1.storjshare.io)
+ 3 / Asia-Pacific Shared Gateway
+   \ (gateway.ap1.storjshare.io)
+endpoint> 1 (as shown when creating the access grant)
+Edit advanced config?
+y) Yes
+n) No (default)
+y/n> n
+```
+
+Note that s3 credentials are generated when you [create an access
+grant](https://docs.storj.io/dcs/api-reference/s3-compatible-gateway#usage).
+
+
+#### Backend quirks
+
+- `--chunk-size` is forced to be 64 MiB or greater. This will use more
+  memory than the default of 5 MiB.
+- Server side copy is disabled as it isn't currently supported in the
+  gateway.
+- GetTier and SetTier are not supported.
+
+#### Comparison with the native protocol
+
+Use the [the native protocol](/tardigrade) to take advantage of
+client-side encryption as well as to achieve the best possible
+download performance. Uploads will be erasure-coded locally, thus a
+1gb upload will result in 2.68gb of data being uploaded to storage
+nodes across the network.
+
+Use this backend and the S3 compatible Hosted Gateway to increase
+upload performance and reduce the load on your systems and network.
+Uploads will be encrypted and erasure-coded server-side, thus a 1GB
+upload will result in only in 1GB of data being uploaded to storage
+nodes across the network.
+
+For more detailed comparison please check the documentation of the
+[tardigrade](/tardigrade) backend.
+
 ## Limitations
 
 `rclone about` is not supported by the S3 backend. Backends without
@@ -2830,4 +2908,3 @@ remote.
 
 See [List of backends that do not support rclone about](https://rclone.org/overview/#optional-features)
 See [rclone about](https://rclone.org/commands/rclone_about/)
-

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -2873,7 +2873,6 @@ y/n> n
 Note that s3 credentials are generated when you [create an access
 grant](https://docs.storj.io/dcs/api-reference/s3-compatible-gateway#usage).
 
-
 #### Backend quirks
 
 - `--chunk-size` is forced to be 64 MiB or greater. This will use more
@@ -2881,6 +2880,31 @@ grant](https://docs.storj.io/dcs/api-reference/s3-compatible-gateway#usage).
 - Server side copy is disabled as it isn't currently supported in the
   gateway.
 - GetTier and SetTier are not supported.
+
+#### Backend bugs
+
+Due to [issue #39](https://github.com/storj/gateway-mt/issues/39)
+uploading multipart files via the S3 gateway causes them to lose their
+metadata. For rclone's purpose this means that the modification time
+is not stored, nor is any MD5SUM (if one is available from the
+source).
+
+This has the following consequences:
+
+- Using `rclone rcat` will fail as the medatada doesn't match after upload
+- Uploading files with `rclone mount` will fail for the same reason
+    - This can worked around by using `--vfs-cache-mode writes` or `--vfs-cache-mode full` or setting `--s3-upload-cutoff` large
+- Files uploaded via a multipart upload won't have their modtimes
+    - This will mean that `rclone sync` will likely keep trying to upload files bigger than `--s3-upload-cutoff`
+    - This can be worked around with `--checksum` or `--size-only` or setting `--s3-upload-cutoff` large
+    - The maximum value for `--s3-upload-cutoff` is 5GiB though
+
+One general purpose workaround is to set `--s3-upload-cutoff 5G`. This
+means that rclone will upload files smaller than 5GiB as single parts.
+Note that this can be set in the config file with `upload_cutoff = 5G`
+or configured in the advanced settings. If you regularly transfer
+files larger than 5G then using `--checksum` or `--size-only` in
+`rclone sync` is the recommended workaround.
 
 #### Comparison with the native protocol
 

--- a/docs/content/tardigrade.md
+++ b/docs/content/tardigrade.md
@@ -9,6 +9,96 @@ description: "Rclone docs for Tardigrade"
 cost-effective object storage service that enables you to store, back up, and 
 archive large amounts of data in a decentralized manner.
 
+## Backend options
+
+Storj can be used both with this native backend and with the [s3
+backend using the Storj S3 compatible gateway](/s3/#storj) (shared or private).
+
+Use this backend to take advantage of client-side encryption as well
+as to achieve the best possible download performance. Uploads will be
+erasure-coded locally, thus a 1gb upload will result in 2.68gb of data
+being uploaded to storage nodes across the network.
+
+Use the s3 backend and one of the S3 compatible Hosted Gateways to
+increase upload performance and reduce the load on your systems and
+network. Uploads will be encrypted and erasure-coded server-side, thus
+a 1GB upload will result in only in 1GB of data being uploaded to
+storage nodes across the network.
+
+Side by side comparison with more details:
+
+* Characteristics:
+  * *Tardigrade backend*: Uses native RPC protocol, connects directly
+    to the storage nodes which hosts the data. Requires more CPU
+    resource of encoding/decoding and has network amplification
+    (especially during the upload), uses lots of TCP connections
+  * *S3 backend*: Uses S3 compatible HTTP Rest API via the shared
+    gateways. There is no network amplification, but performance
+    depends on the shared gateways and the secret encryption key is
+    shared with the gateway.
+* Typical usage:
+  * *Tardigrade backend*: Server environments and desktops with enough
+    resources, internet speed and connectivity - and applications
+    where tardigrades client-side encryption is required.
+  * *S3 backend*: Desktops and similar with limited resources,
+    internet speed or connectivity.
+* Security:
+  * *Tardigrade backend*: __strong__. Private encryption key doesn't
+    need to leave the local computer.
+  * *S3 backend*: __weaker__. Private encryption key is [shared
+    with](https://docs.storj.io/dcs/api-reference/s3-compatible-gateway#security-and-encryption)
+    the authentication service of the hosted gateway, where it's
+    stored encrypted. It can be stronger when combining with the
+    rclone [crypt](/crypt) backend.
+* Bandwidth usage (upload):
+  * *Tardigrade backend*: __higher__. As data is erasure coded on the
+    client side both the original data and the parities should be
+    uploaded. About ~2.7 times more data is required to be uploaded.
+    Client may start to upload with even higher number of nodes (~3.7
+    times more) and abandon/stop the slow uploads.
+  * *S3 backend*: __normal__. Only the raw data is uploaded, erasure
+    coding happens on the gateway.
+* Bandwidth usage (download)
+  * *Tardigrade backend*: __almost normal__. Only the minimal number
+    of data is required, but to avoid very slow data providers a few
+    more sources are used and the slowest are ignored (max 1.2x
+    overhead).
+  * *S3 backend*: __normal__. Only the raw data is downloaded, erasure coding happens on the shared gateway.
+* CPU usage:
+  * *Tardigrade backend*: __higher__, but more predictable. Erasure
+    code and encryption/decryption happens locally which requires
+    significant CPU usage.
+  * *S3 backend*: __less__. Erasure code and encryption/decryption
+    happens on shared s3 gateways (and as is, it depends on the
+    current load on the gateways)
+* TCP connection usage:
+  * *Tardigrade backend*: __high__. A direct connection is required to
+    each of the Storj nodes resulting in 110 connections on upload and
+    35 on download per 64 MB segment. Not all the connections are
+    actively used (slow ones are pruned), but they are all opened.
+    [Adjusting the max open file limit](/tardigrade/#known-issues) may
+    be required.
+  * *S3 backend*: __normal__. Only one connection per download/upload
+    thread is required to the shared gateway.
+* Overall performance:
+  * *Tardigrade backend*: with enough resources (CPU and bandwidth)
+    *tardigrade* backend can provide even 2x better performance. Data
+    is directly downloaded to / uploaded from to the client instead of
+    the gateway.
+  * *S3 backend*: Can be faster on edge devices where CPU and network
+    bandwidth is limited as the shared S3 compatible gateways take
+    care about the encrypting/decryption and erasure coding and no
+    download/upload amplification.
+* Decentralization:
+  * *Tardigrade backend*: __high__. Data is downloaded directly from
+    the distributed cloud of storage providers.
+  * *S3 backend*: __low__. Requires a running S3 gateway (either
+    self-hosted or Storj-hosted).
+* Limitations:
+  * *Tardigrade backend*: `rclone checksum` is not possible without
+    download, as checksum metadata is not calculated during upload
+  * *S3 backend*: secret encryption key is shared with the gateway
+
 ## Configuration
 
 To make a new Tardigrade configuration you need one of the following:


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Make it easier (and documented) to use Storj distributed cloud storage via the s3 interface.

  1. Both on the Tardigrade and S3 backend it's clarified what are the pros and cons of using them.
  2. Storj added as a special s3 provider (with the predefined URL) 

#### Was the change discussed in an issue or in the forum before?

The discussion started here: https://forum.rclone.org/t/backward-compatibility-rules/26569/12
And later moved to #5616

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
