### PR TITLE
onedrive: about the Sites.Read.All permission request

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -144,9 +144,9 @@ Note that the chunks will be buffered into memory.`,
 			Name: "disable_site_permission",
 			Help: `Disable the request for Sites.Read.All permission.
 
-If enabled, you will no longer be able to search for a SharePoint site
-when configuring drive ID.
-Enable if your organization didn't assign Sites.Read.All permission to the
+If set to true, you will no longer be able to search for a SharePoint site when
+configuring drive ID, because rclone will not request Sites.Read.All permission.
+Set it to true if your organization didn't assign Sites.Read.All permission to the
 application, and your organization disallows users to consent app permission
 request on their own.`,
 			Default:  false,
@@ -388,8 +388,8 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 	region, graphURL := getRegionURL(m)
 
 	if config.State == "" {
-		disableSitePermission, ok := m.Get("disable_site_permission")
-		if disableSitePermission == "true" && ok {
+		disableSitePermission, _ := m.Get("disable_site_permission")
+		if disableSitePermission == "true" {
 			oauthConfig.Scopes = scopesWithoutSitePermission
 		} else {
 			oauthConfig.Scopes = scopesWithSitePermission

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -65,9 +65,12 @@ var (
 	authPath  = "/common/oauth2/v2.0/authorize"
 	tokenPath = "/common/oauth2/v2.0/token"
 
+	scopesWithSitePermission    = []string{"Files.Read", "Files.ReadWrite", "Files.Read.All", "Files.ReadWrite.All", "offline_access", "Sites.Read.All"}
+	scopesWithoutSitePermission = []string{"Files.Read", "Files.ReadWrite", "Files.Read.All", "Files.ReadWrite.All", "offline_access"}
+
 	// Description of how to auth for this app for a business account
 	oauthConfig = &oauth2.Config{
-		Scopes:       []string{"Files.Read", "Files.ReadWrite", "Files.Read.All", "Files.ReadWrite.All", "offline_access", "Sites.Read.All"},
+		Scopes:       scopesWithSitePermission,
 		ClientID:     rcloneClientID,
 		ClientSecret: obscure.MustReveal(rcloneEncryptedClientSecret),
 		RedirectURL:  oauthutil.RedirectLocalhostURL,
@@ -136,6 +139,17 @@ Note that the chunks will be buffered into memory.`,
 			Name:     "drive_type",
 			Help:     "The type of the drive (" + driveTypePersonal + " | " + driveTypeBusiness + " | " + driveTypeSharepoint + ").",
 			Default:  "",
