### PR TITLE
librclone: add support for mount commands

### DIFF
--- a/librclone/README.md
+++ b/librclone/README.md
@@ -13,7 +13,7 @@ The shims are a thin wrapper over the rclone RPC.
 
 The implementation is based on cgo; to build it you need Go and a GCC compatible
 C compiler (GCC or Clang). On Windows you can use the MinGW port of GCC,
-installing it via the [MSYS2](https://www.msys2.org) distribution is recommended
+e.g. by installing it in a [MSYS2](https://www.msys2.org) distribution
 (make sure you install GCC in the classic mingw64 subsystem, the ucrt64 version
 is not compatible with cgo).
 
@@ -36,6 +36,14 @@ which is the case for glibc version 2.34 and newer.
 You may add arguments `-ldflags -s` to make the library file smaller. This will
 omit symbol table and debug information, reducing size by about 25% on Linux and
 50% on Windows.
+
+Note that on macOS and Windows the mount functions will not be available unless
+you add additional argument `-tags cmount`. On Windows this also requires you to
+first install the third party utility [WinFsp](http://www.secfs.net/winfsp/),
+with the "Developer" feature selected, and to set environment variable CPATH
+pointing to the fuse include directory within the WinFsp installation
+(typically `C:\Program Files (x86)\WinFsp\inc\fuse`). See also the
+[mount](/commands/rclone_mount/#installing-on-windows) documentation.
 
 ### Documentation
 

--- a/librclone/librclone.go
+++ b/librclone/librclone.go
@@ -38,6 +38,9 @@ import (
 	_ "github.com/rclone/rclone/fs/operations" // import operations/* rc commands
 	_ "github.com/rclone/rclone/fs/sync"       // import sync/*
 	_ "github.com/rclone/rclone/lib/plugin"    // import plugins
+	_ "github.com/rclone/rclone/cmd/mount"     // import mount
+	_ "github.com/rclone/rclone/cmd/mount2"    // import mount2
+	_ "github.com/rclone/rclone/cmd/cmount"    // import cmount
 )
 
 // RcloneInitialize initializes rclone as a library


### PR DESCRIPTION
#### What is the purpose of this change?

Add support for "mount/*" commands in librclone.

See https://github.com/rclone/rclone/pull/5729 for a previous attempt, and see the comments there for some relevant discussions.

TODO:
- Needs to refactor mount commands as linking to them will pull in cobra and all of its dependencies which should be kept out of librclone.

#### Was the change discussed in an issue or in the forum before?

Fixes #5661

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
