### PR TITLE
docs/librclone: document that strings are utf8 encoded

### DIFF
--- a/librclone/librclone.go
+++ b/librclone/librclone.go
@@ -68,12 +68,14 @@ type RcloneRPCResult struct { //nolint:deadcode
 // to the rclone API as described in https://rclone.org/rc/
 //
 //   method is a string, eg "operations/list"
-//   input should be a serialized JSON object
-//   result.Output will be returned as a serialized JSON object
+//   input should be a string with a serialized JSON object
+//   result.Output will be returned as a string with a serialized JSON object
 //   result.Status is a HTTP status return (200=OK anything else fail)
 //
-// Caller is responsible for freeing the memory for result.Output,
-// result itself is passed on the stack.
+// All strings are UTF-8 encoded, on all platforms.
+//
+// Caller is responsible for freeing the memory for result.Output
+// (see RcloneFreeString), result itself is passed on the stack.
 //
 //export RcloneRPC
 func RcloneRPC(method *C.char, input *C.char) (result C.struct_RcloneRPCResult) { //nolint:golint


### PR DESCRIPTION
#### What is the purpose of this change?

Document that strings are utf8 encoded.

#### Was the change discussed in an issue or in the forum before?


#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
