### PR TITLE
lib/file: check max path length for windows

### DIFF
--- a/lib/file/file_windows.go
+++ b/lib/file/file_windows.go
@@ -28,6 +28,12 @@ func OpenFile(path string, mode int, perm os.FileMode) (*os.File, error) {
 	if len(path) == 0 {
 		return nil, syscall.ERROR_FILE_NOT_FOUND
 	}
+	// For windows the max path length is 260 characters
+	// https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+	if len(path) >= 260 {
+		return nil, &os.PathError{Path: path, Op: "open", Err: errors.New("path length higher than 260")}
+	}
+
 	pathp, err := syscall.UTF16PtrFromString(path)
 	if err != nil {
 		return nil, err

--- a/lib/file/file_windows_test.go
+++ b/lib/file/file_windows_test.go
@@ -1,0 +1,16 @@
+//go:build windows
+// +build windows
+
+package file
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileOpenMaxPathLength(t *testing.T) {
+	path := `C:\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path`
+	_, err := OpenFile(path, 0644, 0644)
+	assert.Error(t, err, "mkdir: Max path length can't exceed 260")
+}

--- a/lib/file/mkdir_windows.go
+++ b/lib/file/mkdir_windows.go
@@ -4,6 +4,7 @@
 package file
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -17,6 +18,12 @@ import (
 // Based on source code from golang's os.MkdirAll
 // (https://github.com/golang/go/blob/master/src/os/path.go)
 func MkdirAll(path string, perm os.FileMode) error {
+	// For windows the max path length is 260 characters
+	// https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
+	if len(path) >= 260 {
+		return &os.PathError{Path: path, Op: "open", Err: errors.New("path length higher than 260")}
+	}
+
 	// Fast path: if we can tell whether path is a directory or file, stop with success or error.
 	dir, err := os.Stat(path)
 	if err == nil {

--- a/lib/file/mkdir_windows_test.go
+++ b/lib/file/mkdir_windows_test.go
@@ -130,3 +130,9 @@ func TestMkdirAllOnUnusedDrive(t *testing.T) {
 	errormsg = fmt.Sprintf("mkdir \\\\?\\%s\\: The system cannot find the path specified.", path)
 	checkMkdirAllSubdirs(t, `\\?\`+path, false, errormsg)
 }
+
+func TestMkdirMaxPathLength(t *testing.T) {
+	path := `C:\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path\my\path`
+	err := MkdirAll(path, 0777)
+	assert.Error(t, err, "mkdir: Max path length can't exceed 260")
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Show a better error message when reach max file path for Windows.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/display-warnings-for-paths-that-exceed-windows-path-length-limit/26608
https://github.com/rclone/rclone/issues/5612

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
