### PR TITLE
Use jwt-go (golang-jwt) instead of deprecated jws (x/oauth2/jws)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -32,11 +32,6 @@ issues:
       - staticcheck
       text: 'SA1019: "github.com/rclone/rclone/cmd/serve/httplib" is deprecated'
 
-    # TODO: Remove if/when this is fixed by merging PR #6277.
-    - linters:
-      - staticcheck
-      text: 'SA1019: "golang.org/x/oauth2/jws" is deprecated'
-
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
   timeout: 10m

--- a/go.mod
+++ b/go.mod
@@ -141,7 +141,7 @@ require (
 require (
 	github.com/Microsoft/go-winio v0.5.2 // indirect
 	github.com/ProtonMail/go-crypto v0.0.0-20230217124315-7d5c6f04bbb8
-	github.com/golang-jwt/jwt/v4 v4.5.0 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/pkg/xattr v0.4.9


### PR DESCRIPTION
#### What is the purpose of this change?

golang.org/x/oauth2/jws is deprecated

> this package is not intended for public use and might be removed in the future. It exists for internal use only. Please switch to another JWS package or copy this package into your own source tree.

github.com/golang-jwt/jwt/v4 seems to be a good alternative, and was already an implicit dependency.

Box backend is affected. Code change in common lib/jwtutil as well as backend/box, but only box implementation uses jwtutil I think.

❗ Untested ❗ 

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
