### PR TITLE
cryptdecode: Fix for alias backends

### DIFF
--- a/cmd/cryptdecode/cryptdecode.go
+++ b/cmd/cryptdecode/cryptdecode.go
@@ -48,7 +48,14 @@ See the documentation on the ` + "`crypt`" + ` overlay for more info.
 				return err
 			}
 			if fsInfo.Name != "crypt" {
-				return errors.New("The remote needs to be of type \"crypt\"")
+				fsrc := cmd.NewFsSrc(args)
+				fsInfo, _, _, config, err = fs.ConfigFs(fs.ConfigString(fsrc))
+				if err != nil {
+					return err
+				}
+				if fsInfo.Name != "crypt" {
+					return errors.New("The remote needs to be of type \"crypt\"")
+				}
 			}
 			cipher, err := crypt.NewCipher(config)
 			if err != nil {


### PR DESCRIPTION
Gets the `Name` from the underlying backend

#### What is the purpose of this change?

Fix the detection of crypt backends when they are wrapped by an alias

#### Was the change discussed in an issue or in the forum before?

Not that I know of

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
