### PR TITLE
s3: add note about chunk size decreasing progress accuracy

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1287,7 +1287,14 @@ Files of unknown size are uploaded with the configured
 chunk_size. Since the default chunk size is 5 MiB and there can be at
 most 10,000 chunks, this means that by default the maximum size of
 a file you can stream upload is 48 GiB.  If you wish to stream upload
-larger files then you will need to increase chunk_size.`,
+larger files then you will need to increase chunk_size.
+
+Increasing the chunk size decreases the accuracy of the progress
+statistics displayed with "-P" flag. Rclone treats chunk as sent when
+it's buffered by the AWS SDK, when in fact it may still be uploading.
+A bigger chunk size means a bigger AWS SDK buffer and progress
+reporting more deviating from the truth.
+`,
 			Default:  minChunkSize,
 			Advanced: true,
 		}, {


### PR DESCRIPTION
#### What is the purpose of this change?

Add a note in the S3 docs that increasing the chunk size property decreases the accuracy of the progress statistics.

#### Was the change discussed in an issue or in the forum before?

Yes: https://forum.rclone.org/t/multipart-upload-stops-for-few-minutes-after-4th-chunk/29122/7

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
