### PR TITLE
s3: Digital Ocean quirk: virtualHostStyle=false Fixes #6110

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2212,6 +2212,7 @@ func setQuirks(opt *Options) {
 		urlEncodeListings = false
 	case "DigitalOcean":
 		urlEncodeListings = false
+		virtualHostStyle = false
 	case "Dreamhost":
 		urlEncodeListings = false
 	case "IBMCOS":


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
Fixes #6110 

Digital Ocean does not support virtual host style bucket access.  Their wild card ssl cert only goes one level deep.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
#6110 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
