### PR TITLE
cmd: fix broken example link in help.go

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -165,7 +165,7 @@ func runRoot(cmd *cobra.Command, args []string) {
 // setupRootCommand sets default usage, help, and error handling for
 // the root command.
 //
-// Helpful example: http://rtfcode.com/xref/moby-17.03.2-ce/cli/cobra.go
+// Helpful example: https://github.com/moby/moby/blob/master/cli/cobra.go
 func setupRootCommand(rootCmd *cobra.Command) {
 	ci := fs.GetConfig(context.Background())
 	// Add global flags


### PR DESCRIPTION
This link appears to be broken, so here is another reference to (I think) the same file that provides a good example of coba. We could also do the current commit https://github.com/moby/moby/blob/8312004f41e9500824fa16ae991eeee0083f4771/cli/cobra.go although it might be better to maintain an up to date example.

#### What is the purpose of this change?

The link to the example for how to format usage strings appears to be broken  (404).

#### Was the change discussed in an issue or in the forum before?

Nope.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate (not appropriate).
- [ ] I have added documentation for the changes if appropriate. (not appropriate)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)