### PR TITLE
docs: toc styling

### DIFF
--- a/docs/layouts/chrome/menu.html
+++ b/docs/layouts/chrome/menu.html
@@ -5,6 +5,7 @@
   </div>
   <div class="card-body">
     {{ .TableOfContents }}
+    <p></p>
   </div>
 </div>
 {{end}}

--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -174,11 +174,11 @@ a.badge-primary.focus, a.badge-primary:focus {
 nav#TableOfContents ul {
     list-style-type: none;
     padding: 0.0rem;
-    margin: 0.5rem;
+    margin: 0rem 0.5rem 0rem 0.5rem;
     font-size: 90%;
     white-space: nowrap;
-    overflow:hidden;
+    overflow: hidden;
 }
 nav#TableOfContents ul:hover {
-    overflow:visible;
+    overflow: visible;
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Tweaking the styling of the Table of Contents (TOC) box.

On several pages the TOC behaves a bit strange on mouse-over. At least in my chromium-based browser. Seems to be where there is a TOC, but it is not very large, such as many of the backend docs. See e.g. [fichier](https://rclone.org/fichier/). If you hover over any of the entries, the TOC box "jerks" and shrinks a little. Were unable to track down the exact cause of this (I'm not a css guru), but found a workaround. I also noticed that the margins are a bit different in the TOC compared to the "Share and Enjoy" and "Links" boxes, so fixed this as well.

What I did was to change the margin of the `nav#TableOfContents ul` element in css, removing (setting 0) margin on top and bottom. Then added a dummy `<p></p>` element at the end. The contents of the other menu boxes are wrapped in a `<p class="menu">` element, and it gets 1rem margin at bottom from the bootstrap styling. Adding the dummy `p` makes the TOC margins more similar. But more importantly; it avoids the strange hover-over behavior. I were not able to solve these two things with just styling on the `TableOfContents`, or else I would not have used the dummy `p` element.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
