### PR TITLE
crypt: return crypt-wrapped object even with no-data-encryption

### DIFF
--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -363,7 +363,11 @@ type putFn func(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ..
 // put implements Put or PutStream
 func (f *Fs) put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options []fs.OpenOption, put putFn) (fs.Object, error) {
 	if f.opt.NoDataEncryption {
-		return put(ctx, in, f.newObjectInfo(src, nonce{}), options...)
+		o, err := put(ctx, in, f.newObjectInfo(src, nonce{}), options...)
+		if err == nil && o != nil {
+			o = f.newObject(o)
+		}
+		return o, err
 	}
 
 	// Encrypt the data into wrappedIn


### PR DESCRIPTION
#### What is the purpose of this change?

In presence of `no_data_encryption` the Crypt's Put method used to over-optimize
and returned base object. This patch makes it return Crypt-wrapped object now.

#### Was the change discussed in an issue or in the forum before?

Fixes #5498

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
