### PR TITLE
backend/http: parse get responses when no_head is set

### DIFF
--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -601,23 +601,21 @@ func (o *Object) head(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to stat: %w", err)
 	}
-	return o.stat(ctx, res, true)
+	return o.stat(ctx, res)
 }
 
 // stat updates info fields in the Object according to HTTP response headers
-func (o *Object) stat(ctx context.Context, res *http.Response, isRangeRequest bool) error {
+func (o *Object) stat(ctx context.Context, res *http.Response) error {
 	t, err := http.ParseTime(res.Header.Get("Last-Modified"))
-	if err != nil {
-		t = timeUnset
+	if err == nil {
+		o.modTime = t
 	}
-	o.modTime = t
 
-	// TODO: parse Content-Range for total size
-	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Range_requests
-	if !isRangeRequest {
-		o.size = parseInt64(res.Header.Get("Content-Length"), -1)
-		o.contentType = res.Header.Get("Content-Type")
+	size := rest.ParseSizeFromHeaders(res.Header)
+	if size >= 0 {
+		o.size = size
 	}
+	o.contentType = res.Header.Get("Content-Type")
 
 	// If NoSlash is set then check ContentType to see if it is a directory
 	if o.fs.opt.NoSlash {
@@ -666,8 +664,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	}
 
 	if o.fs.opt.NoHead {
-		isRangeRequest := len(req.Header.Get("Range")) > 0
-		if err = o.stat(ctx, res, isRangeRequest); err != nil {
+		if err = o.stat(ctx, res); err != nil {
 			return nil, fmt.Errorf("Stat failed: %w", err)
 		}
 	}

--- a/backend/http/http_internal_test.go
+++ b/backend/http/http_internal_test.go
@@ -194,31 +194,66 @@ func TestNewObject(t *testing.T) {
 }
 
 func TestOpen(t *testing.T) {
-	f, tidy := prepare(t)
+	m, tidy := prepareServer(t)
 	defer tidy()
 
-	o, err := f.NewObject(context.Background(), "four/under four.txt")
-	require.NoError(t, err)
+	for _, head := range []bool{false, true} {
+		if !head {
+			m.Set("no_head", "true")
+		}
+		f, err := NewFs(context.Background(), remoteName, "", m)
+		require.NoError(t, err)
 
-	// Test normal read
-	fd, err := o.Open(context.Background())
-	require.NoError(t, err)
-	data, err := ioutil.ReadAll(fd)
-	require.NoError(t, err)
-	require.NoError(t, fd.Close())
-	if lineEndSize == 2 {
-		assert.Equal(t, "beetroot\r\n", string(data))
-	} else {
-		assert.Equal(t, "beetroot\n", string(data))
+		for _, rangeRead := range []bool{false, true} {
+			o, err := f.NewObject(context.Background(), "four/under four.txt")
+			require.NoError(t, err)
+
+			if !head {
+				// Test mod time is still indeterminate
+				tObj := o.ModTime(context.Background())
+				assert.Equal(t, time.Duration(0), time.Unix(0, 0).Sub(tObj))
+
+				// Test file size is still indeterminate
+				assert.Equal(t, int64(-1), o.Size())
+			}
+
+			var data []byte
+			if !rangeRead {
+				// Test normal read
+				fd, err := o.Open(context.Background())
+				require.NoError(t, err)
+				data, err = ioutil.ReadAll(fd)
+				require.NoError(t, err)
+				require.NoError(t, fd.Close())
+				if lineEndSize == 2 {
+					assert.Equal(t, "beetroot\r\n", string(data))
+				} else {
+					assert.Equal(t, "beetroot\n", string(data))
+				}
+			} else {
+				// Test with range request
+				fd, err := o.Open(context.Background(), &fs.RangeOption{Start: 1, End: 5})
+				require.NoError(t, err)
+				data, err = ioutil.ReadAll(fd)
+				require.NoError(t, err)
+				require.NoError(t, fd.Close())
+				assert.Equal(t, "eetro", string(data))
+			}
+
+			fi, err := os.Stat(filepath.Join(filesPath, "four", "under four.txt"))
+			require.NoError(t, err)
+			tFile := fi.ModTime()
+
+			// Test the time is always correct on the object after file open
+			tObj := o.ModTime(context.Background())
+			fstest.AssertTimeEqualWithPrecision(t, o.Remote(), tFile, tObj, time.Second)
+
+			if !rangeRead {
+				// Test the file size
+				assert.Equal(t, int64(len(data)), o.Size())
+			}
+		}
 	}
-
-	// Test with range request
-	fd, err = o.Open(context.Background(), &fs.RangeOption{Start: 1, End: 5})
-	require.NoError(t, err)
-	data, err = ioutil.ReadAll(fd)
-	require.NoError(t, err)
-	require.NoError(t, fd.Close())
-	assert.Equal(t, "eetro", string(data))
 }
 
 func TestMimeType(t *testing.T) {

--- a/lib/rest/headers.go
+++ b/lib/rest/headers.go
@@ -1,0 +1,37 @@
+package rest
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+func ParseSizeFromHeaders(headers http.Header) (size int64) {
+	size = -1
+
+	var contentLength = headers.Get("Content-Length")
+	if len(contentLength) != 0 {
+		var err error
+		if size, err = strconv.ParseInt(contentLength, 10, 64); err != nil {
+			return -1
+		}
+	}
+
+	var contentRange = headers.Get("Content-Range")
+	if len(contentRange) == 0 {
+		return size
+	}
+
+	if !strings.HasPrefix(contentRange, "bytes ") {
+		return -1
+	}
+	slash := strings.IndexRune(contentRange, '/')
+	if slash < 0 {
+		return -1
+	}
+	ret, err := strconv.ParseInt(contentRange[slash+1:], 10, 64)
+	if err != nil {
+		return -1
+	}
+	return ret
+}

--- a/lib/rest/headers_test.go
+++ b/lib/rest/headers_test.go
@@ -1,0 +1,41 @@
+package rest
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseSizeFromHeaders(t *testing.T) {
+	testCases := []struct {
+		ContentLength, ContentRange string
+		Size                        int64
+	}{{
+		"", "", -1,
+	}, {
+		"42", "", 42,
+	}, {
+		"42", "invalid", -1,
+	}, {
+		"", "bytes 22-33/42", 42,
+	}, {
+		"12", "bytes 22-33/42", 42,
+	}, {
+		"12", "otherUnit 22-33/42", -1,
+	}, {
+		"12", "bytes 22-33/*", -1,
+	}, {
+		"0", "bytes */42", 42,
+	}}
+	for _, testCase := range testCases {
+		headers := make(http.Header, 2)
+		if len(testCase.ContentLength) > 0 {
+			headers.Set("Content-Length", testCase.ContentLength)
+		}
+		if len(testCase.ContentRange) > 0 {
+			headers.Set("Content-Range", testCase.ContentRange)
+		}
+		assert.Equalf(t, testCase.Size, ParseSizeFromHeaders(headers), "%+v", testCase)
+	}
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

When the `no_head` flag is enabled for a http remote, the `ModTime` was always set to the 1970 UNIX epoch.
This patch support copying a file from the http remote with the correct `ModTime` and `MimeType` without the `HEAD` request.

#### Was the change discussed in an issue or in the forum before?

Not yet, AFAIK.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
