### PR TITLE
hashsum: treat hash values in sum file as case insensitive

### DIFF
--- a/cmd/checksum/checksum.go
+++ b/cmd/checksum/checksum.go
@@ -33,6 +33,8 @@ don't match.  It doesn't alter the file system.
 If you supply the |--download| flag, it will download the data from remote
 and calculate the contents hash on the fly.  This can be useful for remotes
 that don't support hashes or if you really want to check all the data.
+
+Note that hash values in the SUM file are treated as case insensitive.
 `, "|", "`") + check.FlagsHelp,
 	RunE: func(command *cobra.Command, args []string) error {
 		cmd.CheckArgs(3, 3, command, args)

--- a/cmd/hashsum/hashsum.go
+++ b/cmd/hashsum/hashsum.go
@@ -76,7 +76,7 @@ Then
 
     $ rclone hashsum MD5 remote:path
 
-Note that hash names are case insensitive.
+Note that hash names are case insensitive and values are output in lower case.
 `,
 	RunE: func(command *cobra.Command, args []string) error {
 		cmd.CheckArgs(0, 2, command, args)

--- a/docs/content/commands/rclone_checksum.md
+++ b/docs/content/commands/rclone_checksum.md
@@ -20,6 +20,8 @@ If you supply the `--download` flag, it will download the data from remote
 and calculate the contents hash on the fly.  This can be useful for remotes
 that don't support hashes or if you really want to check all the data.
 
+Note that hash values in the SUM file are treated as case insensitive.
+
 If you supply the `--one-way` flag, it will only check that files in
 the source match the files in the destination, not the other way
 around. This means that extra files in the destination that are not in

--- a/docs/content/commands/rclone_hashsum.md
+++ b/docs/content/commands/rclone_hashsum.md
@@ -38,7 +38,7 @@ Then
 
     $ rclone hashsum MD5 remote:path
 
-Note that hash names are case insensitive.
+Note that hash names are case insensitive and values are output in lower case.
 
 
 ```

--- a/fs/operations/check_test.go
+++ b/fs/operations/check_test.go
@@ -330,10 +330,12 @@ func testCheckSum(t *testing.T, download bool) {
 
 	hashType := hash.MD5
 	const (
-		testString1 = "Hello, World!"
-		testDigest1 = "65a8e27d8879283831b664bd8b7f0ad4"
-		testString2 = "I am the walrus"
-		testDigest2 = "87396e030ef3f5b35bbf85c0a09a4fb3"
+		testString1      = "Hello, World!"
+		testDigest1      = "65a8e27d8879283831b664bd8b7f0ad4"
+		testDigest1Upper = "65A8E27D8879283831B664BD8B7F0AD4"
+		testString2      = "I am the walrus"
+		testDigest2      = "87396e030ef3f5b35bbf85c0a09a4fb3"
+		testDigest2Mixed = "87396e030EF3f5b35BBf85c0a09a4FB3"
 	)
 
 	type wantType map[string]string
@@ -428,7 +430,7 @@ func testCheckSum(t *testing.T, download bool) {
 	}
 
 	check := func(runNo, wantChecks, wantErrors int, wantResults wantType) {
-		runName := fmt.Sprintf("move%d", runNo)
+		runName := fmt.Sprintf("subtest%d", runNo)
 		t.Run(runName, func(t *testing.T) {
 			checkRun(runNo, wantChecks, wantErrors, wantResults)
 		})
@@ -517,6 +519,23 @@ func testCheckSum(t *testing.T, download bool) {
 		"missingondst": "orange\n",
 		"match":        "banana\n",
 		"differ":       "potato\n",
+		"error":        "",
+	})
+
+	// test mixed-case checksums
+	file1 = makeFile("banana", testString1)
+	file2 = makeFile("potato", testString2)
+	fcsums = makeSums(operations.HashSums{
+		"banana": testDigest1Upper,
+		"potato": testDigest2Mixed,
+	})
+	fstest.CheckItems(t, r.Fremote, fcsums, file1, file2)
+	check(7, 2, 0, wantType{
+		"combined":     "= banana\n= potato\n",
+		"missingonsrc": "",
+		"missingondst": "",
+		"match":        "banana\npotato\n",
+		"differ":       "",
 		"error":        "",
 	})
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Treat hash values in sum file as case insensitive

Also warn duplicate file paths in sum files.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/rclone-check-sum/25566/45

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

@ncw PTAL