### PR TITLE
Config UI readability

### DIFF
--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -338,6 +338,11 @@ func OkRemote(name string) bool {
 	return false
 }
 
+// newSection prints an empty line to separate sections
+func newSection() {
+	fmt.Println()
+}
+
 // backendConfig configures the backend starting from the state passed in
 //
 // The is the user interface loop that drives the post configuration backend config.
@@ -387,6 +392,7 @@ func backendConfig(ctx context.Context, name string, m configmap.Mapper, ri *fs.
 		if out.State == "" {
 			break
 		}
+		newSection()
 	}
 	return nil
 }
@@ -516,7 +522,7 @@ func NewRemote(ctx context.Context, name string) error {
 		break
 	}
 	LoadedData().SetValue(name, "type", newType)
-
+	newSection()
 	_, err = CreateRemote(ctx, name, newType, nil, UpdateRemoteOpt{
 		All: true,
 	})
@@ -527,13 +533,15 @@ func NewRemote(ctx context.Context, name string) error {
 		SaveConfig()
 		return nil
 	}
+	newSection()
 	return EditRemote(ctx, ri, name)
 }
 
 // EditRemote gets the user to edit a remote
 func EditRemote(ctx context.Context, ri *fs.RegInfo, name string) error {
-	ShowRemote(name)
 	fmt.Printf("Edit remote\n")
+	ShowRemote(name)
+	newSection()
 	for {
 		_, err := UpdateRemote(ctx, name, nil, UpdateRemoteOpt{
 			All: true,
@@ -626,29 +634,44 @@ func EditConfig(ctx context.Context) (err error) {
 		}
 		switch i := Command(what); i {
 		case 'e':
+			newSection()
 			name := ChooseRemote()
+			newSection()
 			fs := mustFindByName(name)
 			err = EditRemote(ctx, fs, name)
 			if err != nil {
 				return err
 			}
 		case 'n':
-			err = NewRemote(ctx, NewRemoteName())
+			newSection()
+			name := NewRemoteName()
+			newSection()
+			err = NewRemote(ctx, name)
 			if err != nil {
 				return err
 			}
 		case 'd':
+			newSection()
 			name := ChooseRemote()
+			newSection()
 			DeleteRemote(name)
 		case 'r':
-			RenameRemote(ChooseRemote())
+			newSection()
+			name := ChooseRemote()
+			newSection()
+			RenameRemote(name)
 		case 'c':
-			CopyRemote(ChooseRemote())
+			newSection()
+			name := ChooseRemote()
+			newSection()
+			CopyRemote(name)
 		case 's':
+			newSection()
 			SetPassword()
 		case 'q':
 			return nil
 		}
+		newSection()
 	}
 }
 

--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -298,10 +298,8 @@ func mustFindByName(name string) *fs.RegInfo {
 	return fs.MustFind(fsType)
 }
 
-// ShowRemote shows the contents of the remote
-func ShowRemote(name string) {
-	fmt.Printf("--------------------\n")
-	fmt.Printf("[%s]\n", name)
+// printRemoteOptions prints the options of the remote
+func printRemoteOptions(name string, prefix string, sep string) {
 	fs := mustFindByName(name)
 	for _, key := range LoadedData().GetKeyList(name) {
 		isPassword := false
@@ -313,17 +311,28 @@ func ShowRemote(name string) {
 		}
 		value := FileGet(name, key)
 		if isPassword && value != "" {
-			fmt.Printf("%s = *** ENCRYPTED ***\n", key)
+			fmt.Printf("%s%s%s*** ENCRYPTED ***\n", prefix, key, sep)
 		} else {
-			fmt.Printf("%s = %s\n", key, value)
+			fmt.Printf("%s%s%s%s\n", prefix, key, sep, value)
 		}
 	}
-	fmt.Printf("--------------------\n")
+}
+
+// listRemoteOptions lists the options of the remote
+func listRemoteOptions(name string) {
+	printRemoteOptions(name, "- ", ": ")
+}
+
+// ShowRemote shows the contents of the remote in config file format
+func ShowRemote(name string) {
+	fmt.Printf("[%s]\n", name)
+	printRemoteOptions(name, "", " = ")
 }
 
 // OkRemote prints the contents of the remote and ask if it is OK
 func OkRemote(name string) bool {
-	ShowRemote(name)
+	fmt.Printf("Configuration of %q remote:\n", name)
+	listRemoteOptions(name)
 	switch i := CommandDefault([]string{"yYes this is OK", "eEdit this remote", "dDelete this remote"}, 0); i {
 	case 'y':
 		return true
@@ -539,8 +548,8 @@ func NewRemote(ctx context.Context, name string) error {
 
 // EditRemote gets the user to edit a remote
 func EditRemote(ctx context.Context, ri *fs.RegInfo, name string) error {
-	fmt.Printf("Edit remote\n")
-	ShowRemote(name)
+	fmt.Printf("Edit existing %q remote with options:\n", name)
+	listRemoteOptions(name)
 	newSection()
 	for {
 		_, err := UpdateRemote(ctx, name, nil, UpdateRemoteOpt{

--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -285,6 +285,7 @@ func ShowRemotes() {
 func ChooseRemote() string {
 	remotes := LoadedData().GetSectionList()
 	sort.Strings(remotes)
+	fmt.Println("Select remote.")
 	return Choose("remote", "value", remotes, nil, "", true, false)
 }
 
@@ -331,8 +332,10 @@ func ShowRemote(name string) {
 
 // OkRemote prints the contents of the remote and ask if it is OK
 func OkRemote(name string) bool {
-	fmt.Printf("Configuration of %q remote:\n", name)
+	fmt.Println("Configuration complete.")
+	fmt.Println("Options:")
 	listRemoteOptions(name)
+	fmt.Printf("Keep this %q remote?\n", name)
 	switch i := CommandDefault([]string{"yYes this is OK", "eEdit this remote", "dDelete this remote"}, 0); i {
 	case 'y':
 		return true
@@ -492,6 +495,7 @@ func ChooseOption(o *fs.Option, name string) string {
 // NewRemoteName asks the user for a name for a new remote
 func NewRemoteName() (name string) {
 	for {
+		fmt.Println("Enter name for new remote.")
 		fmt.Printf("name> ")
 		name = ReadLine()
 		if LoadedData().HasSection(name) {
@@ -548,7 +552,7 @@ func NewRemote(ctx context.Context, name string) error {
 
 // EditRemote gets the user to edit a remote
 func EditRemote(ctx context.Context, ri *fs.RegInfo, name string) error {
-	fmt.Printf("Edit existing %q remote with options:\n", name)
+	fmt.Printf("Editing existing %q remote with options:\n", name)
 	listRemoteOptions(name)
 	newSection()
 	for {


### PR DESCRIPTION
#### What is the purpose of this change?

Improve readability in the config ui.

Primary intention was to add spacing (i.e. empty lines) between individual sections, such as individual options, or questions. But; improving one thing, makes another thing stand out, so I added some more changes to improve consistency and overall readability.

The changes are:
- Empty line between sections, i.e. before each individual option is presented, and before individual questions like "Edit advanced config?"
    - Not a very generic or elegant solution, that would require too much refactoring I think. But to make it obvious where newlines are inserted as part of this I created a separate helper function `newSection`. This should make it easy to read, avoid accidental removal of "duplicate" newlines, and make a good starting point for any future improved implementation.
- More consistent (and less "noisy") listing of configuration options at end of config session, as part of the "Yes this is OK" confirmation. Also at beginning when doing an "Edit existing remote" session.
- Added/extended some header labels to make the different type of sections (individual options, and questions like "Select remote", "Configuration complete" etc) consistent.

Note: The related issue also discusses readability of "multiple choice" listings, but I have not considered that in this PR. I think that is a separate issue, and in my opinion more debatable.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/6187

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
    - There are two commits that I will squash before merge. They are doing similar things, but are separate because the first starts with a conservative approach and the next builds on that, in case we decide to revert to the more conservative approach.
- [X] I'm done, this Pull Request is ready for review :-)
