### PR TITLE
Accept nedev arg

### DIFF
--- a/fs/mount_helper.go
+++ b/fs/mount_helper.go
@@ -208,7 +208,7 @@ func parseHelperOptionString(optString string) (opts []string, err error) {
 				if len(param) == 0 {
 					return nil, errHelperEmptyOption
 				}
-				if param[0] == '-' || param[0] == '_' {
+				if param[0] == '-' {
 					return nil, errHelperOptionName
 				}
 				prev = i + 1

--- a/fs/mount_helper_test.go
+++ b/fs/mount_helper_test.go
@@ -20,7 +20,7 @@ func TestMountHelperArgs(t *testing.T) {
 		src: []string{},
 		dst: []string{"mount", "--daemon"},
 	}, {
-		src: []string{"-o", `x-systemd.automount,vvv,env.HTTPS_PROXY="a b;c,d?EF",ro,rw,args2env`},
+		src: []string{"-o", `x-systemd.automount,vvv,env.HTTPS_PROXY="a b;c,d?EF",ro,rw,args2env,_netdev`},
 		dst: []string{"mount", "--read-only", "--verbose=3", "--daemon"},
 		env: "HTTPS_PROXY=a b;c,d?EF",
 	}}


### PR DESCRIPTION
#### What is the purpose of this change?

Do not trigger an error when parsing mount options starting with an underscore.

#### Was the change discussed in an issue or in the forum before?

This make possible the example given in #5594. 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
