### PR TITLE
drive: added --drive-copy-shortcut-content, fixes #4604

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -300,9 +300,15 @@ a non root folder as its starting point.
 			Help:     "Send files to the trash instead of deleting permanently.\n\nDefaults to true, namely sending files to the trash.\nUse `--drive-use-trash=false` to delete files permanently instead.",
 			Advanced: true,
 		}, {
-			Name:     "copy_shortcut_content",
-			Default:  false,
-			Help:     "Copy the files instead of just shortcuts when performing a server-side transfer.\nUse `--drive-copy-shortcut-content=true` to enable it. ",
+			Name:    "copy_shortcut_content",
+			Default: false,
+			Help: `Server side copy contents of shortcuts instead of the shortcut.
+
+When doing server side copies, normally rclone will copy shortcuts as
+shortcuts.
+
+If this flag is used then rclone will copy the contents of shortcuts
+rather than shortcuts themselves when doing server side copies.`,
 			Advanced: true,
 		}, {
 			Name:     "skip_gdocs",
@@ -2380,7 +2386,9 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 		createInfo.Description = ""
 	}
 
-	// get the ID of the thing to copy - this is the shortcut if available
+	// get the ID of the thing to copy
+	// copy the contents if CopyShortcutContent
+	// copy the shortcut only
 
 	id := shortcutID(srcObj.id)
 

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -300,6 +300,11 @@ a non root folder as its starting point.
 			Help:     "Send files to the trash instead of deleting permanently.\n\nDefaults to true, namely sending files to the trash.\nUse `--drive-use-trash=false` to delete files permanently instead.",
 			Advanced: true,
 		}, {
+			Name:     "copy_shortcut_content",
+			Default:  false,
+			Help:     "Copy the files instead of just shortcuts when performing a server-side transfer.\nUse `--drive-copy-shortcut-content=true` to enable it. ",
+			Advanced: true,
+		}, {
 			Name:     "skip_gdocs",
 			Default:  false,
 			Help:     "Skip google documents in all listings.\n\nIf given, gdocs practically become invisible to rclone.",
@@ -578,6 +583,7 @@ type Options struct {
 	TeamDriveID               string               `config:"team_drive"`
 	AuthOwnerOnly             bool                 `config:"auth_owner_only"`
 	UseTrash                  bool                 `config:"use_trash"`
+	CopyShortcutContent       bool                 `config:"copy_shortcut_content"`
 	SkipGdocs                 bool                 `config:"skip_gdocs"`
 	SkipChecksumGphotos       bool                 `config:"skip_checksum_gphotos"`
 	SharedWithMe              bool                 `config:"shared_with_me"`
@@ -2375,7 +2381,12 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 	}
 
 	// get the ID of the thing to copy - this is the shortcut if available
+
 	id := shortcutID(srcObj.id)
+
+	if f.opt.CopyShortcutContent {
+		id = actualID(srcObj.id)
+	}
 
 	var info *drive.File
 	err = f.pacer.Call(func() (bool, error) {

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -2388,7 +2388,7 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 
 	// get the ID of the thing to copy
 	// copy the contents if CopyShortcutContent
-	// copy the shortcut only
+	// else copy the shortcut only
 
 	id := shortcutID(srcObj.id)
 

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -708,6 +708,17 @@ Use `--drive-use-trash=false` to delete files permanently instead.
 - Type:        bool
 - Default:     true
 
+#### --drive-copy-shortcut-content
+
+Copy the files instead of just shortcuts when performing a server-side transfer.
+
+Defaults to false, creating another shortcut instead of copying content.
+Use `--drive-copy-shortcut-content=true` to enable it. 
+- Config:		copy_shortcut_content
+- Env Var:		CopyShortcutContent
+- Type:			bool
+- Default:		false
+
 #### --drive-skip-gdocs
 
 Skip google documents in all listings.

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -410,7 +410,7 @@ For shortcuts pointing to files:
 - When downloading the contents of the destination file is downloaded.
 - When updating shortcut file with a non shortcut file, the shortcut is removed then a new file is uploaded in place of the shortcut.
 - When server-side moving (renaming) the shortcut is renamed, not the destination file.
-- When server-side copying the shortcut is copied, not the contents of the shortcut.
+- When server-side copying the shortcut is copied, not the contents of the shortcut. (unless `--drive-copy-shortcut-content` is in use in which case the contents of the shortcut gets copied).
 - When deleting the shortcut is deleted not the linked file.
 - When setting the modification time, the modification time of the linked file will be set.
 
@@ -707,17 +707,6 @@ Use `--drive-use-trash=false` to delete files permanently instead.
 - Env Var:     RCLONE_DRIVE_USE_TRASH
 - Type:        bool
 - Default:     true
-
-#### --drive-copy-shortcut-content
-
-Copy the files instead of just shortcuts when performing a server-side transfer.
-
-Defaults to false, creating another shortcut instead of copying content.
-Use `--drive-copy-shortcut-content=true` to enable it. 
-- Config:		copy_shortcut_content
-- Env Var:		CopyShortcutContent
-- Type:			bool
-- Default:		false
 
 #### --drive-skip-gdocs
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
Added --drive-copy-shortcut-content flag, that enables the user to copy the content of shortcuts when performing server side transfer.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
#4604 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
