### PR TITLE
Jottacloud: Fix legacy authentication

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -152,7 +152,7 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 		m.Set(configClientSecret, "")
 
 		srv := rest.NewClient(fshttp.NewClient(ctx))
-		token, tokenEndpoint, username, err := doTokenAuth(ctx, srv, loginToken)
+		token, tokenEndpoint, err := doTokenAuth(ctx, srv, loginToken)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get oauth token: %w", err)
 		}
@@ -161,7 +161,6 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 		if err != nil {
 			return nil, fmt.Errorf("error while saving token: %w", err)
 		}
-		m.Set(configUsername, username)
 		return fs.ConfigGoto("choose_device")
 	case "legacy": // configure a jottacloud backend using legacy authentication
 		m.Set("configVersion", fmt.Sprint(legacyConfigVersion))
@@ -272,30 +271,22 @@ sync or the backup section, for example, you must choose yes.`)
 		if config.Result != "true" {
 			m.Set(configDevice, "")
 			m.Set(configMountpoint, "")
-		}
-		username, userOk := m.Get(configUsername)
-		if userOk && config.Result != "true" {
 			return fs.ConfigGoto("end")
 		}
 		oAuthClient, _, err := getOAuthClient(ctx, name, m)
 		if err != nil {
 			return nil, err
 		}
-		if !userOk {
-			apiSrv := rest.NewClient(oAuthClient).SetRoot(apiURL)
-			cust, err := getCustomerInfo(ctx, apiSrv)
-			if err != nil {
-				return nil, err
-			}
-			username = cust.Username
-			m.Set(configUsername, username)
-			if config.Result != "true" {
-				return fs.ConfigGoto("end")
-			}
-		}
-
 		jfsSrv := rest.NewClient(oAuthClient).SetRoot(jfsURL)
-		acc, err := getDriveInfo(ctx, jfsSrv, username)
+		apiSrv := rest.NewClient(oAuthClient).SetRoot(apiURL)
+
+		cust, err := getCustomerInfo(ctx, apiSrv)
+		if err != nil {
+			return nil, err
+		}
+		m.Set(configUsername, cust.Username)
+
+		acc, err := getDriveInfo(ctx, jfsSrv, cust.Username)
 		if err != nil {
 			return nil, err
 		}
@@ -591,10 +582,10 @@ func doLegacyAuth(ctx context.Context, srv *rest.Client, oauthConfig *oauth2.Con
 }
 
 // doTokenAuth runs the actual token request for V2 authentication
-func doTokenAuth(ctx context.Context, apiSrv *rest.Client, loginTokenBase64 string) (token oauth2.Token, tokenEndpoint string, username string, err error) {
+func doTokenAuth(ctx context.Context, apiSrv *rest.Client, loginTokenBase64 string) (token oauth2.Token, tokenEndpoint string, err error) {
 	loginTokenBytes, err := base64.RawURLEncoding.DecodeString(loginTokenBase64)
 	if err != nil {
-		return token, "", "", err
+		return token, "", err
 	}
 
 	// decode login token
@@ -602,7 +593,7 @@ func doTokenAuth(ctx context.Context, apiSrv *rest.Client, loginTokenBase64 stri
 	decoder := json.NewDecoder(bytes.NewReader(loginTokenBytes))
 	err = decoder.Decode(&loginToken)
 	if err != nil {
-		return token, "", "", err
+		return token, "", err
 	}
 
 	// retrieve endpoint urls
@@ -613,7 +604,7 @@ func doTokenAuth(ctx context.Context, apiSrv *rest.Client, loginTokenBase64 stri
 	var wellKnown api.WellKnown
 	_, err = apiSrv.CallJSON(ctx, &opts, nil, &wellKnown)
 	if err != nil {
-		return token, "", "", err
+		return token, "", err
 	}
 
 	// prepare out token request with username and password
@@ -635,14 +626,14 @@ func doTokenAuth(ctx context.Context, apiSrv *rest.Client, loginTokenBase64 stri
 	var jsonToken api.TokenJSON
 	_, err = apiSrv.CallJSON(ctx, &opts, nil, &jsonToken)
 	if err != nil {
-		return token, "", "", err
+		return token, "", err
 	}
 
 	token.AccessToken = jsonToken.AccessToken
 	token.RefreshToken = jsonToken.RefreshToken
 	token.TokenType = jsonToken.TokenType
 	token.Expiry = time.Now().Add(time.Duration(jsonToken.ExpiresIn) * time.Second)
-	return token, wellKnown.TokenEndpoint, loginToken.Username, err
+	return token, wellKnown.TokenEndpoint, err
 }
 
 // getCustomerInfo queries general information about the account
@@ -944,17 +935,11 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return err
 	})
 
-	user, userOk := m.Get(configUsername)
-	if userOk {
-		f.user = user
-	} else {
-		fs.Infof(nil, "Username not found in config and must be looked up, reconfigure to avoid the extra request")
-		cust, err := getCustomerInfo(ctx, f.apiSrv)
-		if err != nil {
-			return nil, err
-		}
-		f.user = cust.Username
+	cust, err := getCustomerInfo(ctx, f.apiSrv)
+	if err != nil {
+		return nil, err
 	}
+	f.user = cust.Username
 	f.setEndpoints()
 
 	if root != "" && !rootIsDir {

--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -284,7 +284,6 @@ sync or the backup section, for example, you must choose yes.`)
 		if err != nil {
 			return nil, err
 		}
