### PR TITLE
gomobile: iOS support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -339,3 +339,31 @@ jobs:
           RCLONE_CONFIG_PASS: ${{ secrets.RCLONE_CONFIG_PASS }}
         # Upload artifacts if not a PR && not a fork
         if: github.head_ref == '' && github.repository == 'rclone/rclone'
+
+  ios:
+    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual }}
+    timeout-minutes: 30
+    name: "ios-simulator"
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go 1.16
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.16
+
+      - name: install gomobile
+        run: |
+          go get golang.org/x/mobile/cmd/gobind
+          go get golang.org/x/mobile/cmd/gomobile
+          env PATH=$PATH:~/go/bin gomobile init
+
+      - name: ios build
+        shell: bash
+        run: |
+          env PATH=$PATH:~/go/bin gomobile bind -v -target=iossimulator ./librclone/gomobile

--- a/lib/buildinfo/osversion.go
+++ b/lib/buildinfo/osversion.go
@@ -1,5 +1,5 @@
-//go:build !windows
-// +build !windows
+//go:build !windows && !ios
+// +build !windows,!ios
 
 package buildinfo
 

--- a/lib/buildinfo/osversion_ios.go
+++ b/lib/buildinfo/osversion_ios.go
@@ -1,0 +1,9 @@
+//go:build ios
+// +build ios
+
+package buildinfo
+
+// GetOSVersion returns OS version, kernel and bitness
+func GetOSVersion() (osVersion, osKernel string) {
+	return "ios", "unknown"
+}


### PR DESCRIPTION
#### What is the purpose of this change?

Fix Gomobile build for iOS by removing `gopsutil` specifically for the iOS platform.

#### Was the change discussed in an issue or in the forum before?

Yeah. [Link](https://forum.rclone.org/t/gomobile-cannot-build-rclone-librclone-gomobile-for-the-ios-target/28606/4)

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
