### PR TITLE
docs/librclone: add -ldflags -s to suggested build command

### DIFF
--- a/librclone/README.md
+++ b/librclone/README.md
@@ -33,6 +33,10 @@ The library will depend on `libdl` and `libpthread` on Linux/macOS, unless
 linking with a C standard library where their functionality is integrated,
 which is the case for glibc version 2.34 and newer.
 
+You may add arguments `-ldflags -s` to make the library file smaller. This will
+omit symbol table and debug information, reducing size by about 25% on Linux and
+50% on Windows.
+
 ### Documentation
 
 For documentation see the Go documentation for:


### PR DESCRIPTION
#### What is the purpose of this change?

Suggest using build option `-ldflags -s` to create optimized build (omit symbol table and debug information).

With my test, building c-shared on Windows there is a huge different - half the size:
- No optimization: 79 012 KiB
- Optimized (-ldflags -s): 36 917 KiB (53% reduction)

Edit:
- Tested same on Linux, Arch in WSL: Reduction from 74084 KiB to 56319 KiB (24% reduction)
- Adding -w as well, `-ldflags -s -w`, changes nothing.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/pull/5729#issuecomment-950344364

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
