### PR TITLE
docs: align menu items when icons have different sizes

### DIFF
--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -148,6 +148,12 @@ h5 {
     text-align: center;
 }
 
+/* Align menu items when icons have different sizes */
+.menu .fa, .fab, .fad, .fal, .far, .fas {
+    width: 18px;
+    text-align: center;
+}
+
 /* Make primary buttons rclone colours. Should learn sass and do this the proper way! */
 .btn-primary {
     background-color: #3f79ad;


### PR DESCRIPTION
#### What is the purpose of this change?

The "Links" menu looks a little bit "messy", due to icons having different sizes. This adds a custom css to align the icons and the following text labels. Image below shows original first, then the new version:

![Capture](https://user-images.githubusercontent.com/12441419/147760008-9ae912e9-27c3-4526-b5d3-87b11166e3d9.png)

#### Was the change discussed in an issue or in the forum before?

Similar to #5701, which aligned the "Storage systems" drop down. I chose to use width 18px here for the menu, instead of 20px as with dropdown. Concluded that it looked a tiny bit better with the smaller font size, but anything from 16px and up looks fine to me, and since texts are short saving of horizontal space is not something that needs to be considered, so exact value is not important (to me).

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)

