### PR TITLE
chunker: fix md5all test for no-meta test remotes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ fuzz-build.zip
 *.orig
 *.rej
 Thumbs.db
+__pycache__

--- a/backend/chunker/chunker_internal_test.go
+++ b/backend/chunker/chunker_internal_test.go
@@ -695,7 +695,7 @@ func testMetadataInput(t *testing.T, f *Fs) {
 
 // Test that chunker refuses to change on objects with future/unknown metadata
 func testFutureProof(t *testing.T, f *Fs) {
-	if f.opt.MetaFormat == "none" {
+	if !f.useMeta {
 		t.Skip("this test requires metadata support")
 	}
 
@@ -865,9 +865,11 @@ func testChunkerServerSideMove(t *testing.T, f *Fs) {
 func testMD5AllSlow(t *testing.T, f *Fs) {
 	ctx := context.Background()
 	fsResult := deriveFs(ctx, t, f, "md5all", settings{
-		"chunk_size":  "1P",
-		"name_format": "*.#",
-		"hash_type":   "md5all",
+		"chunk_size":   "1P",
+		"name_format":  "*.#",
+		"hash_type":    "md5all",
+		"transactions": "rename",
+		"meta_format":  "simplejson",
 	})
 	chunkFs, ok := fsResult.(*Fs)
 	require.True(t, ok, "fs must be a chunker remote")


### PR DESCRIPTION
#### What is the purpose of this change?

The Md5All chunker test did not take into account test remotes without metadata.
This patch enforces test preconditions.

#### Was the change discussed in an issue or in the forum before?

#5734 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

@ncw PTAL