### PR TITLE
librclone: add RcloneFreeString function

### DIFF
--- a/librclone/README.md
+++ b/librclone/README.md
@@ -31,6 +31,7 @@ For documentation see the Go documentation for:
 - [RcloneInitialize](https://pkg.go.dev/github.com/rclone/rclone/librclone#RcloneInitialize)
 - [RcloneFinalize](https://pkg.go.dev/github.com/rclone/rclone/librclone#RcloneFinalize)
 - [RcloneRPC](https://pkg.go.dev/github.com/rclone/rclone/librclone#RcloneRPC)
+- [RcloneFreeString](https://pkg.go.dev/github.com/rclone/rclone/librclone#RcloneFreeString)
 
 ### C Example
 

--- a/librclone/librclone.go
+++ b/librclone/librclone.go
@@ -20,6 +20,8 @@
 package main
 
 /*
+#include <stdlib.h>
+
 struct RcloneRPCResult {
 	char*	Output;
 	int	Status;
@@ -28,6 +30,8 @@ struct RcloneRPCResult {
 import "C"
 
 import (
+	"unsafe"
+
 	"github.com/rclone/rclone/librclone/librclone"
 
 	_ "github.com/rclone/rclone/backend/all"   // import all backends
@@ -77,6 +81,18 @@ func RcloneRPC(method *C.char, input *C.char) (result C.struct_RcloneRPCResult) 
 	result.Output = C.CString(output)
 	result.Status = C.int(status)
 	return result
+}
+
+// RcloneFreeString may be used to free the string returned by RcloneRPC
+//
+// If the caller has access to the C standard library, the free function can
+// normally be called directly instead. In some cases the caller uses a
+// runtime library which is not compatible, and then this function can be
+// used to release the memory with the same library that allocated it.
+//
+//export RcloneFreeString
+func RcloneFreeString(str *C.char) {
+	C.free(unsafe.Pointer(str))
 }
 
 // do nothing here - necessary for building into a C library


### PR DESCRIPTION
#### What is the purpose of this change?

Export new function `RcloneFreeString` from librclone, to `free` strings returned by `RcloneRPC`.

This basically revives PR #5362, which was closed without being merged (just because it was "abandoned"?).

In the original PR the reasoning was that it would help in a C# client that did not have a convenient way of freeing the string. In my case it is a C++ client, on Windows, using Visual C++ compiler: Building librclone with go, cgo and mingw gcc produces a dll depending on the older C runtime library `MSVCRT.dll`. Building a client application with latest Visual Studio produces an exe depending on `VCRuntime140.dll` and `UCRTBase.dll`. I'm able to get this to work, except attempting to call free on the strings from `RcloneRPC` triggers HeapFailure. Calling the new RcloneFreeString avoids this, because it ensures that `malloc` and `free` are performed from within the same library - using the same C runtime library.

Ideally I should build a `librclone.dll` using the same VCRuntime as my client application, but I don't know yet how to get this through the go-cgo-mingw-gcc "pipeline". But in any case, I think it is good practice (if not a requirement - on Windows) for a plain C API to pair memory allocation and deallocation within the same library boundary.

(I haven't tried librclone before, but now in the early stages of setting up a test bench with C++ and CMake, primarly Windows but possibly cross platform. May result in docs/example PR later on).

#### Was the change discussed in an issue or in the forum before?

#5362

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
