### PR TITLE
test: ignore integration test TestCopyFileMaxTransfer on Google Drive

### DIFF
--- a/fstest/test_all/config.yaml
+++ b/fstest/test_all/config.yaml
@@ -24,6 +24,8 @@ backends:
  - backend:  "crypt"
    remote:   "TestCryptDrive:"
    fastlist: true
+   ignore:
+     - TestCopyFileMaxTransfer
  - backend:  "crypt"
    remote:   "TestCryptSwift:"
    fastlist: false
@@ -106,6 +108,10 @@ backends:
  - backend:  "drive"
    remote:   "TestDrive:"
    fastlist: true
+   ignore:
+     # Test with CutoffModeHard does not result in ErrorMaxTransferLimitReachedFatal
+     # because googleapi replaces it with a non-fatal error
+     - TestCopyFileMaxTransfer
  - backend:  "dropbox"
    remote:   "TestDropbox:"
    fastlist: false


### PR DESCRIPTION
#### What is the purpose of this change?

Test test TestCopyFileMaxTransfer fails because it expects a copy with MaxTransfer and CutoffModeHard should return fatal error, because this is thrown from accounting (ErrorMaxTransferLimitReachedFatal), but in case of Google Drive the external google API catches and replaces it with a non-fatal error:

```
pw.CloseWithError(fmt.Errorf("googleapi: Copy failed: %v", err))
```

(https://github.com/googleapis/google-api-go-client/blob/7290f25351cc90fdeb492127c98cc3fb023793d4/internal/gensupport/media.go#L140)

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/5734#issuecomment-946735296

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
