### PR TITLE
remote setup: Add one more option for Linux/MacOS users to complete the auth on headless box

### DIFF
--- a/docs/content/remote_setup.md
+++ b/docs/content/remote_setup.md
@@ -92,3 +92,24 @@ Configuration file is stored at:
 Now transfer it to the remote box (scp, cut paste, ftp, sftp, etc.) and
 place it in the correct place (use `rclone config file` on the remote
 box to find out where).
+
+## Configuring using SSH Tunnel ##
+
+Linux and MacOS users can utilize SSH Tunnel to redirect the headless box port 53682 to local machine by using the following command:
+```
+ssh -L localhost:53682:localhost:53682 username@remote_server
+```
+Then on the headless box run `rclone` config and answer `Y` to the `Use
+auto config?` question.
+
+```
+...
+Remote config
+Use auto config?
+ * Say Y if not sure
+ * Say N if you are working on a remote or headless machine
+y) Yes (default)
+n) No
+y/n> y
+```
+Then copy and paste the auth url `http://127.0.0.1:53682/auth?state=xxxxxxxxxxxx` to the browser on your local machine, complete the auth and it is done.


### PR DESCRIPTION
Add another option (utilizing SSH Tunnel) for Linux/macOs users to complete the auth on headless box.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
One more option for Linux/MacOS users to complete the auth on headless box
-->

#### Was the change discussed in an issue or in the forum before?

<!--
[Link issues and relevant forum posts here.](https://github.com/rclone/rclone/issues/321)
-->

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ x] I have added tests for all changes in this PR if appropriate.
- [ x] I have added documentation for the changes if appropriate.
- [x ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)
