### PR TITLE
lib/http: Fix bad username check in single auth secret provider

### DIFF
--- a/lib/http/auth/auth.go
+++ b/lib/http/auth/auth.go
@@ -29,6 +29,8 @@ To create an htpasswd file:
 The password file can be updated while rclone is running.
 
 Use --realm to set the authentication realm.
+
+Use --salt to change the password hashing salt from the default.
 `
 
 // CustomAuthFn if used will be used to authenticate user, pass. If an error
@@ -43,6 +45,7 @@ type Options struct {
 	Realm     string       // realm for authentication
 	BasicUser string       // single username for basic auth if not using Htpasswd
 	BasicPass string       // password for BasicUser
+	Salt      string       // password hashing salt
 	Auth      CustomAuthFn `json:"-"` // custom Auth (not set by command line flags)
 }
 
@@ -53,14 +56,16 @@ func Auth(opt Options) http.Middleware {
 	} else if opt.HtPasswd != "" {
 		return HtPasswdAuth(opt.HtPasswd, opt.Realm)
 	} else if opt.BasicUser != "" {
-		return SingleAuth(opt.BasicUser, opt.BasicPass, opt.Realm)
+		return SingleAuth(opt.BasicUser, opt.BasicPass, opt.Realm, opt.Salt)
 	}
 	return nil
 }
 
 // Options set by command line flags
 var (
-	Opt = Options{}
+	Opt = Options{
+		Salt: "dlPL2MqE",
+	}
 )
 
 // AddFlagsPrefix adds flags for http/auth
@@ -69,6 +74,7 @@ func AddFlagsPrefix(flagSet *pflag.FlagSet, prefix string, Opt *Options) {
 	flags.StringVarP(flagSet, &Opt.Realm, prefix+"realm", "", Opt.Realm, "realm for authentication")
 	flags.StringVarP(flagSet, &Opt.BasicUser, prefix+"user", "", Opt.BasicUser, "User name for authentication.")
 	flags.StringVarP(flagSet, &Opt.BasicPass, prefix+"pass", "", Opt.BasicPass, "Password for authentication.")
+	flags.StringVarP(flagSet, &Opt.Salt, prefix+"salt", "", Opt.Salt, "Password hashing salt")
 }
 
 // AddFlags adds flags for the http/auth

--- a/lib/http/auth/basic.go
+++ b/lib/http/auth/basic.go
@@ -85,9 +85,9 @@ func HtPasswdAuth(path, realm string) httplib.Middleware {
 }
 
 // SingleAuth instantiates middleware that authenticates for a single user
-func SingleAuth(user, pass, realm string) httplib.Middleware {
+func SingleAuth(user, pass, realm, salt string) httplib.Middleware {
 	fs.Infof(nil, "Using --user %s --pass XXXX as authenticated user", user)
-	pass = string(auth.MD5Crypt([]byte(pass), []byte("dlPL2MqE"), []byte("$1$")))
+	pass = string(auth.MD5Crypt([]byte(pass), []byte(salt), []byte("$1$")))
 	secretProvider := func(u, r string) string {
 		if user == u {
 			return pass


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

SingleAuth authentication ignores the username due to a bad comparison.

@ivandeex Requested that the salt be factored out. Ideally the user should provide their own salt so that one rainbow table cant be used for all of rclone. I have factored it into a new `--salt` command line option.

#### Was the change discussed in an issue or in the forum before?

Resolves  #5707

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
