### PR TITLE
operations: improve error message when source and destination hashes differ after copying - fixes #5268

### DIFF
--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -1763,14 +1763,14 @@ func (file *openFile) Close() (err error) {
 
 	// Check to see we read the correct number of bytes
 	if file.o.Size() != file.bytes {
-		return fmt.Errorf("object corrupted on transfer - length mismatch (want %d got %d)", file.o.Size(), file.bytes)
+		return fmt.Errorf("corrupted on transfer: lengths differ want %d vs got %d", file.o.Size(), file.bytes)
 	}
 
 	// Check the SHA1
 	receivedSHA1 := file.o.sha1
 	calculatedSHA1 := fmt.Sprintf("%x", file.hash.Sum(nil))
 	if receivedSHA1 != "" && receivedSHA1 != calculatedSHA1 {
-		return fmt.Errorf("object corrupted on transfer - SHA1 mismatch (want %q got %q)", receivedSHA1, calculatedSHA1)
+		return fmt.Errorf("corrupted on transfer: SHA1 hashes differ want %q vs got %q", receivedSHA1, calculatedSHA1)
 	}
 
 	return nil

--- a/backend/compress/compress.go
+++ b/backend/compress/compress.go
@@ -455,7 +455,7 @@ func (f *Fs) verifyObjectHash(ctx context.Context, o fs.Object, hasher *hash.Mul
 		if err != nil {
 			fs.Errorf(o, "Failed to remove corrupted object: %v", err)
 		}
-		return fmt.Errorf("corrupted on transfer: %v compressed hashes differ %q vs %q", ht, srcHash, dstHash)
+		return fmt.Errorf("corrupted on transfer: %v compressed hashes differ src(%s) %q vs dst(%s) %q", ht, f.Fs, srcHash, o.Fs(), dstHash)
 	}
 	return nil
 }

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -520,7 +520,7 @@ func (f *Fs) put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options [
 				if err != nil {
 					fs.Errorf(o, "Failed to remove corrupted object: %v", err)
 				}
-				return nil, fmt.Errorf("corrupted on transfer: %v encrypted hash differ src %q vs dst %q", ht, srcHash, dstHash)
+				return nil, fmt.Errorf("corrupted on transfer: %v encrypted hashes differ src(%s) %q vs dst(%s) %q", ht, f.Fs, srcHash, o.Fs(), dstHash)
 			}
 			fs.Debugf(src, "%v = %s OK", ht, srcHash)
 		}

--- a/fs/operations/copy.go
+++ b/fs/operations/copy.go
@@ -266,14 +266,14 @@ func (c *copy) manualCopy(ctx context.Context) (actionTaken string, newDst fs.Ob
 func (c *copy) verify(ctx context.Context, newDst fs.Object) (err error) {
 	// Verify sizes are the same after transfer
 	if sizeDiffers(ctx, c.src, newDst) {
-		return fmt.Errorf("corrupted on transfer: sizes differ %d vs %d", c.src.Size(), newDst.Size())
+		return fmt.Errorf("corrupted on transfer: sizes differ src(%s) %d vs dst(%s) %d", c.src.Fs(), c.src.Size(), c.dst.Fs(), c.dst.Size())
 	}
 	// Verify hashes are the same after transfer - ignoring blank hashes
 	if c.hashType != hash.None {
 		// checkHashes has logs and counts errors
 		equal, _, srcSum, dstSum, _ := checkHashes(ctx, c.src, newDst, c.hashType)
 		if !equal {
-			return fmt.Errorf("corrupted on transfer: %v hash differ %q vs %q", c.hashType, srcSum, dstSum)
+			return fmt.Errorf("corrupted on transfer: %v hashes differ src(%s) %q vs dst(%s) %q", c.hashType, c.src.Fs(), srcSum, c.dst.Fs(), dstSum)
 		}
 	}
 	return nil

--- a/vfs/read.go
+++ b/vfs/read.go
@@ -363,7 +363,7 @@ func (fh *ReadFileHandle) checkHash() error {
 			return err
 		}
 		if !hash.Equals(dstSum, srcSum) {
-			return fmt.Errorf("corrupted on transfer: %v hash differ %q vs %q", hashType, dstSum, srcSum)
+			return fmt.Errorf("corrupted on transfer: %v hashes differ src %q vs dst %q", hashType, srcSum, dstSum)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Improves the error message to include the names of the source and destination filesystems, when the source and destination file hashes differ after copying.

For example, if we are copying a file from the local filesystem to Amazon S3 and the file hashes are different after copying, then currently, we'll get the following error message:

> corrupted on transfer: md5 hash differ "eb260e9ae827821beceeed4104f0ad89" vs "59d0d19fc45ca69230d858f60a5557f8"

After this improvement, the error message will be:

> corrupted on transfer: md5 hash differ. source(local): "eb260e9ae827821beceeed4104f0ad89", destination(s3): "59d0d19fc45ca69230d858f60a5557f8"

I couldn't see an existing test for this error, let me know if you want me to try and add one.

I also noticed that the following error in the same function could benefit from a similar change, would you like me to make that change in a different PR?

https://github.com/rclone/rclone/blob/051685baa1e5c58d16e6dcc1d11ff136cfec8dae/fs/operations/operations.go#L513-L519

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/5268

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
