### PR TITLE
docs: align dropdown items when icons have different sizes

### DIFF
--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -142,6 +142,12 @@ h5 {
     font-size: 95%;
 }
 
+/* Align dropdown items when icons have different sizes */
+.dropdown-item .fa, .fab, .fad, .fal, .far, .fas {
+    width: 20px;
+    text-align: center;
+}
+
 /* Make primary buttons rclone colours. Should learn sass and do this the proper way! */
 .btn-primary {
     background-color: #3f79ad;


### PR DESCRIPTION
#### What is the purpose of this change?

The "Storage systems" drop down looks a little bit "messy", due to icons having different sizes. This adds a custom css to align the icons and the following text labels.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
