### PR TITLE
Make azureblob.validateAccessTier case-insensitive, fixes #5943

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -370,16 +370,19 @@ func (o *Object) split() (container, containerPath string) {
 }
 
 // validateAccessTier checks if azureblob supports user supplied tier
+// by comparing tier to the azblob.AccessTier* constants in a case-insensitive
+// manner
 func validateAccessTier(tier string) bool {
-	switch tier {
-	case string(azblob.AccessTierHot),
-		string(azblob.AccessTierCool),
-		string(azblob.AccessTierArchive):
-		// valid cases
+
+	if strings.EqualFold(tier, string(azblob.AccessTierHot)) ||
+		strings.EqualFold(tier, string(azblob.AccessTierCool)) ||
+		strings.EqualFold(tier, string(azblob.AccessTierArchive)) {
+
 		return true
-	default:
-		return false
 	}
+
+	// else...
+	return false
 }
 
 // validatePublicAccess checks if azureblob supports use supplied public access level
@@ -555,7 +558,8 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	if opt.AccessTier == "" {
 		opt.AccessTier = string(defaultAccessTier)
 	} else if !validateAccessTier(opt.AccessTier) {
-		return nil, fmt.Errorf("Azure Blob: Supported access tiers are %s, %s and %s",
+		return nil, fmt.Errorf("Azure Blob: Specified access tier '%s' is unsupported.  Supported access tiers are %s, %s and %s",
+			opt.AccessTier,
 			string(azblob.AccessTierHot), string(azblob.AccessTierCool), string(azblob.AccessTierArchive))
 	}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This makes the azureblob backend handle the 'accessTier' config option in a case-insensitive manner.

#### Was the change discussed in an issue or in the forum before?


#5943

#### Checklist

- [X ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [N/A ] I have added tests for all changes in this PR if appropriate.
- [N/A] I have added documentation for the changes if appropriate.
- [X ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X ] I'm done, this Pull Request is ready for review :-)
