### PR TITLE
docs: clarify default path for --workdir on MacOS

### DIFF
--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -8,6 +8,7 @@ description: "Bidirectional cloud sync solution in rclone"
 - [Install rclone](/install/) and setup your remotes.
 - Bisync will create its working directory
   at `~/.cache/rclone/bisync` on Linux
+  or `~/Library/Caches/rclone/bisync` on MacOS
   or `C:\Users\MyLogin\AppData\Local\rclone\bisync` on Windows.
   Make sure that this location is writable.
 - Run bisync with the `--resync` flag, specifying the paths
@@ -97,7 +98,7 @@ Optional Flags:
       --localtime               Use local time in listings (default: UTC)
       --no-cleanup              Retain working files (useful for troubleshooting and testing).
       --workdir PATH            Use custom working directory (useful for testing).
-                                (default: `~/.cache/rclone/bisync`)
+                                (default: `~/.cache/rclone/bisync`. It varies according to the operating system.)
   -n, --dry-run                 Go through the motions - No files are copied/deleted.
   -v, --verbose                 Increases logging verbosity.
                                 May be specified more than once for more details.
@@ -123,7 +124,7 @@ Path1 and Path2 are treated equally, in that neither has priority for
 file changes, and access efficiency does not change whether a remote
 is on Path1 or Path2.
 
-The listings in bisync working directory (default: `~/.cache/rclone/bisync`)
+The listings in bisync working directory (default: `~/.cache/rclone/bisync`. It varies according to the operating system.)
 are named based on the Path1 and Path2 arguments so that separate syncs
 to individual directories within the tree may be set up, e.g.:
 `path_to_local_tree..dropbox_subdir.lst`.

--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -6,11 +6,12 @@ description: "Bidirectional cloud sync solution in rclone"
 ## Getting started {#getting-started}
 
 - [Install rclone](/install/) and setup your remotes.
-- Bisync will create its working directory
+- Bisync will create a default working directory
   at `~/.cache/rclone/bisync` on Linux
   or `~/Library/Caches/rclone/bisync` on MacOS
   or `C:\Users\MyLogin\AppData\Local\rclone\bisync` on Windows.
   Make sure that this location is writable.
+  The default working directory is derived from [--cache-dir](https://rclone.org/docs/#cache-dir-dir) and can be specified by the `--workdir` flag.
 - Run bisync with the `--resync` flag, specifying the paths
   to the local and remote sync directory roots.
 - For successive sync runs, leave off the `--resync` flag.

--- a/docs/content/commands/rclone_bisync.md
+++ b/docs/content/commands/rclone_bisync.md
@@ -41,7 +41,7 @@ rclone bisync remote1:path1 remote2:path2 [flags]
       --no-cleanup              Retain working files (useful for troubleshooting and testing).
       --remove-empty-dirs       Remove empty directories at the final cleanup step.
   -1, --resync                  Performs the resync run. Path1 files may overwrite Path2 versions. Consider using --verbose or --dry-run first.
-      --workdir string          Use custom working dir - useful for testing. (default: $HOME/.cache/rclone/bisync)
+      --workdir string          Use custom working dir - useful for testing. (default: $HOME/.cache/rclone/bisync. It varies according to operating sytem and is derived from --cache-dir)
 ```
 
 See the [global flags page](/flags/) for global options not listed here.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
clarify default path for --workdir on MacOS in the documentation.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
https://github.com/rclone/rclone/issues/6095
<!--
[Link issues and relevant forum posts here](https://github.com/rclone/rclone/issues/6095).
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).

- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
