### PR TITLE
docs: remove application type "other" from drive.md

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -1320,8 +1320,7 @@ of "External" above, but this has not been tested/documented so far).
 6.  Click on the "+ CREATE CREDENTIALS" button at the top of the screen,
 then select "OAuth client ID".
 
-7. Choose an application type of "Desktop app" if you using a Google account or "Other" if 
-you using a GSuite account and click "Create". (the default name is fine)
+7. Choose an application type of "Desktop app" and click "Create". (the default name is fine)
 
 8. It will show you a client ID and client secret. Make a note of these.
 


### PR DESCRIPTION
The application type "other" is not an option anymore.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

remove application type "other" from drive.md

#### Was the change discussed in an issue or in the forum before?

no

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
