### PR TITLE
seafile: fix error when not configured for 2fa

### DIFF
--- a/backend/seafile/seafile.go
+++ b/backend/seafile/seafile.go
@@ -310,7 +310,8 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 
 	is2faEnabled, _ := m.Get(config2FA)
 	if is2faEnabled != "true" {
-		return nil, errors.New("two-factor authentication is not enabled on this account")
+		// no need to do anything here
+		return nil, nil
 	}
 
 	username, _ := m.Get(configUser)

--- a/backend/seafile/seafile_internal_test.go
+++ b/backend/seafile/seafile_internal_test.go
@@ -136,6 +136,7 @@ func Test2FAStateMachine(t *testing.T) {
 		expectErrorMessage string
 		expectResult       string
 		expectFail         bool
+		expectNil          bool
 	}{
 		{
 			name:       "no url",
@@ -144,16 +145,16 @@ func Test2FAStateMachine(t *testing.T) {
 			expectFail: true,
 		},
 		{
-			name:       "2fa not set",
-			mapper:     configmap.Simple{"url": "http://localhost/"},
-			input:      fs.ConfigIn{State: ""},
-			expectFail: true,
-		},
-		{
 			name:       "unknown state",
 			mapper:     configmap.Simple{"url": "http://localhost/", "2fa": "true", "user": "username"},
 			input:      fs.ConfigIn{State: "unknown"},
 			expectFail: true,
+		},
+		{
+			name:      "2fa not set",
+			mapper:    configmap.Simple{"url": "http://localhost/"},
+			input:     fs.ConfigIn{State: ""},
+			expectNil: true,
 		},
 		{
 			name:        "no password in config",
@@ -213,6 +214,10 @@ func Test2FAStateMachine(t *testing.T) {
 			if fixture.expectFail {
 				require.Error(t, err)
 				t.Log(err)
+				return
+			}
+			if fixture.expectNil {
+				require.Nil(t, output)
 				return
 			}
 			assert.Equal(t, fixture.expectState, output.State)


### PR DESCRIPTION

#### What is the purpose of this change?

Fix error message triggered with creating a new Seafile remote with 2fa **not** activated.
(the remote was actually created but the error message was puzzling to say the least 😄 )

#### Was the change discussed in an issue or in the forum before?

Issue #5660, also in the forum: https://forum.rclone.org/t/seafile-fatal-error-two-factor-authentication-is-not-enabled-on-this-account/26771

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
