### PR TITLE
drive: prevent retries when query filter returned no entries

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1693,6 +1693,11 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 	var paths []string
 	var grouping int32
 
+	usingQueryFilter := false
+	if fi, use := filter.GetConfig(ctx), filter.GetUseFilter(ctx); fi != nil && use {
+		usingQueryFilter = true
+	}
+
 	for dir := range in {
 		dirs = append(dirs[:0], dir.id)
 		paths = append(paths[:0], dir.path)
@@ -1765,7 +1770,8 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 		// drive where (A in parents) or (B in parents) returns nothing
 		// sometimes. See #3114, #4289 and
 		// https://issuetracker.google.com/issues/149522397
-		if len(dirs) > 1 && !foundItems {
+		// However, empty result is legitimate if query filter was applied.
+		if len(dirs) > 1 && !foundItems && !usingQueryFilter {
 			if atomic.SwapInt32(&f.grouping, 1) != 1 {
 				fs.Debugf(f, "Disabling ListR to work around bug in drive as multi listing (%d) returned no entries", len(dirs))
 			}
@@ -1783,7 +1789,8 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 		}
 		// If using a grouping of 1 and dir was empty then check to see if it
 		// is part of the group that caused grouping to be disabled.
-		if grouping == 1 && len(dirs) == 1 && !foundItems {
+		// However, empty result is legitimate if query filter was applied.
+		if grouping == 1 && len(dirs) == 1 && !foundItems && !usingQueryFilter {
 			f.listRmu.Lock()
 			if _, found := f.listRempties[dirs[0]]; found {
 				// Remove the ID


### PR DESCRIPTION
#### What is the purpose of this change?

This patch fixes retries caused by optimization introduced by
- #5023

The `driveFs.ListR` result handler `listRRunner` treated empty directory listings returned by Google Drive in response to query constrained by `--min-age` and/or `--max-age` as an indication of the Google bug and retried the listing request with `--fast-list` turned off resulting in overall degraded performance.

There are two possible solutions for that:
1. disable query filter optimization in presence of `--fast-list` i.e. call ` SetUseFilter(ctx,false)` in `listRRunner()` to reset the optimization flag.
2. treat empty directory listings as an acceptable result if the query optimization was applied (ignoring possible server bugs)

This PR applies the latter solution, which bears risk of hitting the drive empty result bug
but it can provide better overall performance.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/performance-degradation-between-v1-56-2-and-v1-57-0-when-copying-to-google-drive-using-max-age-min-age-and-fast-list/27580/2

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
    **IDK what a proper unit test should look like. Leaving unit test until review time.**
- [ ] I have added documentation for the changes if appropriate.
   **It's a bug fix, it needs no docs.**
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
