### PR TITLE
drive: add Workload Identity Federation support

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1086,15 +1086,12 @@ func getClient(ctx context.Context, opt *Options) *http.Client {
 
 func getServiceAccountClient(ctx context.Context, opt *Options, credentialsData []byte) (*http.Client, error) {
 	scopes := driveScopes(opt.Scope)
-	conf, err := google.JWTConfigFromJSON(credentialsData, scopes...)
+	credentials, err := google.CredentialsFromJSON(ctx, credentialsData, scopes...)
 	if err != nil {
 		return nil, fmt.Errorf("error processing credentials: %w", err)
 	}
-	if opt.Impersonate != "" {
-		conf.Subject = opt.Impersonate
-	}
 	ctxWithSpecialClient := oauthutil.Context(ctx, getClient(ctx, opt))
-	return oauth2.NewClient(ctxWithSpecialClient, conf.TokenSource(ctxWithSpecialClient)), nil
+	return oauth2.NewClient(ctxWithSpecialClient, credentials.TokenSource), nil
 }
 
 func createOAuthClient(ctx context.Context, opt *Options, name string, m configmap.Mapper) (*http.Client, error) {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

For supporting Workload Identity Federation, use `google.CredentialsFromJSON` instead of `google.JWTConfigFromJSON`.

This changes make possible to use GitHub Actions with Workload Identity Federation like below.

```
    steps:
      - uses: actions/checkout@master
      - id: 'auth'
        name: 'Authenticate to Google Cloud'
        uses: 'google-github-actions/auth@v0'
        with:
          workload_identity_provider: 'your identity provider'
          service_account: 'your service account email'
      - run: rclone ls "drive:"
        env:
           RCLONE_DRIVE_SERVICE_ACCOUNT_FILE: "${{steps.auth.outputs.credentials_file_path}}" 
```

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
