### PR TITLE
Add curl to the rclone docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN ./rclone version
 # Begin final image
 FROM alpine:latest
 
-RUN apk --no-cache add ca-certificates fuse tzdata && \
+RUN apk --no-cache add ca-certificates curl fuse tzdata && \
   echo "user_allow_other" >> /etc/fuse.conf
 
 COPY --from=builder /go/src/github.com/rclone/rclone/rclone /usr/local/bin/


### PR DESCRIPTION
#### What is the purpose of this change?

Add curl to the Docker image, this is useful if you use the container to perform a sync and want to send an HTTP request to a service like https://healthchecks.io/ when the sync has completed. Take for example:

```yaml
---
version: "3.8"

services:
  backup:
    image: docker.io/rclone/rclone:1.57.0
    container_name: backup
    entrypoint: /bin/sh
    command:
      - "rclone"
      - "--config"
      - "/config/rclone.conf"
      - "--progress"
      - "sync"
      - "/mnt/test"
      - "backblaze:rcUFz3wc/"
      - "&&"
      - "curl"
      - "-fsS"
      - "-m" 
      - "10"
      - "--retry"
      - "5"
      - "-o"
      - "/dev/null https://healthchecks.io/xyz"
```

This way I will be only notified if the command fails and my sync didn't happen.

There's many other benefits to having curl in the image as well.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
