### PR TITLE
Add scripts to generate repos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,12 @@ upload:
 upload_github:
 	./bin/upload-github $(TAG)
 
+repo_apt:
+	./bin/make_repo_apt.sh
+
+repo_yum:
+	./bin/make_repo_yum.sh
+
 cross:	doc
 	go run bin/cross-compile.go -release current $(BUILD_FLAGS) $(BUILDTAGS) $(BUILD_ARGS) $(TAG)
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,6 +31,8 @@ This file describes how to make the various kinds of releases
   * make upload
   * make upload_website
   * make upload_github
+  * make apt_repo
+  * make yum_repo
   * make startdev # make startstable for stable branch
   * # announce with forum post, twitter post, patreon post
 

--- a/bin/make_repo_apt.sh
+++ b/bin/make_repo_apt.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+#
+# Upload a release
+#
+# Requires reprepro from https://github.com/ionos-cloud/reprepro
+
+set -e
+
+FINGERPRINT=${1:-"FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA"}
+BUCKET_PATH=${2:-"/mnt/apt.rclone.org"}
+
+# path for persistant files in bucket
+LOCAL_PATH="$BUCKET_PATH/.local"
+REPREPRO_PATH="$LOCAL_PATH/reprepro"
+
+# if the bucket path does not exist, give error
+if [[ ! -d $BUCKET_PATH ]]
+then
+	echo "Bucket not mounted. Expected directory at ${BUCKET_PATH}."
+	exit 1
+elif [[ ! -d $REPREPRO_PATH ]]
+then
+	echo "Config dir not found. Performing first time setup."
+	mkdir -p "$REPREPRO_PATH/conf"; mkdir -p "$REPREPRO_PATH/db"; mkdir -p "$REPREPRO_PATH/log"
+	cat <<- EOF > "$REPREPRO_PATH/conf/options"
+		basedir $BUCKET_PATH
+		dbdir $REPREPRO_PATH/db
+		logdir $REPREPRO_PATH/log
+	EOF
+	cat <<- EOF > "$REPREPRO_PATH/conf/distributions"
+		Origin: apt.rclone.org
+		Label: Rclone
+		Codename: any
+		Architectures: amd64 i386 arm64 armhf armel mips mipsel
+		Components: main
+		Description: Apt repository for Rclone
+		SignWith: $FINGERPRINT
+		Limit: 20
+	EOF
+fi
+
+for build in build/*.deb; do
+	if [[ ${build} == *-arm.deb ]]
+	then
+		# do nothing because both arm and arm-v7 are armhf?
+		echo "Skipping ${build}."
+	else
+		reprepro --confdir "$REPREPRO_PATH/conf" includedeb any "${build}"
+		echo "Added ${build} to APT repo."
+	fi
+done
+
+echo "Done"

--- a/bin/make_repo_yum.sh
+++ b/bin/make_repo_yum.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+#
+# Upload a release
+#
+# Requires createrepo-c and rpm
+
+set -e
+
+FINGERPRINT=${1:-"FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA"}
+BUCKET_PATH=${2:-"/mnt/yum.rclone.org"}
+
+if [[ ! -d $BUCKET_PATH ]]
+then
+	echo "Bucket not mounted. Expected directory at ${BUCKET_PATH}."
+	exit 1
+fi
+
+update_rpm_repo() {
+	local RPM_FILE="$1"
+	local RPM_REPO_DIR="$2"
+
+	# query rpm version and package name
+	local RPM_FULLNAME=$(rpm -qp "${RPM_FILE}")
+
+	# query rpm arch separately
+	local RPM_ARCH=$(rpm -qp --qf "%{arch}" "${RPM_FILE}")
+
+	mkdir -p "${RPM_REPO_DIR}/${RPM_ARCH}/" &&
+	cp "${RPM_FILE}" "${RPM_REPO_DIR}/${RPM_ARCH}/${RPM_FULLNAME}.rpm"
+	echo "Copied ${RPM_FILE} to ${RPM_REPO_DIR}/${RPM_ARCH}/${RPM_FULLNAME}.rpm"
+
+	# remove and replace repodata
+	createrepo_c  --update "${RPM_REPO_DIR}/${RPM_ARCH}"
+
+	rm -f "${RPM_REPO_DIR}/${RPM_ARCH}/repodata/repomd.xml.asc" &&
+	gpg --default-key "$3" -absq -o "${RPM_REPO_DIR}/${RPM_ARCH}/repodata/repomd.xml.asc" "${RPM_REPO_DIR}/${RPM_ARCH}/repodata/repomd.xml"
+}
+
+for build in build/*.rpm; do
+	update_rpm_repo "$build" "$BUCKET_PATH" "$FINGERPRINT"
+	echo "Added ${build} to YUM repo."
+done
+
+echo "Done"


### PR DESCRIPTION
#### What is the purpose of this change?

This adds two scripts. One builds the apt repo and the other builds the yum repo. The scripts can be run using `make repo_apt` and `make repo_yum`.

#### Was the change discussed in an issue or in the forum before?

Once done, this should close #136.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
