### PR TITLE
ftp: add hook for about command

### DIFF
--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -4,15 +4,18 @@ package ftp
 import (
 	"context"
 	"crypto/tls"
+	"encoding/json"
 	"io"
 	"net"
 	"net/textproto"
+	"os/exec"
 	"path"
 	"runtime"
 	"strings"
 	"sync"
 	"time"
 
+	"github.com/google/shlex"
 	"github.com/jlaffaye/ftp"
 	"github.com/pkg/errors"
 	"github.com/rclone/rclone/fs"
@@ -139,6 +142,10 @@ Enabled by default. Use 0 to disable.`,
 			Default:  fs.Duration(60 * time.Second),
 			Advanced: true,
 		}, {
+			Name:     "about_command",
+			Help:     "A command that returns JSON with free space, e.g. `rclone about --json sftp-remote:`",
+			Advanced: true,
+		}, {
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,
 			Advanced: true,
@@ -178,6 +185,7 @@ type Options struct {
 	IdleTimeout       fs.Duration          `config:"idle_timeout"`
 	CloseTimeout      fs.Duration          `config:"close_timeout"`
 	ShutTimeout       fs.Duration          `config:"shut_timeout"`
+	AboutCommand      string               `config:"about_command"`
 	Enc               encoder.MultiEncoder `config:"encoding"`
 }
 
@@ -201,6 +209,7 @@ type Fs struct {
 	fGetTime bool      // true if the ftp library accepts GetTime
 	fSetTime bool      // true if the ftp library accepts SetTime
 	fLstTime bool      // true if the List call returns precise time
+	aboutCmd []string
 }
 
 // Object describes an FTP file
@@ -495,6 +504,18 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (ff fs.Fs
 	f.features = (&fs.Features{
 		CanHaveEmptyDirectories: true,
 	}).Fill(ctx, f)
+	// About is supported only if custom command is configured and valid
+	if cmdLine := strings.TrimSpace(f.opt.AboutCommand); cmdLine != "" {
+		cmdTokens, err := shlex.Split(cmdLine)
+		if err != nil {
+			fs.Errorf(f, "Failed to parse the about command")
+		} else if len(cmdTokens) > 0 {
+			f.aboutCmd = cmdTokens
+		}
+	}
+	if len(f.aboutCmd) == 0 {
+		f.features.About = nil
+	}
 	// set the pool drainer timer going
 	if f.opt.IdleTimeout > 0 {
 		f.drain = time.AfterFunc(time.Duration(opt.IdleTimeout), func() { _ = f.drainPool(ctx) })
@@ -959,6 +980,24 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 	return nil
 }
 
+// About gets quota information
+func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
+	command := f.aboutCmd
+	if len(command) == 0 {
+		return nil, errors.New("about is not supported")
+	}
+	cmd := exec.Command(command[0], command[1:]...)
+	buf, err := cmd.Output()
+	if err != nil {
+		return nil, errors.Wrap(err, "running the about command")
+	}
+	var usage fs.Usage
+	if err = json.Unmarshal(buf, &usage); err != nil {
+		return nil, errors.Wrap(err, "parsing the about json")
+	}
+	return &usage, nil
+}
+
 // ------------------------------------------------------------
 
 // Fs returns the parent Fs
@@ -1206,5 +1245,6 @@ var (
 	_ fs.DirMover    = &Fs{}
 	_ fs.PutStreamer = &Fs{}
 	_ fs.Shutdowner  = &Fs{}
+	_ fs.Abouter     = &Fs{}
 	_ fs.Object      = &Object{}
 )

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	github.com/go-chi/chi/v5 v5.0.3
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
+	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/google/uuid v1.3.0
 	github.com/hanwen/go-fuse/v2 v2.1.0
 	github.com/iguanesolutions/go-systemd/v5 v5.1.0

--- a/go.sum
+++ b/go.sum
@@ -299,6 +299,8 @@ github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
+github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=


### PR DESCRIPTION
#### What is the purpose of this change?

FTP servers do not have a standard way to report used or free space. The rclone FTP client consequently does not implement the About feature. This locks it from being used in Union with space-related policies.

However many clouds provide FTP and SFTP together. While SFTP on average has lower transfer speed than FTP, it's more widespread and usually **SFTP is able to report used/free space**. Here comes the idea to fill another gap in the FTP backend on the way to finally become a first class citizen in the rclone ecosystem.

This patch adds new `--ftp-about-command "shell command"` flag and related backend option allowing users to transparently submit output of `rclone about --json twin_sftp_remote:` as a hint for `rclone about ftp_remote:`
In fact, any shell command can be used if its output is compatible with rclone's **about report (json)**.

@ncw Please review. Do you think it looks too niche?

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
