### PR TITLE
sync/test: ConcurrentTruncate test needs empty files - skip on uptobox

### DIFF
--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -2091,6 +2091,9 @@ func testSyncConcurrent(t *testing.T, subtest string) {
 	fstest.CheckItems(t, r.Fremote, itemsBefore...)
 	stats.ResetErrors()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
+	if err == fs.ErrorCantUploadEmptyFiles {
+		t.Skipf("Skip test because remote cannot upload empty files")
+	}
 	assert.NoError(t, err, "Sync must not return a error")
 	assert.False(t, stats.Errored(), "Low level errors must not have happened")
 	fstest.CheckItems(t, r.Fremote, itemsAfter...)


### PR DESCRIPTION
#### What is the purpose of this change?

Fix integration test on `uptobox` remote. The test wants to upload empty files which is impossible with uptobox. The test will skip itself after seeing the `can't do` error code.

See my comment below regarding failure of this test on Onedrive. It's a different beast.

#### Was the change discussed in an issue or in the forum before?

#5734

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
