### PR TITLE
Fix missing response when using custom auth handler in http serve

### DIFF
--- a/lib/http/auth/basic.go
+++ b/lib/http/auth/basic.go
@@ -113,6 +113,7 @@ func CustomAuth(fn CustomAuthFn, realm string) httplib.Middleware {
 				if value != nil {
 					r = r.WithContext(context.WithValue(r.Context(), ContextAuthKey, value))
 				}
+				next.ServeHTTP(w, r)
 			}
 		})
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

I was running the staticcheck linter and investigated the following reported issues:

> this value of r is never used (SA4006)
> WithContext is a pure function but its return value is ignored (SA4017)

On the following line:

https://github.com/rclone/rclone/blob/fdd2f8e6d21d1cf95b33fd2bb09f9c1caef0069d/lib/http/auth/basic.go#L114

I'm not sure I understand this line and the `CustomAuth` function it is in, but my impression is that staticcheck is in fact correct here, and that this line does nothing as the implementation currently is.

```
// WithContext returns a shallow copy of r with its context changed
// to ctx. The provided ctx must be non-nil.
//
// For outgoing client request, the context controls the entire
// lifetime of a request and its response: obtaining a connection,
// sending the request, and reading the response headers and body.
//
// To create a new request with a context, use NewRequestWithContext.
// To change the context of a request, such as an incoming request you
// want to modify before sending back out, use Request.Clone. Between
// those two uses, it's rare to need WithContext.
```

If this is true then is it not the case that the CustomAuth function does nothing at all, on success, and that an http serve would not work at all if "custom auth" is enabled (I have no idea how to do that)? Wild guess: It should have called `next.ServeHTTP(w, r)`, using the copy of `r` returned from `WithContext`, just like the handler implementation of the other auth implementations (HtPasswdAuth and SingleAuth).

https://github.com/rclone/rclone/blob/fdd2f8e6d21d1cf95b33fd2bb09f9c1caef0069d/lib/http/auth/basic.go#L73

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
