### PR TITLE
ftp: set correct encoding in integration tests with ProFtpd,PureFtpd,VsFtpd

### DIFF
--- a/docs/content/ftp.md
+++ b/docs/content/ftp.md
@@ -317,3 +317,7 @@ Not all FTP servers can have all characters in file names, for example:
 | --------- |:--------------------:|
 | proftpd   | `*`                  |
 | pureftpd  | `\ [ ]`              |
+
+This backend's interactive configuration wizard provides a selection of
+sensible encoding settings for major FTP servers: ProFTPd, PureFTPd, VsFTPd.
+Just hit a selection number when prompted.

--- a/fstest/test_all/config.yaml
+++ b/fstest/test_all/config.yaml
@@ -213,18 +213,12 @@ backends:
    fastlist: false
  - backend:  "ftp"
    remote:   "TestFTPProftpd:"
-   ignore:
-     - TestIntegration/FsMkdir/FsEncoding/punctuation
    fastlist: false
- # - backend:  "ftp"
- #   remote:   "TestFTPVsftpd:"
- #   ignore:
- #     - TestIntegration/FsMkdir/FsEncoding/punctuation
- #   fastlist: false
  - backend:  "ftp"
    remote:   "TestFTPPureftpd:"
-   ignore:
-     - TestIntegration/FsMkdir/FsEncoding/punctuation
+   fastlist: false
+ - backend:  "ftp"
+   remote:   "TestFTPVsftpd:"
    fastlist: false
  - backend:  "ftp"
    remote:   "TestFTPRclone:"


### PR DESCRIPTION
#### What is the purpose of this change?

PR #5589 established recommended encodings to use with major FTP servers: ProFtpd, PureFtpd, VsFtpd.
This PR updates integration tests correspondingly.

I also mention interactive encoding selector in the FTP backend documentation (forgot it earlier).

@ncw 
Please update `encoding` of the FTP test remotes on the integration box as recommended by https://github.com/rclone/rclone/pull/5589#issuecomment-916364725:
```
[TestFTPProftpd]
type = ftp
host = localhost
port = CI_FTP_PORT_PROFTPD
user = rclone
pass = CI_FTP_PASS_OBSCURED
encoding = Asterisk,Ctl,Dot,Slash

[TestFTPPureftpd]
type = ftp
host = localhost
port = CI_FTP_PORT_PUREFTPD
user = rclone
pass = CI_FTP_PASS_OBSCURED
encoding = BackSlash,Ctl,Del,Dot,RightSpace,Slash,SquareBracket

[TestFTPVsftpd]
type = ftp
host = localhost
port = CI_FTP_PORT_VSFTPD
user = rclone
pass = CI_FTP_PASS_OBSCURED
encoding = Ctl,LeftPeriod,Slash
```

#### Was the change discussed in an issue or in the forum before?

Proposed by @ncw at https://github.com/rclone/rclone/pull/5589#pullrequestreview-768268939

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
