### PR TITLE
docs/jottacloud: add note that mime types are not available with --fast-list

### DIFF
--- a/docs/content/jottacloud.md
+++ b/docs/content/jottacloud.md
@@ -169,6 +169,9 @@ Note that the implementation in Jottacloud always uses only a single
 API request to get the entire list, so for large folders this could
 lead to long wait time before the first results are shown.
 
+Note also that with rclone version 1.58 and newer information about
+[MIME types](/overview/#mime-type) are not available when using `--fast-list`.
+
 ### Modified time and hashes
 
 Jottacloud allows modification times to be set on objects accurate to 1


### PR DESCRIPTION
#### What is the purpose of this change?

Added note in docs related to change in https://github.com/rclone/rclone/pull/5823.

Did not add a mark/note in the table at https://rclone.org/overview/#features, where Jottacloud is "rated R" in the MIME types column, but can add it if you think it deserves it...?

#### Was the change discussed in an issue or in the forum before?


#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
