### PR TITLE
s3: Add Wasabi AP Northeast 2 endpoint info

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -761,7 +761,11 @@ func init() {
 				Provider: "Wasabi",
 			}, {
 				Value:    "s3.ap-northeast-1.wasabisys.com",
-				Help:     "Wasabi AP Northeast endpoint",
+				Help:     "Wasabi AP Northeast 1 (Tokyo) endpoint",
+				Provider: "Wasabi",
+			}, {
+				Value:    "s3.ap-northeast-2.wasabisys.com",
+				Help:     "Wasabi AP Northeast 2 (Osaka) endpoint",
 				Provider: "Wasabi",
 			}},
 		}, {

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -1062,7 +1062,9 @@ Required when using an S3 clone.
     - "s3.eu-central-1.wasabisys.com"
         - Wasabi EU Central endpoint
     - "s3.ap-northeast-1.wasabisys.com"
-        - Wasabi AP Northeast endpoint
+        - Wasabi AP Northeast 1 (Tokyo) endpoint
+    - "s3.ap-northeast-2.wasabisys.com"
+        - Wasabi AP Northeast 2 (Osaka) endpoint
 
 #### --s3-location-constraint
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Wasabi started to provide **AP Northeast 2 (Osaka)** endpoint as `s3.ap-northeast-2.wasabisys.com`, so add it to the list.


ref:
- [Wasabi Technologies Accelerates APAC Operations and Growth with New Storage Region in Osaka](https://wasabi.com/press-releases/wasabi-technologies-accelerates-apac-operations-and-growth-with-new-storage-region-in-osaka/)
- [What are the service URLs for Wasabi's different storage regions? – Wasabi Knowledge Base](https://wasabi-support.zendesk.com/hc/en-us/articles/360015106031-What-are-the-service-URLs-for-Wasabi-s-different-storage-regions-)

#### Was the change discussed in an issue or in the forum before?

no.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
