### PR TITLE
backend/ftp: increase testUploadTimeout.maxTime to 10 seconds

### DIFF
--- a/backend/ftp/ftp_internal_test.go
+++ b/backend/ftp/ftp_internal_test.go
@@ -36,7 +36,7 @@ func (f *Fs) testUploadTimeout(t *testing.T) {
 	const (
 		fileSize    = 100000000             // 100 MiB
 		idleTimeout = 40 * time.Millisecond // small because test server is local
-		maxTime     = 5 * time.Second       // prevent test hangup
+		maxTime     = 10 * time.Second      // prevent test hangup
 	)
 
 	if testing.Short() {


### PR DESCRIPTION
On slow machines (e.g. Github CI), especially if GOARCH=386,
the test for cmd/serve/ftp could fail if this value is too small.

Fixes #5783


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
