### PR TITLE
backend: adding description option to all backend filesystems

### DIFF
--- a/backend/alias/alias_internal_test.go
+++ b/backend/alias/alias_internal_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/configfile"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -104,4 +106,27 @@ func TestNewFSInvalidRemote(t *testing.T) {
 
 	require.Error(t, err)
 	require.Nil(t, f)
+}
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionComplete = "description_complete"
+		newDescription      = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionComplete,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionComplete, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }

--- a/backend/amazonclouddrive/amazonclouddrive.go
+++ b/backend/amazonclouddrive/amazonclouddrive.go
@@ -69,11 +69,7 @@ func init() {
 		Prefix:      "acd",
 		Description: "Amazon Drive",
 		NewFs:       NewFs,
-		Config: func(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
-			return oauthutil.ConfigOut("", &oauthutil.Options{
-				OAuth2Config: acdConfig,
-			})
-		},
+		Config:      riConfig,
 		Options: append(oauthutil.SharedOptions, []fs.Option{{
 			Name:     "checkpoint",
 			Help:     "Checkpoint for internal polling (debug).",
@@ -335,6 +331,25 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return f, fs.ErrorIsFile
 	}
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return oauthutil.ConfigOut("description", &oauthutil.Options{
+			OAuth2Config: acdConfig,
+		})
+	case "description":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to amazoncloudrive Config. state: %s", config.State)
+	}
 }
 
 // getRootInfo gets the root folder info

--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -71,6 +71,7 @@ func init() {
 		Name:        "azureblob",
 		Description: "Microsoft Azure Blob Storage",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name: "account",
 			Help: "Storage Account Name.\n\nLeave blank to use SAS URL or Emulator.",
@@ -324,6 +325,21 @@ type Object struct {
 }
 
 // ------------------------------------------------------------
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to azureblob Config. state: %s", config.State)
+	}
+}
 
 // Name of the remote (as passed into NewFs)
 func (f *Fs) Name() string {

--- a/backend/azureblob/azureblob_internal_test.go
+++ b/backend/azureblob/azureblob_internal_test.go
@@ -4,8 +4,12 @@
 package azureblob
 
 import (
+	"context"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,4 +37,27 @@ func TestIncrement(t *testing.T) {
 		increment(test.in)
 		assert.Equal(t, test.want, test.in)
 	}
+}
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionComplete = "description_complete"
+		newDescription      = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionComplete,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionComplete, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }

--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -73,6 +73,7 @@ func init() {
 		Name:        "b2",
 		Description: "Backblaze B2",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "account",
 			Help:     "Account ID or Application Key ID.",
@@ -259,6 +260,21 @@ type Object struct {
 }
 
 // ------------------------------------------------------------
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown state %q", config.State)
+	}
+}
 
 // Name of the remote (as passed into NewFs)
 func (f *Fs) Name() string {

--- a/backend/b2/b2_internal_test.go
+++ b/backend/b2/b2_internal_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fstest"
 )
 
@@ -167,4 +169,27 @@ func TestParseTimeString(t *testing.T) {
 		}
 	}
 
+}
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }

