### PR TITLE
version: report correct friendly-name for windows 10/11 versions after 2004

### DIFF
--- a/lib/buildinfo/osversion_windows.go
+++ b/lib/buildinfo/osversion_windows.go
@@ -39,9 +39,18 @@ func GetOSVersion() (osVersion, osKernel string) {
 		}
 	}
 
-	friendlyName := getRegistryVersionString("ReleaseId")
-	if osVersion != "" && friendlyName != "" {
-		osVersion += " " + friendlyName
+	if osVersion != "" {
+		// Include the friendly-name of the version, which is typically what is referred to.
+		// Until Windows 10 version 2004 (May 2020) this can be found from registry entry
+		// ReleaseID, after that we must use entry DisplayVersion (ReleaseId is stuck at 2009).
+		// Source: https://ss64.com/nt/ver.html
+		friendlyName := getRegistryVersionString("DisplayVersion")
+		if friendlyName == "" {
+			friendlyName = getRegistryVersionString("ReleaseId")
+		}
+		if friendlyName != "" {
+			osVersion += " " + friendlyName
+		}
 	}
 
 	updateRevision := getRegistryVersionInt("UBR")


### PR DESCRIPTION
#### What is the purpose of this change?

Fix output of `rclone version` on Windows 11 (as well as the later versions of Windows 10).

Note: On rclone version 1.57 it reports "Windows 10" even on Windows 11, but this is fixed via updated dependency in latest master.

Sample output before:

```
rclone v1.58.0-beta.5948.c504d9701
- os/version: Microsoft Windows 11 Pro 2009 (64 bit)
- os/kernel: 10.0.22000.434 (x86_64)
- os/type: windows
- os/arch: amd64
- go/version: go1.17.6
- go/linking: dynamic
- go/tags: cmount
```

This PR changes the following line:

```
- os/version: Microsoft Windows 11 Pro 21H2 (64 bit)
```

Implementation details:

Until Windows 10 version 2004 (May 2020) the friendly-name (codename) can be found from registry entry ReleaseID, but after that we must use entry DisplayVersion (ReleaseId is stuck at 2009). I simply try to read DisplayVersion, and fallback to ReleaseId. Do not actually check if ReleaseId is < 2004. Seems that should work, everwhere. 
Source: https://ss64.com/nt/ver.html

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
