### PR TITLE
docs: add label before options spec list

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -329,12 +329,29 @@ func showBackend(name string) {
 			if opt.IsPassword {
 				fmt.Printf("**NB** Input to this must be obscured - see [rclone obscure](/commands/rclone_obscure/).\n\n")
 			}
+			fmt.Printf("Properties:\n\n")
 			fmt.Printf("- Config:      %s\n", opt.Name)
 			fmt.Printf("- Env Var:     %s\n", opt.EnvVarName(backend.Prefix))
+			if opt.Provider != "" {
+				fmt.Printf("- Provider:    %s\n", opt.Provider)
+			}
 			fmt.Printf("- Type:        %s\n", opt.Type())
-			fmt.Printf("- Default:     %s\n", quoteString(opt.GetValue()))
+			defaultValue := opt.GetValue()
+			// Default value and Required are related: Required means option must
+			// have a value, but if there is a default then a value does not have
+			// to be explicitely set and then Required makes no difference.
+			if defaultValue != "" {
+				fmt.Printf("- Default:     %s\n", quoteString(defaultValue))
+			} else {
+				fmt.Printf("- Required:    %v\n", opt.Required)
+			}
+			// List examples / possible choices
 			if len(opt.Examples) > 0 {
-				fmt.Printf("- Examples:\n")
+				if opt.Exclusive {
+					fmt.Printf("- Choices:\n")
+				} else {
+					fmt.Printf("- Examples:\n")
+				}
 				for _, ex := range opt.Examples {
 					fmt.Printf("    - %s\n", quoteString(ex.Value))
 					for _, line := range strings.Split(ex.Help, "\n") {


### PR DESCRIPTION
#### What is the purpose of this change?

See this section: https://rclone.org/http/#http-no-head

The help description for this flag ends with a list, and when the generic help template appends default list items (Config, Env Var, Type etc) after this help text it will be automatically joined into the same list, which is not the intention. I've rewritten that particular text in another pr, but in general I think it is better to extend the generic help template to include a small "intro" before the list items, to make sure it is separated from the rest of the help text.

~I could not come up with a better name than "Specification"... Can you??~

EDIT:
- Added header "Properties:" as per  [comment](#issuecomment-1021375128").
- Added Provider as an additional entry, if set. 
   - s3 docs have a lot of variants of same options with different provider filters, to set different multiple choice lists for the providers. The Provider filter was not included in the docs, which lead to a lot of seemingly duplicate options.
- Added Required as an additional entry
    - Only showing it when Default is not set (empty), and then not showing Default. I.e. only showing one of them: Default if set (non-empty), else Required (true/false). The reality is that Required means option must have a value, but if there is a default then a value does not have to be explicitely set and therefore Required makes no real difference.
- Some examples showing the above:
    ```
    Properties:

    - Config:      requester_pays
    - Env Var:     RCLONE_S3_REQUESTER_PAYS
    - Provider:    AWS
    - Type:        bool
    - Default:     false
    ```

    ```
    Properties:

    - Config:      shared_credentials_file
    - Env Var:     RCLONE_S3_SHARED_CREDENTIALS_FILE
    - Type:        string
    - Required:    false
    ```

    ```
    Properties:

    - Config:      location_constraint
    - Env Var:     RCLONE_S3_LOCATION_CONSTRAINT
    - Provider:    IBMCOS
    - Type:        string
    - Required:    false
    - Examples:
        - "us-standard"
            - US Cross Region Standard
        - "us-vault"
            - US Cross Region Vault
        - "us-cold"
    ```
 - Renamed "Examples" to "Choices" when the Exclusive property is set, since the list is then the possible values and not what I would think of as "examples". Considered adding more alternative wordings here (like "Must be one of", "Must be one of, if set" or something like that) depending on the Required and Default properties, which also play a part related to decide if empty value is allowed or not, but stuck with the two.
     - Required=true && Default=="" means empty is not allowed, so if Exclusive=True it means the value must be strictly from the list:
         ```
         - Required:     true
         - Choices:
             - "must"
             - "choose"
         ```
        Else, if Exclusive=False it means it must be set to something - i.e. not empty, but not necessarily from the list:
         ```
         - Required:     true
         - Examples:
             - "may"
             - "choose"
             - "or write something else"
         ```
     - (Required=false || Default!="") means empty value is allowed, but if Exclusive=True and a non-empty value is specified it must still be strictly from the list:
         ```
         - Default:     "some"
         - Choices:
             - "may"
             - "choose"
             - "or stick with default"
         ```
        Else, if Exclusive=False it can be anything - i.e. empty input allowed, as it will mean default:
         ```
         - Default:     "some"
         - Examples:
             - "may"
             - "choose"
             - "or write something else"
             - "or stick with default"
         ```
- Ref: https://github.com/rclone/rclone/pull/5551

#### Was the change discussed in an issue or in the forum before?

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
