### PR TITLE
lib/rest: process HTML entities within XML

### DIFF
--- a/lib/rest/rest.go
+++ b/lib/rest/rest.go
@@ -167,6 +167,10 @@ func DecodeJSON(resp *http.Response, result interface{}) (err error) {
 func DecodeXML(resp *http.Response, result interface{}) (err error) {
 	defer fs.CheckClose(resp.Body, &err)
 	decoder := xml.NewDecoder(resp.Body)
+	// MEGAcmd has included escaped HTML entities in its XML output, so we have to be able to
+	// decode them.
+	decoder.Strict = false
+	decoder.Entity = xml.HTMLEntity
 	return decoder.Decode(result)
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The MEGA SDK - and, by extension, MEGAcmd - [escapes many HTML entities](https://github.com/meganz/sdk/blob/f1f05bc7d7ec67cb6d03d9e327ec3ee64e82562d/src/utils.cpp#L2125-L2398) in the XML it serves as the WebDAV server. This is not conformant XML, and I have already [submitted a PR](https://github.com/meganz/sdk/pull/2600) to fix this. That having been said, I am submitting a fix for rclone too for a couple of reasons:
- MEGAcmd development seems to be rather slow, and it could be some time until it's updated with the latest SDK - that is, _if_ a fix is merged into the SDK. Moreover, the `mega` backend currently has an issue (#4695) that makes it difficult to use, making this WebDAV functionality useful.
- The MEGA SDK might not be the only WebDAV application exhibiting this behavior. In these cases, it should be preferable for rclone to process the entities rather than throwing an error.

For reference, this is what currently happens when using a problematic filename with MEGAcmd's WebDAV server, and rclone:
```
2020/11/16 12:50:00 ERROR : IO error: couldn't list files: XML syntax error on line 253: invalid character entity &add;
```

#### Was the change discussed in an issue or in the forum before?

Most directly, this issue is reported [here](https://github.com/rclone/rclone/issues/4695#issuecomment-728256438) and in #4885. The "rather strict" XML parser is also discussed in [this](https://github.com/rclone/rclone/issues/3345#issuecomment-532625962) comment.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

Thanks!