### PR TITLE
drive: extract function for escaping search titles

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -806,6 +806,25 @@ func (f *Fs) getRootID(ctx context.Context) (string, error) {
 	return info.Id, nil
 }
 
+// Replaces `\` to `\\` and `'` to `\'`
+// Escaping backslashes requirement is not documented
+// See https://stackoverflow.com/a/32310092
+func escapeSingleQuotesAndBackslashes(s string) string {
+	n := strings.Count(s, "\\") + strings.Count(s, "'")
+	var b strings.Builder
+	b.Grow(len(s) + n)
+	start := 0
+	for pos, c := range s {
+		if c == '\\' || c == '\'' {
+			b.WriteString(s[start:pos])
+			b.Write([]byte{'\\', byte(c)})
+			start = pos + 1
+		}
+	}
+	b.WriteString(s[start:])
+	return b.String()
+}
+
 // Lists the directory required calling the user function on each item found
 //
 // If the user fn ever returns true then it early exits with found = true
@@ -860,8 +879,7 @@ func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directorie
 	if title != "" {
 		searchTitle := f.opt.Enc.FromStandardName(title)
 		// Escaping the backslash isn't documented but seems to work
-		searchTitle = strings.ReplaceAll(searchTitle, `\`, `\\`)
-		searchTitle = strings.ReplaceAll(searchTitle, `'`, `\'`)
+		searchTitle = escapeSingleQuotesAndBackslashes(searchTitle)
 
 		var titleQuery bytes.Buffer
 		_, _ = fmt.Fprintf(&titleQuery, "(name='%s'", searchTitle)


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Slight optimization opportunity. Instead of calling `strings.ReplaceAll` twice, we can loop over the search title once while minimizing unnecessary allocations.

#### Was the change discussed in an issue or in the forum before?

Nope. I'm just working on some optimizations/simplifications for the `list` function in `drive.go`.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
