### PR TITLE
Backup dir fix

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -49,6 +49,11 @@ extended explanation in the [copy](/commands/rclone_copy/) command if unsure.
 If dest:path doesn't exist, it is created and the source:path contents
 go there.
 
+It is not possible to sync overlapping remotes. However, you may exclude
+the destination from the sync with a filter rule or by putting an 
+exclude-if-present file inside the destination directory and sync to a
+destination that is inside the source directory.
+
 **Note**: Use the ` + "`-P`" + `/` + "`--progress`" + ` flag to view real-time transfer statistics
 
 **Note**: Use the ` + "`rclone dedupe`" + ` command to deal with "Duplicate object/directory found in source/destination - ignoring" errors.

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -582,7 +582,8 @@ been added) in DIR, then it will be overwritten.
 
 The remote in use must support server-side move or copy and you must
 use the same remote as the destination of the sync.  The backup
-directory must not overlap the destination directory.
+directory must not overlap the destination directory without it being
+excluded by a filter rule.
 
 For example
 

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -40,7 +40,7 @@ var (
 	ErrorNotAFile                    = errors.New("is not a regular file")
 	ErrorNotDeleting                 = errors.New("not deleting files as there were IO errors")
 	ErrorNotDeletingDirs             = errors.New("not deleting directories as there were IO errors")
-	ErrorOverlapping                 = errors.New("can't sync or move files on overlapping remotes")
+	ErrorOverlapping                 = errors.New("can't sync or move files on overlapping remotes (try excluding the destination with a filter rule)")
 	ErrorDirectoryNotEmpty           = errors.New("directory not empty")
 	ErrorImmutableModified           = errors.New("immutable file modified")
 	ErrorPermissionDenied            = errors.New("permission denied")

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -814,17 +814,6 @@ func fixRoot(f fs.Info) string {
 	return s
 }
 
-// Overlapping returns true if fdst and fsrc point to the same
-// underlying Fs and they overlap.
-func Overlapping(fdst, fsrc fs.Info) bool {
-	if !SameConfig(fdst, fsrc) {
-		return false
-	}
-	fdstRoot := fixRoot(fdst)
-	fsrcRoot := fixRoot(fsrc)
-	return strings.HasPrefix(fdstRoot, fsrcRoot) || strings.HasPrefix(fsrcRoot, fdstRoot)
-}
-
 // OverlappingFilterCheck returns true if fdst and fsrc point to the same
 // underlying Fs and they overlap without fdst being excluded by any filter rule.
 func OverlappingFilterCheck(ctx context.Context, fdst fs.Fs, fsrc fs.Fs) bool {
@@ -1848,10 +1837,10 @@ func BackupDir(ctx context.Context, fdst fs.Fs, fsrc fs.Fs, srcFileName string) 
 			return nil, fserrors.FatalError(errors.New("parameter to --backup-dir has to be on the same remote as destination"))
 		}
 		if srcFileName == "" {
-			if Overlapping(fdst, backupDir) {
+			if OverlappingFilterCheck(ctx, backupDir, fdst) {
 				return nil, fserrors.FatalError(errors.New("destination and parameter to --backup-dir mustn't overlap"))
 			}
-			if Overlapping(fsrc, backupDir) {
+			if OverlappingFilterCheck(ctx, backupDir, fsrc) {
 				return nil, fserrors.FatalError(errors.New("source and parameter to --backup-dir mustn't overlap"))
 			}
 		} else {

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -1243,35 +1243,6 @@ func TestSame(t *testing.T) {
 	}
 }
 
-func TestOverlapping(t *testing.T) {
-	a := &testFsInfo{name: "name", root: "root"}
-	slash := string(os.PathSeparator) // native path separator
-	for _, test := range []struct {
-		name     string
-		root     string
-		expected bool
-	}{
-		{"name", "root", true},
-		{"namey", "root", false},
-		{"name", "rooty", false},
-		{"namey", "rooty", false},
-		{"name", "roo", false},
-		{"name", "root/toot", true},
-		{"name", "root/toot/", true},
-		{"name", "root" + slash + "toot", true},
-		{"name", "root" + slash + "toot" + slash, true},
-		{"name", "", true},
-		{"name", "/", true},
-	} {
-		b := &testFsInfo{name: test.name, root: test.root}
-		what := fmt.Sprintf("(%q,%q) vs (%q,%q)", a.name, a.root, b.name, b.root)
-		actual := operations.Overlapping(a, b)
-		assert.Equal(t, test.expected, actual, what)
-		actual = operations.Overlapping(b, a)
-		assert.Equal(t, test.expected, actual, what)
-	}
-}
-
 // testFs is for unit testing fs.Fs
 type testFs struct {
 	testFsInfo


### PR DESCRIPTION
#### What is the purpose of this change?

I noticed while reading the changelog for v1.59.0 that changes have been listed that weren't actually implemented. I guess I must've missed the usage of the Overlapping function in the --backup-dir option. This PR replaces the old Overlapping function with the new filter-sensitive one and also adds documentation notes and hints in error messages.
Sorry for this oversight.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
