### PR TITLE
sync/test: skip test ConcurrentTruncate on uptobox (take 2)

### DIFF
--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -2091,7 +2091,7 @@ func testSyncConcurrent(t *testing.T, subtest string) {
 	fstest.CheckItems(t, r.Fremote, itemsBefore...)
 	stats.ResetErrors()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
-	if err == fs.ErrorCantUploadEmptyFiles {
+	if errors.Cause(err) == fs.ErrorCantUploadEmptyFiles {
 		t.Skipf("Skip test because remote cannot upload empty files")
 	}
 	assert.NoError(t, err, "Sync must not return a error")


### PR DESCRIPTION
#### What is the purpose of this change?

The test `ConcurrentTruncate` is not applicable to uptobox which can't upload empty files.
The test was not skipped as intended because the direct error was compared.
This fix will compare error Cause because Sync wraps the error.

#### Was the change discussed in an issue or in the forum before?

- #5734
- #5745 
- https://github.com/rclone/rclone/commit/70297c3aed39c1073a95aa20c67d5a5366af05ef

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
