### PR TITLE
fs/config, lib/terminal: use golang.org/x/term

### DIFF
--- a/fs/config/config_read_password.go
+++ b/fs/config/config_read_password.go
@@ -1,9 +1,8 @@
-// ReadPassword for OSes which are supported by golang.org/x/crypto/ssh/terminal
+// ReadPassword for OSes which are supported by golang.org/x/term
 // See https://github.com/golang/go/issues/14441 - plan9
-//     https://github.com/golang/go/issues/13085 - solaris
 
-//go:build !solaris && !plan9
-// +build !solaris,!plan9
+//go:build !plan9
+// +build !plan9
 
 package config
 

--- a/fs/config/config_read_password_unsupported.go
+++ b/fs/config/config_read_password_unsupported.go
@@ -1,9 +1,8 @@
-// ReadPassword for OSes which are not supported by golang.org/x/crypto/ssh/terminal
+// ReadPassword for OSes which are not supported by golang.org/x/term
 // See https://github.com/golang/go/issues/14441 - plan9
-//     https://github.com/golang/go/issues/13085 - solaris
 
-//go:build solaris || plan9
-// +build solaris plan9
+//go:build plan9
+// +build plan9
 
 package config
 

--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
+	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac
 	google.golang.org/api v0.60.0
@@ -117,7 +118,6 @@ require (
 	github.com/vivint/infectious v0.0.0-20200605153912-25a574ae18a3 // indirect
 	github.com/zeebo/errs v1.2.2 // indirect
 	go.opencensus.io v0.23.0 // indirect
-	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20211104193956-4c6863e31247 // indirect
 	google.golang.org/grpc v1.42.0 // indirect

--- a/lib/terminal/terminal_normal.go
+++ b/lib/terminal/terminal_normal.go
@@ -7,13 +7,13 @@ import (
 	"fmt"
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // GetSize reads the dimensions of the current terminal or returns a
 // sensible default
 func GetSize() (w, h int) {
-	w, h, err := terminal.GetSize(int(os.Stdout.Fd()))
+	w, h, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		w, h = 80, 25
 	}
@@ -22,14 +22,14 @@ func GetSize() (w, h int) {
 
 // IsTerminal returns whether the fd passed in is a terminal or not
 func IsTerminal(fd int) bool {
-	return terminal.IsTerminal(fd)
+	return term.IsTerminal(fd)
 }
 
 // ReadPassword reads a line of input from a terminal without local echo. This
 // is commonly used for inputting passwords and other sensitive data. The slice
 // returned does not include the \n.
 func ReadPassword(fd int) ([]byte, error) {
-	return terminal.ReadPassword(fd)
+	return term.ReadPassword(fd)
 }
 
 // WriteTerminalTitle writes a string to the terminal title


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

golang.org/x/crypto/ssh/terminal is deprecated in favor of
golang.org/x/term, see https://pkg.go.dev/golang.org/x/crypto/ssh/terminal

The latter also supports ReadPassword on solaris, so enable the
respective functionality in fs/config for solaris as well.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
