### PR TITLE
Remove legacy OS X remnants from mount code

### DIFF
--- a/cmd/mount/dir.go
+++ b/cmd/mount/dir.go
@@ -38,7 +38,6 @@ func (d *Dir) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 	a.Atime = modTime
 	a.Mtime = modTime
 	a.Ctime = modTime
-	a.Crtime = modTime
 	// FIXME include Valid so get some caching?
 	// FIXME fs.Debugf(d.path, "Dir.Attr %+v", a)
 	return nil

--- a/cmd/mount/file.go
+++ b/cmd/mount/file.go
@@ -36,7 +36,6 @@ func (f *File) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 	a.Atime = modTime
 	a.Mtime = modTime
 	a.Ctime = modTime
-	a.Crtime = modTime
 	a.Blocks = Blocks
 	return nil
 }

--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -27,7 +27,6 @@ func mountOptions(VFS *vfs.VFS, device string, opt *mountlib.Options) (options [
 		fuse.MaxReadahead(uint32(opt.MaxReadAhead)),
 		fuse.Subtype("rclone"),
 		fuse.FSName(device),
-		fuse.VolumeName(opt.VolumeName),
 
 		// Options from benchmarking in the fuse module
 		//fuse.MaxReadahead(64 * 1024 * 1024),
@@ -104,12 +103,6 @@ func mount(VFS *vfs.VFS, mountpoint string, opt *mountlib.Options) (<-chan error
 		}
 		errChan <- err
 	}()
-
-	// check if the mount process has an error to report
-	<-c.Ready
-	if err := c.MountError; err != nil {
-		return nil, nil, err
-	}
 
 	unmount := func() error {
 		// Shutdown the VFS


### PR DESCRIPTION
#### What is the purpose of this change?


The bazil.org/fuse library did support macOS, but this was removed as described in #4393.

This PR removes some remnants in code, as detected by the staticcheck lint tool:

fuse.VolumeName is deprecated: Ignored, OS X remnant.  (SA1019)
c.MountError is deprecated: Not used, OS X remnant.  (SA1019)
c.Ready is deprecated: Not used, OS X remnant.  (SA1019)
a.Crtime is deprecated: Not used, OS X remnant.  (SA1019)
a.Crtime is deprecated: Not used, OS X remnant.  (SA1019)

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
