### PR TITLE
jobs: add ability to stop group

### DIFF
--- a/fs/rc/jobs/job_test.go
+++ b/fs/rc/jobs/job_test.go
@@ -452,6 +452,48 @@ func TestRcSyncJobStop(t *testing.T) {
 	assert.Equal(t, false, out["success"])
 }
 
+func TestRcJobStopGroup(t *testing.T) {
+	ctx := context.Background()
+	jobID = 0
+	_, _, err := NewJob(ctx, ctxFn, rc.Params{
+		"_async": true,
+		"_group": "myparty",
+	})
+	require.NoError(t, err)
+	_, _, err = NewJob(ctx, ctxFn, rc.Params{
+		"_async": true,
+		"_group": "myparty",
+	})
+	require.NoError(t, err)
+
+	call := rc.Calls.Get("job/stopgroup")
+	assert.NotNil(t, call)
+	in := rc.Params{"group": "myparty"}
+	out, err := call.Fn(context.Background(), in)
+	require.NoError(t, err)
+	require.Empty(t, out)
+
+	in = rc.Params{}
+	_, err = call.Fn(context.Background(), in)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Didn't find key")
+
+	time.Sleep(10 * time.Millisecond)
+
+	call = rc.Calls.Get("job/status")
+	assert.NotNil(t, call)
+	for i := 1; i <= 2; i++ {
+		in = rc.Params{"jobid": i}
+		out, err = call.Fn(context.Background(), in)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		assert.Equal(t, "myparty", out["group"])
+		assert.Equal(t, "context canceled", out["error"])
+		assert.Equal(t, true, out["finished"])
+		assert.Equal(t, false, out["success"])
+	}
+}
+
 func TestOnFinish(t *testing.T) {
 	jobID = 0
 	done := make(chan struct{})


### PR DESCRIPTION
Adds new rc call to stop all running jobs in a group. Fixes #5561

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Adds new rc call `job/stopgroup` to stop jobs by _group

#### Was the change discussed in an issue or in the forum before?

#5561

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
