### PR TITLE
Documentation: added global flags missing from remote control page

### DIFF
--- a/docs/content/rc.md
+++ b/docs/content/rc.md
@@ -150,6 +150,16 @@ use these methods.  The alternative is to use `--rc-user` and
 
 Default Off.
 
+### --rc-baseurl
+
+Prefix for URLs.
+
+Default is root
+
+### --rc-template
+
+User-specified template.
+
 ## Accessing the remote control via the rclone rc command {#api-rc}
 
 Rclone itself implements the remote control protocol in its `rclone


### PR DESCRIPTION
#### What is the purpose of this change?

Global flags documentation page listed flags that were not listed in the remote control documentation page, so I added them.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
