### PR TITLE
Mct install set modes mac

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -12,7 +12,7 @@ set -e
 #when adding a tool to the list make sure to also add its corresponding command further in the script
 unzip_tools_list=('unzip' '7z' 'busybox')
 
-usage() { echo "Usage: curl https://rclone.org/install.sh | sudo bash [-s beta]" 1>&2; exit 1; }
+usage() { echo "Usage: sudo -v ; curl https://rclone.org/install.sh | sudo bash [-s beta]" 1>&2; exit 1; }
 
 #check for beta flag
 if [ -n "$1" ] && [ "$1" != "beta" ]; then

--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -12,7 +12,7 @@ set -e
 #when adding a tool to the list make sure to also add its corresponding command further in the script
 unzip_tools_list=('unzip' '7z' 'busybox')
 
-usage() { echo "Usage: sudo -v ; curl https://rclone.org/install.sh | sudo bash [-s beta]" 1>&2; exit 1; }
+usage() { echo "Usage: curl https://rclone.org/install.sh | sudo bash [-s beta]" 1>&2; exit 1; }
 
 #check for beta flag
 if [ -n "$1" ] && [ "$1" != "beta" ]; then
@@ -172,16 +172,25 @@ case "$OS" in
     makewhatis
     ;;
   'osx')
+	### - - - - - - - - - - - - - - - - - - - -
     #binary
-    mkdir -m 0555 -p ${binTgtDir}
-    cp rclone ${binTgtDir}/rclone.new
-    mv ${binTgtDir}/rclone.new ${binTgtDir}/rclone
-    chmod a=x ${binTgtDir}/rclone
+	sudo -v
+	sudo -s -- <<-EOT
+		mkdir -m 0555 -p ${binTgtDir}
+		cp rclone ${binTgtDir}/rclone.new
+		mv ${binTgtDir}/rclone.new ${binTgtDir}/rclone
+		chmod a=x ${binTgtDir}/rclone
+	EOT
+	### - - - - - - - - - - - - - - - - - - - -
     #manual
-    mkdir -m 0555 -p ${man1TgtDir}
-    cp rclone.1 ${man1TgtDir}    
-    chmod a=r ${man1TgtDir}/rclone.1
+	sudo -v
+	sudo -s -- <<-EOT
+		mkdir -m 0555 -p ${man1TgtDir}
+		cp rclone.1 ${man1TgtDir}    
+		chmod a=r ${man1TgtDir}/rclone.1
+	EOT
     ;;
+	### - - - - - - - - - - - - - - - - - - - -
   *)
     echo 'OS not supported'
     exit 2

--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -180,7 +180,7 @@ case "$OS" in
         cp rclone ${binTgtDir}/rclone.new && \
         mv ${binTgtDir}/rclone.new ${binTgtDir}/rclone && \
         chmod a=x ${binTgtDir}/rclone && \
-		chown root:root ${binTgtDir}/rclone"
+        chown root:root ${binTgtDir}/rclone"
     ### - - - - - - - - - - - - - - - - - - - -
     #manual
     sudo -v

--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -37,7 +37,7 @@ for tool in ${unzip_tools_list[*]}; do
         unzip_tool="$tool"
         break
     fi
-done  
+done
 set -e
 
 # exit if no unzip tools available
@@ -78,7 +78,7 @@ case $OS in
     ;;
   OpenBSD)
     OS='openbsd'
-    ;;  
+    ;;
   Darwin)
     OS='osx'
     binTgtDir=/usr/local/bin
@@ -155,7 +155,7 @@ case "$OS" in
     #manual
     if ! [ -x "$(command -v mandb)" ]; then
         echo 'mandb not found. The rclone man docs will not be installed.'
-    else 
+    else
         mkdir -p /usr/local/share/man/man1
         cp rclone.1 /usr/local/share/man/man1/
         mandb
@@ -172,25 +172,25 @@ case "$OS" in
     makewhatis
     ;;
   'osx')
-	### - - - - - - - - - - - - - - - - - - - -
+    ### - - - - - - - - - - - - - - - - - - - -
     #binary
-	sudo -v
-	sudo -s -- <<-EOT
-		mkdir -m 0555 -p ${binTgtDir}
-		cp rclone ${binTgtDir}/rclone.new
-		mv ${binTgtDir}/rclone.new ${binTgtDir}/rclone
-		chmod a=x ${binTgtDir}/rclone
-	EOT
-	### - - - - - - - - - - - - - - - - - - - -
+    sudo -v
+    sudo -s -- <<-EOT
+        mkdir -m 0555 -p ${binTgtDir}
+        cp rclone ${binTgtDir}/rclone.new
+        mv ${binTgtDir}/rclone.new ${binTgtDir}/rclone
+        chmod a=x ${binTgtDir}/rclone
+    EOT
+    ### - - - - - - - - - - - - - - - - - - - -
     #manual
-	sudo -v
-	sudo -s -- <<-EOT
-		mkdir -m 0555 -p ${man1TgtDir}
-		cp rclone.1 ${man1TgtDir}    
-		chmod a=r ${man1TgtDir}/rclone.1
-	EOT
+    sudo -v
+    sudo -s -- <<-EOT
+        mkdir -m 0555 -p ${man1TgtDir}
+        cp rclone.1 ${man1TgtDir}
+        chmod a=r ${man1TgtDir}/rclone.1
+    EOT
     ;;
-	### - - - - - - - - - - - - - - - - - - - -
+    ### - - - - - - - - - - - - - - - - - - - -
   *)
     echo 'OS not supported'
     exit 2

--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -175,20 +175,19 @@ case "$OS" in
     ### - - - - - - - - - - - - - - - - - - - -
     #binary
     sudo -v
-    sudo -s -- <<-EOT
-        mkdir -m 0555 -p ${binTgtDir}
-        cp rclone ${binTgtDir}/rclone.new
-        mv ${binTgtDir}/rclone.new ${binTgtDir}/rclone
-        chmod a=x ${binTgtDir}/rclone
-    EOT
+    sudo -u root -- bash -c "\
+        mkdir -m 0755 -p ${binTgtDir} && \
+        cp rclone ${binTgtDir}/rclone.new && \
+        mv ${binTgtDir}/rclone.new ${binTgtDir}/rclone && \
+        chmod a=x ${binTgtDir}/rclone && \
+		chown root:root ${binTgtDir}/rclone"
     ### - - - - - - - - - - - - - - - - - - - -
     #manual
     sudo -v
-    sudo -s -- <<-EOT
-        mkdir -m 0555 -p ${man1TgtDir}
-        cp rclone.1 ${man1TgtDir}
-        chmod a=r ${man1TgtDir}/rclone.1
-    EOT
+    sudo -u root -- bash -c "\
+        mkdir -m 0555 -p ${man1TgtDir} && \
+        cp rclone.1 ${man1TgtDir} && \
+        chmod a=r ${man1TgtDir}/rclone.1"
     ;;
     ### - - - - - - - - - - - - - - - - - - - -
   *)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

I tried to keep the changes specific for Macintosh 'osx' installation target.

- Added target specific variables used for locations.
- Changed to not assume anything (if possible).
- Target directory creation is attempted. If successful, modes and ownership are set.
- Files are copied and ownership and modes are deterministically set.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ n] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ n/a] I have added tests for all changes in this PR if appropriate.
- [ y] I have added documentation for the changes if appropriate.
- [ ?] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ y] I'm done, this Pull Request is ready for review :-)

As an FYI, this 'patch' mirrors what I did for the installation process under the 'linux' heading.