### PR TITLE
docs/serve: move help for template option into separate section

### DIFF
--- a/cmd/serve/http/data/data.go
+++ b/cmd/serve/http/data/data.go
@@ -16,7 +16,10 @@ import (
 )
 
 // Help describes the options for the serve package
-var Help = `--template allows a user to specify a custom markup template for http
+var Help = `
+#### Template
+
+--template allows a user to specify a custom markup template for http
 and webdav serve functions.  The server exports the following markup
 to be used within the template to server pages:
 


### PR DESCRIPTION
#### What is the purpose of this change?

See:

https://rclone.org/commands/rclone_serve_http/#ssl-tls

The help text for lib/http, ending with a SSL/TLS section, is joined with the help text for data - which does not begin with a header and is therefore included in the unrelated SSL/TLS section.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
