### PR TITLE
content: add Yandex Disk as tested bisync backend

### DIFF
--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -363,6 +363,7 @@ Bisync is considered _BETA_ and has been tested with the following backends:
 - OneDrive
 - S3
 - SFTP
+- Yandex Disk
 
 It has not been fully tested with other services yet.
 If it works, or sorta works, please let us know and we'll update the list.


### PR DESCRIPTION

#### What is the purpose of this change?

I tested Yandex Disk backend through bisync tests. Now we can add one more tested backend to bisync doc page.

[test.log](https://github.com/rclone/rclone/files/8791797/test.log)


#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
