### PR TITLE
Jottacloud: Add full support for custom device/mountpoints

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -127,7 +127,7 @@ func init() {
 func Config(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
 	switch config.State {
 	case "":
-		return fs.ConfigChooseFixed("auth_type_done", "config_type", `Authentication type.`, []fs.OptionExample{{
+		return fs.ConfigChooseExclusiveFixed("auth_type_done", "config_type", `Authentication type.`, []fs.OptionExample{{
 			Value: "standard",
 			Help:  "Standard authentication.\nUse this if you're a normal Jottacloud user.",
 		}, {
@@ -286,7 +286,7 @@ machines.`)
 		if err != nil {
 			return nil, err
 		}
-		return fs.ConfigChoose("choose_device_result", "config_device", `Please select the device to use. Normally this will be Jotta`, len(acc.Devices), func(i int) (string, string) {
+		return fs.ConfigChooseExclusive("choose_device_result", "config_device", `Please select the device to use. Normally this will be Jotta`, len(acc.Devices), func(i int) (string, string) {
 			return acc.Devices[i].Name, ""
 		})
 	case "choose_device_result":
@@ -304,7 +304,7 @@ machines.`)
 		if err != nil {
 			return nil, err
 		}
-		return fs.ConfigChoose("choose_device_mountpoint", "config_mountpoint", `Please select the mountpoint to use. Normally this will be Archive.`, len(dev.MountPoints), func(i int) (string, string) {
+		return fs.ConfigChooseExclusive("choose_device_mountpoint", "config_mountpoint", `Please select the mountpoint to use. Normally this will be Archive.`, len(dev.MountPoints), func(i int) (string, string) {
 			return dev.MountPoints[i].Name, ""
 		})
 	case "choose_device_mountpoint":

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -834,12 +834,12 @@ func getOAuthClient(ctx context.Context, name string, m configmap.Mapper) (oAuth
 	if ok {
 		ver, err = strconv.Atoi(version)
 		if err != nil {
-			return nil, nil, errors.New("Failed to parse config version")
+			return nil, nil, errors.New("failed to parse config version")
 		}
 		ok = (ver == configVersion) || (ver == legacyConfigVersion)
 	}
 	if !ok {
-		return nil, nil, errors.New("Outdated config - please reconfigure this backend")
+		return nil, nil, errors.New("outdated config - please reconfigure this backend")
 	}
 
 	baseClient := fshttp.NewClient(ctx)
@@ -885,7 +885,7 @@ func getOAuthClient(ctx context.Context, name string, m configmap.Mapper) (oAuth
 	// Create OAuth Client
 	oAuthClient, ts, err = oauthutil.NewClientWithBaseClient(ctx, name, m, oauthConfig, baseClient)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to configure Jottacloud oauth client: %w", err)
+		return nil, nil, fmt.Errorf("failed to configure Jottacloud oauth client: %w", err)
 	}
 	return oAuthClient, ts, nil
 }
@@ -1172,7 +1172,7 @@ func parseListRStream(ctx context.Context, r io.Reader, filesystem *Fs, callback
 
 	if expected.Folders != actual.Folders ||
 		expected.Files != actual.Files {
-		return fmt.Errorf("Invalid result from listStream: expected[%#v] != actual[%#v]", expected, actual)
+		return fmt.Errorf("invalid result from listStream: expected[%#v] != actual[%#v]", expected, actual)
 	}
 	return nil
 }

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -424,7 +424,7 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 
 	switch config.State {
 	case "choose_type":
-		return fs.ConfigChooseFixed("choose_type_done", "config_type", "Type of connection", []fs.OptionExample{{
+		return fs.ConfigChooseExclusiveFixed("choose_type_done", "config_type", "Type of connection", []fs.OptionExample{{
 			Value: "onedrive",
 			Help:  "OneDrive Personal or Business",
 		}, {

--- a/docs/content/jottacloud.md
+++ b/docs/content/jottacloud.md
@@ -75,60 +75,83 @@ s) Set configuration password
 q) Quit config
 n/s/q> n
 name> remote
+Option Storage.
 Type of storage to configure.
-Enter a string value. Press Enter for the default ("").
-Choose a number from below, or type in your own value
+Choose a number from below, or type in your own value.
 [snip]
 XX / Jottacloud
-   \ "jottacloud"
+   \ (jottacloud)
 [snip]
 Storage> jottacloud
-** See help for jottacloud backend at: https://rclone.org/jottacloud/ **
-
-Edit advanced config? (y/n)
-y) Yes
-n) No
-y/n> n
-Remote config
-Use legacy authentication?.
-This is only required for certain whitelabel versions of Jottacloud and not recommended for normal users.
+Edit advanced config?
 y) Yes
 n) No (default)
 y/n> n
-
-Generate a personal login token here: https://www.jottacloud.com/web/secure
+Option config_type.
+Select authentication type.
+Choose a number from below, or type in an existing string value.
+Press Enter for the default (standard).
+   / Standard authentication.
+ 1 | Use this if you're a normal Jottacloud user.
+   \ (standard)
+   / Legacy authentication.
+ 2 | This is only required for certain whitelabel versions of Jottacloud and not recommended for normal users.
+   \ (legacy)
+   / Telia Cloud authentication.
+ 3 | Use this if you are using Telia Cloud.
+   \ (telia)
+   / Tele2 Cloud authentication.
+ 4 | Use this if you are using Tele2 Cloud.
+   \ (tele2)
+config_type> 1
+Personal login token.
+Generate here: https://www.jottacloud.com/web/secure
 Login Token> <your token here>
-
-Do you want to use a non standard device/mountpoint e.g. for accessing files uploaded using the official Jottacloud client?
-
+Use a non-standard device/mountpoint?
+Choosing no, the default, will let you access the storage used for the archive
+section of the official Jottacloud client. If you instead want to access the
+sync or the backup section, for example, you must choose yes.
 y) Yes
-n) No
+n) No (default)
 y/n> y
-Please select the device to use. Normally this will be Jotta
-Choose a number from below, or type in an existing value
+Option config_device.
+The device to use. In standard setup the built-in Jotta device is used,
+which contains predefined mountpoints for archive, sync etc. All other devices
+are treated as backup devices by the official Jottacloud client. You may create
+a new by entering a unique name.
+Choose a number from below, or type in your own string value.
+Press Enter for the default (DESKTOP-3H31129).
  1 > DESKTOP-3H31129
  2 > Jotta
-Devices> 2
-Please select the mountpoint to user. Normally this will be Archive
-Choose a number from below, or type in an existing value
+config_device> 2
+Option config_mountpoint.
+The mountpoint to use for the built-in device Jotta.
+The standard setup is to use the Archive mountpoint. Most other mountpoints
+have very limited support in rclone and should generally be avoided.
+Choose a number from below, or type in an existing string value.
+Press Enter for the default (Archive).
  1 > Archive
- 2 > Links
+ 2 > Shared
  3 > Sync
-
-Mountpoints> 1
+config_mountpoint> 1
 --------------------
-[jotta]
+[remote]
 type = jottacloud
+configVersion = 1
+client_id = jottacli
+client_secret =
+tokenURL = https://id.jottacloud.com/auth/realms/jottacloud/protocol/openid-connect/token
 token = {........}
+username = 2940e57271a93d987d6f8a21
 device = Jotta
 mountpoint = Archive
-configVersion = 1
 --------------------
-y) Yes this is OK
+y) Yes this is OK (default)
 e) Edit this remote
 d) Delete this remote
 y/e/d> y
 ```
+
 Once configured you can then use `rclone` like this,
 
 List directories in top level of your Jottacloud
@@ -145,19 +168,27 @@ To copy a local directory to an Jottacloud directory called backup
 
 ### Devices and Mountpoints
 
-The official Jottacloud client registers a device for each computer you install it on,
-and then creates a mountpoint for each folder you select for Backup.
-The web interface uses a special device called Jotta for the Archive and Sync mountpoints.
+The official Jottacloud client registers a device for each computer you install
+it on, and shows them in the backup section of the user interface. For each
+folder you select for backup it will create a mountpoint within this device.
+A built-in device called Jotta is special, and contains mountpoints Archive,
+Sync and some others, used for corresponding features in official clients.
 
-With rclone you'll want to use the Jotta/Archive device/mountpoint in most cases, however if you
-want to access files uploaded by any of the official clients rclone provides the option to select
-other devices and mountpoints during config. Note that uploading files is currently not supported
-to other devices than Jotta.
+With rclone you'll want to use the standard Jotta/Archive device/mountpoint in
+most cases. However, you may for example want to access files from the sync or
+backup functionality provided by the official clients, and rclone therefore
+provides the option to select other devices and mountpoints during config.
 
-The built-in Jotta device may also contain several other mountpoints, such as: Latest, Links, Shared and Trash.
-These are special mountpoints with a different internal representation than the "regular" mountpoints.
-Rclone will only to a very limited degree support them. Generally you should avoid these, unless you know what you
-are doing.
+You are allowed to create new devices and mountpoints. All devices except the
+built-in Jotta device are treated as backup devices by official Jottacloud
+clients, and the mountpoints on them are individual backup sets.
+
+With the built-in Jotta device, only existing, built-in, mountpoints can be
+selected. In addition to the mentioned Archive and Sync, it may contain
+several other mountpoints such as: Latest, Links, Shared and Trash. All of
+these are special mountpoints with a different internal representation than
+the "regular" mountpoints. Rclone will only to a very limited degree support
+them. Generally you should avoid these, unless you know what you are doing.
 
 ### --fast-list
 

--- a/fs/backend_config.go
+++ b/fs/backend_config.go
@@ -176,7 +176,13 @@ func ConfigConfirm(state string, Default bool, name string, help string) (*Confi
 	}, nil
 }
 
-// ConfigChooseFixed returns a ConfigOut structure which has a list of items to choose from.
+// ConfigChooseExclusiveFixed returns a ConfigOut structure which has a list of
+// items to choose from.
+//
+// Possible items must be supplied as a fixed list.
+//
+// User is required to supply a value, and is restricted to the specified list,
+// i.e. free text input is not allowed.
 //
 // state should be the next state required
 // name is the config name for this item
@@ -185,8 +191,8 @@ func ConfigConfirm(state string, Default bool, name string, help string) (*Confi
 //
 // It chooses the first item to be the default.
 // If there are no items then it will return an error.
-// If there is only one item it will short cut to the next state
-func ConfigChooseFixed(state string, name string, help string, items []OptionExample) (*ConfigOut, error) {
+// If there is only one item it will short cut to the next state.
+func ConfigChooseExclusiveFixed(state string, name string, help string, items []OptionExample) (*ConfigOut, error) {
 	if len(items) == 0 {
 		return nil, fmt.Errorf("no items found in: %s", help)
 	}
@@ -208,7 +214,13 @@ func ConfigChooseFixed(state string, name string, help string, items []OptionExa
 	return choose, nil
 }
 
-// ConfigChoose returns a ConfigOut structure which has a list of items to choose from.
+// ConfigChooseExclusive returns a ConfigOut structure which has a list of
+// items to choose from.
+//
+// Possible items are retrieved from a supplied function.
+//
+// User is required to supply a value, and is restricted to the specified list,
+// i.e. free text input is not allowed.
 //
 // state should be the next state required
 // name is the config name for this item
@@ -218,7 +230,60 @@ func ConfigChooseFixed(state string, name string, help string, items []OptionExa
 //
 // It chooses the first item to be the default.
 // If there are no items then it will return an error.
-// If there is only one item it will short cut to the next state
+// If there is only one item it will short cut to the next state.
+func ConfigChooseExclusive(state string, name string, help string, n int, getItem func(i int) (itemValue string, itemHelp string)) (*ConfigOut, error) {
+	items := make(OptionExamples, n)
+	for i := range items {
+		items[i].Value, items[i].Help = getItem(i)
+	}
+	return ConfigChooseExclusiveFixed(state, name, help, items)
+}
+
+// ConfigChooseFixed returns a ConfigOut structure which has a list of
+// suggested items.
+//
+// Suggested items must be supplied as a fixed list.
+//
+// User is required to supply a value, but is not restricted to the specified
+// list, i.e. free text input is accepted.
+//
+// state should be the next state required
+// name is the config name for this item
+// help should be the help shown to the user
+// items should be the items in the list
+//
+// It chooses the first item to be the default.
+func ConfigChooseFixed(state string, name string, help string, items []OptionExample) (*ConfigOut, error) {
+	choose := &ConfigOut{
+		State: state,
+		Option: &Option{
+			Name:     name,
+			Help:     help,
+			Examples: items,
+			Required: true,
+		},
+	}
+	if len(choose.Option.Examples) > 0 {
+		choose.Option.Default = choose.Option.Examples[0].Value
+	}
+	return choose, nil
+}
+
+// ConfigChoose returns a ConfigOut structure which has a list of suggested
+// items.
+//
+// Suggested items are retrieved from a supplied function.
+//
+// User is required to supply a value, but is not restricted to the specified
+// list, i.e. free text input is accepted.
+//
+// state should be the next state required
+// name is the config name for this item
+// help should be the help shown to the user
+// n should be the number of items in the list
+// getItem should return the items (value, help)
+//
+// It chooses the first item to be the default.
 func ConfigChoose(state string, name string, help string, n int, getItem func(i int) (itemValue string, itemHelp string)) (*ConfigOut, error) {
 	items := make(OptionExamples, n)
 	for i := range items {


### PR DESCRIPTION
#### What is the purpose of this change?

Default device/mountpoint setup is, as before, Jotta/Archive.

Previously one could configure custom device/mountpoint, but then only existing ones. Also uploading was only supported when using the built-in Jotta device (trying to do it on other devices would log an error).

This PR mainly adds two things:
1. Support for upload on any device/mountpoint.
2. Support for creating new device/mountpoints.

##### Regarding 1: Support for upload on any device/mountpoint.

The upload implementation is (as before) using the so called "allocate api", where we send a post request to endpoint `files/v1/allocate` and supply the file path as parameter. The existing code used paths of form `<mountpoint>/<folders...>/<file>`, which means the device is implied. I found that an alternative form is `/jfs/<device>/<mountpoint>/<folders...>/<file>`, which means we can use it for any device. (I guess either `/<mountpoint>` is a kind of alias to `/jfs/Jotta/<mountpoint>`, or its the fact that `<mountpoint>/..` is a relative path resolved to the `/jfs/Jotta/...`, I haven't digged deeper into that, yet)

##### Regarding 2: Support for creating new device/mountpoints.

The api for creating devices and mountpoints is simple, its very similar to creating a folder. Any devices other than the built-in Jotta device are treated as part of the backup feature in the official clients. Mountpoints are "backup sets", or what to call it, within each device. When you first start the official client it will automatically create a device with your current computer name, and when you select folders to backup each of them (roots) will become mountpoints.

We do not allow creating new mountpoints on the Jotta device. This is actually possible in the api, but such mountpoints will not be shown in official clients, so although it could be a neat trick to create a "hidden mountpoint" maybe its best to avoid it to not confuse users, and in case there are some consequences we are not aware of.

##### Bonus

Added some small refactoring, because it got confusing to keep track of the different api endpoints and the different paths on them.

##### Todo?

When creating new devices/mountpoints, should we run the names through the "encode" process to handle (replace) characters that may cause problems in Jottacloud? I do not do that, currently. When testing, everything I throw at it, except slash, seem to work just fine.

#### Was the change discussed in an issue or in the forum before?

Related: #5894

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] ~I have added tests for all changes in this PR if appropriate.~
    - Not added new ones, but the important parts should be covered by existing integration tests. I've been running these with default setup (Jotta/Archive) and custom setup (custom device and mountpoint).
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
    - Not sure about the refactor commits, though, don't know how to make "user-friendly" messages of such changes...
- [X] I'm done, this Pull Request is ready for review :-)
