### PR TITLE
backend/union/upstream/upstream.go: fix alignment of struct field

### DIFF
--- a/backend/union/upstream/upstream.go
+++ b/backend/union/upstream/upstream.go
@@ -24,6 +24,10 @@ var (
 
 // Fs is a wrap of any fs and its configs
 type Fs struct {
+	// In order to ensure memory alignment on 32-bit architectures
+	// when this field is accessed through sync/atomic functions,
+	// it must be the first entry in the struct
+	cacheExpiry int64 // usage cache expiry time
 	fs.Fs
 	RootFs      fs.Fs
 	RootPath    string
@@ -32,7 +36,6 @@ type Fs struct {
 	creatable   bool
 	usage       *fs.Usage     // Cache the usage
 	cacheTime   time.Duration // cache duration
-	cacheExpiry int64         // usage cache expiry time
 	cacheMutex  sync.RWMutex
 	cacheOnce   sync.Once
 	cacheUpdate bool // if the cache is updating


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

On Void Linux i686 glibc, with go1.18.3 and rclone 1.59.0, this test failure happens:

```
$ RCLONE_CONFIG="/notfound" go test ./backend/union
--- FAIL: TestStandard (0.00s)
    fstests.go:451: Using remote "TestUnion:"
panic: unaligned 64-bit atomic operation [recovered]
        panic: unaligned 64-bit atomic operation

goroutine 70 [running]:
testing.tRunner.func1.2({0x56d97520, 0x56e25540})
        /usr/lib/go/src/testing/testing.go:1389 +0x2c5
testing.tRunner.func1()
        /usr/lib/go/src/testing/testing.go:1392 +0x4a5
panic({0x56d97520, 0x56e25540})
        /usr/lib/go/src/runtime/panic.go:844 +0x265
runtime/internal/atomic.panicUnaligned()
        /usr/lib/go/src/runtime/internal/atomic/unaligned.go:8 +0x38
runtime/internal/atomic.Load64(0x5859d4cc)
        /usr/lib/go/src/runtime/internal/atomic/atomic_386.s:225 +0x10
github.com/rclone/rclone/backend/union/upstream.(*Fs).GetFreeSpace(0x5859d4a0)
        /home/ricci/src/rclone/backend/union/upstream/upstream.go:312 +0x54
github.com/rclone/rclone/backend/union/policy.(*EpMfs).mfs(0x571b67e4, {0x5871a200, 0x3, 0x4})
        /home/ricci/src/rclone/backend/union/policy/epmfs.go:24 +0x5e
github.com/rclone/rclone/backend/union/policy.(*EpMfs).Create(0x571b67e4, {0x56e28528, 0x5841c150}, {0x58618be0, 0x3, 0x3}, {0x0, 0x0})
        /home/ricci/src/rclone/backend/union/policy/epmfs.go:83 +0x98
github.com/rclone/rclone/backend/union.(*Fs).create(...)
        /home/ricci/src/rclone/backend/union/union.go:752
github.com/rclone/rclone/backend/union.(*Fs).mkdir(0x5849e800, {0x56e28528, 0x5841c150}, {0x0, 0x0})
        /home/ricci/src/rclone/backend/union/union.go:148 +0x65
github.com/rclone/rclone/backend/union.(*Fs).Mkdir(0x5849e800, {0x56e28528, 0x5841c150}, {0x0, 0x0})
        /home/ricci/src/rclone/backend/union/union.go:177 +0x42
github.com/rclone/rclone/fstest/fstests.Run(0x58636f00, 0x5861c300)
        /home/ricci/src/rclone/fstest/fstests/fstests.go:542 +0xffb
github.com/rclone/rclone/backend/union_test.TestStandard(0x58636f00)
        /home/ricci/src/rclone/backend/union/union_test.go:33 +0x3e7
testing.tRunner(0x58636f00, 0x56e23a40)
        /usr/lib/go/src/testing/testing.go:1439 +0x150
created by testing.(*T).Run
        /usr/lib/go/src/testing/testing.go:1486 +0x3a8
FAIL    github.com/rclone/rclone/backend/union  0.069s
FAIL
```

After removing this check
https://github.com/rclone/rclone/blob/00a684d877548b47990a96cef8eeb1462a590c2a/fstest/fstests/fstests.go#L396-L398
I found commit 1d2fe0d8564bc679ece166c24b24e6fe7dc1455c using `git bisect`.

The explaination is in the commit message.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
Existing tests should be enough
- [x] I have added documentation for the changes if appropriate.
None required
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
