### PR TITLE
about: improved error message

### DIFF
--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -1743,7 +1743,7 @@ func (f *Fs) CleanUp(ctx context.Context) error {
 func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	do := f.Fs.Features().About
 	if do == nil {
-		return nil, errors.New("About not supported")
+		return nil, errors.New("not supported by underlying remote")
 	}
 	return do(ctx)
 }

--- a/backend/chunker/chunker.go
+++ b/backend/chunker/chunker.go
@@ -1895,7 +1895,7 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 func (f *Fs) CleanUp(ctx context.Context) error {
 	do := f.base.Features().CleanUp
 	if do == nil {
-		return errors.New("can't CleanUp")
+		return errors.New("not supported by underlying remote")
 	}
 	return do(ctx)
 }
@@ -1904,7 +1904,7 @@ func (f *Fs) CleanUp(ctx context.Context) error {
 func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	do := f.base.Features().About
 	if do == nil {
-		return nil, errors.New("About not supported")
+		return nil, errors.New("not supported by underlying remote")
 	}
 	return do(ctx)
 }

--- a/backend/compress/compress.go
+++ b/backend/compress/compress.go
@@ -900,7 +900,7 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 func (f *Fs) CleanUp(ctx context.Context) error {
 	do := f.Fs.Features().CleanUp
 	if do == nil {
-		return errors.New("can't CleanUp: not supported by underlying remote")
+		return errors.New("not supported by underlying remote")
 	}
 	return do(ctx)
 }
@@ -909,7 +909,7 @@ func (f *Fs) CleanUp(ctx context.Context) error {
 func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	do := f.Fs.Features().About
 	if do == nil {
-		return nil, errors.New("can't About: not supported by underlying remote")
+		return nil, errors.New("not supported by underlying remote")
 	}
 	return do(ctx)
 }

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -597,7 +597,7 @@ func (f *Fs) PutUnchecked(ctx context.Context, in io.Reader, src fs.ObjectInfo, 
 func (f *Fs) CleanUp(ctx context.Context) error {
 	do := f.Fs.Features().CleanUp
 	if do == nil {
-		return errors.New("can't CleanUp")
+		return errors.New("not supported by underlying remote")
 	}
 	return do(ctx)
 }
@@ -606,7 +606,7 @@ func (f *Fs) CleanUp(ctx context.Context) error {
 func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	do := f.Fs.Features().About
 	if do == nil {
-		return nil, errors.New("About not supported")
+		return nil, errors.New("not supported by underlying remote")
 	}
 	return do(ctx)
 }

--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -1269,7 +1269,7 @@ func (f *Fs) About(ctx context.Context) (usage *fs.Usage, err error) {
 		return shouldRetry(ctx, err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("about failed: %w", err)
+		return nil, err
 	}
 	var total uint64
 	if q.Allocation != nil {

--- a/backend/hasher/hasher.go
+++ b/backend/hasher/hasher.go
@@ -278,7 +278,7 @@ func (f *Fs) CleanUp(ctx context.Context) error {
 	if do := f.Fs.Features().CleanUp; do != nil {
 		return do(ctx)
 	}
-	return errors.New("CleanUp not supported")
+	return errors.New("not supported by underlying remote")
 }
 
 // About gets quota information from the Fs
@@ -286,7 +286,7 @@ func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	if do := f.Fs.Features().About; do != nil {
 		return do(ctx)
 	}
-	return nil, errors.New("About not supported")
+	return nil, errors.New("not supported by underlying remote")
 }
 
 // ChangeNotify calls the passed function with a path that has had changes.

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -1482,7 +1482,7 @@ func (f *Fs) About(ctx context.Context) (usage *fs.Usage, err error) {
 		return shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("about failed: %w", err)
+		return nil, err
 	}
 	q := drive.Quota
 	// On (some?) Onedrive sharepoints these are all 0 so return unknown in that case

--- a/backend/pcloud/pcloud.go
+++ b/backend/pcloud/pcloud.go
@@ -906,7 +906,7 @@ func (f *Fs) About(ctx context.Context) (usage *fs.Usage, err error) {
 		return shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("about failed: %w", err)
+		return nil, err
 	}
 	usage = &fs.Usage{
 		Total: fs.NewUsageValue(q.Quota),               // quota of bytes that can be used

--- a/backend/premiumizeme/premiumizeme.go
+++ b/backend/premiumizeme/premiumizeme.go
@@ -783,10 +783,10 @@ func (f *Fs) About(ctx context.Context) (usage *fs.Usage, err error) {
 		return shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("CreateDir http: %w", err)
+		return nil, err
 	}
 	if err = info.AsErr(); err != nil {
-		return nil, fmt.Errorf("CreateDir: %w", err)
+		return nil, err
 	}
 	usage = &fs.Usage{
 		Used: fs.NewUsageValue(int64(info.SpaceUsed)),

--- a/backend/putio/fs.go
+++ b/backend/putio/fs.go
@@ -647,7 +647,7 @@ func (f *Fs) About(ctx context.Context) (usage *fs.Usage, err error) {
 		return shouldRetry(ctx, err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("about failed: %w", err)
+		return nil, err
 	}
 	return &fs.Usage{
 		Total: fs.NewUsageValue(ai.Disk.Size),  // quota of bytes that can be used

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -1218,7 +1218,7 @@ func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	}
 	stdout, err := f.run(ctx, "df -k "+escapedPath)
 	if err != nil {
-		return nil, fmt.Errorf("your remote may not support About: %w", err)
+		return nil, fmt.Errorf("your remote may not have the required df utility: %w", err)
 	}
 
 	usageTotal, usageUsed, usageAvail := parseUsage(stdout)

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -1148,7 +1148,7 @@ func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 		return f.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
-		return nil, fmt.Errorf("about call failed: %w", err)
+		return nil, err
 	}
 	usage := &fs.Usage{}
 	if i, err := strconv.ParseInt(q.Used, 10, 64); err == nil && i >= 0 {

--- a/cmd/about/about.go
+++ b/cmd/about/about.go
@@ -102,7 +102,7 @@ see complete list in [documentation](https://rclone.org/overview/#optional-featu
 			}
 			u, err := doAbout(context.Background())
 			if err != nil {
-				return fmt.Errorf("About call failed: %w", err)
+				return fmt.Errorf("about call failed: %w", err)
 			}
 			if u == nil {
 				return errors.New("nil usage returned")


### PR DESCRIPTION
#### What is the purpose of this change?

Avoid overly self-aware error messages like this:

> 2022/01/14 21:43:36 Failed to about: About call failed: about failed: file does not exist

The command processing starts with the "Failed to <commandname>".

The about and rc outer layers wrap any errors with "about call failed: "
- The first letter was actually uppercase in the about command, I changed it to lowercase as is the convention.

Now, in the backend's About functions, there is no need to shout out even more that this is about ... about...

#### Was the change discussed in an issue or in the forum before?


#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
