### PR TITLE
stats: fix missing computation of transferQueueSize

### DIFF
--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -24,6 +24,8 @@ const (
 var MaxCompletedTransfers = 100
 
 // StatsInfo accounts all transfers
+// N.B.: if this struct is modified, please remember to also update sum() function in stats_groups
+// to correctly count the updated fields
 type StatsInfo struct {
 	mu                sync.RWMutex
 	ctx               context.Context

--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -359,23 +359,31 @@ func (sg *statsGroups) sum(ctx context.Context) *StatsInfo {
 		{
 			sum.bytes += stats.bytes
 			sum.errors += stats.errors
-			sum.fatalError = sum.fatalError || stats.fatalError
-			sum.retryError = sum.retryError || stats.retryError
-			sum.checks += stats.checks
-			sum.transfers += stats.transfers
-			sum.deletes += stats.deletes
-			sum.deletedDirs += stats.deletedDirs
-			sum.renames += stats.renames
-			sum.checking.merge(stats.checking)
-			sum.transferring.merge(stats.transferring)
-			sum.inProgress.merge(stats.inProgress)
 			if sum.lastError == nil && stats.lastError != nil {
 				sum.lastError = stats.lastError
 			}
-			sum.startedTransfers = append(sum.startedTransfers, stats.startedTransfers...)
+			sum.fatalError = sum.fatalError || stats.fatalError
+			sum.retryError = sum.retryError || stats.retryError
+			if stats.retryAfter.After(sum.retryAfter) {
+				// Update the retryAfter field only if it is a later date than the current one in the sum
+				sum.retryAfter = stats.retryAfter
+			}
+			sum.checks += stats.checks
+			sum.checking.merge(stats.checking)
+			sum.checkQueue += stats.checkQueue
+			sum.checkQueueSize += stats.checkQueueSize
+			sum.transfers += stats.transfers
+			sum.transferring.merge(stats.transferring)
 			sum.transferQueueSize += stats.transferQueueSize
-			sum.oldDuration += stats.oldDuration
+			sum.renames += stats.renames
+			sum.renameQueue += stats.renameQueue
+			sum.renameQueueSize += stats.renameQueueSize
+			sum.deletes += stats.deletes
+			sum.deletedDirs += stats.deletedDirs
+			sum.inProgress.merge(stats.inProgress)
+			sum.startedTransfers = append(sum.startedTransfers, stats.startedTransfers...)
 			sum.oldTimeRanges = append(sum.oldTimeRanges, stats.oldTimeRanges...)
+			sum.oldDuration += stats.oldDuration
 			stats.average.mu.Lock()
 			sum.average.speed += stats.average.speed
 			stats.average.mu.Unlock()

--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -373,6 +373,7 @@ func (sg *statsGroups) sum(ctx context.Context) *StatsInfo {
 				sum.lastError = stats.lastError
 			}
 			sum.startedTransfers = append(sum.startedTransfers, stats.startedTransfers...)
+			sum.transferQueueSize += stats.transferQueueSize
 			sum.oldDuration += stats.oldDuration
 			sum.oldTimeRanges = append(sum.oldTimeRanges, stats.oldTimeRanges...)
 			stats.average.mu.Lock()

--- a/fs/accounting/stats_groups_test.go
+++ b/fs/accounting/stats_groups_test.go
@@ -47,12 +47,14 @@ func TestStatsGroupOperations(t *testing.T) {
 		t.Parallel()
 		stats1 := NewStats(ctx)
 		stats1.bytes = 5
+		stats1.transferQueueSize = 10
 		stats1.errors = 6
 		stats1.oldDuration = time.Second
 		stats1.oldTimeRanges = []timeRange{{time.Now(), time.Now().Add(time.Second)}}
 		stats2 := NewStats(ctx)
 		stats2.bytes = 10
 		stats2.errors = 12
+		stats1.transferQueueSize = 20
 		stats2.oldDuration = 2 * time.Second
 		stats2.oldTimeRanges = []timeRange{{time.Now(), time.Now().Add(2 * time.Second)}}
 		sg := newStatsGroups()
@@ -60,6 +62,7 @@ func TestStatsGroupOperations(t *testing.T) {
 		sg.set(ctx, "test2", stats2)
 		sum := sg.sum(ctx)
 		assert.Equal(t, stats1.bytes+stats2.bytes, sum.bytes)
+		assert.Equal(t, stats1.transferQueueSize+stats2.transferQueueSize, sum.transferQueueSize)
 		assert.Equal(t, stats1.errors+stats2.errors, sum.errors)
 		assert.Equal(t, stats1.oldDuration+stats2.oldDuration, sum.oldDuration)
 		assert.Equal(t, stats1.average.speed+stats2.average.speed, sum.average.speed)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
This fixes the value of `transferQueueSize`, that was not summed up when calculating the sum of the statistics group, resulting in the bug described in #5749 .
Since I don't have familiarity with the code base, I don't know if this change may introduce any side effect.

#### Was the change discussed in an issue or in the forum before?
#5749 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
