### PR TITLE
docs: Remove broken dependency from automount unit in `rclone mount` documentation

### DIFF
--- a/docs/content/commands/rclone_mount.md
+++ b/docs/content/commands/rclone_mount.md
@@ -354,7 +354,6 @@ optionally accompanied by systemd automount unit
 ```
 # /etc/systemd/system/mnt-data.automount
 [Unit]
-After=network-online.target
 Before=remote-fs.target
 [Automount]
 Where=/mnt/data


### PR DESCRIPTION
#### What is the purpose of this change?

The purpose of this change is to fix the example systemd automount unit file in the `rclone mount` documentation, so that it no longer gives users a broken configuration.

As noted in [the systemd.automount manpage](https://www.freedesktop.org/software/systemd/man/systemd.automount.html), giving an automount unit for a remote filesystem a dependency on `network-online.target` is unnecessary, since what actually requires the network is the mount itself.  It can also create ordering cycles, for instance on my server:

```
local-fs.target: Found ordering cycle on mnt-rclone.automount/start
local-fs.target: Found dependency on network-online.target/start
local-fs.target: Found dependency on network.target/start
local-fs.target: Found dependency on networking.service/start
local-fs.target: Found dependency on apparmor.service/start
local-fs.target: Found dependency on local-fs.target/start
local-fs.target: Job mnt-rclone.automount/start deleted to break ordering cycle starting with local-fs.target/start
```

#### Was the change discussed in an issue or in the forum before?

Not that I'm aware of.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
