### PR TITLE
Make bash completion respect --config.

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -48,11 +48,22 @@ __rclone_custom_func() {
         else
             __rclone_init_completion -n : || return
         fi
-	local rclone=(command rclone --ask-password=false)
+        local rclone=(command rclone --ask-password=false)
         if [[ $cur != *:* ]]; then
+            local config_file=""
+            for idx in ${!words[@]}; do
+              if [[ "${words[idx]}" == "--config" && "${#words[@]}" -gt $((idx+1)) ]]; then
+                config_file="${words[idx+1]}"
+              fi
+            done
             local ifs=$IFS
             IFS=$'\n'
-            local remotes=($("${rclone[@]}" listremotes 2> /dev/null))
+            local remotes=""
+            if [[ -z "${config_file}" ]]; then
+              remotes=($("${rclone[@]}" listremotes 2> /dev/null))
+            else
+              remotes=($("${rclone[@]}" --config "${config_file}" listremotes 2> /dev/null))
+            fi
             IFS=$ifs
             local remote
             for remote in "${remotes[@]}"; do


### PR DESCRIPTION
The bash completion script may add remotes to the candidates, by running
`rclone listremotes`. However it does not make sense if the current
command is `rclone --config MY_CONFIG_FILE`.

With this commit, the bash completion script will try to extract the
config file, then run `rclone --cofnig MY_CONFIG_FILE listremotes`
instead.

#### What is the purpose of this change?
See above (commit message)

#### Was the change discussed in an issue or in the forum before?
No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
