### PR TITLE
s3: add ACL comparison and synchronization for S3 storages by flag #4834

### DIFF
--- a/docs/content/commands/rclone_check.md
+++ b/docs/content/commands/rclone_check.md
@@ -19,6 +19,8 @@ match.  It doesn't alter the source or destination.
 If you supply the `--size-only` flag, it will only compare the sizes not
 the hashes as well.  Use this for a quick check.
 
+If you supply the `--compare-acl` flag, it will compare ACLs of objects as well.
+
 If you supply the `--download` flag, it will download the data from
 both remotes and check them against each other on the fly.  This can
 be useful for remotes that don't support hashes or if you really want

--- a/docs/content/commands/rclone_sync.md
+++ b/docs/content/commands/rclone_sync.md
@@ -47,6 +47,8 @@ rclone sync source:path dest:path [flags]
 
 ## Options
 
+If you supply the `--compare-acl` flag, it will synchronize ACLs of objects as well.
+
 ```
       --create-empty-src-dirs   Create empty source dirs on destination after sync
   -h, --help                    help for sync

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -27,6 +27,7 @@ These flags are available for every command.
   -c, --checksum                             Skip based on checksum (if available) & size, not mod-time & size
       --client-cert string                   Client SSL certificate (PEM) for mutual TLS auth
       --client-key string                    Client SSL private key (PEM) for mutual TLS auth
+      --compare-acl                          Compares access control lists (ACL), for example, for S3 storages
       --compare-dest stringArray             Include additional comma separated server-side paths during comparison
       --config string                        Config file (default "$HOME/.config/rclone/rclone.conf")
       --contimeout duration                  Connect timeout (default 1m0s)
@@ -250,7 +251,7 @@ and may be set in the config file.
       --chunker-chunk-size SizeSuffix                Files larger than chunk size will be split in chunks (default 2Gi)
       --chunker-fail-hard                            Choose how chunker should handle files with missing or invalid chunks
       --chunker-hash-type string                     Choose how chunker handles hash sums (default "md5")
-      --chunker-remote string                        Remote to chunk/unchunk
+      --chunker-remote string                        Remote to chunk/unchunk                                  
       --compress-level int                           GZIP compression level (-2 to 9) (default -1)
       --compress-mode string                         Compression mode (default "gzip")
       --compress-ram-cache-limit SizeSuffix          Some remotes don't allow the upload of files with unknown size (default 20Mi)

--- a/fs/config.go
+++ b/fs/config.go
@@ -52,6 +52,7 @@ type ConfigInfo struct {
 	Interactive            bool
 	CheckSum               bool
 	SizeOnly               bool
+	CompareACL             bool
 	IgnoreTimes            bool
 	IgnoreExisting         bool
 	IgnoreErrors           bool

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -53,6 +53,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.StringVarP(flagSet, &tempDir, "temp-dir", "", os.TempDir(), "Directory rclone will use for temporary files")
 	flags.BoolVarP(flagSet, &ci.CheckSum, "checksum", "c", ci.CheckSum, "Skip based on checksum (if available) & size, not mod-time & size")
 	flags.BoolVarP(flagSet, &ci.SizeOnly, "size-only", "", ci.SizeOnly, "Skip based on size only, not mod-time or checksum")
+	flags.BoolVarP(flagSet, &ci.CompareACL, "compare-acl", "", ci.CompareACL, "Checks ACL as well")
 	flags.BoolVarP(flagSet, &ci.IgnoreTimes, "ignore-times", "I", ci.IgnoreTimes, "Don't skip files that match size and time - transfer all files")
 	flags.BoolVarP(flagSet, &ci.IgnoreExisting, "ignore-existing", "", ci.IgnoreExisting, "Skip all files that exist on destination")
 	flags.BoolVarP(flagSet, &ci.IgnoreErrors, "ignore-errors", "", ci.IgnoreErrors, "Delete even if there are I/O errors")

--- a/fs/operations/check.go
+++ b/fs/operations/check.go
@@ -132,6 +132,19 @@ func (c *checkMarch) checkIdentical(ctx context.Context, dst, src fs.Object) (di
 	if ci.SizeOnly {
 		return false, false, nil
 	}
+	if ci.CompareACL {
+		var srcACL, dstACL string
+		same, err := CheckACL(ctx, src, dst, &srcACL, &dstACL)
+		if err != nil {
+			fs.Errorf(fmt.Sprintf("SRC: %v, DST: %v", src, dst), "%v", err)
+			return true, false, nil
+		}
+		if !same {
+			err = errors.New(fmt.Sprintf("ACL differs: SRC ACL: %v, DST ACL: %v", srcACL, dstACL))
+			fs.Errorf(fmt.Sprintf("SRC: %v, DST: %v", src, dst), "%v", err)
+			return true, false, nil
+		}
+	}
 	return c.opt.Check(ctx, dst, src)
 }
 

--- a/fs/types.go
+++ b/fs/types.go
@@ -113,6 +113,15 @@ type ObjectInfo interface {
 	Storable() bool
 }
 
+// ObjectWithACL is an Object with Access Control List (ACL) like AWS S3
+type ObjectWithACL interface {
+	Object
+
+	// IsEqualToACL returns true if object's ACL is equal to ACL of dstWithACL
+	// and stores serialized ACLs to srcACL and dstACL respectively
+	IsEqualToACL(dstWithACL *ObjectWithACL, srcACL, dstACL *string) (bool, error)
+}
+
 // DirEntry provides read only information about the common subset of
 // a Dir or Object.  These are returned from directory listings - type
 // assert them into the correct type.

--- a/go.mod
+++ b/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.1.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/hashicorp/go-uuid v1.0.2 // indirect


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Add support for checking and synchronizing ACLs by flag (`--compare-acl`) for S3 storages. So, if flag is set, then `rclone sync` will copy ACLs from source objects to destination ones, and the same works for `rclone check` command
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
Yes, https://github.com/rclone/rclone/issues/4834

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
