### PR TITLE
serve/docker: skip race test until we find a solution for deadlock

### DIFF
--- a/cmd/serve/docker/docker_test.go
+++ b/cmd/serve/docker/docker_test.go
@@ -1,3 +1,6 @@
+//go:build !race
+// +build !race
+
 package docker_test
 
 import (


### PR DESCRIPTION
#### What is the purpose of this change?

Race test of serve/docker experiences frequent deadlocks on Linux CI with go 1.17
**hindering other PR tests and beta builds**. It hurts to restart every CI build...
This patch will **temporarily** disable race test of serve/docker everywhere
until we find a permanent solution. I don't feel like I can find it right soon 😢 


#### Was the change discussed in an issue or in the forum before?

- #5738

Related to #5734

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have ~~added~~ `removed`  😈  tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

@ncw PTAL
