### PR TITLE
librclone: allow empty string or null input instead of empty json object

### DIFF
--- a/librclone/librclone/librclone.go
+++ b/librclone/librclone/librclone.go
@@ -88,9 +88,11 @@ func RPC(method string, input string) (output string, status int) {
 	}()
 
 	// create a buffer to capture the output
-	err := json.NewDecoder(strings.NewReader(input)).Decode(&in)
-	if err != nil {
-		return writeError(method, in, fmt.Errorf("failed to read input JSON: %w", err), http.StatusBadRequest)
+	if input != "" {
+		err := json.NewDecoder(strings.NewReader(input)).Decode(&in)
+		if err != nil {
+			return writeError(method, in, fmt.Errorf("failed to read input JSON: %w", err), http.StatusBadRequest)
+		}
 	}
 
 	// Find the call


### PR DESCRIPTION
#### What is the purpose of this change?

Currently rpc methods must always specify a valid json string as "input", even for methods which does not take any "arguments" - such as listremotes. This means one must send the string "{}". Trying to send empty string, or null, results in status code 400 and error message: "failed to read input JSON: EOF".

With this change I suggest treating empty string and null same as "{}".

#### Was the change discussed in an issue or in the forum before?

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
