### PR TITLE
size: warn about inaccurate results when objects with unknown size

### DIFF
--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -30,20 +30,26 @@ var commandDefinition = &cobra.Command{
 		cmd.Run(false, false, command, func() error {
 			var err error
 			var results struct {
-				Count int64 `json:"count"`
-				Bytes int64 `json:"bytes"`
+				Count    int64 `json:"count"`
+				Bytes    int64 `json:"bytes"`
+				Sizeless int64 `json:"sizeless"`
 			}
 
-			results.Count, results.Bytes, err = operations.Count(context.Background(), fsrc)
+			results.Count, results.Bytes, results.Sizeless, err = operations.Count(context.Background(), fsrc)
 			if err != nil {
 				return err
 			}
-
+			if results.Sizeless > 0 {
+				fs.Logf(fsrc, "Size may be underestimated due to %d objects with unknown size", results.Sizeless)
+			}
 			if jsonOutput {
 				return json.NewEncoder(os.Stdout).Encode(results)
 			}
 			fmt.Printf("Total objects: %s (%d)\n", fs.CountSuffix(results.Count), results.Count)
 			fmt.Printf("Total size: %s (%d Byte)\n", fs.SizeSuffix(results.Bytes).ByteUnit(), results.Bytes)
+			if results.Sizeless > 0 {
+				fmt.Printf("Total objects with unknown size: %s (%d)\n", fs.CountSuffix(results.Sizeless), results.Sizeless)
+			}
 			return nil
 		})
 	},

--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -24,6 +24,25 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "size remote:path",
 	Short: `Prints the total size and number of objects in remote:path.`,
+	Long: `
+Counts objects in the path and calculates the total size. Prints the
+result to standard output.
+
+By default the output is in human-readable format, but shows values in
+both human-readable format as well as the raw numbers (global option
+` + "`--human-readable`" + ` is not considered). Use option ` + "`--json`" + `
+to format output as JSON instead.
+
+Recurses by default, use ` + "`--max-depth 1`" + ` to stop the
+recursion.
+
+Some backends do not always provide file sizes, see for example
+[Google Photos](/googlephotos/#size) and
+[Google Drive](/drive/#limitations-of-google-docs).
+Rclone will then show a notice in the log indicating how many such
+files were encountered, and count them in as empty files in the output
+of the size command.
+`,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)

--- a/cmd/test/memory/memory.go
+++ b/cmd/test/memory/memory.go
@@ -25,7 +25,7 @@ var commandDefinition = &cobra.Command{
 		cmd.Run(false, false, command, func() error {
 			ctx := context.Background()
 			ci := fs.GetConfig(context.Background())
-			objects, _, err := operations.Count(ctx, fsrc)
+			objects, _, _, err := operations.Count(ctx, fsrc)
 			if err != nil {
 				return err
 			}

--- a/docs/content/rc.md
+++ b/docs/content/rc.md
@@ -1285,6 +1285,7 @@ Returns:
 
 - count - number of files
 - bytes - number of bytes in those files
+- sizeless - number of files with unknown size, included in count but not accounted for in bytes
 
 See the [size command](/commands/rclone_size/) command for more information on the above.
 

--- a/fs/operations/dedupe_test.go
+++ b/fs/operations/dedupe_test.go
@@ -121,7 +121,7 @@ func TestDeduplicateFirst(t *testing.T) {
 	// list until we get one object
 	var objects, size int64
 	for try := 1; try <= *fstest.ListRetries; try++ {
-		objects, size, err = operations.Count(context.Background(), r.Fremote)
+		objects, size, _, err = operations.Count(context.Background(), r.Fremote)
 		require.NoError(t, err)
 		if objects == 1 {
 			break

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -1070,11 +1070,13 @@ func HashSumStream(ht hash.Type, outputBase64 bool, in io.ReadCloser, w io.Write
 // Count counts the objects and their sizes in the Fs
 //
 // Obeys includes and excludes
-func Count(ctx context.Context, f fs.Fs) (objects int64, size int64, err error) {
+func Count(ctx context.Context, f fs.Fs) (objects int64, size int64, sizelessObjects int64, err error) {
 	err = ListFn(ctx, f, func(o fs.Object) {
 		atomic.AddInt64(&objects, 1)
 		objectSize := o.Size()
-		if objectSize > 0 {
+		if objectSize < 0 {
+			atomic.AddInt64(&sizelessObjects, 1)
+		} else if objectSize > 0 {
 			atomic.AddInt64(&size, objectSize)
 		}
 	})

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -401,10 +401,11 @@ func TestCount(t *testing.T) {
 	// Check the MaxDepth too
 	ci.MaxDepth = 1
 
-	objects, size, err := operations.Count(ctx, r.Fremote)
+	objects, size, sizeless, err := operations.Count(ctx, r.Fremote)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), objects)
 	assert.Equal(t, int64(61), size)
+	assert.Equal(t, int64(0), sizeless)
 }
 
 func TestDelete(t *testing.T) {

--- a/fs/operations/rc.go
+++ b/fs/operations/rc.go
@@ -344,13 +344,14 @@ func rcSize(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	if err != nil {
 		return nil, err
 	}
-	count, bytes, err := Count(ctx, f)
+	count, bytes, sizeless, err := Count(ctx, f)
 	if err != nil {
 		return nil, err
 	}
 	out = make(rc.Params)
 	out["count"] = count
 	out["bytes"] = bytes
+	out["sizeless"] = sizeless
 	return out, nil
 }
 

--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -451,8 +451,9 @@ func TestRcSize(t *testing.T) {
 	out, err := call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params{
-		"count": int64(3),
-		"bytes": int64(120),
+		"count":    int64(3),
+		"bytes":    int64(120),
+		"sizeless": int64(0),
 	}, out)
 }
 


### PR DESCRIPTION
#### What is the purpose of this change?

Some backends do not provide object size and simply return -1, e.g. Google Docs documents in Google Drive backend. The reported size will ignore these, i.e. assume size 0. This PR adds information when this is the case.

This PR adds reporting of a notice log message:

```
2022/04/06 14:09:32 NOTICE: Google drive root '': Size may be underestimated due to 2 objects with unknown size
Total objects: 13 (13)
Total size: 27.125 MiB (28442166 Byte)
```

An alternative could be to include it in the output string:

```
Total objects: 13 (13)
Total size: 27.125 MiB (28442166 Byte) [Size may be underestimated due to 2 objects with unknown size]
```

I've also included the relevant information in the json and rc output, that is: The number of objects with unknown size. Don't know if this is something we want? I named the property `sizeless`, which is probably not the best name for it...!

By using log message alternative above this will be shown always, regardless if json output or not. If switching to the alternative 2 above (including the information in output string only), then called with option for json output this information would have to be included in the json (as it currently is) for user to get the information.

A third alternative could be to do it all: Log it as a notice log message, include it in the output string, and possibly also include in the json/rc output.

#### Was the change discussed in an issue or in the forum before?

Related to #6085, which handles similar case for `rclone ncdu` command.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
