### PR TITLE
vfs: Fix bug caused by vfs cache special character ("rune") escape ("quoting") inconsistency

### DIFF
--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -196,7 +196,6 @@ func createRootDirs(parentOSPath string, relativeDirOSPath string) (dataOSPath s
 // Returns an os path for the data cache file.
 func (c *Cache) createItemDir(name string) (string, error) {
 	parent := vfscommon.FindParent(name)
-	leaf := filepath.Base(name)
 	parentPath := c.toOSPath(parent)
 	err := createDir(parentPath)
 	if err != nil {
@@ -207,7 +206,7 @@ func (c *Cache) createItemDir(name string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to create metadata cache item directory: %w", err)
 	}
-	return filepath.Join(parentPath, leaf), nil
+	return c.toOSPath(name), nil
 }
 
 // getBackend gets a backend for a cache root dir


### PR DESCRIPTION
#### What is the purpose of this change?

When `vfs-cache` is enabled, rclone fails to upload every file with a name that contains special characters (those which are called "runes" in the rclone's codebase). But, if the runes are only in the directory names, it succeeds.
From what I have inspected, it is because rclone copies original files to cache with a fully escaped path (with a quote character in front of each rune), but when it flushes the cache to the actual remote, it looks for the cached file in a partially escaped path (with a quote character only in front of each rune in the directory part of the path).
The correct operation would be fully escaping the cache paths every time they are referred to.
So, I submit the patch in this pull request.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
