### PR TITLE
filter: add `{{ regexp }}` syntax to pattern matches - fixes #4074

### DIFF
--- a/fs/filter/glob.go
+++ b/fs/filter/glob.go
@@ -19,7 +19,7 @@ func GlobToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
 	}
 	if strings.HasPrefix(glob, "/") {
 		glob = glob[1:]
-		_, _ = re.WriteRune('^')
+		_ = re.WriteByte('^')
 	} else {
 		_, _ = re.WriteString("(^|/)")
 	}
@@ -38,13 +38,43 @@ func GlobToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
 		consecutiveStars = 0
 		return nil
 	}
+	overwriteLastChar := func(c byte) {
+		buf := re.Bytes()
+		buf[len(buf)-1] = c
+	}
 	inBraces := false
 	inBrackets := 0
 	slashed := false
+	inRegexp := false    // inside {{ ... }}
+	inRegexpEnd := false // have received }} waiting for more
+	var next, last rune
 	for _, c := range glob {
+		next, last = c, next
 		if slashed {
 			_, _ = re.WriteRune(c)
 			slashed = false
+			continue
+		}
+		if inRegexpEnd {
+			if c == '}' {
+				// Regexp is ending with }} choose longest segment
+				// Replace final ) with }
+				overwriteLastChar('}')
+				_ = re.WriteByte(')')
+				continue
+			} else {
+				inRegexpEnd = false
+			}
+		}
+		if inRegexp {
+			if c == '}' && last == '}' {
+				inRegexp = false
+				inRegexpEnd = true
+				// Replace final } with )
+				overwriteLastChar(')')
+			} else {
+				_, _ = re.WriteRune(c)
+			}
 			continue
 		}
 		if c != '*' {
@@ -78,24 +108,30 @@ func GlobToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
 			return nil, fmt.Errorf("mismatched ']' in glob %q", glob)
 		case '{':
 			if inBraces {
-				return nil, fmt.Errorf("can't nest '{' '}' in glob %q", glob)
+				if last == '{' {
+					inRegexp = true
+					inBraces = false
+				} else {
+					return nil, fmt.Errorf("can't nest '{' '}' in glob %q", glob)
+				}
+			} else {
+				inBraces = true
+				_ = re.WriteByte('(')
 			}
-			inBraces = true
-			_, _ = re.WriteRune('(')
 		case '}':
 			if !inBraces {
 				return nil, fmt.Errorf("mismatched '{' and '}' in glob %q", glob)
 			}
-			_, _ = re.WriteRune(')')
+			_ = re.WriteByte(')')
 			inBraces = false
 		case ',':
 			if inBraces {
-				_, _ = re.WriteRune('|')
+				_ = re.WriteByte('|')
 			} else {
 				_, _ = re.WriteRune(c)
 			}
 		case '.', '+', '(', ')', '|', '^', '$': // regexp meta characters not dealt with above
-			_, _ = re.WriteRune('\\')
+			_ = re.WriteByte('\\')
 			_, _ = re.WriteRune(c)
 		default:
 			_, _ = re.WriteRune(c)
@@ -111,7 +147,10 @@ func GlobToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
 	if inBraces {
 		return nil, fmt.Errorf("mismatched '{' and '}' in glob %q", glob)
 	}
-	_, _ = re.WriteRune('$')
+	if inRegexp {
+		return nil, fmt.Errorf("mismatched '{{' and '}}' in glob %q", glob)
+	}
+	_ = re.WriteByte('$')
 	result, err := regexp.Compile(re.String())
 	if err != nil {
 		return nil, fmt.Errorf("bad glob pattern %q (regexp %q): %w", glob, re.String(), err)
@@ -120,8 +159,10 @@ func GlobToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
 }
 
 var (
-	// Can't deal with / or ** in {}
-	tooHardRe = regexp.MustCompile(`{[^{}]*(\*\*|/)[^{}]*}`)
+	// Can't deal with
+	//   / or ** in {}
+	//   {{ regexp }}
+	tooHardRe = regexp.MustCompile(`({[^{}]*(\*\*|/)[^{}]*})|\{\{|\}\}`)
 
 	// Squash all /
 	squashSlash = regexp.MustCompile(`/{2,}`)


### PR DESCRIPTION
There has been a desire from more advanced rclone users to have regexp filtering as well as the glob filtering.

This patch adds regexp filtering using this syntax `{{ regexp }}` which is currently a syntax error, so is backwards compatibile.

This means regexps can be used everywhere globs can be used, and that they also can be mixed with globs in the same pattern, eg `*.{{jpe?g}}`

See: #4074 for background

Fixes #4074 

@ivandeex and @albertony  would appreciate your feedback on this - is this a good idea or not?