### PR TITLE
jottacloud: fix scope in token request

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -519,7 +519,7 @@ func doTokenAuth(ctx context.Context, apiSrv *rest.Client, loginTokenBase64 stri
 	values.Set("client_id", defaultClientID)
 	values.Set("grant_type", "password")
 	values.Set("password", loginToken.AuthToken)
-	values.Set("scope", "offline_access+openid")
+	values.Set("scope", "openid offline_access")
 	values.Set("username", loginToken.Username)
 	values.Encode()
 	opts = rest.Opts{


### PR DESCRIPTION
#### What is the purpose of this change?

OpenId standard states: "Multiple scope values MAY be used by creating a space-delimited, case-sensitive list of ASCII scope values." (https://openid.net/specs/openid-connect-basic-1_0.html#Scopes). Scope "openid" is required, and "offline_access" is required if we want a refresh token.

Jottacloud's OpenID configuration endpoint returns "scopes_supported" as list: openid address email full jotta-default offline_access phone profile roles web-origins.

When encoding token request body space will be replaced with "+".

Existing code in rclone set value "offline_access+openid", when encoded in body it will become "offline_access%2Bopenid". I think this is wrong. Probably an artifact of "double urlencoding" mixup - either in rclone or in the jottacloud cli tool version it was sniffed from? It does work, though. The token received will have scopes "email offline_access" in it, and the same is true if I change to only sending "offline_access" as scope.

If I instead use proper space delimited list of "offline_access openid" in the request, the response also includes openid scope: "openid email offline_access". I think this is more correct, and therefore suggest changing to this. The same scope is returned if I send "openid email offline_access", "openid offline_access jotta-default" etc. The telia and tele2 specific implementations in rclone uses this last one ("openid jotta-default offline_access"). I'm not able to test what the jottacloud cli currently sets, but the official gui tool (at least in the past) sends a lot of the claims encoded in get request url "openid%20address%20email%20jotta-default%20offline_access%20phone%20profile%20roles%20web-origins", but it uses different more regular oauth authentication flow with redirect_uri etc. I assume the access claims jotta-default, email, profile, phone etc.. are not really in use by Jottacloud, and therefore not important, but we could include "jotta-default" as we do for telia and tele2, if we wanted to..

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
