### PR TITLE
Implement a way to force rclone to use ipv4/ipv6

### DIFF
--- a/fs/config.go
+++ b/fs/config.go
@@ -55,6 +55,8 @@ type ConfigInfo struct {
 	IgnoreTimes            bool
 	IgnoreExisting         bool
 	IgnoreErrors           bool
+	PreferIPv4             bool
+	PreferIPv6             bool
 	ModifyWindow           time.Duration
 	Checkers               int
 	Transfers              int

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -137,6 +137,8 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &ci.DisableHTTP2, "disable-http2", "", ci.DisableHTTP2, "Disable HTTP/2 in the global transport")
 	flags.BoolVarP(flagSet, &ci.HumanReadable, "human-readable", "", ci.HumanReadable, "Print numbers in a human-readable format, sizes with suffix Ki|Mi|Gi|Ti|Pi")
 	flags.DurationVarP(flagSet, &ci.KvLockTime, "kv-lock-time", "", ci.KvLockTime, "Maximum time to keep key-value database locked by process")
+	flags.BoolVarP(flagSet, &ci.PreferIPv4, "prefer-ipv4", "", ci.PreferIPv4, "Force rclone to prefer IPv4 connections for all backends")
+	flags.BoolVarP(flagSet, &ci.PreferIPv6, "prefer-ipv6", "", ci.PreferIPv6, "Force rclone to prefer IPv6 connections for all backends")
 }
 
 // ParseHeaders converts the strings passed in via the header flags into HTTPOptions
@@ -178,6 +180,9 @@ func SetFlags(ci *fs.ConfigInfo) {
 	}
 	if (ci.DryRun || ci.Interactive) && ci.StatsLogLevel > fs.LogLevelNotice {
 		ci.StatsLogLevel = fs.LogLevelNotice
+	}
+	if ci.PreferIPv4 && ci.PreferIPv6 {
+		log.Fatalf("Cant force IPv4 and IPv6 at the same time")
 	}
 	if quiet {
 		if verbose > 0 {

--- a/fs/fshttp/dialer.go
+++ b/fs/fshttp/dialer.go
@@ -52,7 +52,16 @@ var warnDSCPFail, warnDSCPWindows sync.Once
 
 // DialContext connects to the network address using the provided context.
 func (d *Dialer) DialContext(ctx context.Context, network, address string) (net.Conn, error) {
-	c, err := d.Dialer.DialContext(ctx, network, address)
+	var c net.Conn
+	var err error
+	ci := fs.GetConfig(ctx)
+	if ci.PreferIPv4 {
+		c, err = d.Dialer.DialContext(ctx, "tcp4", address)
+	} else if ci.PreferIPv6 {
+		c, err = d.Dialer.DialContext(ctx, "tcp6", address)
+	} else {
+		c, err = d.Dialer.DialContext(ctx, network, address)
+	}
 	if err != nil {
 		return c, err
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Implement a way force rclone to use IPv4/IPv6 on a dual-stack network as requested in #6124 . This was the simplest way I could think of that should have desired effect. 

Limitations include this forcing the dialer to make tcp connections only. This shouldn't be problem for `net/http` since HTTP/1.1 and HTTP/2 are tcp only .
I might have also missed other problems with this approach.

Alternative ways of achieving this is modifying address resolution probably by providing a custom resolver to the dialer.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
