### PR TITLE
Verbosity environment variable information

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -2234,7 +2234,7 @@ override the environment variable setting.
 Or to always use the trash in drive `--drive-use-trash`, set
 `RCLONE_DRIVE_USE_TRASH=true`.
 
-Verbosity is slightly different, the environment variable equivalent if `--verbose` or `-v` is `RCLONE_VERBOSE=1` or for `-vv`, `RCLONE_VERBOSE=2`
+Verbosity is slightly different, the environment variable equivalent of `--verbose` or `-v` is `RCLONE_VERBOSE=1`, or for `-vv`, `RCLONE_VERBOSE=2`
 
 The same parser is used for the options and the environment variables
 so they take exactly the same form.

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -788,7 +788,9 @@ See `--compare-dest` and `--backup-dir`.
 
 ### --dedupe-mode MODE ###
 
-Mode to run dedupe command in.  One of `interactive`, `skip`, `first`, `newest`, `oldest`, `rename`.  The default is `interactive`.  See the dedupe command for more information as to what these options mean.
+Mode to run dedupe command in.  One of `interactive`, `skip`, `first`, 
+`newest`, `oldest`, `rename`.  The default is `interactive`.  
+See the dedupe command for more information as to what these options mean.
 
 ### --disable FEATURE,FEATURE,... ###
 
@@ -1086,7 +1088,12 @@ have a signal to rotate logs.
 
 ### --log-format LIST ###
 
-Comma separated list of log format options. Accepted options are `date`, `time`, `microseconds`, `pid`, `longfile`, `shortfile`, `UTC`. Any other keywords will be silently ignored. `pid` will tag log messages with process identifier which useful with `rclone mount --daemon`. Other accepted options are explained in the [go documentation](https://pkg.go.dev/log#pkg-constants). The default log format is "`date`,`time`".
+Comma separated list of log format options. Accepted options are `date`, 
+`time`, `microseconds`, `pid`, `longfile`, `shortfile`, `UTC`. Any other 
+keywords will be silently ignored. `pid` will tag log messages with process
+identifier which useful with `rclone mount --daemon`. Other accepted
+options are explained in the [go documentation](https://pkg.go.dev/log#pkg-constants).
+The default log format is "`date`,`time`".
 
 ### --log-level LEVEL ###
 
@@ -1867,7 +1874,8 @@ With `-vv` rclone will become very verbose telling you about every
 file it considers and transfers.  Please send bug reports with a log
 with this setting.
 
-When setting verbosity as an environment variable, use `RCLONE_VERBOSE=1` or `RCLONE_VERBOSE=2` for `-v` and `-vv` respectively.
+When setting verbosity as an environment variable, use
+`RCLONE_VERBOSE=1` or `RCLONE_VERBOSE=2` for `-v` and `-vv` respectively.
 
 ### -V, --version ###
 
@@ -2234,7 +2242,9 @@ override the environment variable setting.
 Or to always use the trash in drive `--drive-use-trash`, set
 `RCLONE_DRIVE_USE_TRASH=true`.
 
-Verbosity is slightly different, the environment variable equivalent of `--verbose` or `-v` is `RCLONE_VERBOSE=1`, or for `-vv`, `RCLONE_VERBOSE=2`
+Verbosity is slightly different, the environment variable 
+equivalent of `--verbose` or `-v` is `RCLONE_VERBOSE=1`, 
+or for `-vv`, `RCLONE_VERBOSE=2`.
 
 The same parser is used for the options and the environment variables
 so they take exactly the same form.

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1867,6 +1867,8 @@ With `-vv` rclone will become very verbose telling you about every
 file it considers and transfers.  Please send bug reports with a log
 with this setting.
 
+When setting verbosity as an environment variable, use `RCLONE_VERBOSE=1` or `RCLONE_VERBOSE=2` for `-v` and `-vv` respectively.
+
 ### -V, --version ###
 
 Prints the version number
@@ -2231,6 +2233,8 @@ override the environment variable setting.
 
 Or to always use the trash in drive `--drive-use-trash`, set
 `RCLONE_DRIVE_USE_TRASH=true`.
+
+Verbosity is slightly different, the environment variable equivalent if `--verbose` or `-v` is `RCLONE_VERBOSE=1` or for `-vv`, `RCLONE_VERBOSE=2`
 
 The same parser is used for the options and the environment variables
 so they take exactly the same form.


### PR DESCRIPTION
RCLONE_VERBOSE does not use a true/false setting, instead using a 0,1,2 setting. This updates the documents to reflect this information.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Update documentation for environment variable RCLONE_VERBOSE

#### Was the change discussed in an issue or in the forum before?

[6207](https://github.com/rclone/rclone/issues/6207)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
