### PR TITLE
Set proper exit code for errors that are not low-level retried (e.g. size/timestamp changing)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -491,7 +491,7 @@ func resolveExitCode(err error) {
 		os.Exit(exitcode.TransferExceeded)
 	case fserrors.ShouldRetry(err):
 		os.Exit(exitcode.RetryError)
-	case fserrors.IsNoRetryError(err):
+	case fserrors.IsNoRetryError(err), fserrors.IsNoLowLevelRetryError(err):
 		os.Exit(exitcode.NoRetryError)
 	case fserrors.IsFatalError(err):
 		os.Exit(exitcode.FatalError)


### PR DESCRIPTION
#### What is the purpose of this change?

Setting the following exit code when error is NoLowLevelRetryError, same as for NoRetryError:

> 6 - Less serious errors (like 461 errors from dropbox) (NoRetry errors)

Only case where this error is returned, is currently in local backend, when size or timestamp are changing during sync.

#### Was the change discussed in an issue or in the forum before?

Fixes #5785

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
