### PR TITLE
config: allow reading from FIFO

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -755,7 +755,11 @@ editing the configuration file.
 The configuration file will typically contain login information, and
 should therefore have restricted permissions so that only the current user
 can read it. Rclone tries to ensure this when it writes the file.
-You may also choose to [encrypt](#configuration-encryption) the file.
+You may also choose to [encrypt](#configuration-encryption) the file. 
+Alternately, you can use [Mozilla SOPS](https://github.com/mozilla/sops) to
+encrypt the configuration file, and pass it in with decryption being transparently
+handled by SOPS, thus not needing password input - useful for cron.
+See [SOPS](#sops) for more information.
 
 When token-based authentication are used, the configuration file
 must be writable, because rclone needs to update the tokens inside it.
@@ -1987,6 +1991,21 @@ it will be relevant for commands that do operate on backends in
 general, but are used without referencing a stored remote, e.g.
 listing local filesystem paths, or
 [connection strings](#connection-strings): `rclone --config="" ls .`
+
+### SOPS
+
+Alternately, you can choose to encrypt the file externally with SOPS.
+The encrypted configuration file would then be passed in, like so:
+`sops exec-file $RCLONE_CONFIG "rclone --config={} $RCLONE_COMMAND`.
+
+One downside to this is that as it's passed in via FIFO, it's not available
+for Windows users, and also can't be reloaded since the pipe is closed as soon
+as it's read. SOPS includes a `--no-fifo` option that can be passed, which
+writes the decrypted file to a temporary location, and removes it as soon
+as the process has exited.
+
+The other downside is that you'll need to manually decrypt the file before
+it can be edited, either with `rclone config`, or manually.
 
 Developer options
 -----------------

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -758,7 +758,7 @@ can read it. Rclone tries to ensure this when it writes the file.
 You may also choose to [encrypt](#configuration-encryption) the file. 
 Alternately, you can use [Mozilla SOPS](https://github.com/mozilla/sops) to
 encrypt the configuration file, and pass it in with decryption being transparently
-handled by SOPS, thus not needing password input - useful for cron.
+handled by SOPS, thus not needing password input.
 See [SOPS](#sops) for more information.
 
 When token-based authentication are used, the configuration file

--- a/fs/config/configfile/configfile_test.go
+++ b/fs/config/configfile/configfile_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"runtime"
 	"strings"
-	"syscall"
 	"testing"
 
 	"github.com/rclone/rclone/fs/config"
@@ -243,34 +242,4 @@ func TestConfigFileNoConfig(t *testing.T) {
 	t.Run("NotFound", func(t *testing.T) {
 		testConfigFileNoConfig(t, "/notfound")
 	})
-}
-
-func TestConfigFileFIFO(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Named pipes are not supported on Windows")
-	}
-
-	fifoName := config.GetConfigPath() + ".fifo"
-	syscall.Mkfifo(fifoName, 0666)
-	ch := make(chan byte, 1)
-
-	defer func() {
-		assert.NoError(t, os.Remove(fifoName))
-	}()
-
-	go func() {
-		f, err := os.OpenFile(fifoName, os.O_WRONLY, os.ModeNamedPipe)
-		require.NoError(t, err)
-		f.Write([]byte(configData))
-		defer f.Close()
-	}()
-
-	go func() {
-		f, _ := os.OpenFile(fifoName, os.O_RDONLY, os.ModeNamedPipe)
-		b, _ := ioutil.ReadAll(f)
-		assert.Equal(t, configData, string(b))
-		f.Close()
-		ch <- 1
-	}()
-	<-ch
 }

--- a/fs/config/configfile/configfile_unix_test.go
+++ b/fs/config/configfile/configfile_unix_test.go
@@ -1,0 +1,135 @@
+// Specific Unix-only tests
+
+//go:build !windows
+// +build !windows
+
+package configfile
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func WriteToPipe(name string, data string) {
+	time.Sleep(100 * time.Millisecond)
+	f, err := os.OpenFile(name, os.O_WRONLY, os.ModeNamedPipe)
+	if err != nil {
+		panic(err)
+	}
+	f.Write([]byte(data))
+	f.Close()
+}
+
+func FillStorageFromPipe(name string, stor *Storage, wg *sync.WaitGroup) {
+	defer wg.Done()
+	time.Sleep(100 * time.Millisecond)
+	f, err := os.OpenFile(name, os.O_RDONLY|syscall.O_NONBLOCK, os.ModeNamedPipe)
+	if err != nil {
+		panic(err)
+	}
+	data, err := ioutil.ReadAll(f)
+	var b bytes.Buffer
+	stor.dataReader = bufio.NewWriter(&b)
+	//io.Copy(stor.dataReader, bytes.NewReader(data))
+	if err != nil {
+		panic(err)
+	}
+	f.Close()
+}
+
+// b rclone/fs/config/configfile/configfile_unix_test.go:
+func TestConfigFileFIFO(t *testing.T) {
+	var wg sync.WaitGroup
+	wg.Add(1)
+	fifoName := config.GetConfigPath() + ".fifo"
+	require.NoError(t, syscall.Mkfifo(fifoName, 0600))
+
+	savedPath := config.GetConfigPath()
+	config.SetConfigPath(fifoName)
+	defer config.SetConfigPath(savedPath)
+	data := &Storage{}
+
+	go WriteToPipe(fifoName, configData)
+	go FillStorageFromPipe(fifoName, data, &wg)
+
+	loadErr := data.Load()
+	assert.NoError(t, loadErr)
+
+	buf := new(bytes.Buffer)
+	io.Copy(buf, data.dataReader)
+	assert.Equal(t, configData, buf.String())
+
+	wg.Wait()
+	defer func() {
+		assert.NoError(t, os.Remove(fifoName))
+	}()
+}
+
+/*
+testData := "[sect1]\nvar1=data1\n"
+
+// sops creates fifo BEFORE exec, right?
+testFifoFd, err := mkfifo(testFifoPath)
+go func() {
+   // but sops can be slow to fill fifo, right?
+   time.Sleep(100 * time.Millisecond) // simulate slow sops
+  ... Write(testFifo, testData) ...
+  wg.Done()
+}()
+
+// wg.Wait WOULD be here if SOPS guaranteed to finish writing BEFORE exec - but I assume it can be lazy, right?
+// wg.Wait()
+
+// point rclone at test fifo - just for test
+savedPath := config.GetConfigPath()
+config.SetConfigPath(testFifoPath)
+defer func() {
+	config.SetConfigPath(savedPath)
+}()
+
+stor := &configfile.Storage{}
+err := stor.Load() // test must not stuck here!
+assert.NoError(err) // must be able to read fifo!
+
+// Wait being here means that Sops might delay writing - I assume yes
+wg.Wait()
+
+// ReadAll in _loadFifo must wait till the data end, **but not get stuck**!
+// will it get stuck if sops is keeping fifo open until exec end?
+// if it deadlocks,  then ReadAll in _loadFifo must be replaced by something else,
+// something that exits after a reasonable timeout, e.g. 1-2 seconds (will sops write longer?)
+
+// we get here if Load didn't deadlock
+// that's fine, but did it read FULL contents? let's check
+// please fix this part after me!
+// stor.dataReader might have been already emptied by _load!
+// if yes, then instead of dataReader you'd better pass dataBytes!
+assert.Equal(testData, readAll(stor.dataReader))
+
+// more detailed read test
+val1, err := stor.GetValue("sect1","val1")
+assert.NoError...
+assert.Equal("data1",val1)
+
+// writing to fifo must fail or warn loudly - see comment below
+errSet := stor.SetValue("sect1","val1","data2")
+// assert.Error(errSet)
+
+// sops will remove fifo only AFTER rclone exits, right?
+_ = testFifoFd.Close()
+_ = os.Remove(testFifoPath)
+
+// etc etc
+
+*/

--- a/fs/config/crypt_test.go
+++ b/fs/config/crypt_test.go
@@ -103,7 +103,7 @@ func TestConfigLoadEncryptedFailures(t *testing.T) {
 	err = config.Data().Load()
 	require.Error(t, err)
 
-	// This file contains invalid base64 characters.
+	// This file's header starts with RCLONE_ENCRYPT_V1 instead of V0.
 	assert.NoError(t, config.SetConfigPath("./testdata/enc-too-new.conf"))
 	err = config.Data().Load()
 	require.Error(t, err)

--- a/fs/config/crypt_test.go
+++ b/fs/config/crypt_test.go
@@ -103,7 +103,7 @@ func TestConfigLoadEncryptedFailures(t *testing.T) {
 	err = config.Data().Load()
 	require.Error(t, err)
 
-	// This file's header starts with RCLONE_ENCRYPT_V1 instead of V0.
+	// This file contains invalid base64 characters.
 	assert.NoError(t, config.SetConfigPath("./testdata/enc-too-new.conf"))
 	err = config.Data().Load()
 	require.Error(t, err)

--- a/fstest/testserver/init.d/TestHdfs
+++ b/fstest/testserver/init.d/TestHdfs
@@ -25,6 +25,7 @@ start() {
     echo type=hdfs
     echo namenode=127.0.0.1:8020
     echo username=root
+    echo _connect=${namenode}
 }
 stop() {
     if status ; then


### PR DESCRIPTION
#### What is the purpose of this change?

To fix [Issue #5744](https://github.com/rclone/rclone/issues/5744), which prevents rclone from reading in from named pipes.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/config-not-read-from-fifo-anymore/24415/13

Fixes #5744

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
-    ^ See comment for test.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
