### PR TITLE
config: fix display of config choices with empty help text

### DIFF
--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -111,14 +111,14 @@ func Choose(what string, kind string, choices, help []string, defaultValue strin
 	attributes := []string{terminal.HiRedFg, terminal.HiGreenFg}
 	for i, text := range choices {
 		var lines []string
-		if help != nil {
+		if help != nil && help[i] != "" {
 			parts := strings.Split(help[i], "\n")
 			lines = append(lines, parts...)
+			lines = append(lines, fmt.Sprintf("(%s)", text))
 		}
-		lines = append(lines, fmt.Sprintf("(%s)", text))
 		pos := i + 1
 		terminal.WriteString(attributes[i%len(attributes)])
-		if len(lines) == 1 {
+		if len(lines) == 0 {
 			fmt.Printf("%2d > %s\n", pos, text)
 		} else {
 			mid := (len(lines) - 1) / 2


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes issue introduced in #5551.

Instead of:
```
Option config_mountpoint.
Please select the mountpoint to use. Normally this will be Archive.
Choose a number from below, or type in an existing string value.
Press Enter for the default (Archive).
 1 /
   \ (Archive)
 2 /
   \ (Shared)
 3 /
   \ (Sync)
```

Then:

```
Option config_mountpoint.
Please select the mountpoint to use. Normally this will be Archive.
Choose a number from below, or type in an existing string value.
Press Enter for the default (Archive).
 1 > Archive
 2 > Shared
 3 > Sync
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
