### PR TITLE
rc: error on web GUI update won't be fatal - fixes #5385

### DIFF
--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -86,7 +86,7 @@ func newServer(ctx context.Context, opt *rc.Options, mux *http.ServeMux) *Server
 		fileHandler = http.FileServer(http.Dir(opt.Files))
 	} else if opt.WebUI {
 		if err := webgui.CheckAndDownloadWebGUIRelease(opt.WebGUIUpdate, opt.WebGUIForceUpdate, opt.WebGUIFetchURL, config.GetCacheDir()); err != nil {
-			log.Fatalf("Error while fetching the latest release of Web GUI: %v", err)
+			fs.Errorf(nil, "Error while fetching the latest release of Web GUI: %v", err)
 		}
 		if opt.NoAuth {
 			opt.NoAuth = false


### PR DESCRIPTION
I have zero knowledge of Go and of the code structure of rclone so please review carefully, I might have done something wrong.

#### What is the purpose of this change?

Makes the error about retrieving latest web GUI version non-fatal; If there is no network rclone will fail regardless.
The API can return 403 if for some reason the rate limit is exceeded and this will make rclone fail, but there is no reason it should.

#### Was the change discussed in an issue or in the forum before?

#5385 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
