### PR TITLE
cmd/ncdu: display correct path in delete confirmation dialog

### DIFF
--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/cmd/ncdu/scan"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/fspath"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/spf13/cobra"
 )
@@ -512,7 +513,7 @@ func (u *UI) delete() {
 		}
 		u.popupBox([]string{
 			"Delete this file?",
-			u.fsName + dirEntry.String()})
+			fspath.JoinRootPath(u.fsName, dirEntry.String())})
 	} else {
 		u.boxMenuHandler = func(f fs.Fs, p string, o int) (string, error) {
 			if o != 1 {
@@ -531,7 +532,7 @@ func (u *UI) delete() {
 		u.popupBox([]string{
 			"Purge this directory?",
 			"ALL files in it will be deleted",
-			u.fsName + dirEntry.String()})
+			fspath.JoinRootPath(u.fsName, dirEntry.String())})
 	}
 }
 
@@ -642,7 +643,7 @@ func (u *UI) sortCurrentDir() {
 func (u *UI) setCurrentDir(d *scan.Dir) {
 	u.d = d
 	u.entries = d.Entries()
-	u.path = path.Join(u.fsName, d.Path())
+	u.path = fspath.JoinRootPath(u.fsName, d.Path())
 	u.sortCurrentDir()
 }
 
@@ -725,7 +726,7 @@ func NewUI(f fs.Fs) *UI {
 		f:                  f,
 		path:               "Waiting for root...",
 		dirListHeight:      20, // updated in Draw
-		fsName:             f.Name() + ":" + f.Root(),
+		fsName:             fs.ConfigString(f),
 		showGraph:          true,
 		showCounts:         false,
 		showDirAverageSize: false,


### PR DESCRIPTION
If the remote on the command line is "remote:subdir", when
deleting "filename", the confirmation message shows the path
"remote:subdirfilename". Using path.Join() fixes this.
A superfluous '/' will be added after the ':' even if the
remote is just "remote:", but that's still a valid syntax.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
