### PR TITLE
sync: overlap check is now filter-sensitive

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -806,13 +806,13 @@ func OverlappingFilterCheck(ctx context.Context, fdst fs.Fs, fsrc fs.Fs) bool {
 	fsrcRoot := fixRoot(fsrc)
 	if strings.HasPrefix(fdstRoot, fsrcRoot) {
 		fdstRelative := fdstRoot[len(fsrcRoot):]
-		return FilterCheckR(ctx, fdstRelative, 0, fsrc)
+		return filterCheckR(ctx, fdstRelative, 0, fsrc)
 	}
 	return strings.HasPrefix(fsrcRoot, fdstRoot)
 }
 
-// FilterCheckR checks if fdst would be included in the sync
-func FilterCheckR(ctx context.Context, fdstRelative string, pos int, fsrc fs.Fs) bool {
+// filterCheckR checks if fdst would be included in the sync
+func filterCheckR(ctx context.Context, fdstRelative string, pos int, fsrc fs.Fs) bool {
 	include := true
 	fi := filter.GetConfig(ctx)
 	includeDirectory := fi.IncludeDirectory(ctx, fsrc)
@@ -831,7 +831,7 @@ func FilterCheckR(ctx context.Context, fdstRelative string, pos int, fsrc fs.Fs)
 				return true
 			}
 			pos++
-			include = FilterCheckR(ctx, fdstRelative, pos, fsrc)
+			include = filterCheckR(ctx, fdstRelative, pos, fsrc)
 		}
 	}
 	return include

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -805,7 +805,7 @@ func OverlappingFilterCheck(ctx context.Context, fdst fs.Fs, fsrc fs.Fs) bool {
 	fdstRoot := fixRoot(fdst)
 	fsrcRoot := fixRoot(fsrc)
 	if strings.HasPrefix(fdstRoot, fsrcRoot) {
-		fdstRelative := strings.ReplaceAll(fdstRoot, fsrcRoot, "")
+		fdstRelative := fdstRoot[len(fsrcRoot):]
 		return FilterCheckR(ctx, fdstRelative, 0, fsrc)
 	}
 	return strings.HasPrefix(fsrcRoot, fdstRoot)
@@ -821,29 +821,19 @@ func FilterCheckR(ctx context.Context, fdstRelative string, pos int, fsrc fs.Fs)
 	for i := 0; i <= pos; i++ {
 		newPath += dirs[i]
 	}
-	dir := fs.NewDir(newPath, time.Now())
-	currentPath := dir.Remote()
-	if !strings.HasSuffix(currentPath, "/") {
-		currentPath += "/"
+	if !strings.HasSuffix(newPath, "/") {
+		newPath += "/"
 	}
-	if strings.HasPrefix(fdstRelative, currentPath) {
-		include, _ = includeDirectory(currentPath)
+	if strings.HasPrefix(fdstRelative, newPath) {
+		include, _ = includeDirectory(newPath)
 		if include {
-			if currentPath == fdstRelative {
+			if newPath == fdstRelative {
 				return true
 			}
 			pos++
 			include = FilterCheckR(ctx, fdstRelative, pos, fsrc)
 		}
 	}
-
-	if !include {
-		err := fsrc.Mkdir(ctx, fdstRelative)
-		if err != nil {
-			return true
-		}
-	}
-
 	return include
 }
 

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -1252,6 +1252,93 @@ func TestOverlapping(t *testing.T) {
 	}
 }
 
+// testFs is for unit testing fs.Fs
+type testFs struct {
+	testFsInfo
+}
+
+func (i *testFs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
+	return nil, nil
+}
+
+func (i *testFs) NewObject(ctx context.Context, remote string) (fs.Object, error) { return nil, nil }
+
+func (i *testFs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	return nil, nil
+}
+
+func (i *testFs) Mkdir(ctx context.Context, dir string) error { return nil }
+
+func (i *testFs) Rmdir(ctx context.Context, dir string) error { return nil }
+
+// copied from TestOverlapping because the behavior of OverlappingFilterCheck should be identical to Overlapping
+// when no filters are set
+func TestOverlappingFilterCheckWithoutFilter(t *testing.T) {
+	ctx := context.Background()
+	src := &testFs{testFsInfo{name: "name", root: "root"}}
+	slash := string(os.PathSeparator) // native path separator
+	for _, test := range []struct {
+		name     string
+		root     string
+		expected bool
+	}{
+		{"name", "root", true},
+		{"namey", "root", false},
+		{"name", "rooty", false},
+		{"namey", "rooty", false},
+		{"name", "roo", false},
+		{"name", "root/toot", true},
+		{"name", "root/toot/", true},
+		{"name", "root" + slash + "toot", true},
+		{"name", "root" + slash + "toot" + slash, true},
+		{"name", "", true},
+		{"name", "/", true},
+	} {
+		dst := &testFs{testFsInfo{name: test.name, root: test.root}}
+		what := fmt.Sprintf("(%q,%q) vs (%q,%q)", src.name, src.root, dst.name, dst.root)
+		actual := operations.OverlappingFilterCheck(ctx, src, dst)
+		assert.Equal(t, test.expected, actual, what)
+		actual = operations.OverlappingFilterCheck(ctx, dst, src)
+		assert.Equal(t, test.expected, actual, what)
+	}
+}
+
+func TestOverlappingFilterCheckWithFilter(t *testing.T) {
+	ctx := context.Background()
+	fi, err := filter.NewFilter(nil)
+	require.NoError(t, err)
+	require.NoError(t, fi.Add(false, "*/exclude/"))
+	fi.Opt.ExcludeFile = ".ignore"
+	ctx = filter.ReplaceConfig(ctx, fi)
+
+	src := &testFs{testFsInfo{name: "name", root: "root"}}
+	slash := string(os.PathSeparator) // native path separator
+	for _, test := range []struct {
+		name     string
+		root     string
+		expected bool
+	}{
+		{"name", "root", true},
+		{"name", "root/", true},
+		{"name", "root" + slash, true},
+		{"name", "root/exclude", false},
+		{"name", "root/exclude/", false},
+		{"name", "root" + slash + "exclude", false},
+		{"name", "root" + slash + "exclude" + slash, false},
+		{"name", "root/.ignore", false},
+		{"name", "root" + slash + ".ignore", false},
+		{"namey", "root/include", false},
+		{"namey", "root/include/", false},
+		{"namey", "root" + slash + "include", false},
+		{"namey", "root" + slash + "include" + slash, false},
+	} {
+		dst := &testFs{testFsInfo{name: test.name, root: test.root}}
+		what := fmt.Sprintf("(%q,%q) vs (%q,%q)", src.name, src.root, dst.name, dst.root)
+		actual := operations.OverlappingFilterCheck(ctx, dst, src)
+		assert.Equal(t, test.expected, actual, what)
+	}
+}
+
 func TestListFormat(t *testing.T) {
 	item0 := &operations.ListJSONItem{
 		Path:      "a",

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -97,7 +97,7 @@ func (strategy trackRenamesStrategy) leaf() bool {
 }
 
 func newSyncCopyMove(ctx context.Context, fdst, fsrc fs.Fs, deleteMode fs.DeleteMode, DoMove bool, deleteEmptySrcDirs bool, copyEmptySrcDirs bool) (*syncCopyMove, error) {
-	if (deleteMode != fs.DeleteModeOff || DoMove) && operations.Overlapping(fdst, fsrc) {
+	if (deleteMode != fs.DeleteModeOff || DoMove) && operations.OverlappingFilterCheck(ctx, fdst, fsrc) {
 		return nil, fserrors.FatalError(fs.ErrorOverlapping)
 	}
 	ci := fs.GetConfig(ctx)

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1452,6 +1452,7 @@ func TestSyncOverlapWithFilter(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, fi.Add(false, "/rclone-sync-test/"))
 	require.NoError(t, fi.Add(false, "*/layer2/"))
+	fi.Opt.ExcludeFile = ".ignore"
 	ctx = filter.ReplaceConfig(ctx, fi)
 
 	subRemoteName := r.FremoteName + "/rclone-sync-test"
@@ -1463,6 +1464,12 @@ func TestSyncOverlapWithFilter(t *testing.T) {
 	FremoteSync2, err := fs.NewFs(ctx, subRemoteName2)
 	require.NoError(t, FremoteSync2.Mkdir(ctx, ""))
 	require.NoError(t, err)
+
+	subRemoteName3 := r.FremoteName + "/rclone-sync-test-ignore-file"
+	FremoteSync3, err := fs.NewFs(ctx, subRemoteName3)
+	require.NoError(t, FremoteSync3.Mkdir(ctx, ""))
+	require.NoError(t, err)
+	r.WriteObject(context.Background(), "/rclone-sync-test-ignore-file/.ignore", "-", t1)
 
 	checkErr := func(err error) {
 		require.Error(t, err)
@@ -1483,6 +1490,11 @@ func TestSyncOverlapWithFilter(t *testing.T) {
 	checkErr(Sync(ctx, r.Fremote, FremoteSync2, false))
 	checkErr(Sync(ctx, r.Fremote, r.Fremote, false))
 	checkErr(Sync(ctx, FremoteSync2, FremoteSync2, false))
+
+	checkNoErr(Sync(ctx, FremoteSync3, r.Fremote, false))
+	checkErr(Sync(ctx, r.Fremote, FremoteSync3, false))
+	checkErr(Sync(ctx, r.Fremote, r.Fremote, false))
+	checkErr(Sync(ctx, FremoteSync3, FremoteSync3, false))
 }
 
 // Test with CompareDest set

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1451,11 +1451,17 @@ func TestSyncOverlapWithFilter(t *testing.T) {
 	fi, err := filter.NewFilter(nil)
 	require.NoError(t, err)
 	require.NoError(t, fi.Add(false, "/rclone-sync-test/"))
+	require.NoError(t, fi.Add(false, "*/layer2/"))
 	ctx = filter.ReplaceConfig(ctx, fi)
 
 	subRemoteName := r.FremoteName + "/rclone-sync-test"
 	FremoteSync, err := fs.NewFs(ctx, subRemoteName)
-	FremoteSync.Mkdir(ctx, "")
+	require.NoError(t, FremoteSync.Mkdir(ctx, ""))
+	require.NoError(t, err)
+
+	subRemoteName2 := r.FremoteName + "/rclone-sync-test-include/layer2"
+	FremoteSync2, err := fs.NewFs(ctx, subRemoteName2)
+	require.NoError(t, FremoteSync2.Mkdir(ctx, ""))
 	require.NoError(t, err)
 
 	checkErr := func(err error) {
@@ -1472,6 +1478,11 @@ func TestSyncOverlapWithFilter(t *testing.T) {
 	checkErr(Sync(ctx, r.Fremote, FremoteSync, false))
 	checkErr(Sync(ctx, r.Fremote, r.Fremote, false))
 	checkErr(Sync(ctx, FremoteSync, FremoteSync, false))
+
+	checkNoErr(Sync(ctx, FremoteSync2, r.Fremote, false))
+	checkErr(Sync(ctx, r.Fremote, FremoteSync2, false))
+	checkErr(Sync(ctx, r.Fremote, r.Fremote, false))
+	checkErr(Sync(ctx, FremoteSync2, FremoteSync2, false))
 }
 
 // Test with CompareDest set


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Previously, the overlap check was based on simple prefix checks of the source and destination paths. Now it actually checks whether the destination is excluded via any filter rule or a "--exclude-if-present"-file.

#### Was the change discussed in an issue or in the forum before?

[Forum Post](https://forum.rclone.org/t/excluding-overlapping-destination/29591)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
