### PR TITLE
Hashsum: Changed output format when listing algorithms

### DIFF
--- a/fs/hash/hash.go
+++ b/fs/hash/hash.go
@@ -410,7 +410,7 @@ func HelpString(indent int) string {
 	help.WriteString(padding)
 	help.WriteString("Supported hashes are:\n")
 	for _, h := range supported {
-		fmt.Fprintf(&help, "%s  * %v\n", padding, h.String())
+		fmt.Fprintf(&help, "%s- %v\n", padding, h.String())
 	}
 	return help.String()
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Suggestion for a supermicro change.... switching the list output format of `rclone hashsum` command from `*` prefixed (with indention) to `-` prefixed (without indention).

Only reason to do this is consistency, or perhaps also readability? (Or maybe actually less readable?) Somewhat related to https://github.com/rclone/rclone/pull/6211. In docs (markdown) we ususally use `-` prefixed list entries, and therefore this is also what is presented in help command output and config ui. The `hashsum` command  (without arguments) output information (list of supported algorithms) in "human-readable markdown-like list format", similar to help and config commands, and therefore I feel it is more consistent to use the same `-` prefixed list format also for this. Not sure what other commands have similar output? There are commands that output list-like information, such as `listremotes`, but it outputs it as plain newline-separated strings. The difference is that this is the "primary and intended output" of the command. The `hashsum` command is a bit different, perhaps, as the output is more of a help text? (Or else it could also just list without the header text and without list item prefixes.)

Current (before this PR):
```
$ rclone.exe hashsum
Supported hashes are:
  * md5
  * sha1
  * whirlpool
  * crc32
  * sha256
  * dropbox
  * mailru
  * quickxor
```

New (after this PR):
```
$ rclone.exe hashsum
Supported hashes are:
- md5
- sha1
- whirlpool
- crc32
- sha256
- dropbox
- mailru
- quickxor
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
