### PR TITLE
support --disable-dir-list for serve http 

### DIFF
--- a/cmd/serve/http/http.go
+++ b/cmd/serve/http/http.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rclone/rclone/cmd/serve/http/data"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/accounting"
+	"github.com/rclone/rclone/fs/config/flags"
 	httplib "github.com/rclone/rclone/lib/http"
 	"github.com/rclone/rclone/lib/http/auth"
 	"github.com/rclone/rclone/lib/http/serve"
@@ -36,11 +37,16 @@ var DefaultOpt = Options{}
 // Opt is options set by command line flags
 var Opt = DefaultOpt
 
+var (
+	disableGETDir = false
+)
+
 func init() {
 	data.AddFlags(Command.Flags(), "", &Opt.Options)
 	httplib.AddFlags(Command.Flags())
 	auth.AddFlags(Command.Flags())
 	vfsflags.AddFlags(Command.Flags())
+	flags.BoolVarP(Command.Flags(), &disableGETDir, "disable-dir-list", "", false, "Disable HTML directory list on GET request for a directory")
 }
 
 // Command definition for cobra
@@ -111,7 +117,7 @@ func (s *server) Bind(router chi.Router) {
 func (s *server) handler(w http.ResponseWriter, r *http.Request) {
 	isDir := strings.HasSuffix(r.URL.Path, "/")
 	remote := strings.Trim(r.URL.Path, "/")
-	if isDir {
+	if !disableGETDir && (r.Method == "GET" || r.Method == "HEAD") && isDir {
 		s.serveDir(w, r, remote)
 	} else {
 		s.serveFile(w, r, remote)


### PR DESCRIPTION
Support the --disable-dir-list flag for serve http. I used a similar way made for webdev (#4191).

#### Was the change discussed in an issue or in the forum before?

#4000

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
