### PR TITLE
backend: Fix union eplus policy returned nil

### DIFF
--- a/backend/union/policy/eplus.go
+++ b/backend/union/policy/eplus.go
@@ -39,7 +39,7 @@ func (p *EpLus) lus(upstreams []*upstream.Fs) (*upstream.Fs, error) {
 }
 
 func (p *EpLus) lusEntries(entries []upstream.Entry) (upstream.Entry, error) {
-	var minUsedSpace int64
+	var minUsedSpace int64 = math.MaxInt64
 	var lusEntry upstream.Entry
 	for _, e := range entries {
 		space, err := e.UpstreamFs().GetFreeSpace()


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Union generated a `panic` when it had to select the least-used-space backend, because the `lusEntries` function returned `nil`.

<!--
Describe the changes here
-->

To solve it: I initialized the `minUsedSpace` variable with `math.MaxInt64` so that the first backend would trigger the condition `if space < minUsedSpace`, thus `entry` would never be `nil` after the loop.

#### Was the change discussed in an issue or in the forum before?

Not that I could find.

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
