### PR TITLE
B2: Dynamically adjust --b2-chunk-size when necessary

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -35,6 +35,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/ncw/swift/v2"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/chunksize"
 	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/configstruct"
@@ -3789,7 +3790,7 @@ func (o *Object) uploadMultipart(ctx context.Context, req *s3.PutObjectInput, si
 	}
 
 	// calculate size of parts
-	partSize := int(f.opt.ChunkSize)
+	partSize := f.opt.ChunkSize
 
 	// size can be -1 here meaning we don't know the size of the incoming file. We use ChunkSize
 	// buffers here (default 5 MiB). With a maximum number of parts (10,000) this will be a file of
@@ -3800,11 +3801,7 @@ func (o *Object) uploadMultipart(ctx context.Context, req *s3.PutObjectInput, si
 				f.opt.ChunkSize, fs.SizeSuffix(int64(partSize)*uploadParts))
 		})
 	} else {
-		// Adjust partSize until the number of parts is small enough.
-		if size/int64(partSize) >= uploadParts {
-			// Calculate partition size rounded up to the nearest MiB
-			partSize = int((((size / uploadParts) >> 20) + 1) << 20)
-		}
+		partSize = chunksize.Calculator(o, int(uploadParts), f.opt.ChunkSize)
 	}
 
 	memPool := f.getMemoryPool(int64(partSize))

--- a/fs/chunksize/chunksize.go
+++ b/fs/chunksize/chunksize.go
@@ -1,0 +1,36 @@
+// Package chunksize calculates a suitable chunk size for large uploads
+package chunksize
+
+import (
+	"github.com/rclone/rclone/fs"
+)
+
+/*
+ Calculator calculates the minimum chunk size needed to fit within the maximum number of parts, rounded up to the nearest fs.Mebi
+
+ For most backends, (chunk_size) * (concurrent_upload_routines) memory will be required so we want to use the smallest
+ possible chunk size that's going to allow the upload to proceed. Rounding up to the nearest fs.Mebi on the assumption
+ that some backends may only allow integer type parameters when specifying the chunk size.
+
+ Returns the default chunk size if it is sufficiently large enough to support the given file size otherwise returns the
+ smallest chunk size necessary to allow the upload to proceed.
+*/
+func Calculator(objInfo fs.ObjectInfo, maxParts int, defaultChunkSize fs.SizeSuffix) fs.SizeSuffix {
+	fileSize := fs.SizeSuffix(objInfo.Size())
+	requiredChunks := fileSize / defaultChunkSize
+	if requiredChunks < fs.SizeSuffix(maxParts) || (requiredChunks == fs.SizeSuffix(maxParts) && fileSize%defaultChunkSize == 0) {
+		return defaultChunkSize
+	}
+
+	minChunk := fileSize / fs.SizeSuffix(maxParts)
+	remainder := minChunk % fs.Mebi
+	if remainder != 0 {
+		minChunk += fs.Mebi - remainder
+	}
+	if fileSize/minChunk == fs.SizeSuffix(maxParts) && fileSize%fs.SizeSuffix(maxParts) != 0 { // when right on the boundary, we need to add a MiB
+		minChunk += fs.Mebi
+	}
+
+	fs.Debugf(objInfo, "size: %v, parts: %v, default: %v, new: %v; default chunk size insufficient, returned new chunk size", fileSize, maxParts, defaultChunkSize, minChunk)
+	return minChunk
+}

--- a/fs/chunksize/chunksize_test.go
+++ b/fs/chunksize/chunksize_test.go
@@ -1,0 +1,40 @@
+package chunksize
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/object"
+)
+
+func TestComputeChunkSize(t *testing.T) {
+	tests := map[string]struct {
+		fileSize         fs.SizeSuffix
+		maxParts         int
+		defaultChunkSize fs.SizeSuffix
+		expected         fs.SizeSuffix
+	}{
+		"default size returned when file size is small enough":             {fileSize: 1000, maxParts: 10000, defaultChunkSize: toSizeSuffixMiB(10), expected: toSizeSuffixMiB(10)},
+		"default size returned when file size is just 1 byte small enough": {fileSize: toSizeSuffixMiB(100000) - 1, maxParts: 10000, defaultChunkSize: toSizeSuffixMiB(10), expected: toSizeSuffixMiB(10)},
+		"no rounding up when everything divides evenly":                    {fileSize: toSizeSuffixMiB(1000000), maxParts: 10000, defaultChunkSize: toSizeSuffixMiB(100), expected: toSizeSuffixMiB(100)},
+		"rounding up to nearest MiB when not quite enough parts":           {fileSize: toSizeSuffixMiB(1000000), maxParts: 9999, defaultChunkSize: toSizeSuffixMiB(100), expected: toSizeSuffixMiB(101)},
+		"rounding up to nearest MiB when one extra byte":                   {fileSize: toSizeSuffixMiB(1000000) + 1, maxParts: 10000, defaultChunkSize: toSizeSuffixMiB(100), expected: toSizeSuffixMiB(101)},
+		"expected MiB value when rounding sets to absolute minimum":        {fileSize: toSizeSuffixMiB(1) - 1, maxParts: 1, defaultChunkSize: toSizeSuffixMiB(1), expected: toSizeSuffixMiB(1)},
+		"expected MiB value when rounding to absolute min with extra":      {fileSize: toSizeSuffixMiB(1) + 1, maxParts: 1, defaultChunkSize: toSizeSuffixMiB(1), expected: toSizeSuffixMiB(2)},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			src := object.NewStaticObjectInfo("mock", time.Now(), int64(tc.fileSize), true, nil, nil)
+			result := Calculator(src, tc.maxParts, tc.defaultChunkSize)
+			if result != tc.expected {
+				t.Fatalf("expected: %v, got: %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func toSizeSuffixMiB(size int64) fs.SizeSuffix {
+	return fs.SizeSuffix(size * int64(fs.Mebi))
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
<!--
Describe the changes here
-->
Add support for dynamic modification of `--b2-chunk-size` when necessary as discussed in #4643.

Created a new package, `chunksize` that implements a chunk size calculator, which is then called by B2 to dynamically adjust the chunk size when needed.  This package was created with the intent to eventually leverage this calculator in all backends that need to do dynamic chunk size adjustments (S3 at a minimum).

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
Yes.  #4643
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
