### PR TITLE
Fix strict Sigv4 spec incompatibility

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -4104,6 +4104,16 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 			headers = putObj.HTTPRequest.Header
 		}
 
+		if !o.fs.opt.V2Auth {
+			if headers == nil {
+				headers = putObj.HTTPRequest.Header
+			}
+
+			if headers.Get("x-amz-content-sha256") == "" {
+				headers.Set("x-amz-content-sha256", "UNSIGNED-PAYLOAD")
+			}
+		}
+
 		// Set request to nil if empty so as not to make chunked encoding
 		if size == 0 {
 			in = nil


### PR DESCRIPTION
Set unsigned-payload value for x-amz-content-sha256 if unavailable.
Fixes #5422 (cause of incompatibility with R2).

#### What is the purpose of this change?
Fix incompatibility with any S3 provider that implements the Sigv4 spec strictly by making sure `x-amz-content-sha256` is always set if not present (the value is documented as being required to be `UNSIGNED_PAYLOAD`).

#### Was the change discussed in an issue or in the forum before?

#5422
Also on internal-only R2 private beta Discord channel.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
