### PR TITLE
Configurable version suffix independent of version number

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -245,18 +245,18 @@ retag:
 startdev:
 	@echo "Version is $(VERSION)"
 	@echo "Next version is $(NEXT_VERSION)"
-	echo -e "package fs\n\n// Version of rclone\nvar Version = \"$(NEXT_VERSION)-DEV\"\n" | gofmt > fs/version.go
+	echo -e "package fs\n\n// VersionTag of rclone\nvar VersionTag = \"$(NEXT_VERSION)\"\n" | gofmt > fs/versiontag.go
 	echo -n "$(NEXT_VERSION)" > docs/layouts/partials/version.html
 	echo "$(NEXT_VERSION)" > VERSION
-	git commit -m "Start $(NEXT_VERSION)-DEV development" fs/version.go VERSION docs/layouts/partials/version.html
+	git commit -m "Start $(NEXT_VERSION)-DEV development" fs/versiontag.go VERSION docs/layouts/partials/version.html
 
 startstable:
 	@echo "Version is $(VERSION)"
 	@echo "Next stable version is $(NEXT_PATCH_VERSION)"
-	echo -e "package fs\n\n// Version of rclone\nvar Version = \"$(NEXT_PATCH_VERSION)-DEV\"\n" | gofmt > fs/version.go
+	echo -e "package fs\n\n// VersionTag of rclone\nvar VersionTag = \"$(NEXT_PATCH_VERSION)\"\n" | gofmt > fs/versiontag.go
 	echo -n "$(NEXT_PATCH_VERSION)" > docs/layouts/partials/version.html
 	echo "$(NEXT_PATCH_VERSION)" > VERSION
-	git commit -m "Start $(NEXT_PATCH_VERSION)-DEV development" fs/version.go VERSION docs/layouts/partials/version.html
+	git commit -m "Start $(NEXT_PATCH_VERSION)-DEV development" fs/versiontag.go VERSION docs/layouts/partials/version.html
 
 winzip:
 	zip -9 rclone-$(TAG).zip rclone.exe

--- a/fs/version.go
+++ b/fs/version.go
@@ -1,4 +1,14 @@
 package fs
 
-// Version of rclone
-var Version = "v1.59.0-DEV"
+// Version of rclone containing the complete version string
+var Version string
+
+func init() {
+	if Version == "" {
+		if VersionSuffix == "" {
+			Version = VersionTag
+		} else {
+			Version = VersionTag + "-" + VersionSuffix
+		}
+	}
+}

--- a/fs/versionsuffix.go
+++ b/fs/versionsuffix.go
@@ -1,0 +1,4 @@
+package fs
+
+// VersionSuffix of rclone containing the pre-release label if any
+var VersionSuffix = "DEV"

--- a/fs/versiontag.go
+++ b/fs/versiontag.go
@@ -1,0 +1,4 @@
+package fs
+
+// VersionTag of rclone
+var VersionTag = "v1.59.0"


### PR DESCRIPTION
#### What is the purpose of this change?

Introduces a way to quickly set a custom pre-release label / version suffix on my own builds of rclone. 

As of now master version is "v1.58.0-DEV". I can override this easily with something like `-ldflags "-X github.com/rclone/rclone/fs.Version=v9.9.9-CUSTOM"`, but then I loose the version number it was based on. It would be better if I could keep the *number*, and only set my own suffix. That could be achived, of course, with a little `sed` magic or similar. But with this PR I can simply just set fs.VersionSuffix instead. This makes the build command very easy on any platform, and easy configurable in IDEs like VSCode etc.

Nice to have? Definitely not a must have. And perhaps there are better ways to do this already? Perhaps this file needs to be single variable-only to not break some build pipeline I'm not aware of?

PS: I would like to leave out the `-` separator from the VersionSuffix, which makes it more "semver-safe", but then it would no longer be variables-only file, so I started with the simplest "proof of concept" suggestion...

```
var Version = "v" + VersionNumber
if VersionSuffix != "" {
	Version += "-" + VersionSuffix
}
```

PS2: For reference, .NET uses the name `VersionPrefix` for the number part ("1.58.0") and `VersionSuffix` for the pre-release label ("DEV"), and `Version` for the combination of the two separated with `-`. And it also has a `InformationalVersion` which typically is the combination of `Version` and a commit hash separated with `+` ("1.58.0-DEV+27d5f545fa0e2f09629d0bcbb0e571fc79341f2b").

PS3: Speaking of semver-safe... in `cmd/version/version.go` and `bin/cross-compile.go` we parse the string into a semver struct (after first trimming off the "v" prefix which is not strict semver) and use the version number components:
https://github.com/rclone/rclone/blob/aa2d7f00c2376f2dc44f50afb3276402ddfdb44d/bin/cross-compile.go#L202-L227

#### Was the change discussed in an issue or in the forum before?

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
