### PR TITLE
local: Evaluate symlinks for remote root path

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1327,6 +1327,10 @@ func cleanRootPath(s string, noUNC bool, enc encoder.MultiEncoder) string {
 			if err == nil {
 				s = s2
 			}
+			s2, err = filepath.EvalSymlinks(s)
+			if err == nil {
+				s = s2
+			}
 		}
 		s = filepath.ToSlash(s)
 		vol := filepath.VolumeName(s)
@@ -1341,6 +1345,10 @@ func cleanRootPath(s string, noUNC bool, enc encoder.MultiEncoder) string {
 	}
 	if !filepath.IsAbs(s) {
 		s2, err := filepath.Abs(s)
+		if err == nil {
+			s = s2
+		}
+		s2, err = filepath.EvalSymlinks(s)
 		if err == nil {
 			s = s2
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Using the move command to a destination directory which happens to be the source directory but not with the same path (with use of symlinks) results in directory content removal. The purpose is to prevent user error by detecting that source and destination are actually the same in this particular scenario.

#### Change description
Evaluate symlinks for the root path of local remote:
rclone already checks if the canonicalised root path are the same, this change add sylmlinks evaluation to the canonicalisation of root paths.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
[https://forum.rclone.org/t/more-foolproof-move-command-destination-is-symlink-pointing-to-source/29468](https://forum.rclone.org/t/more-foolproof-move-command-destination-is-symlink-pointing-to-source/29468)
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
