### PR TITLE
Replace deprecated fuse.ENOSYS with syscall.ENOSYS in mount

### DIFF
--- a/cmd/mount/dir.go
+++ b/cmd/mount/dir.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"syscall"
 	"time"
 
 	"bazil.org/fuse"
@@ -237,7 +238,7 @@ var _ fusefs.NodeLinker = (*Dir)(nil)
 // existing Node. Receiver must be a directory.
 func (d *Dir) Link(ctx context.Context, req *fuse.LinkRequest, old fusefs.Node) (newNode fusefs.Node, err error) {
 	defer log.Trace(d, "req=%v, old=%v", req, old)("new=%v, err=%v", &newNode, &err)
-	return nil, fuse.ENOSYS
+	return nil, syscall.ENOSYS
 }
 
 // Check interface satisfied

--- a/cmd/mount/file.go
+++ b/cmd/mount/file.go
@@ -5,6 +5,7 @@ package mount
 
 import (
 	"context"
+	"syscall"
 	"time"
 
 	"bazil.org/fuse"
@@ -98,14 +99,14 @@ func (f *File) Fsync(ctx context.Context, req *fuse.FsyncRequest) (err error) {
 //
 // If there is no xattr by that name, returns fuse.ErrNoXattr.
 func (f *File) Getxattr(ctx context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
-	return fuse.ENOSYS // we never implement this
+	return syscall.ENOSYS // we never implement this
 }
 
 var _ fusefs.NodeGetxattrer = (*File)(nil)
 
 // Listxattr lists the extended attributes recorded for the node.
 func (f *File) Listxattr(ctx context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
-	return fuse.ENOSYS // we never implement this
+	return syscall.ENOSYS // we never implement this
 }
 
 var _ fusefs.NodeListxattrer = (*File)(nil)
@@ -113,7 +114,7 @@ var _ fusefs.NodeListxattrer = (*File)(nil)
 // Setxattr sets an extended attribute with the given name and
 // value for the node.
 func (f *File) Setxattr(ctx context.Context, req *fuse.SetxattrRequest) error {
-	return fuse.ENOSYS // we never implement this
+	return syscall.ENOSYS // we never implement this
 }
 
 var _ fusefs.NodeSetxattrer = (*File)(nil)
@@ -122,7 +123,7 @@ var _ fusefs.NodeSetxattrer = (*File)(nil)
 //
 // If there is no xattr by that name, returns fuse.ErrNoXattr.
 func (f *File) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) error {
-	return fuse.ENOSYS // we never implement this
+	return syscall.ENOSYS // we never implement this
 }
 
 var _ fusefs.NodeRemovexattrer = (*File)(nil)

--- a/cmd/mount/fs.go
+++ b/cmd/mount/fs.go
@@ -98,7 +98,7 @@ func translateError(err error) error {
 	case vfs.EROFS:
 		return fuse.Errno(syscall.EROFS)
 	case vfs.ENOSYS, fs.ErrorNotImplemented:
-		return fuse.ENOSYS
+		return syscall.ENOSYS
 	case vfs.EINVAL:
 		return fuse.Errno(syscall.EINVAL)
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes the following "problem" detected by the staticcheck lint tool:

> fuse.ENOSYS is deprecated: Return a syscall.Errno directly. See ToErrno for exact rules.  (SA1019)

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
