### PR TITLE
librclone: add missing mount/* rc methods

### DIFF
--- a/librclone/librclone/librclone.go
+++ b/librclone/librclone/librclone.go
@@ -22,6 +22,9 @@ import (
 	"github.com/rclone/rclone/fs/log"
 	"github.com/rclone/rclone/fs/rc"
 	"github.com/rclone/rclone/fs/rc/jobs"
+
+	_ "github.com/rclone/rclone/cmd/mount"
+	_ "github.com/rclone/rclone/cmd/mountlib"
 )
 
 // Initialize initializes rclone as a library


### PR DESCRIPTION

#### What is the purpose of this change?

Enable `mount/*` endpoints when using `librclone`. A couple additional imports were needed in `librclone.go`. I've used this for a little while and haven't had any problems so far.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/missing-endpoints-when-using-librclone/26295/2

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
