### PR TITLE
ncdu: fix issue where dir size is summed when file sizes are -1

### DIFF
--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -42,15 +42,31 @@ builds an in memory representation.  rclone ncdu can be used during
 this scanning phase and you will see it building up the directory
 structure as it goes along.
 
-Here are the keys - press '?' to toggle the help on and off
+You can interact with the user interface using key presses,
+press '?' to toggle the help on and off. The supported keys are:
 
     ` + strings.Join(helpText()[1:], "\n    ") + `
+
+Listed files/directories may be prefixed by a one-character flag,
+some of them combined with a description in brackes at end of line.
+These flags have the following meaning:
+
+    e means this is an empty directory, i.e. contains no files (but
+      may contain empty subdirectories)
+    ~ means this is a directory where some of the files (possibly in
+      subdirectories) have unknown size, and therefore the directory
+      size may be underestimated (and average size inaccurate, as it
+      is average of the files with known sizes).
+    . means an error occurred while reading a subdirectory, and
+      therefore the directory size may be underestimated (and average
+      size inaccurate)
+    ! means an error occurred while reading this directory
 
 This an homage to the [ncdu tool](https://dev.yorhel.nl/ncdu) but for
 rclone remotes.  It is missing lots of features at the moment
 but is useful as it stands.
 
-Note that it might take some time to delete big files/folders. The
+Note that it might take some time to delete big files/directories. The
 UI won't respond in the meantime since the deletion is done synchronously.
 `,
 	Run: func(command *cobra.Command, args []string) {

--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -299,9 +299,9 @@ func (u *UI) biggestEntry() (biggest int64) {
 		return
 	}
 	for i := range u.entries {
-		size, _, _, _, _, _, _ := u.d.AttrI(u.sortPerm[i])
-		if size > biggest {
-			biggest = size
+		attrs, _ := u.d.AttrI(u.sortPerm[i])
+		if attrs.Size > biggest {
+			biggest = attrs.Size
 		}
 	}
 	return
@@ -313,8 +313,8 @@ func (u *UI) hasEmptyDir() bool {
 		return false
 	}
 	for i := range u.entries {
-		_, count, _, isDir, _, _, _ := u.d.AttrI(u.sortPerm[i])
-		if isDir && count == 0 {
+		attrs, _ := u.d.AttrI(u.sortPerm[i])
+		if attrs.IsDir && attrs.Count == 0 {
 			return true
 		}
 	}
@@ -359,9 +359,9 @@ func (u *UI) Draw() error {
 			if y >= h-1 {
 				break
 			}
-			size, count, countUnknownSize, isDir, readable, entriesHaveErrors, err := u.d.AttrI(u.sortPerm[n])
+			attrs, err := u.d.AttrI(u.sortPerm[n])
 			fg := termbox.ColorWhite
-			if entriesHaveErrors {
+			if attrs.EntriesHaveErrors {
 				fg = termbox.ColorYellow
 			}
 			if err != nil {
@@ -372,19 +372,19 @@ func (u *UI) Draw() error {
 				fg, bg = bg, fg
 			}
 			mark := ' '
-			if isDir {
+			if attrs.IsDir {
 				mark = '/'
 			}
 			fileFlag := ' '
 			message := ""
-			if !readable {
+			if !attrs.Readable {
 				message = " [not read yet]"
 			}
-			if countUnknownSize > 0 {
-				message = fmt.Sprintf(" [%d of %d files have unknown size, size may be underestimated]", countUnknownSize, count)
+			if attrs.CountUnknownSize > 0 {
+				message = fmt.Sprintf(" [%d of %d files have unknown size, size may be underestimated]", attrs.CountUnknownSize, attrs.Count)
 				fileFlag = '~'
 			}
-			if entriesHaveErrors {
+			if attrs.EntriesHaveErrors {
 				message = " [some subdirectories could not be read, size may be underestimated]"
 				fileFlag = '.'
 			}
@@ -394,35 +394,29 @@ func (u *UI) Draw() error {
 			}
 			extras := ""
 			if u.showCounts {
-				ss := operations.CountStringField(count, u.humanReadable, 9) + " "
-				if count > 0 {
+				ss := operations.CountStringField(attrs.Count, u.humanReadable, 9) + " "
+				if attrs.Count > 0 {
 					extras += ss
 				} else {
 					extras += strings.Repeat(" ", len(ss))
 				}
 			}
-			var averageSize float64
-			if count > 0 {
-				countForAverage := count - countUnknownSize
-				if countForAverage > 0 {
-					averageSize = float64(size) / float64(countForAverage)
-				}
-			}
 			if u.showDirAverageSize {
-				ss := operations.SizeStringField(int64(averageSize), u.humanReadable, 9) + " "
-				if averageSize > 0 {
+				avg := attrs.AverageSize()
+				ss := operations.SizeStringField(int64(avg), u.humanReadable, 9) + " "
+				if avg > 0 {
 					extras += ss
 				} else {
 					extras += strings.Repeat(" ", len(ss))
 				}
 			}
 			if showEmptyDir {
-				if isDir && count == 0 && fileFlag == ' ' {
+				if attrs.IsDir && attrs.Count == 0 && fileFlag == ' ' {
 					fileFlag = 'e'
 				}
 			}
 			if u.showGraph {
-				bars := (size + perBar/2 - 1) / perBar
+				bars := (attrs.Size + perBar/2 - 1) / perBar
 				// clip if necessary - only happens during startup
 				if bars > 10 {
 					bars = 10
@@ -431,7 +425,7 @@ func (u *UI) Draw() error {
 				}
 				extras += "[" + graph[graphBars-bars:2*graphBars-bars] + "] "
 			}
-			Linef(0, y, w, fg, bg, ' ', "%c %s %s%c%s%s", fileFlag, operations.SizeStringField(size, u.humanReadable, 12), extras, mark, path.Base(entry.Remote()), message)
+			Linef(0, y, w, fg, bg, ' ', "%c %s %s%c%s%s", fileFlag, operations.SizeStringField(attrs.Size, u.humanReadable, 12), extras, mark, path.Base(entry.Remote()), message)
 			y++
 		}
 	}
@@ -582,14 +576,14 @@ type ncduSort struct {
 // Less is part of sort.Interface.
 func (ds *ncduSort) Less(i, j int) bool {
 	var iAvgSize, jAvgSize float64
-	isize, icount, _, _, _, _, _ := ds.d.AttrI(ds.sortPerm[i])
-	jsize, jcount, _, _, _, _, _ := ds.d.AttrI(ds.sortPerm[j])
+	iattrs, _ := ds.d.AttrI(ds.sortPerm[i])
+	jattrs, _ := ds.d.AttrI(ds.sortPerm[j])
 	iname, jname := ds.entries[ds.sortPerm[i]].Remote(), ds.entries[ds.sortPerm[j]].Remote()
-	if icount > 0 {
-		iAvgSize = float64(isize / icount)
+	if iattrs.Count > 0 {
+		iAvgSize = iattrs.AverageSize()
 	}
-	if jcount > 0 {
-		jAvgSize = float64(jsize / jcount)
+	if jattrs.Count > 0 {
+		jAvgSize = jattrs.AverageSize()
 	}
 
 	switch {
@@ -598,33 +592,33 @@ func (ds *ncduSort) Less(i, j int) bool {
 	case ds.u.sortByName > 0:
 		break
 	case ds.u.sortBySize < 0:
-		if isize != jsize {
-			return isize < jsize
+		if iattrs.Size != jattrs.Size {
+			return iattrs.Size < jattrs.Size
 		}
 	case ds.u.sortBySize > 0:
-		if isize != jsize {
-			return isize > jsize
+		if iattrs.Size != jattrs.Size {
+			return iattrs.Size > jattrs.Size
 		}
 	case ds.u.sortByCount < 0:
-		if icount != jcount {
-			return icount < jcount
+		if iattrs.Count != jattrs.Count {
+			return iattrs.Count < jattrs.Count
 		}
 	case ds.u.sortByCount > 0:
-		if icount != jcount {
-			return icount > jcount
+		if iattrs.Count != jattrs.Count {
+			return iattrs.Count > jattrs.Count
 		}
 	case ds.u.sortByAverageSize < 0:
 		if iAvgSize != jAvgSize {
 			return iAvgSize < jAvgSize
 		}
 		// if avgSize is equal, sort by size
-		return isize < jsize
+		return iattrs.Size < jattrs.Size
 	case ds.u.sortByAverageSize > 0:
 		if iAvgSize != jAvgSize {
 			return iAvgSize > jAvgSize
 		}
 		// if avgSize is equal, sort by size
-		return isize > jsize
+		return iattrs.Size > jattrs.Size
 	}
 	// if everything equal, sort by name
 	return iname < jname

--- a/cmd/ncdu/scan/scan.go
+++ b/cmd/ncdu/scan/scan.go
@@ -16,8 +16,9 @@ type Dir struct {
 	parent            *Dir
 	path              string
 	mu                sync.Mutex
-	count             int64
 	size              int64
+	count             int64
+	countUnknownSize  int64
 	entries           fs.DirEntries
 	dirs              map[string]*Dir
 	readError         error
@@ -49,7 +50,13 @@ func newDir(parent *Dir, dirPath string, entries fs.DirEntries, err error) *Dir 
 	for _, entry := range entries {
 		if o, ok := entry.(fs.Object); ok {
 			d.count++
-			d.size += o.Size()
+			size := o.Size()
+			if size < 0 {
+				// Some backends may return -1 because size of object is not known
+				d.countUnknownSize++
+			} else {
+				d.size += size
+			}
 		}
 	}
 	// Set my directory entry in parent
@@ -62,8 +69,9 @@ func newDir(parent *Dir, dirPath string, entries fs.DirEntries, err error) *Dir 
 	// Accumulate counts in parents
 	for ; parent != nil; parent = parent.parent {
 		parent.mu.Lock()
-		parent.count += d.count
 		parent.size += d.size
+		parent.count += d.count
+		parent.countUnknownSize += d.countUnknownSize
 		if d.readError != nil {
 			parent.entriesHaveErrors = true
 		}
@@ -91,17 +99,24 @@ func (d *Dir) Remove(i int) {
 // Call with d.mu held
 func (d *Dir) remove(i int) {
 	size := d.entries[i].Size()
+	countUnknownSize := int64(0)
+	if size < 0 {
+		size = 0
+		countUnknownSize = 1
+	}
 	count := int64(1)
 
 	subDir, ok := d.getDir(i)
 	if ok {
 		size = subDir.size
 		count = subDir.count
+		countUnknownSize = subDir.countUnknownSize
 		delete(d.dirs, path.Base(subDir.path))
 	}
 
 	d.size -= size
 	d.count -= count
+	d.countUnknownSize -= countUnknownSize
 	d.entries = append(d.entries[:i], d.entries[i+1:]...)
 
 	dir := d
@@ -111,6 +126,7 @@ func (d *Dir) remove(i int) {
 		parent.dirs[path.Base(dir.path)] = dir
 		parent.size -= size
 		parent.count -= count
+		parent.countUnknownSize -= countUnknownSize
 		dir = parent
 		parent.mu.Unlock()
 	}
@@ -151,19 +167,19 @@ func (d *Dir) Attr() (size int64, count int64) {
 }
 
 // AttrI returns the size, count and flags for the i-th directory entry
-func (d *Dir) AttrI(i int) (size int64, count int64, isDir bool, readable bool, entriesHaveErrors bool, err error) {
+func (d *Dir) AttrI(i int) (size int64, count int64, countUnknownSize int64, isDir bool, readable bool, entriesHaveErrors bool, err error) {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	subDir, isDir := d.getDir(i)
 
 	if !isDir {
-		return d.entries[i].Size(), 0, false, true, d.entriesHaveErrors, d.readError
+		return d.entries[i].Size(), 0, 0, false, true, d.entriesHaveErrors, d.readError
 	}
 	if subDir == nil {
-		return 0, 0, true, false, false, nil
+		return 0, 0, 0, true, false, false, nil
 	}
 	size, count = subDir.Attr()
-	return size, count, true, true, subDir.entriesHaveErrors, subDir.readError
+	return size, count, subDir.countUnknownSize, true, true, subDir.entriesHaveErrors, subDir.readError
 }
 
 // Scan the Fs passed in, returning a root directory channel and an


### PR DESCRIPTION
#### What is the purpose of this change?

Some backends do not provide object size and simply return -1, e.g. Google Docs documents in Google Drive backend.
Current version of ncdu does not consider this and end up summing directory sizes including such negative numbers.

##### Main changes with this PR:

- Files are still reported with size -1 as before, when that is what the backend reports.
- Directory sizes skip negative file sizes (assumes size 0) in the sum, and a new flag `~` is added at start of line and description indicating the size may be underestimated at end of line for directories which contain any such files (recursively).
   - The value for average size in directory does *not* consider such files, i.e. the average is an average over files with known sizes. This means it may be *over*estimated rather than *under*estimated which is always the case with total sizes.
- Adds documentation of all supported one-character flags.

##### Details:

Average size is as stated above an average over files with known sizes. An alternative method could be to also include the files with unknown size, treat them as files with size 0. This would underestimate the average, possibly by much, compared to the current method which ignores them completely (in the count and size when calculating size/count). Its a matter of interpretation (average is average of what?) and of taste, probably, but the chosen approach should give least surprises, and is now documented.

Picked `~` as indicator to indicate "size issues", because it typically represents an approximation, and also it is not used by "upstream" ncdu (http://manpages.ubuntu.com/manpages/impish/man1/ncdu.1.html#file%20flags). This means rclone ncdu currently supports the following:
- Indicator `~` (**new**) that can occur on directories, and it indicates that this directory, or any of its subdirectories, contain a file which the backend reported size -1 for. This file is not included, i.e. treated as size 0, in the summed directory size. It is not included in calculation of the average, neither in count or size, i.e. average is average over files with known sizes only.
    - Combined with line suffix `[1 of 27 files have unknown size, size may be underestimated]`
        - TODO: A bit long suffix string!? But no longer than the existing for indicator `.`. In addition, it states the size may be *under*estimated, while if showing average sizes, these may be *over*estimated or *under*estimated depending on the characteristics of the files (e.g. if the files with unknown sizes not included in average calculation is larger or smaller than the rest). Though, the message could be interpreted as primarily referring to the directory total size, which is shown by default, and not so much to the optional average size field. Also existing message for for indicator `.` already used "size may be underestimated". Or perhaps "1 of 27 files have unknown size" is enough to tell users that size is underestimated or inaccurate or whatever? No strong preference, but ended up with the above suggestion.
- Indicator `e` (**existing**) means it is an empty directory, i.e. contains no files - count is zero.
    - Could also mean directory has been discovered but not traversed yet, then there will be a suffix `[not read yet]`.
        - TODO: Could have changed this to use the new `~` indicator instead, but still with the `[not read yet]` suffix?
- Indicator `.` (**existing**) means failed to read a subdirectory, and the entire line will be colored yellow.
    - Combined with line suffix `[some subdirectories could not be read, size may be underestimated]`.
- Indicator `!` (**existing**) means failed to read that directory, and the entire line will be colored red, and a suffix with error message is added.

See also comments below for more details, from testing and discussing different solutions.

##### Additional notes:

- In the code I implemented handling of the new `~` indicator by just extending on the same approach as existing code, but its starting to get a bit many number of different variables to pass around and combinations to handle, so it would probably benefit from some refactoring. I chose not to go there with this pr, but can do it if reviewer prefer..
- The `rclone size` also reports -1 size for files in the same cases as above, but it already correctly ignores them in directory sums. It does not indicate anything like "size may be underestimated" in these cases though, but perhaps that should be implemented as well. Update: Done with #6089.

#### Was the change discussed in an issue or in the forum before?

Fixes #6084

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
