### PR TITLE
webdav: add support for spec compliant modification time update

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -88,6 +88,9 @@ func init() {
 				Value: "sharepoint-ntlm",
 				Help:  "Sharepoint with NTLM authentication, usually self-hosted or on-premises",
 			}, {
+				Value: "fastmail",
+				Help:  "Fastmail",
+			}, {
 				Value: "other",
 				Help:  "Other site/service or software",
 			}},
@@ -596,6 +599,12 @@ func (f *Fs) setQuirks(ctx context.Context, vendor string) error {
 		// so we must perform an extra check to detect this
 		// condition and return a proper error code.
 		f.checkBeforePurge = true
+	case "fastmail":
+		if !f.opt.UpdateModTime.Valid {
+			f.precision = time.Second
+			f.opt.UpdateModTime.Valid = true
+			f.opt.UpdateModTime.Value = true
+		}
 	case "other":
 	default:
 		fs.Debugf(f, "Unknown vendor %q", vendor)


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Add support for spec compliant modification time update to WebDav backend.
rfc4918 section 15.7 states that getlastmodified SHOULD be protected
(read-only) but does not mandate it. implementations are free to choose
whether it is possible to update modification time. one such
implementation operating in the wild that allows it is FastMail WebDav
access. since specification recommends property to be protected make it
disabled by default.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