-		m.Set(configUsername, cust.Username)
 
 		acc, err := getDriveInfo(ctx, jfsSrv, cust.Username)
 		if err != nil {
@@ -317,10 +316,14 @@ a new by entering a unique name.`, defaultDevice)
 			return nil, err
 		}
 		jfsSrv := rest.NewClient(oAuthClient).SetRoot(jfsURL)
+		apiSrv := rest.NewClient(oAuthClient).SetRoot(apiURL)
 
-		username, _ := m.Get(configUsername)
+		cust, err := getCustomerInfo(ctx, apiSrv)
+		if err != nil {
+			return nil, err
+		}
 
-		acc, err := getDriveInfo(ctx, jfsSrv, username)
+		acc, err := getDriveInfo(ctx, jfsSrv, cust.Username)
 		if err != nil {
 			return nil, err
 		}
@@ -335,7 +338,7 @@ a new by entering a unique name.`, defaultDevice)
 		var dev *api.JottaDevice
 		if isNew {
 			fs.Debugf(nil, "Creating new device: %s", device)
-			dev, err = createDevice(ctx, jfsSrv, path.Join(username, device))
+			dev, err = createDevice(ctx, jfsSrv, path.Join(cust.Username, device))
 			if err != nil {
 				return nil, err
 			}
@@ -343,7 +346,7 @@ a new by entering a unique name.`, defaultDevice)
 		m.Set(configDevice, device)
 
 		if !isNew {
-			dev, err = getDeviceInfo(ctx, jfsSrv, path.Join(username, device))
+			dev, err = getDeviceInfo(ctx, jfsSrv, path.Join(cust.Username, device))
 			if err != nil {
 				return nil, err
 			}
@@ -373,11 +376,16 @@ You may create a new by entering a unique name.`, device)
 			return nil, err
 		}
 		jfsSrv := rest.NewClient(oAuthClient).SetRoot(jfsURL)
+		apiSrv := rest.NewClient(oAuthClient).SetRoot(apiURL)
 
-		username, _ := m.Get(configUsername)
+		cust, err := getCustomerInfo(ctx, apiSrv)
+		if err != nil {
+			return nil, err
+		}
+
 		device, _ := m.Get(configDevice)
 
-		dev, err := getDeviceInfo(ctx, jfsSrv, path.Join(username, device))
+		dev, err := getDeviceInfo(ctx, jfsSrv, path.Join(cust.Username, device))
 		if err != nil {
 			return nil, err
 		}
@@ -395,7 +403,7 @@ You may create a new by entering a unique name.`, device)
 				return nil, fmt.Errorf("custom mountpoints not supported on built-in %s device: %w", defaultDevice, err)
 			}
 			fs.Debugf(nil, "Creating new mountpoint: %s", mountpoint)
-			_, err := createMountPoint(ctx, jfsSrv, path.Join(username, device, mountpoint))
+			_, err := createMountPoint(ctx, jfsSrv, path.Join(cust.Username, device, mountpoint))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
#### What is the purpose of this change?

Reverts the commit that changed config to always store username in config, also for standard auth. It broke legacy auth.

Also avoids storing the username in config at all unless using legacy auth. Previously (before the mentioned reverted commit) it was only stored to pass the information between config steps, but not really a relevant configuration parameter. This was something I introduced myself when implementing support for custom device/mountpoint sequence in #5926. Although this now adds even more customer info requests, which is something I have tried to reduce, it is only during the config phase, and I think it makes it more consistent and avoids unnecessary information in config.

See commit messages for more details.

#### Was the change discussed in an issue or in the forum before?

Fixes #6309

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
