### PR TITLE
refactor: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/backend/chunker/chunker.go
+++ b/backend/chunker/chunker.go
@@ -515,7 +515,7 @@ func (f *Fs) setChunkNameFormat(pattern string) error {
 
 	strRegex := regexp.QuoteMeta(pattern)
 	strRegex = reHashes.ReplaceAllLiteralString(strRegex, reDataOrCtrl)
-	strRegex = strings.Replace(strRegex, "\\*", mainNameRegStr, -1)
+	strRegex = strings.ReplaceAll(strRegex, "\\*", mainNameRegStr)
 	strRegex = fmt.Sprintf("^%s(?:%s|%s)?$", strRegex, tempSuffixRegStr, tempSuffixRegOld)
 	f.nameRegexp = regexp.MustCompile(strRegex)
 
@@ -524,7 +524,7 @@ func (f *Fs) setChunkNameFormat(pattern string) error {
 	if numDigits > 1 {
 		fmtDigits = fmt.Sprintf("%%0%dd", numDigits)
 	}
-	strFmt := strings.Replace(pattern, "%", "%%", -1)
+	strFmt := strings.ReplaceAll(pattern, "%", "%%")
 	strFmt = strings.Replace(strFmt, "*", "%s", 1)
 	f.dataNameFmt = reHashes.ReplaceAllLiteralString(strFmt, fmtDigits)
 	f.ctrlNameFmt = reHashes.ReplaceAllLiteralString(strFmt, "_%s")

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -829,8 +829,8 @@ func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directorie
 	if title != "" {
 		searchTitle := f.opt.Enc.FromStandardName(title)
 		// Escaping the backslash isn't documented but seems to work
-		searchTitle = strings.Replace(searchTitle, `\`, `\\`, -1)
-		searchTitle = strings.Replace(searchTitle, `'`, `\'`, -1)
+		searchTitle = strings.ReplaceAll(searchTitle, `\`, `\\`)
+		searchTitle = strings.ReplaceAll(searchTitle, `'`, `\'`)
 
 		var titleQuery bytes.Buffer
 		_, _ = fmt.Fprintf(&titleQuery, "(name='%s'", searchTitle)

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -562,7 +562,7 @@ func (f *Fs) list(ctx context.Context, filter api.SearchFilter, fn listFn) (err 
 		for i := range items {
 			item := &result.MediaItems[i]
 			remote := item.Filename
-			remote = strings.Replace(remote, "/", "／", -1)
+			remote = strings.ReplaceAll(remote, "/", "／")
 			err = fn(remote, item, false)
 			if err != nil {
 				return err

--- a/backend/hubic/hubic.go
+++ b/backend/hubic/hubic.go
@@ -119,7 +119,7 @@ func (f *Fs) getCredentials(ctx context.Context) (err error) {
 	defer fs.CheckClose(resp.Body, &err)
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {
 		body, _ := ioutil.ReadAll(resp.Body)
-		bodyStr := strings.TrimSpace(strings.Replace(string(body), "\n", " ", -1))
+		bodyStr := strings.TrimSpace(strings.ReplaceAll(string(body), "\n", " "))
 		return fmt.Errorf("failed to get credentials: %s: %s", resp.Status, bodyStr)
 	}
 	decoder := json.NewDecoder(resp.Body)

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -191,7 +191,7 @@ machines.`)
 		m.Set("auth_code", "")
 		return fs.ConfigGoto("legacy_do_auth")
 	case "legacy_auth_code":
-		authCode := strings.Replace(config.Result, "-", "", -1) // remove any "-" contained in the code so we have a 6 digit number
+		authCode := strings.ReplaceAll(config.Result, "-", "") // remove any "-" contained in the code so we have a 6 digit number
 		m.Set("auth_code", authCode)
 		return fs.ConfigGoto("legacy_do_auth")
 	case "legacy_do_auth":
@@ -649,7 +649,7 @@ func errorHandler(resp *http.Response) error {
 
 // Jottacloud wants '+' to be URL encoded even though the RFC states it's not reserved
 func urlPathEscape(in string) string {
-	return strings.Replace(rest.URLPathEscape(in), "+", "%2B", -1)
+	return strings.ReplaceAll(rest.URLPathEscape(in), "+", "%2B")
 }
 
 // filePathRaw returns an unescaped file path (f.root, file)

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2966,7 +2966,7 @@ func (f *Fs) Precision() time.Duration {
 // pathEscape escapes s as for a URL path.  It uses rest.URLPathEscape
 // but also escapes '+' for S3 and Digital Ocean spaces compatibility
 func pathEscape(s string) string {
-	return strings.Replace(rest.URLPathEscape(s), "+", "%2B", -1)
+	return strings.ReplaceAll(rest.URLPathEscape(s), "+", "%2B")
 }
 
 // copy does a server-side copy

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -109,7 +109,7 @@ when the ssh-agent contains many keys.`,
 			Default: false,
 		}, {
 			Name: "use_insecure_cipher",
-			Help: `Enable the use of insecure ciphers and key exchange methods. 
+			Help: `Enable the use of insecure ciphers and key exchange methods.
 
 This enables the use of the following insecure ciphers and key exchange methods:
 
@@ -1311,7 +1311,7 @@ var shellEscapeRegex = regexp.MustCompile("[^A-Za-z0-9_.,:/\\@\u0080-\uFFFFFFFF\
 // when sending it to a shell.
 func shellEscape(str string) string {
 	safe := shellEscapeRegex.ReplaceAllString(str, `\$0`)
-	return strings.Replace(safe, "\n", "'\n'", -1)
+	return strings.ReplaceAll(safe, "\n", "'\n'")
 }
 
 // Converts a byte array from the SSH session returned by

--- a/bin/cross-compile.go
+++ b/bin/cross-compile.go
@@ -173,8 +173,8 @@ func buildZip(dir string) string {
 func buildDebAndRpm(dir, version, goarch string) []string {
 	// Make internal version number acceptable to .deb and .rpm
 	pkgVersion := version[1:]
-	pkgVersion = strings.Replace(pkgVersion, "β", "-beta", -1)
-	pkgVersion = strings.Replace(pkgVersion, "-", ".", -1)
+	pkgVersion = strings.ReplaceAll(pkgVersion, "β", "-beta")
+	pkgVersion = strings.ReplaceAll(pkgVersion, "-", ".")
 	nfpmArch, ok := goarchToNfpm[goarch]
 	if !ok {
 		nfpmArch = goarch

--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -79,7 +79,7 @@ rclone.org website.`,
 		var description = map[string]string{}
 		var addDescription func(root *cobra.Command)
 		addDescription = func(root *cobra.Command) {
-			name := strings.Replace(root.CommandPath(), " ", "_", -1) + ".md"
+			name := strings.ReplaceAll(root.CommandPath(), " ", "_") + ".md"
 			description[name] = root.Short
 			for _, c := range root.Commands() {
 				addDescription(c)
@@ -93,11 +93,11 @@ rclone.org website.`,
 			base := strings.TrimSuffix(name, path.Ext(name))
 			data := frontmatter{
 				Date:        now,
-				Title:       strings.Replace(base, "_", " ", -1),
+				Title:       strings.ReplaceAll(base, "_", " "),
 				Description: description[name],
 				Slug:        base,
 				URL:         "/commands/" + strings.ToLower(base) + "/",
-				Source:      strings.Replace(strings.Replace(base, "rclone", "cmd", -1), "_", "/", -1) + "/",
+				Source:      strings.ReplaceAll(strings.ReplaceAll(base, "rclone", "cmd"), "_", "/") + "/",
 			}
 			var buf bytes.Buffer
 			err := frontmatterTemplate.Execute(&buf, data)

--- a/cmd/rc/rc.go
+++ b/cmd/rc/rc.go
@@ -290,7 +290,7 @@ func list(ctx context.Context) error {
 		if !ok {
 			return errors.New("bad JSON")
 		}
-		fmt.Printf("### %s: %s {#%s}\n\n", info["Path"], info["Title"], strings.Replace(info["Path"].(string), "/", "-", -1))
+		fmt.Printf("### %s: %s {#%s}\n\n", info["Path"], info["Title"], strings.ReplaceAll(info["Path"].(string), "/", "-"))
 		fmt.Printf("%s\n\n", info["Help"])
 		if authRequired := info["AuthRequired"]; authRequired != nil {
 			if authRequired.(bool) {

--- a/cmd/serve/sftp/connection.go
+++ b/cmd/serve/sftp/connection.go
@@ -43,7 +43,7 @@ var shellUnEscapeRegex = regexp.MustCompile(`\\(.)`)
 
 // Unescape a string that was escaped by rclone
 func shellUnEscape(str string) string {
-	str = strings.Replace(str, "'\n'", "\n", -1)
+	str = strings.ReplaceAll(str, "'\n'", "\n")
 	str = shellUnEscapeRegex.ReplaceAllString(str, `$1`)
 	return str
 }

--- a/fs/backend_config.go
+++ b/fs/backend_config.go
@@ -230,7 +230,7 @@ func ConfigChoose(state string, name string, help string, n int, getItem func(i 
 // StatePush pushes a new values onto the front of the config string
 func StatePush(state string, values ...string) string {
 	for i := range values {
-		values[i] = strings.Replace(values[i], ",", "，", -1) // replace comma with unicode wide version
+		values[i] = strings.ReplaceAll(values[i], ",", "，") // replace comma with unicode wide version
 	}
 	if state != "" {
 		values = append(values[:len(values):len(values)], state)
@@ -262,7 +262,7 @@ func StatePop(state string) (newState string, value string) {
 		return "", state
 	}
 	value, newState = state[:comma], state[comma+1:]
-	value = strings.Replace(value, "，", ",", -1) // replace unicode wide comma with comma
+	value = strings.ReplaceAll(value, "，", ",") // replace unicode wide comma with comma
 	return newState, value
 }
 

--- a/fs/config.go
+++ b/fs/config.go
@@ -248,11 +248,11 @@ func AddConfig(ctx context.Context) (context.Context, *ConfigInfo) {
 // "ignore-size") into an environment name
 // "RCLONE_CONFIG_MY-REMOTE_IGNORE_SIZE"
 func ConfigToEnv(section, name string) string {
-	return "RCLONE_CONFIG_" + strings.ToUpper(section+"_"+strings.Replace(name, "-", "_", -1))
+	return "RCLONE_CONFIG_" + strings.ToUpper(section+"_"+strings.ReplaceAll(name, "-", "_"))
 }
 
 // OptionToEnv converts an option name, e.g. "ignore-size" into an
 // environment name "RCLONE_IGNORE_SIZE"
 func OptionToEnv(name string) string {
-	return "RCLONE_" + strings.ToUpper(strings.Replace(name, "-", "_", -1))
+	return "RCLONE_" + strings.ToUpper(strings.ReplaceAll(name, "-", "_"))
 }

--- a/fs/config/configfile/configfile_test.go
+++ b/fs/config/configfile/configfile_test.go
@@ -50,7 +50,7 @@ func setConfigFile(t *testing.T, data string) func() {
 // toUnix converts \r\n to \n in buf
 func toUnix(buf string) string {
 	if runtime.GOOS == "windows" {
-		return strings.Replace(buf, "\r\n", "\n", -1)
+		return strings.ReplaceAll(buf, "\r\n", "\n")
 	}
 	return buf
 }

--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -417,7 +417,7 @@ func ChooseOption(o *fs.Option, name string) string {
 	fmt.Printf("Option %s.\n", o.Name)
 	if o.Help != "" {
 		// Show help string without empty lines.
-		help := strings.Replace(strings.TrimSpace(o.Help), "\n\n", "\n", -1)
+		help := strings.ReplaceAll(strings.TrimSpace(o.Help), "\n\n", "\n")
 		fmt.Println(help)
 	}
 

--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -208,7 +208,7 @@ loop:
 				value := path[prev : i-1]
 				// replace any doubled quotes if there were any
 				if doubled {
-					value = strings.Replace(value, string(quote)+string(quote), string(quote), -1)
+					value = strings.ReplaceAll(value, string(quote)+string(quote), string(quote))
 				}
 				prev = i + 1
 				parsed.Config[param] = value

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -1407,7 +1407,7 @@ func TestDirMove(t *testing.T) {
 	require.NoError(t, operations.DirMove(ctx, r.Fremote, "A1", "A2"))
 
 	for i := range files {
-		files[i].Path = strings.Replace(files[i].Path, "A1/", "A2/", -1)
+		files[i].Path = strings.ReplaceAll(files[i].Path, "A1/", "A2/")
 	}
 
 	fstest.CheckListingWithPrecision(
@@ -1432,7 +1432,7 @@ func TestDirMove(t *testing.T) {
 	require.NoError(t, operations.DirMove(ctx, r.Fremote, "A2", "A3"))
 
 	for i := range files {
-		files[i].Path = strings.Replace(files[i].Path, "A2/", "A3/", -1)
+		files[i].Path = strings.ReplaceAll(files[i].Path, "A2/", "A3/")
 	}
 
 	fstest.CheckListingWithPrecision(

--- a/fs/registry.go
+++ b/fs/registry.go
@@ -44,7 +44,7 @@ type RegInfo struct {
 
 // FileName returns the on disk file name for this backend
 func (ri *RegInfo) FileName() string {
-	return strings.Replace(ri.Name, " ", "", -1)
+	return strings.ReplaceAll(ri.Name, " ", "")
 }
 
 // Options is a slice of configuration Option for a backend
@@ -210,7 +210,7 @@ func (o *Option) Type() string {
 
 // FlagName for the option
 func (o *Option) FlagName(prefix string) string {
-	name := strings.Replace(o.Name, "_", "-", -1) // convert snake_case to kebab-case
+	name := strings.ReplaceAll(o.Name, "_", "-") // convert snake_case to kebab-case
 	if !o.NoPrefix {
 		name = prefix + "-" + name
 	}

--- a/fstest/test_all/run.go
+++ b/fstest/test_all/run.go
@@ -317,7 +317,7 @@ func (r *Run) RemoveTestBinary() {
 func (r *Run) Name() string {
 	ns := []string{
 		r.Backend,
-		strings.Replace(r.Path, "/", ".", -1),
+		strings.ReplaceAll(r.Path, "/", "."),
 		r.Remote,
 	}
 	if r.FastList {
@@ -325,7 +325,7 @@ func (r *Run) Name() string {
 	}
 	ns = append(ns, fmt.Sprintf("%d", r.Try))
 	s := strings.Join(ns, "-")
-	s = strings.Replace(s, ":", "", -1)
+	s = strings.ReplaceAll(s, ":", "")
 	return s
 }
 

--- a/lib/version/version.go
+++ b/lib/version/version.go
@@ -30,7 +30,7 @@ func Add(fileName string, t time.Time) string {
 	base, ext := splitExt(fileName)
 	s := t.Format(versionFormat)
 	// Replace the '.' with a '-'
-	s = strings.Replace(s, ".", "-", -1)
+	s = strings.ReplaceAll(s, ".", "-")
 	return base + s + ext
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Replace `strings.Replace(s, old, new, -1)` with `strings.ReplaceAll(s, old, new)`. `strings.ReplaceAll` is a wrapper function for `strings.Replace`, but `strings.ReplaceAll` is more readable and removes the hardcoded `-1`.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
