### PR TITLE
S3 backend restore command to skip non-GLACIER objects

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -3247,6 +3247,10 @@ func (f *Fs) Command(ctx context.Context, name string, arg []string, opt map[str
 				st.Status = "Not an S3 object"
 				return
 			}
+			if o.storageClass != "GLACIER" && o.storageClass != "DEEP_ARCHIVE" {
+				st.Status = "Not GLACIER or DEEP_ARCHIVE storage class"
+				return
+			}
 			bucket, bucketPath := o.split()
 			reqCopy := req
 			reqCopy.Bucket = &bucket


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Rclone incorrectly requests to restore listed objects which are not in Glacier storage class.

This change checks the storage class before attempting to restore the object. This saves a unnecessary chargeable request.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
No.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