--- a/backend/box/box_internal_test.go
+++ b/backend/box/box_internal_test.go
@@ -1,0 +1,34 @@
+package box
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+// TODO: Test more than just "description" states
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionState         = "description"
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "description input",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -67,6 +67,7 @@ func init() {
 		Description: "Cache a remote",
 		NewFs:       NewFs,
 		CommandHelp: commandHelp,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "remote",
 			Help:     "Remote to cache.\n\nNormally should contain a ':' and a path, e.g. \"myremote:path/to/dir\",\n\"myremote:bucket\" or maybe \"myremote:\" (not recommended).",
@@ -342,6 +343,21 @@ func parseRootPath(path string) (string, error) {
 }
 
 var warnDeprecated sync.Once
+
+// riConfig query the user for additional backend configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to cache Config. state: %s", config.State)
+	}
+}
 
 // NewFs constructs an Fs from the path, container:path
 func NewFs(ctx context.Context, name, rootPath string, m configmap.Mapper) (fs.Fs, error) {

--- a/backend/cache/cache_upload_test.go
+++ b/backend/cache/cache_upload_test.go
@@ -1,7 +1,7 @@
 //go:build !plan9 && !js && !race
 // +build !plan9,!js,!race
 
-package cache_test
+package cache
 
 import (
 	"context"
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rclone/rclone/backend/cache"
 	_ "github.com/rclone/rclone/backend/drive"
 	"github.com/rclone/rclone/fs"
 	"github.com/stretchr/testify/require"
@@ -30,7 +29,7 @@ func TestInternalUploadTempDirCreated(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func testInternalUploadQueueOneFile(t *testing.T, id string, rootFs fs.Fs, boltDb *cache.Persistent) {
+func testInternalUploadQueueOneFile(t *testing.T, id string, rootFs fs.Fs, boltDb *Persistent) {
 	// create some rand test data
 	testSize := int64(524288000)
 	testReader := runInstance.randomReader(t, testSize)

--- a/backend/chunker/chunker.go
+++ b/backend/chunker/chunker.go
@@ -146,6 +146,7 @@ func init() {
 		Name:        "chunker",
 		Description: "Transparently chunk/split large files",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "remote",
 			Required: true,
@@ -345,6 +346,21 @@ func NewFs(ctx context.Context, name, rpath string, m configmap.Mapper) (fs.Fs, 
 	f.features.Disable("ListR") // Recursive listing may cause chunker skip files
 
 	return f, err
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to chunker Config. state: %s", config.State)
+	}
 }
 
 // Options defines the configuration for this backend

--- a/backend/chunker/chunker_internal_test.go
+++ b/backend/chunker/chunker_internal_test.go
@@ -899,6 +899,29 @@ func testMD5AllSlow(t *testing.T, f *Fs) {
 	require.NoError(t, operations.Purge(ctx, baseFs, ""))
 }
 
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionComplete = "description_complete"
+		newDescription      = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionComplete,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionComplete, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}
+
 // InternalTest dispatches all internal tests
 func (f *Fs) InternalTest(t *testing.T) {
 	t.Run("PutLarge", func(t *testing.T) {

--- a/backend/compress/compress.go
+++ b/backend/compress/compress.go
@@ -70,6 +70,7 @@ func init() {
 		Name:        "compress",
 		Description: "Compress a remote",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "remote",
 			Help:     "Remote to compress.",
@@ -115,6 +116,21 @@ type Options struct {
 }
 
 /*** FILESYSTEM FUNCTIONS ***/
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to compress Config. state: %s", config.State)
+	}
+}
 
 // Fs represents a wrapped fs.Fs
 type Fs struct {

--- a/backend/compress/compress_internal_test.go
+++ b/backend/compress/compress_internal_test.go
@@ -1,0 +1,32 @@
+package compress
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionComplete = "description_complete"
+		newDescription      = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionComplete,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionComplete, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/compress/compress_test.go
+++ b/backend/compress/compress_test.go
@@ -1,11 +1,12 @@
-// Test Crypt filesystem interface
-package compress
+// Test Compress filesystem interface
+package compress_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
+	"github.com/rclone/rclone/backend/compress"
 	_ "github.com/rclone/rclone/backend/drive"
 	_ "github.com/rclone/rclone/backend/local"
 	_ "github.com/rclone/rclone/backend/s3"
@@ -18,7 +19,7 @@ import (
 func TestIntegration(t *testing.T) {
 	opt := fstests.Opt{
 		RemoteName: *fstest.RemoteName,
-		NilObject:  (*Object)(nil),
+		NilObject:  (*compress.Object)(nil),
 		UnimplementableFsMethods: []string{
 			"OpenWriterAt",
 			"MergeDirs",
@@ -42,7 +43,7 @@ func TestRemoteGzip(t *testing.T) {
 	name := "TestCompressGzip"
 	fstests.Run(t, &fstests.Opt{
 		RemoteName: name + ":",
-		NilObject:  (*Object)(nil),
+		NilObject:  (*compress.Object)(nil),
 		UnimplementableFsMethods: []string{
 			"OpenWriterAt",
 			"MergeDirs",

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -28,6 +28,7 @@ func init() {
 		Description: "Encrypt/Decrypt a remote",
 		NewFs:       NewFs,
 		CommandHelp: commandHelp,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "remote",
 			Help:     "Remote to encrypt/decrypt.\n\nNormally should contain a ':' and a path, e.g. \"myremote:path/to/dir\",\n\"myremote:bucket\" or maybe \"myremote:\" (not recommended).",
@@ -244,6 +245,21 @@ func NewFs(ctx context.Context, name, rpath string, m configmap.Mapper) (fs.Fs, 
 	}).Fill(ctx, f).Mask(ctx, wrappedFs).WrapsFs(f, wrappedFs)
 
 	return f, err
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to crypt Config. state: %s", config.State)
+	}
 }
 
 // Options defines the configuration for this backend

--- a/backend/crypt/crypt_internal_test.go
+++ b/backend/crypt/crypt_internal_test.go
@@ -10,8 +10,10 @@ import (
 	"time"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/object"
+	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/lib/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -135,9 +137,33 @@ func testComputeHash(t *testing.T, f *Fs) {
 	assert.Equal(t, remoteObjHash, computedHash)
 }
 
+func testRiConfig(t *testing.T) {
+	const (
+		descriptionComplete = "description_complete"
+		newDescription      = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionComplete,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionComplete, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}
+
 // InternalTest is called by fstests.Run to extra tests
 func (f *Fs) InternalTest(t *testing.T) {
 	t.Run("ObjectInfo", func(t *testing.T) { testObjectInfo(t, f, false) })
 	t.Run("ObjectInfoWrap", func(t *testing.T) { testObjectInfo(t, f, true) })
 	t.Run("ComputeHash", func(t *testing.T) { testComputeHash(t, f) })
+	t.Run("ConfigRi", func(t *testing.T) { testRiConfig(t) })
 }

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -18,6 +18,7 @@ import (
 
 	_ "github.com/rclone/rclone/backend/local"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
@@ -458,6 +459,35 @@ func (f *Fs) InternalTestCopyID(t *testing.T) {
 		require.NoError(t, err)
 		checkFile("potato.txt")
 	})
+}
+
+// TODO: Test states other than just "description" states
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New drive description."
+		driveIdResult            = "driveIdResult"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: "teamdrive_final", Result: driveIdResult},
+			ExpectState: descriptionCompleteState,
+			ExpectMapper: configmap.Simple{
+				"team_drive":     driveIdResult,
+				"root_folder_id": "",
+			},
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }
 
 // TestIntegration/FsMkdir/FsPutFiles/Internal/AgeQuery

--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -143,15 +143,7 @@ func init() {
 		Name:        "dropbox",
 		Description: "Dropbox",
 		NewFs:       NewFs,
-		Config: func(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
-			return oauthutil.ConfigOut("", &oauthutil.Options{
-				OAuth2Config: getOauthConfig(m),
-				NoOffline:    true,
-				OAuth2Opts: []oauth2.AuthCodeOption{
-					oauth2.SetAuthURLParam("token_access_type", "offline"),
-				},
-			})
-		},
+		Config:      riConfig,
 		Options: append(oauthutil.SharedOptions, []fs.Option{{
 			Name: "chunk_size",
 			Help: fmt.Sprintf(`Upload chunk size (< %v).
@@ -579,6 +571,29 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		}
 	}
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return oauthutil.ConfigOut("description", &oauthutil.Options{
+			OAuth2Config: getOauthConfig(m),
+			NoOffline:    true,
+			OAuth2Opts: []oauth2.AuthCodeOption{
+				oauth2.SetAuthURLParam("token_access_type", "offline"),
+			},
+		})
+	case "description":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to dropbox Config. state: %s", config.State)
+	}
 }
 
 // headerGenerator for dropbox sdk

--- a/backend/dropbox/dropbox_internal_test.go
+++ b/backend/dropbox/dropbox_internal_test.go
@@ -3,6 +3,9 @@ package dropbox
 import (
 	"testing"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -41,4 +44,34 @@ func TestInternalCheckPathLength(t *testing.T) {
 		err := checkPathLength(test.in)
 		assert.Equal(t, test.ok, err == nil, test.in)
 	}
+}
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionState         = "description"
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionState,
+		},
+		{
+			Name:        "description",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }

--- a/backend/fichier/fichier.go
+++ b/backend/fichier/fichier.go
@@ -36,6 +36,7 @@ func init() {
 		Name:        "fichier",
 		Description: "1Fichier",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Help: "Your API Key, get it from https://1fichier.com/console/params.pl.",
 			Name: "api_key",
@@ -101,6 +102,21 @@ type Fs struct {
 	baseClient *http.Client
 	pacer      *fs.Pacer
 	rest       *rest.Client
+}
+
+// riConfig configure additional items for the backend.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to fichier Config. state: %s", config.State)
+	}
 }
 
 // FindLeaf finds a directory of name leaf in the folder with ID pathID

--- a/backend/fichier/fichier_internal_test.go
+++ b/backend/fichier/fichier_internal_test.go
@@ -1,0 +1,32 @@
+package fichier
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/fichier/fichier_test.go
+++ b/backend/fichier/fichier_test.go
@@ -1,5 +1,5 @@
 // Test 1Fichier filesystem interface
-package fichier
+package fichier_test
 
 import (
 	"testing"

--- a/backend/filefabric/filefabric.go
+++ b/backend/filefabric/filefabric.go
@@ -63,6 +63,7 @@ func init() {
 		Name:        "filefabric",
 		Description: "Enterprise File Fabric",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "url",
 			Help:     "URL of the Enterprise File Fabric to connect to.",
@@ -495,6 +496,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		}
 	}
 	return f, errReturn
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to filefabric Config. state: %s", config.State)
+	}
 }
 
 // set the capabilities of this version of software

--- a/backend/filefabric/filefabric_internal_test.go
+++ b/backend/filefabric/filefabric_internal_test.go
@@ -1,0 +1,32 @@
+package filefabric
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -47,6 +47,7 @@ func init() {
 		Name:        "ftp",
 		Description: "FTP Connection",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "host",
 			Help:     "FTP host to connect to.\n\nE.g. \"ftp.example.com\".",
@@ -547,6 +548,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (ff fs.Fs
 		return f, fs.ErrorIsFile
 	}
 	return f, err
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to ftp Config. state: %s", config.State)
+	}
 }
 
 // Shutdown the backend, closing any background tasks and any

--- a/backend/ftp/ftp_internal_test.go
+++ b/backend/ftp/ftp_internal_test.go
@@ -112,4 +112,27 @@ func (f *Fs) InternalTest(t *testing.T) {
 	t.Run("TimePrecision", f.testTimePrecision)
 }
 
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}
+
 var _ fstests.InternalTester = (*Fs)(nil)

--- a/backend/googlecloudstorage/googlecloudstorage_internal_test.go
+++ b/backend/googlecloudstorage/googlecloudstorage_internal_test.go
@@ -1,0 +1,71 @@
+package googlecloudstorage
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestConfigRi test that configRi handles ConfigIn.State correctly
+func TestConfigRi(t *testing.T) {
+	const (
+		descriptionState         = "description"
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description."
+	)
+
+	ctx := context.Background()
+	cm := configmap.Simple{}
+	ci := fs.ConfigIn{State: ""}
+
+	configOut, _ := riConfig(ctx, "gcs", cm, ci)
+
+	assert.Equal(t, descriptionState, configOut.State)
+
+	ci = fs.ConfigIn{State: descriptionState}
+	configOut, _ = riConfig(ctx, "gcs", cm, ci)
+
+	assert.Equal(t, descriptionCompleteState, configOut.State)
+
+	ci = fs.ConfigIn{State: descriptionCompleteState, Result: newDescription}
+	configOut, _ = riConfig(ctx, "gcs", cm, ci)
+
+	assert.Equal(t, configmap.Simple{
+		fs.ConfigDescription: newDescription,
+	}, cm)
+	assert.Nil(t, configOut)
+}
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionState         = "description"
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionState},
+			ExpectState:     descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/googlephotos/googlephotos_internal_test.go
+++ b/backend/googlephotos/googlephotos_internal_test.go
@@ -1,0 +1,47 @@
+package googlephotos
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		googlephotosCompleteState = "googlephotos_complete"
+		newDescription            = "New description."
+		descriptionState          = "description"
+		descriptionCompleteState  = "description_complete"
+		warningState              = "warning"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: warningState,
+		},
+		{
+			Name:        "warning state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: warningState},
+			ExpectState: descriptionState,
+		},
+		{
+			Name:        "description state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete state",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectNilOutput: true,
+			ExpectMapper:     configmap.Simple{fs.ConfigDescription: newDescription},
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/hasher/hasher.go
+++ b/backend/hasher/hasher.go
@@ -27,6 +27,7 @@ func init() {
 		Name:        "hasher",
 		Description: "Better checksums for other remotes",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		CommandHelp: commandHelp,
 		Options: []fs.Option{{
 			Name:     "remote",
@@ -163,6 +164,21 @@ func NewFs(ctx context.Context, fsname, rpath string, cmap configmap.Mapper) (fs
 
 	cache.PinUntilFinalized(f.Fs, f)
 	return f, err
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to hasher Config. state: %s", config.State)
+	}
 }
 
 //

--- a/backend/hasher/hasher_internal_test.go
+++ b/backend/hasher/hasher_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fstest"
@@ -73,6 +74,29 @@ func (f *Fs) InternalTest(t *testing.T) {
 		t.Skip("hasher is not supported on this OS")
 	}
 	t.Run("UploadFromCrypt", f.testUploadFromCrypt)
+}
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }
 
 var _ fstests.InternalTester = (*Fs)(nil)

--- a/backend/hdfs/hdfs.go
+++ b/backend/hdfs/hdfs.go
@@ -4,11 +4,14 @@
 package hdfs
 
 import (
+	"context"
+	"fmt"
 	"path"
 	"strings"
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config"
+	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/lib/encoder"
 )
 
@@ -17,6 +20,7 @@ func init() {
 		Name:        "hdfs",
 		Description: "Hadoop distributed file system",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "namenode",
 			Help:     "Hadoop name node and port.\n\nE.g. \"namenode:8020\" to connect to host namenode at port 8020.",
@@ -57,6 +61,21 @@ datanodes. Possible values are 'authentication', 'integrity' and
 		}},
 	}
 	fs.Register(fsi)
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to hdfs Config. state: %s", config.State)
+	}
 }
 
 // Options for this backend

--- a/backend/hdfs/hdfs_internal_test.go
+++ b/backend/hdfs/hdfs_internal_test.go
@@ -1,0 +1,32 @@
+package hdfs
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -37,6 +37,7 @@ func init() {
 		Name:        "http",
 		Description: "http Connection",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "url",
 			Help:     "URL of http host to connect to.\n\nE.g. \"https://example.com\", or \"https://user:pass@example.com\" to use a username and password.",
@@ -272,6 +273,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to http Config. state: %s", config.State)
+	}
 }
 
 // Name returns the configured name of the file system

--- a/backend/http/http_internal_test.go
+++ b/backend/http/http_internal_test.go
@@ -479,3 +479,26 @@ func TestFsNoSlashRoots(t *testing.T) {
 		}
 	}
 }
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/hubic/hubic_internal_test.go
+++ b/backend/hubic/hubic_internal_test.go
@@ -1,0 +1,39 @@
+package hubic
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionState         = "description"
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionState,
+		},
+		{
+			Name:        "description state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -83,7 +83,7 @@ func init() {
 		Name:        "jottacloud",
 		Description: "Jottacloud",
 		NewFs:       NewFs,
-		Config:      Config,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "md5_memory_limit",
 			Help:     "Files bigger than this will be cached on disk to calculate the MD5 if required.",
@@ -123,8 +123,8 @@ func init() {
 	})
 }
 
-// Config runs the backend configuration protocol
-func Config(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+// riConfig configure additional items for the backend.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
 	switch config.State {
 	case "":
 		return fs.ConfigChooseFixed("auth_type_done", "config_type", `Authentication type.`, []fs.OptionExample{{
@@ -313,6 +313,11 @@ machines.`)
 		return fs.ConfigGoto("end")
 	case "end":
 		// All the config flows end up here in case we need to carry on with something
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
 		return nil, nil
 	}
 	return nil, fmt.Errorf("unknown state %q", config.State)

--- a/backend/jottacloud/jottacloud_internal_test.go
+++ b/backend/jottacloud/jottacloud_internal_test.go
@@ -6,6 +6,9 @@ import (
 	"io"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/lib/readers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,4 +42,29 @@ func TestReadMD5(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TODO: test all ConfigIn states, not just "description" states
+func TestRiConfig(t *testing.T) {
+	const (
+		endState                 = "end"
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description."
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "end state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: endState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }

--- a/backend/koofr/koofr.go
+++ b/backend/koofr/koofr.go
@@ -30,6 +30,7 @@ func init() {
 		Name:        "koofr",
 		Description: "Koofr, Digi Storage and other Koofr-compatible storage providers",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name: fs.ConfigProvider,
 			Help: "Choose your storage provider.",
@@ -363,6 +364,21 @@ func NewFsFromOptions(ctx context.Context, name, root string, opt *Options) (ff 
 		err = nil
 	}
 	return f, err
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to koofr Config. state: %s", config.State)
+	}
 }
 
 // List returns a list of items in a directory

--- a/backend/koofr/koofr_internal_test.go
+++ b/backend/koofr/koofr_internal_test.go
@@ -1,0 +1,32 @@
+package koofr
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -41,6 +41,7 @@ func init() {
 		Name:        "local",
 		Description: "Local Disk",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		CommandHelp: commandHelp,
 		Options: []fs.Option{{
 			Name:     "nounc",
@@ -296,6 +297,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return f, fs.ErrorIsFile
 	}
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to local Config. state: %s", config.State)
+	}
 }
 
 // Determine whether a file is a 'regular' file,

--- a/backend/local/local_internal_test.go
+++ b/backend/local/local_internal_test.go
@@ -229,3 +229,26 @@ func TestHashOnDelete(t *testing.T) {
 	_, err = o.Hash(ctx, hash.MD5)
 	require.Error(t, err)
 }
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/mailru/mailru.go
+++ b/backend/mailru/mailru.go
@@ -85,6 +85,7 @@ func init() {
 		Name:        "mailru",
 		Description: "Mail.ru Cloud",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "user",
 			Help:     "User name (usually email).",
@@ -385,6 +386,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to mailru Config. state: %s", config.State)
+	}
 }
 
 // Internal maintenance flags (to be removed when the backend matures).

--- a/backend/mailru/mailru_internal_test.go
+++ b/backend/mailru/mailru_internal_test.go
@@ -1,0 +1,32 @@
+package mailru
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/mega/mega.go
+++ b/backend/mega/mega.go
@@ -57,6 +57,7 @@ func init() {
 		Name:        "mega",
 		Description: "Mega",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "user",
 			Help:     "User name.",
@@ -250,6 +251,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return f, err
 	}
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to mega Config. state: %s", config.State)
+	}
 }
 
 // splitNodePath splits nodePath into / separated parts, returning nil if it

--- a/backend/mega/mega_internal_test.go
+++ b/backend/mega/mega_internal_test.go
@@ -1,0 +1,32 @@
+package mega
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/memory/memory.go
+++ b/backend/memory/memory.go
@@ -33,6 +33,7 @@ func init() {
 	fs.Register(&fs.RegInfo{
 		Name:        "memory",
 		Description: "In memory object storage system.",
+		Config:      riConfig,
 		NewFs:       NewFs,
 		Options:     []fs.Option{},
 	})
@@ -254,6 +255,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		}
 	}
 	return f, err
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to memory Config. state: %s", config.State)
+	}
 }
 
 // newObject makes an object from a remote and an objectData

--- a/backend/memory/memory_internal_test.go
+++ b/backend/memory/memory_internal_test.go
@@ -1,0 +1,32 @@
+package memory
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/opendrive/opendrive.go
+++ b/backend/opendrive/opendrive.go
@@ -40,6 +40,7 @@ func init() {
 		Name:        "opendrive",
 		Description: "OpenDrive",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "username",
 			Help:     "Username.",
@@ -251,6 +252,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return f, fs.ErrorIsFile
 	}
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to opendrive Config. state: %s", config.State)
+	}
 }
 
 // rootSlash returns root with a slash on if it is empty, otherwise empty string

--- a/backend/opendrive/opendrive_internal_test.go
+++ b/backend/opendrive/opendrive_internal_test.go
@@ -1,0 +1,32 @@
+package opendrive
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/pcloud/pcloud_internal_test.go
+++ b/backend/pcloud/pcloud_internal_test.go
@@ -1,0 +1,39 @@
+package pcloud
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		descriptionState         = "description"
+		newDescription           = "New description."
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionState,
+		},
+		{
+			Name:        "description",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/premiumizeme/premiumizeme_internal_test.go
+++ b/backend/premiumizeme/premiumizeme_internal_test.go
@@ -1,0 +1,39 @@
+package premiumizeme
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		descriptionState         = "description"
+		newDescription           = "New description."
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionState,
+		},
+		{
+			Name:        "description",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/putio/fs.go
+++ b/backend/putio/fs.go
@@ -127,6 +127,26 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (f fs.Fs,
 	return p, nil
 }
 
+// riConfig configure additional items for the backend.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return oauthutil.ConfigOut("description", &oauthutil.Options{
+			OAuth2Config: putioConfig,
+			NoOffline:    true,
+		})
+	case "description":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to putio Config. state: %s", config.State)
+	}
+}
+
 func itoa(i int64) string {
 	return strconv.FormatInt(i, 10)
 }

--- a/backend/putio/putio.go
+++ b/backend/putio/putio.go
@@ -1,13 +1,11 @@
 package putio
 
 import (
-	"context"
 	"regexp"
 	"time"
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config"
-	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/rclone/rclone/lib/dircache"
 	"github.com/rclone/rclone/lib/encoder"
@@ -59,12 +57,7 @@ func init() {
 		Name:        "putio",
 		Description: "Put.io",
 		NewFs:       NewFs,
-		Config: func(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
-			return oauthutil.ConfigOut("", &oauthutil.Options{
-				OAuth2Config: putioConfig,
-				NoOffline:    true,
-			})
-		},
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,

--- a/backend/putio/putio_internal_test.go
+++ b/backend/putio/putio_internal_test.go
@@ -1,0 +1,39 @@
+package putio
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		descriptionState         = "description"
+		newDescription           = "New description."
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionState,
+		},
+		{
+			Name:        "description",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/putio/putio_test.go
+++ b/backend/putio/putio_test.go
@@ -1,9 +1,10 @@
 // Test Put.io filesystem interface
-package putio
+package putio_test
 
 import (
 	"testing"
 
+	"github.com/rclone/rclone/backend/putio"
 	"github.com/rclone/rclone/fstest/fstests"
 )
 
@@ -11,6 +12,6 @@ import (
 func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
 		RemoteName: "TestPutio:",
-		NilObject:  (*Object)(nil),
+		NilObject:  (*putio.Object)(nil),
 	})
 }

--- a/backend/qingstor/qingstor.go
+++ b/backend/qingstor/qingstor.go
@@ -38,6 +38,7 @@ func init() {
 		Name:        "qingstor",
 		Description: "QingCloud Object Storage",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:    "env_auth",
 			Help:    "Get QingStor credentials from runtime.\n\nOnly applies if access_key_id and secret_access_key is blank.",
@@ -379,6 +380,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		}
 	}
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to b2 Config. state: %s", config.State)
+	}
 }
 
 // Name of the remote (as passed into NewFs)

--- a/backend/qingstor/qingstor_internal_test.go
+++ b/backend/qingstor/qingstor_internal_test.go
@@ -1,0 +1,32 @@
+package qingstor
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -60,6 +60,7 @@ func init() {
 		Name:        "s3",
 		Description: "Amazon S3 Compliant Storage Providers including AWS, Alibaba, Ceph, Digital Ocean, Dreamhost, IBM COS, Lyve Cloud, Minio, RackCorp, SeaweedFS, and Tencent COS",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		CommandHelp: commandHelp,
 		Options: []fs.Option{{
 			Name: fs.ConfigProvider,
@@ -2140,6 +2141,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 	// f.listMultipartUploads()
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to s3 Config. state: %s", config.State)
+	}
 }
 
 // Return an Object from a path

--- a/backend/s3/s3_internal_test.go
+++ b/backend/s3/s3_internal_test.go
@@ -1,0 +1,32 @@
+package s3
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -55,6 +55,7 @@ func init() {
 		Name:        "sftp",
 		Description: "SSH/SFTP Connection",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "host",
 			Help:     "SSH host to connect to.\n\nE.g. \"example.com\".",
@@ -733,6 +734,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	return NewFsWithConnection(ctx, f, name, root, m, opt, sshConfig)
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to sftp Config. state: %s", config.State)
+	}
 }
 
 // Do the keyboard interactive challenge

--- a/backend/sftp/sftp_internal_test.go
+++ b/backend/sftp/sftp_internal_test.go
@@ -7,6 +7,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -49,4 +52,27 @@ func TestParseUsage(t *testing.T) {
 		gotSpaceTotal, gotSpaceUsed, gotSpaceAvail := parseUsage([]byte(test.sshOutput))
 		assert.Equal(t, test.usage, [3]int64{gotSpaceTotal, gotSpaceUsed, gotSpaceAvail}, fmt.Sprintf("Test %d sshOutput = %q", i, test.sshOutput))
 	}
+}
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }

--- a/backend/sharefile/sharefile_internal_test.go
+++ b/backend/sharefile/sharefile_internal_test.go
@@ -1,0 +1,39 @@
+package sharefile
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		descriptionState         = "description"
+		newDescription           = "New description."
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionState,
+		},
+		{
+			Name:        "description",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/sia/sia.go
+++ b/backend/sia/sia.go
@@ -38,6 +38,7 @@ func init() {
 		Name:        "sia",
 		Description: "Sia Decentralized Cloud",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name: "api_url",
 			Help: `Sia daemon API URL, like http://sia.daemon.host:9980.
@@ -485,6 +486,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("Invalid config state provided to sia Config. state: %s", config.State)
+	}
 }
 
 // errorHandler translates Siad errors into native rclone filesystem errors.

--- a/backend/sia/sia_internal_test.go
+++ b/backend/sia/sia_internal_test.go
@@ -1,0 +1,32 @@
+package sia
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/storj/storj_internal_test.go
+++ b/backend/storj/storj_internal_test.go
@@ -1,0 +1,34 @@
+package storj
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+// TODO: Test states other than just "description" states
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		descriptionState         = "description"
+		newDescription           = "New description."
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "description state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/sugarsync/sugarsync_internal_test.go
+++ b/backend/sugarsync/sugarsync_internal_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -56,4 +59,29 @@ func TestErrorHandler(t *testing.T) {
 			assert.Equal(t, test.want, got.Error())
 		})
 	}
+}
+
+// TODO: Test more than just "description" states
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		descriptionState         = "description"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "description state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }

--- a/backend/swift/swift.go
+++ b/backend/swift/swift.go
@@ -77,6 +77,7 @@ func init() {
 		Name:        "swift",
 		Description: "OpenStack Swift (Rackspace Cloud Files, Memset Memstore, OVH)",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: append([]fs.Option{{
 			Name:    "env_auth",
 			Help:    "Get swift credentials from environment variables in standard OpenStack form.",
@@ -507,6 +508,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return nil, err
 	}
 	return NewFsWithConnection(ctx, opt, name, root, c, false)
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown state %q", config.State)
+	}
 }
 
 // Return an Object from a path

--- a/backend/swift/swift_internal_test.go
+++ b/backend/swift/swift_internal_test.go
@@ -6,7 +6,10 @@ import (
 	"time"
 
 	"github.com/ncw/swift/v2"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/fserrors"
+	"github.com/rclone/rclone/fstest"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -65,4 +68,27 @@ func TestInternalShouldRetryHeaders(t *testing.T) {
 	dt = after.Sub(start)
 	assert.True(t, dt >= time.Hour-time.Second && dt <= time.Hour+time.Second)
 
+}
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }

--- a/backend/union/union.go
+++ b/backend/union/union.go
@@ -29,6 +29,7 @@ func init() {
 		Name:        "union",
 		Description: "Union merges the contents of several upstream fs",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "upstreams",
 			Help:     "List of space separated upstreams.\n\nCan be 'upstreama:test/dir upstreamb:', '\"upstreama:test/space:ro dir\" upstreamb:', etc.",
@@ -913,6 +914,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	f.hashSet = hashSet
 
 	return f, fserr
+}
+
+// riConfig query the user for additional configuration items.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown state %q", config.State)
+	}
 }
 
 func parentDir(absPath string) string {

--- a/backend/union/union_internal_test.go
+++ b/backend/union/union_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/object"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fstest"
@@ -155,4 +156,27 @@ func TestMoveCopy(t *testing.T) {
 			assert.Equal(t, fileMemory.Size, obj.Size())
 		})
 	})
+}
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
 }

--- a/backend/uptobox/uptobox.go
+++ b/backend/uptobox/uptobox.go
@@ -42,6 +42,7 @@ func init() {
 		Name:        "uptobox",
 		Description: "Uptobox",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Help: "Your access token.\n\nGet it from https://uptobox.com/my_account.",
 			Name: "access_token",
@@ -229,6 +230,21 @@ func NewFs(ctx context.Context, name string, root string, config configmap.Mappe
 	}
 
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown state %q", config.State)
+	}
 }
 
 func (f *Fs) decodeError(resp *http.Response, response interface{}) (err error) {

--- a/backend/uptobox/uptobox_internal_test.go
+++ b/backend/uptobox/uptobox_internal_test.go
@@ -1,0 +1,32 @@
+package uptobox
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		newDescription           = "New description"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -68,6 +68,7 @@ func init() {
 		Name:        "webdav",
 		Description: "Webdav",
 		NewFs:       NewFs,
+		Config:      riConfig,
 		Options: []fs.Option{{
 			Name:     "url",
 			Help:     "URL of http host to connect to.\n\nE.g. https://example.com.",
@@ -476,6 +477,21 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return f, fs.ErrorIsFile
 	}
 	return f, nil
+}
+
+// riConfig query the user for additional configurations.
+func riConfig(ctx context.Context, name string, m configmap.Mapper, config fs.ConfigIn) (*fs.ConfigOut, error) {
+	switch config.State {
+	case "":
+		return fs.ConfigBackendDescription("description_complete")
+	case "description_complete":
+		if config.Result != "" {
+			m.Set(fs.ConfigDescription, config.Result)
+		}
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("unknown state %q", config.State)
+	}
 }
 
 // sets the BearerToken up

--- a/backend/yandex/yandex_internal_test.go
+++ b/backend/yandex/yandex_internal_test.go
@@ -1,0 +1,39 @@
+package yandex
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		descriptionState         = "description"
+		newDescription           = "New description."
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "empty state",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: ""},
+			ExpectState: descriptionState,
+		},
+		{
+			Name:        "description",
+			Mapper:      configmap.Simple{},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:            "description complete",
+			Mapper:          configmap.Simple{},
+			Input:           fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper:    configmap.Simple{fs.ConfigDescription: newDescription},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/backend/zoho/zoho_internal_test.go
+++ b/backend/zoho/zoho_internal_test.go
@@ -1,0 +1,38 @@
+package zoho
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest"
+)
+
+// TODO: Test more than just "description" states
+func TestRiConfig(t *testing.T) {
+	const (
+		descriptionCompleteState = "description_complete"
+		descriptionState         = "description"
+		newDescription           = "New description."
+		region                   = "testRegion"
+	)
+	states := []fstest.ConfigStateTestFixture{
+		{
+			Name:        "description",
+			Mapper:      configmap.Simple{"region": region},
+			Input:       fs.ConfigIn{State: descriptionState},
+			ExpectState: descriptionCompleteState,
+		},
+		{
+			Name:   "description complete",
+			Mapper: configmap.Simple{"region": region},
+			Input:  fs.ConfigIn{State: descriptionCompleteState, Result: newDescription},
+			ExpectMapper: configmap.Simple{
+				fs.ConfigDescription: newDescription,
+				"region":             region,
+			},
+			ExpectNilOutput: true,
+		},
+	}
+	fstest.AssertConfigStates(t, states, riConfig)
+}

--- a/fs/backend_config.go
+++ b/fs/backend_config.go
@@ -20,6 +20,13 @@ const (
 
 	// ConfigKeyEphemeralPrefix marks config keys which shouldn't be stored in the config file
 	ConfigKeyEphemeralPrefix = "config_"
+
+	// ConfigDescription is the description of the configuration
+	ConfigDescription = "description"
+
+	// ConfigDescriptionHelp is the help for the ConfigDescription
+	ConfigDescriptionHelp = "The description for the backend."
+
 )
 
 // ConfigOAuth should be called to do the OAuth
@@ -107,6 +114,13 @@ func ConfigInput(state string, name string, help string) (*ConfigOut, error) {
 	out, _ := ConfigInputOptional(state, name, help)
 	out.Option.Required = true
 	return out, nil
+}
+
+// ConfigBackendDescription asks the user for a description of the backend.
+//
+// state the next state required
+func ConfigBackendDescription(state string) (*ConfigOut, error) {
+	return ConfigInputOptional(state, ConfigDescription, ConfigDescriptionHelp)
 }
 
 // ConfigPassword asks the user for a password
@@ -345,6 +359,15 @@ func configAll(ctx context.Context, name string, m configmap.Mapper, ri *RegInfo
 	// Find the current option
 	option := &ri.Options[optionNumber]
 
+	// return &ConfigOut{
+	// 	State: "oauth",
+	// 	Option: &Option{
+	// 		Name:     "description",
+	// 		Help:     "The description for the configuration",
+	// 		Advanced: true,
+	// 		Required: false,
+	// 	},
+	// }, nil
 	switch state {
 	case "*all":
 		// If option is hidden or doesn't match advanced setting then skip it


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)

Attempting to add the feature as discussed in [this issue](https://github.com/rclone/rclone/issues/4391).

A piece I could be missing, but I'm unsure of how it's used, is adding documentation to each of the markdown files for the backends for `--description` or `--s3-description` [here for s3](https://github.com/rclone/rclone/blame/5ce3019fc1b64fccfce3aef7e25be97ee453fca2/docs/content/s3.md#L1823), and this would apply to each of the backends.

If I'm missing tests, please let me know. It wasn't clear to me that the backends test that each of the options exist.

Thank you!