### PR TITLE
Use variable type int instead of time.Duration for keeping number of seconds

### DIFF
--- a/backend/mailru/mailru.go
+++ b/backend/mailru/mailru.go
@@ -2277,7 +2277,7 @@ type serverPool struct {
 	pool      pendingServerMap
 	mu        sync.Mutex
 	path      string
-	expirySec time.Duration
+	expirySec int
 	fs        *Fs
 }
 
@@ -2384,7 +2384,7 @@ func (p *serverPool) addServer(url string, now time.Time) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	expiry := now.Add(p.expirySec * time.Second)
+	expiry := now.Add(time.Duration(p.expirySec) * time.Second)
 
 	expiryStr := []byte("-")
 	if p.fs.ci.LogLevel >= fs.LogLevelInfo {


### PR DESCRIPTION
#### What is the purpose of this change?

This started out as an issue reported by the staticcheck linting tool: "Poorly chosen name for variable of type time.Duration" (ST1011). It refers to the `serverPool.expirySec` variable. I fixed this by renaming it from `expirySec` to just `expiry`. But this revealed another problem: It is initialized with value of constant `serverExpirySec`, integer 180, but despite the name of this constant its value in this assignment will be treated as nanoseconds! I fixed this by multiplying with `time.Second`, which makes the code/naming consistent, and I assume this is according to the intention ❓ But it changes the actual logic since the initial value is now 180 seconds while before was 180 nanoseconds ❗

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
