### PR TITLE
s3: support execution in EKS (WebIdentityRole)

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"path"
 	"regexp"
 	"sort"
@@ -26,12 +27,14 @@ import (
 	"github.com/aws/aws-sdk-go/aws/corehandlers"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/defaults"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/ncw/swift/v2"
 	"github.com/pkg/errors"
 	"github.com/rclone/rclone/fs"
@@ -1547,6 +1550,14 @@ func s3Connection(ctx context.Context, opt *Options, client *http.Client) (*s3.S
 
 		// Pick up IAM role if we're in an ECS task
 		defaults.RemoteCredProvider(*def.Config, def.Handlers),
+
+		// WebIdentityRole if we're in EKS
+		stscreds.NewWebIdentityRoleProvider(
+			sts.New(awsSession),
+			os.Getenv("AWS_ROLE_ARN"),
+			"rclone-session",
+			os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE"),
+		),
 
 		// Pick up IAM role in case we're on EC2
 		&ec2rolecreds.EC2RoleProvider{


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Allow to execute rclone for S3 natively in AWS EKS environments where AWS Credentials are rather retrieved from WebIdentity than environment or EC2 credentials.

<!--
Describe the changes here
-->

To achieve this, the stscreds NewWebIdentityRoleProvider of the aws sdk has been added to the Credentials Provider chain.

#### Was the change discussed in an issue or in the forum before?

I don't know.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
