### PR TITLE
docs: include all commands in online help top menu drop-down

### DIFF
--- a/docs/layouts/chrome/navbar.html
+++ b/docs/layouts/chrome/navbar.html
@@ -34,24 +34,14 @@
         </a>
         <div class="dropdown-menu pre-scrollable" aria-labelledby="navbarDropdown">
           <a class="dropdown-item" href="/commands/"><i class="fas fa-map"></i> Overview</a>
-          <div class="dropdown-divider"></div>          
-          <a class="dropdown-item" href="/commands/rclone_config/"><i class="fa fa-book"></i> rclone config</a>
-          <a class="dropdown-item" href="/commands/rclone_copy/"><i class="fa fa-book"></i> rclone copy</a>
-          <a class="dropdown-item" href="/commands/rclone_sync/"><i class="fa fa-book"></i> rclone sync</a>
-          <a class="dropdown-item" href="/commands/rclone_move/"><i class="fa fa-book"></i> rclone move</a>
-          <a class="dropdown-item" href="/commands/rclone_purge/"><i class="fa fa-book"></i> rclone purge</a>
-          <a class="dropdown-item" href="/commands/rclone_mkdir/"><i class="fa fa-book"></i> rclone mkdir</a>
-          <a class="dropdown-item" href="/commands/rclone_rmdir/"><i class="fa fa-book"></i> rclone rmdir</a>
-          <a class="dropdown-item" href="/commands/rclone_check/"><i class="fa fa-book"></i> rclone check</a>
-          <a class="dropdown-item" href="/commands/rclone_ls/"><i class="fa fa-book"></i> rclone ls</a>
-          <a class="dropdown-item" href="/commands/rclone_lsd/"><i class="fa fa-book"></i> rclone lsd</a>
-          <a class="dropdown-item" href="/commands/rclone_delete/"><i class="fa fa-book"></i> rclone delete</a>
-          <a class="dropdown-item" href="/commands/rclone_size/"><i class="fa fa-book"></i> rclone size</a>
-          <a class="dropdown-item" href="/commands/rclone_mount/"><i class="fa fa-book"></i> rclone mount</a>
-          <a class="dropdown-item" href="/commands/rclone_ncdu/"><i class="fa fa-book"></i> rclone ncdu</a>
-          <a class="dropdown-item" href="/commands/rclone_cat/"><i class="fa fa-book"></i> rclone cat</a>
-          <a class="dropdown-item" href="/commands/rclone_rcat/"><i class="fa fa-book"></i> rclone rcat</a>
-          <a class="dropdown-item" href="/commands/rclone_serve/"><i class="fa fa-book"></i> rclone serve</a>
+          <div class="dropdown-divider"></div>
+          {{ with .Site.GetPage "/commands" }}
+            {{ range .Data.Pages }}
+              {{ if lt (countwords .Title) 3 }}
+                <a class="dropdown-item" href="{{ .RelPermalink }}"><i class="fa fa-book"></i> {{ .Title | markdownify }}</a>
+              {{ end }}
+            {{ end }}
+          {{ end }}
         </div>
       </li>
       <li class="nav-item active dropdown">
@@ -60,7 +50,7 @@
         </a>
         <div class="dropdown-menu pre-scrollable" aria-labelledby="navbarDropdown">
           <a class="dropdown-item" href="/overview/"><i class="fas fa-map"></i> Overview</a>
-          <div class="dropdown-divider"></div>          
+          <div class="dropdown-divider"></div>
           <a class="dropdown-item" href="/fichier/"><i class="fa fa-archive"></i> 1Fichier</a>
           <a class="dropdown-item" href="/alias/"><i class="fa fa-link"></i> Alias</a>
           <a class="dropdown-item" href="/amazonclouddrive/"><i class="fab fa-amazon"></i> Amazon Drive</a>


### PR DESCRIPTION
#### What is the purpose of this change?

*This is suggestion, up for discussion (see below).*

This makes it easier for new users to know what commands are available. There have been cases where users did not know about a command because they only looked at the dropdown showing the few most common ones. They would have to go into the "Overview" site to find the rest.

I kept the existing entries as is, added a divider, and then appended all the missing ones. Did not include subcommands (like "config create") that are linked to from parent ("config") docs.

A possible confusion is that the top ones (the existing ones) are ordered according to relevance, and then the ones below the divider are in alphabetic order. This means "copyto" and "copyurl" are next to each other in the lower section, but "rclone copy" is in a different position in the top section.

Up for discussion:

❓ An alternative could be to included all in alphabetic order in the lower section, duplicated the ones in the top section? Perhaps then see if we can reduce the top section, e.g. remove cat, rcat, ncdu, lsd etc..

❓ Another alternative could be to drop the top section with the main commands ordered by relevance, and just show all in alphabetic order? ☑️ I think I'm voting for this one!

PS: I personally have also found it a bit inconsistent that the "Storage Systems" drop down show all, but not the "Commands". Sometimes when I am going to look for a backend doc I mix up the two in my head; I am so used to go into "Overview" of the "Commands" so I also click "Overview" of "Storage Systems" - but there are no links to the backend docs, they are only in the drop down. My point is that some improved consistency between them will be good, although this is in reality a second issue regarding the Overview pages, while what I have covered above is the drop-downs. I considered extended the "Storage Systems > Overview" to include links, but the downside of this is that the markdown, which is already not very minimalistic, gets quite ugly and tables get wide columns...

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
