### PR TITLE
rc: Allow user to disable authentication for web gui

### DIFF
--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -95,20 +95,20 @@ func newServer(ctx context.Context, opt *rc.Options, mux *http.ServeMux) *Server
 			fs.Errorf(nil, "Error while fetching the latest release of Web GUI: %v", err)
 		}
 		if opt.NoAuth {
-			opt.NoAuth = false
-			fs.Infof(nil, "Cannot run Web GUI without authentication, using default auth")
-		}
-		if opt.HTTPOptions.BasicUser == "" {
-			opt.HTTPOptions.BasicUser = "gui"
-			fs.Infof(nil, "No username specified. Using default username: %s \n", rcflags.Opt.HTTPOptions.BasicUser)
-		}
-		if opt.HTTPOptions.BasicPass == "" {
-			randomPass, err := random.Password(128)
-			if err != nil {
-				log.Fatalf("Failed to make password: %v", err)
+			fs.Logf(nil, "It is recommended to use web gui with auth.")
+		} else {
+			if opt.HTTPOptions.BasicUser == "" {
+				opt.HTTPOptions.BasicUser = "gui"
+				fs.Infof(nil, "No username specified. Using default username: %s \n", rcflags.Opt.HTTPOptions.BasicUser)
 			}
-			opt.HTTPOptions.BasicPass = randomPass
-			fs.Infof(nil, "No password specified. Using random password: %s \n", randomPass)
+			if opt.HTTPOptions.BasicPass == "" {
+				randomPass, err := random.Password(128)
+				if err != nil {
+					log.Fatalf("Failed to make password: %v", err)
+				}
+				opt.HTTPOptions.BasicPass = randomPass
+				fs.Infof(nil, "No password specified. Using random password: %s \n", randomPass)
+			}
 		}
 		opt.Serve = true
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

As per https://github.com/rclone/rclone-webui-react/issues/139, if the user has secured their server using some alternate mechanism, we should allow them to bypass the authentication in rclone by using an existing flag `--rc-no-auth`.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No

<!--
Link issues and relevant forum posts here.
-->
https://github.com/rclone/rclone-webui-react/issues/139

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
