### PR TITLE
walk: cover edge case where a dir is also an object (e.g. via embedding)

### DIFF
--- a/fs/walk/walk.go
+++ b/fs/walk/walk.go
@@ -100,18 +100,16 @@ func (l ListType) Filter(in *fs.DirEntries) {
 	if l == ListAll {
 		return
 	}
-	out := (*in)[:0]
+	var (
+		out          = (*in)[:0]
+		isObj, isDir bool
+	)
 	for _, entry := range *in {
-		switch entry.(type) {
-		case fs.Object:
-			if l.Objects() {
-				out = append(out, entry)
-			}
-		case fs.Directory:
-			if l.Dirs() {
-				out = append(out, entry)
-			}
-		default:
+		if _, isObj = entry.(fs.Object); isObj && l.Objects() {
+			out = append(out, entry)
+		} else if _, isDir = entry.(fs.Directory); isDir && l.Dirs() {
+			out = append(out, entry)
+		} else if !isObj && !isDir {
 			fs.Errorf(nil, "Unknown object type %T", entry)
 		}
 	}

--- a/fs/walk/walk_test.go
+++ b/fs/walk/walk_test.go
@@ -959,3 +959,23 @@ func TestDirMapSendEntries(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []string(nil), got)
 }
+
+// mockDirObj mocks a directory, that is also an object.
+type mockDirObj struct {
+	mockobject.Object
+}
+
+func (m mockDirObj) Items() int64 { return 0 }
+func (m mockDirObj) ID() string   { return "" }
+
+// TestDirIsAnObject covers ListType filter when a value is both a directory
+// and an object.
+func TestDirIsAnObject(t *testing.T) {
+	entries := &fs.DirEntries{
+		mockDirObj{mockobject.Object("dir/a")},
+		mockDirObj{mockobject.Object("dir/b")},
+	}
+	// Previously, this filter would filter out directories.
+	ListDirs.Filter(entries)
+	assert.Equal(t, 2, entries.Len())
+}


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix an edge case regarding [`ListType.Filter`](https://github.com/rclone/rclone/blob/e43b5ce5e59b5717a9819ff81805dd431f710c10/fs/walk/walk.go#L98-L119).


Background: A prototypical backend has a relatively uniform abstraction which allows
to have a situation where a directory embeds an object.

    type Object struct ...

    type Directory struct {
        Object
    }

    ...

However, now a directory is also an object and would not be filtered
correctly, when using [`ListType.Filter`](https://github.com/rclone/rclone/blob/e43b5ce5e59b5717a9819ff81805dd431f710c10/fs/walk/walk.go#L98-L119).

This fix covers this edge case.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No.

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
