### PR TITLE
serve/docker: fix octal umask

### DIFF
--- a/cmd/serve/docker/options.go
+++ b/cmd/serve/docker/options.go
@@ -1,6 +1,7 @@
 package docker
 
 import (
+	"strconv"
 	"strings"
 
 	"github.com/rclone/rclone/cmd/mountlib"
@@ -270,8 +271,14 @@ func getVFSOption(vfsOpt *vfscommon.Options, opt rc.Params, key string) (ok bool
 
 	// unprefixed unix-only vfs options
 	case "umask":
-		intVal, err = opt.GetInt64(key)
-		vfsOpt.Umask = int(intVal)
+		// GetInt64 doesn't support the `0octal` umask syntax - parse locally
+		var strVal string
+		if strVal, err = opt.GetString(key); err == nil {
+			var longVal int64
+			if longVal, err = strconv.ParseInt(strVal, 0, 0); err == nil {
+				vfsOpt.Umask = int(longVal)
+			}
+		}
 	case "uid":
 		intVal, err = opt.GetInt64(key)
 		vfsOpt.UID = uint32(intVal)


### PR DESCRIPTION
#### What is the purpose of this change?

The `umask` volume option was intepreted as decimal even if it started from octal `0`.
This fixes it so e.g. `0022` is interpreted as octal.

#### Was the change discussed in an issue or in the forum before?

Fixes #5617

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

See manual test at https://github.com/rclone/rclone/issues/5617#issuecomment-937700423
`umask` is documented elsewhere https://rclone.org/commands/rclone_mount/#options

@ncw PTAL