+			Advanced: true,
+		}, {
+			Name: "disable_site_permission",
+			Help: `Disable the request for Sites.Read.All permission.
+
+If enabled, you will no longer be able to search for a SharePoint site
+when configuring drive ID.
+Enable if your organization didn't assign Sites.Read.All permission to the
+application, and your organization disallows users to consent app permission
+request on their own.`,
+			Default:  false,
 			Advanced: true,
 		}, {
 			Name: "expose_onenote_files",
@@ -374,6 +388,12 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 	region, graphURL := getRegionURL(m)
 
 	if config.State == "" {
+		disableSitePermission, ok := m.Get("disable_site_permission")
+		if disableSitePermission == "true" && ok {
+			oauthConfig.Scopes = scopesWithoutSitePermission
+		} else {
+			oauthConfig.Scopes = scopesWithSitePermission
+		}
 		oauthConfig.Endpoint = oauth2.Endpoint{
 			AuthURL:  authEndpoint[region] + authPath,
 			TokenURL: authEndpoint[region] + tokenPath,
@@ -527,6 +547,7 @@ type Options struct {
 	ChunkSize               fs.SizeSuffix        `config:"chunk_size"`
 	DriveID                 string               `config:"drive_id"`
 	DriveType               string               `config:"drive_type"`
+	DisableSitePermission   bool                 `config:"disable_site_permission"`
 	ExposeOneNoteFiles      bool                 `config:"expose_onenote_files"`
 	ServerSideAcrossConfigs bool                 `config:"server_side_across_configs"`
 	ListChunk               int64                `config:"list_chunk"`
@@ -789,6 +810,11 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	rootURL := graphAPIEndpoint[opt.Region] + "/v1.0" + "/drives/" + opt.DriveID
+	if opt.DisableSitePermission {
+		oauthConfig.Scopes = scopesWithoutSitePermission
+	} else {
+		oauthConfig.Scopes = scopesWithSitePermission
+	}
 	oauthConfig.Endpoint = oauth2.Endpoint{
 		AuthURL:  authEndpoint[opt.Region] + authPath,
 		TokenURL: authEndpoint[opt.Region] + tokenPath,

--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -132,10 +132,12 @@ Client ID and Key by following the steps below:
 2. Enter a name for your app, choose account type `Accounts in any organizational directory (Any Azure AD directory - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)`, select `Web` in `Redirect URI`, then type (do not copy and paste) `http://localhost:53682/` and click Register. Copy and keep the `Application (client) ID` under the app name for later use.
 3. Under `manage` select `Certificates & secrets`, click `New client secret`. Enter a description (can be anything) and set `Expires` to 24 months. Copy and keep that secret _Value_ for later use (you _won't_ be able to see this value afterwards).
 4. Under `manage` select `API permissions`, click `Add a permission` and select `Microsoft Graph` then select `delegated permissions`.
-5. Search and select the following permissions: `Files.Read`, `Files.ReadWrite`, `Files.Read.All`, `Files.ReadWrite.All`, `offline_access`, `User.Read`, `Sites.Read.All` (optional). Once selected click `Add permissions` at the bottom.
+5. Search and select the following permissions: `Files.Read`, `Files.ReadWrite`, `Files.Read.All`, `Files.ReadWrite.All`, `offline_access`, `User.Read`, and optionally `Sites.Read.All` (see below). Once selected click `Add permissions` at the bottom.
 
 Now the application is complete. Run `rclone config` to create or edit a OneDrive remote.
 Supply the app ID and password as Client ID and Secret, respectively. rclone will walk you through the remaining steps.
+
+The `Sites.Read.All` permission is required if you need to [search SharePoint sites when configuring the remote](https://github.com/rclone/rclone/pull/5883). However, if that permission is not assigned, you need to set `disable_site_permission` option to true in the advanced options.
 
 ### Modification time and hashes
 

--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -132,7 +132,7 @@ Client ID and Key by following the steps below:
 2. Enter a name for your app, choose account type `Accounts in any organizational directory (Any Azure AD directory - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)`, select `Web` in `Redirect URI`, then type (do not copy and paste) `http://localhost:53682/` and click Register. Copy and keep the `Application (client) ID` under the app name for later use.
 3. Under `manage` select `Certificates & secrets`, click `New client secret`. Enter a description (can be anything) and set `Expires` to 24 months. Copy and keep that secret _Value_ for later use (you _won't_ be able to see this value afterwards).
 4. Under `manage` select `API permissions`, click `Add a permission` and select `Microsoft Graph` then select `delegated permissions`.
-5. Search and select the following permissions: `Files.Read`, `Files.ReadWrite`, `Files.Read.All`, `Files.ReadWrite.All`, `offline_access`, `User.Read`. Once selected click `Add permissions` at the bottom.
+5. Search and select the following permissions: `Files.Read`, `Files.ReadWrite`, `Files.Read.All`, `Files.ReadWrite.All`, `offline_access`, `User.Read`, `Sites.Read.All` (optional). Once selected click `Add permissions` at the bottom.
 
 Now the application is complete. Run `rclone config` to create or edit a OneDrive remote.
 Supply the app ID and password as Client ID and Secret, respectively. rclone will walk you through the remaining steps.
@@ -493,7 +493,7 @@ setting:
 4. `Set-SPOTenant -EnableMinimumVersionRequirement $False`
 5. `Disconnect-SPOService` (to disconnect from the server)
 
-*Below are the steps for normal users to disable versioning. If you don't see the "No Versioning" option, make sure the above requirements are met.*  
+*Below are the steps for normal users to disable versioning. If you don't see the "No Versioning" option, make sure the above requirements are met.*
 
 User [Weropol](https://github.com/Weropol) has found a method to disable
 versioning on OneDrive
@@ -527,8 +527,8 @@ is a great way to see what it would do.
 
 ### Excessive throttling or blocked on SharePoint
 
-If you experience excessive throttling or is being blocked on SharePoint then it may help to set the user agent explicitly with a flag like this: `--user-agent "ISV|rclone.org|rclone/v1.55.1"`  
- 
+If you experience excessive throttling or is being blocked on SharePoint then it may help to set the user agent explicitly with a flag like this: `--user-agent "ISV|rclone.org|rclone/v1.55.1"`
+
 The specific details can be found in the Microsoft document: [Avoid getting throttled or blocked in SharePoint Online](https://docs.microsoft.com/en-us/sharepoint/dev/general-development/how-to-avoid-getting-throttled-or-blocked-in-sharepoint-online#how-to-decorate-your-http-traffic-to-avoid-throttling)
 
 ### Unexpected file size/hash differences on Sharepoint ####
@@ -537,7 +537,7 @@ It is a
 [known](https://github.com/OneDrive/onedrive-api-docs/issues/935#issuecomment-441741631)
 issue that Sharepoint (not OneDrive or OneDrive for Business) silently modifies
 uploaded files, mainly Office files (.docx, .xlsx, etc.), causing file size and
-hash checks to fail. There are also other situations that will cause OneDrive to 
+hash checks to fail. There are also other situations that will cause OneDrive to
 report inconsistent file sizes. To use rclone with such
 affected files on Sharepoint, you
 may disable these checks with the following command line arguments:
@@ -548,9 +548,9 @@ may disable these checks with the following command line arguments:
 
 Alternatively, if you have write access to the OneDrive files, it may be possible
 to fix this problem for certain files, by attempting the steps below.
-Open the web interface for [OneDrive](https://onedrive.live.com) and find the 
+Open the web interface for [OneDrive](https://onedrive.live.com) and find the
 affected files (which will be in the error messages/log for rclone). Simply click on
-each of these files, causing OneDrive to open them on the web. This will cause each 
+each of these files, causing OneDrive to open them on the web. This will cause each
 file to be converted in place to a format that is functionally equivalent
 but which will no longer trigger the size discrepancy. Once all problematic files
 are converted you will no longer need the ignore options above.


### PR DESCRIPTION
#### What is the purpose of this change?

In fix of #1770 , a new permission request was added in the OneDrive backend support: `Sites.Read.All`. This is intended to solve the error when using a custom SharePoint site. However, such changes are undocumented. 

On a domain with an excessively strict authorization policy (e.g. my university), the domain disallows users to consent permissions on their own and the `Sites.Read.All` permission is undocumented thus not configured, the extra `Sites.Read.All` scope when requesting an access token will trigger "Application needs permission to access resources in your organization that only an admin can grant. Please ask an admin to grant permission to this app before you can use it." message.

Therefore, this PR involves a new advanced config entry `disable_site_permission` (default to false). When turned on, this config will prevent the OAuth client to request `Sites.Read.All` permission. The "Search for a SharePoint site" may be unusable because of this, but for those under a strict policy who don't need custom site configuration, this should be enough.

For the documentation, since I'm unfamiliar with the documentation structure, I didn't attempt to include all documentation for this. Instructions on writing docs will be much appreciated

#### Was the change discussed in an issue or in the forum before?

See #1770

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate. (not applicable)
- [ ] I have added documentation for the changes if appropriate. (See above)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
