### PR TITLE
build: force utf8 when updating backend docs from python

### DIFF
--- a/bin/make_backend_docs.py
+++ b/bin/make_backend_docs.py
@@ -33,7 +33,7 @@ def alter_doc(backend):
         raise ValueError("Didn't find doc file %s" % (doc_file,))
     new_file = doc_file+"~new~"
     altered = False
-    with open(doc_file, "r") as in_file, open(new_file, "w") as out_file:
+    with open(doc_file, "r", encoding="utf_8") as in_file, open(new_file, "w", encoding="utf_8") as out_file:
         in_docs = False
         for line in in_file:
             if not in_docs:


### PR DESCRIPTION
#### What is the purpose of this change?

Force use of UTF-8 when reading and writing backend doc .md files from python script make_backend_docs.py.

The default in Python is to use os locale, as returned by `locale.getpreferredencoding()`, but on a typical Windows computer in western europe this returns `cp1252`. The script will then report errors such as:

`'charmap' codec can't decode byte 0x8f in position 2276: character maps to <undefined>`

#### Was the change discussed in an issue or in the forum before?

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
