### PR TITLE
Support for symlinks in mount / vfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ __pycache__
 .DS_Store
 resource_windows_*.syso
 .devcontainer
+*.kate-swp

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ __pycache__
 resource_windows_*.syso
 .devcontainer
 *.kate-swp
+*debug*bin*
+.vscode/

--- a/backend/local/local_internal_test.go
+++ b/backend/local/local_internal_test.go
@@ -110,7 +110,7 @@ func TestSymlink(t *testing.T) {
 	require.NoError(t, lChtimes(symlinkPath, modTime2, modTime2))
 
 	// Object viewed as symlink
-	file2 := fstest.NewItem("symlink.txt"+linkSuffix, "file.txt", modTime2)
+	file2 := fstest.NewItem("symlink.txt"+fs.LinkSuffix, "file.txt", modTime2)
 
 	// Object viewed as destination
 	file2d := fstest.NewItem("symlink.txt", "hello", modTime1)
@@ -139,7 +139,7 @@ func TestSymlink(t *testing.T) {
 
 	// Create a symlink
 	modTime3 := fstest.Time("2002-03-03T04:05:10.123123123Z")
-	file3 := r.WriteObjectTo(ctx, r.Flocal, "symlink2.txt"+linkSuffix, "file.txt", modTime3, false)
+	file3 := r.WriteObjectTo(ctx, r.Flocal, "symlink2.txt"+fs.LinkSuffix, "file.txt", modTime3, false)
 	fstest.CheckListingWithPrecision(t, r.Flocal, []fstest.Item{file1, file2, file3}, nil, fs.ModTimeNotSupported)
 	if haveLChtimes {
 		r.CheckLocalItems(t, file1, file2, file3)
@@ -155,9 +155,9 @@ func TestSymlink(t *testing.T) {
 	assert.Equal(t, "file.txt", linkText)
 
 	// Check that NewObject gets the correct object
-	o, err := r.Flocal.NewObject(ctx, "symlink2.txt"+linkSuffix)
+	o, err := r.Flocal.NewObject(ctx, "symlink2.txt"+fs.LinkSuffix)
 	require.NoError(t, err)
-	assert.Equal(t, "symlink2.txt"+linkSuffix, o.Remote())
+	assert.Equal(t, "symlink2.txt"+fs.LinkSuffix, o.Remote())
 	assert.Equal(t, int64(8), o.Size())
 
 	// Check that NewObject doesn't see the non suffixed version
@@ -165,7 +165,7 @@ func TestSymlink(t *testing.T) {
 	require.Equal(t, fs.ErrorObjectNotFound, err)
 
 	// Check that NewFs works with the suffixed version and --links
-	f2, err := NewFs(ctx, "local", filepath.Join(dir, "symlink2.txt"+linkSuffix), configmap.Simple{
+	f2, err := NewFs(ctx, "local", filepath.Join(dir, "symlink2.txt"+fs.LinkSuffix), configmap.Simple{
 		"links": "true",
 	})
 	require.Equal(t, fs.ErrorIsFile, err)

--- a/cmd/mount/dir.go
+++ b/cmd/mount/dir.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
+	"strings"
 	"syscall"
 	"time"
 
@@ -27,13 +29,21 @@ type Dir struct {
 // Check interface satisfied
 var _ fusefs.Node = (*Dir)(nil)
 
+func fallbackStat(dir *vfs.Dir, leaf string) (node vfs.Node, err error) {
+	node, err = dir.Stat(leaf)
+	if err == vfs.ENOENT && dir.VFS().Opt.Links {
+		node, err = dir.Stat(leaf + fs.LinkSuffix)
+	}
+	return node, err
+}
+
 // Attr updates the attributes of a directory
 func (d *Dir) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 	defer log.Trace(d, "")("attr=%+v, err=%v", a, &err)
 	a.Valid = time.Duration(d.fsys.opt.AttrTimeout)
 	a.Gid = d.VFS().Opt.GID
 	a.Uid = d.VFS().Opt.UID
-	a.Mode = os.ModeDir | os.FileMode(d.VFS().Opt.DirPerms)
+	a.Mode = d.Mode()
 	modTime := d.ModTime()
 	a.Atime = modTime
 	a.Mtime = modTime
@@ -73,7 +83,7 @@ var _ fusefs.NodeRequestLookuper = (*Dir)(nil)
 // Lookup need not to handle the names "." and "..".
 func (d *Dir) Lookup(ctx context.Context, req *fuse.LookupRequest, resp *fuse.LookupResponse) (node fusefs.Node, err error) {
 	defer log.Trace(d, "name=%q", req.Name)("node=%+v, err=%v", &node, &err)
-	mnode, err := d.Dir.Stat(req.Name)
+	mnode, err := fallbackStat(d.Dir, req.Name)
 	if err != nil {
 		return nil, translateError(err)
 	}
@@ -116,7 +126,7 @@ func (d *Dir) ReadDirAll(ctx context.Context) (dirents []fuse.Dirent, err error)
 		Name: "..",
 	})
 	for _, node := range items {
-		name := node.Name()
+		name, isLink := d.VFS().TrimSymlink(node.Name())
 		if len(name) > mountlib.MaxLeafSize {
 			fs.Errorf(d, "Name too long (%d bytes) for FUSE, skipping: %s", len(name), name)
 			continue
@@ -126,7 +136,9 @@ func (d *Dir) ReadDirAll(ctx context.Context) (dirents []fuse.Dirent, err error)
 			Type: fuse.DT_File,
 			Name: name,
 		}
-		if node.IsDir() {
+		if isLink {
+			dirent.Type = fuse.DT_Link
+		} else if node.IsDir() {
 			dirent.Type = fuse.DT_Dir
 		}
 		dirents = append(dirents, dirent)
@@ -140,11 +152,13 @@ var _ fusefs.NodeCreater = (*Dir)(nil)
 // Create makes a new file
 func (d *Dir) Create(ctx context.Context, req *fuse.CreateRequest, resp *fuse.CreateResponse) (node fusefs.Node, handle fusefs.Handle, err error) {
 	defer log.Trace(d, "name=%q", req.Name)("node=%v, handle=%v, err=%v", &node, &handle, &err)
-	file, err := d.Dir.Create(req.Name, int(req.Flags))
+	// translate the fuse flags to os flags
+	osFlags := int(req.Flags) | os.O_CREATE
+	file, err := d.Dir.Create(req.Name, osFlags)
 	if err != nil {
 		return nil, nil, translateError(err)
 	}
-	fh, err := file.Open(int(req.Flags) | os.O_CREATE)
+	fh, err := file.Open(osFlags)
 	if err != nil {
 		return nil, nil, translateError(err)
 	}
@@ -174,7 +188,18 @@ var _ fusefs.NodeRemover = (*Dir)(nil)
 // may correspond to a file (unlink) or to a directory (rmdir).
 func (d *Dir) Remove(ctx context.Context, req *fuse.RemoveRequest) (err error) {
 	defer log.Trace(d, "name=%q", req.Name)("err=%v", &err)
-	err = d.Dir.RemoveName(req.Name)
+
+	name := req.Name
+
+	if d.VFS().Opt.Links {
+		node, err := fallbackStat(d.Dir, name)
+
+		if err == nil {
+			name = node.Name()
+		}
+	}
+
+	err = d.Dir.RemoveName(name)
 	if err != nil {
 		return translateError(err)
 	}
@@ -201,7 +226,22 @@ func (d *Dir) Rename(ctx context.Context, req *fuse.RenameRequest, newDir fusefs
 		return fmt.Errorf("unknown Dir type %T", newDir)
 	}
 
-	err = d.Dir.Rename(req.OldName, req.NewName, destDir.Dir)
+	oldName := req.OldName
+	newName := req.NewName
+
+	if d.VFS().Opt.Links {
+		node, err := fallbackStat(d.Dir, oldName)
+
+		if err == nil {
+			oldName = node.Name()
+
+			if strings.HasSuffix(oldName, fs.LinkSuffix) {
+				newName += fs.LinkSuffix
+			}
+		}
+	}
+
+	err = d.Dir.Rename(oldName, newName, destDir.Dir)
 	if err != nil {
 		return translateError(err)
 	}
@@ -237,6 +277,51 @@ var _ fusefs.NodeLinker = (*Dir)(nil)
 func (d *Dir) Link(ctx context.Context, req *fuse.LinkRequest, old fusefs.Node) (newNode fusefs.Node, err error) {
 	defer log.Trace(d, "req=%v, old=%v", req, old)("new=%v, err=%v", &newNode, &err)
 	return nil, syscall.ENOSYS
+}
+
+var _ fusefs.NodeSymlinker = (*Dir)(nil)
+
+// Symlink create a symbolic link.
+func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (node fusefs.Node, err error) {
+	defer log.Trace(d, "Requested to symlink newname=%v, target=%v", req.NewName, req.Target)("node=%v, err=%v", &node, &err)
+
+	newName := path.Join(d.Path(), req.NewName)
+	target := req.Target
+
+	if d.VFS().Opt.Links {
+		// The user must NOT provide .rclonelink suffix
+		if strings.HasSuffix(newName, fs.LinkSuffix) {
+			fs.Errorf(nil, "Invalid name suffix provided: %v", newName)
+			return nil, vfs.EINVAL
+		}
+
+		newName += fs.LinkSuffix
+	} else if !strings.HasSuffix(newName, fs.LinkSuffix) {
+		// The user must provide .rclonelink suffix
+		fs.Errorf(nil, "Invalid name suffix provided: %v", newName)
+		return nil, vfs.EINVAL
+	}
+
+	// Add target suffix when linking to a link
+	if !strings.HasSuffix(target, fs.LinkSuffix) {
+		vnode, err := fallbackStat(d.Dir, target)
+		if err == nil && strings.HasSuffix(vnode.Name(), fs.LinkSuffix) {
+			target += fs.LinkSuffix
+		}
+	}
+
+	err = d.VFS().Symlink(target, newName)
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := d.Stat(path.Base(newName))
+	if err != nil {
+		return nil, err
+	}
+
+	node = &File{n.(*vfs.File), d.fsys}
+	return node, nil
 }
 
 // Check interface satisfied

--- a/cmd/mount/file.go
+++ b/cmd/mount/file.go
@@ -5,11 +5,13 @@ package mount
 import (
 	"context"
 	"os"
+	"strings"
 	"syscall"
 	"time"
 
 	"bazil.org/fuse"
 	fusefs "bazil.org/fuse/fs"
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/log"
 	"github.com/rclone/rclone/vfs"
 )
@@ -32,7 +34,7 @@ func (f *File) Attr(ctx context.Context, a *fuse.Attr) (err error) {
 	Blocks := (Size + 511) / 512
 	a.Gid = f.VFS().Opt.GID
 	a.Uid = f.VFS().Opt.UID
-	a.Mode = os.FileMode(f.VFS().Opt.FilePerms)
+	a.Mode = f.File.Mode() &^ os.ModeAppend
 	a.Size = Size
 	a.Atime = modTime
 	a.Mtime = modTime
@@ -129,3 +131,30 @@ func (f *File) Removexattr(ctx context.Context, req *fuse.RemovexattrRequest) er
 }
 
 var _ fusefs.NodeRemovexattrer = (*File)(nil)
+
+var _ fusefs.NodeReadlinker = (*File)(nil)
+
+// Readlink read symbolic link target.
+func (f *File) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (ret string, err error) {
+	defer log.Trace(f, "Requested to read link")("ret=%v, err=%v", &ret, &err)
+
+	path := f.Path()
+
+	if f.VFS().Opt.Links {
+		// The user must NOT provide .rclonelink suffix
+		// if strings.HasSuffix(path, fs.LinkSuffix) {
+		// 	fs.Errorf(nil, "Invalid name suffix provided: %v", path)
+		// 	return "", vfs.EINVAL
+		// }
+
+		// path += fs.LinkSuffix
+	} else if !strings.HasSuffix(path, fs.LinkSuffix) {
+		// The user must provide .rclonelink suffix
+		fs.Errorf(nil, "Invalid name suffix provided: %v", path)
+		return "", vfs.EINVAL
+	}
+
+	ret, err = f.VFS().Readlink(path)
+	ret, _ = f.VFS().TrimSymlink(ret)
+	return ret, err
+}

--- a/cmd/mount2/fs.go
+++ b/cmd/mount2/fs.go
@@ -51,14 +51,38 @@ func (f *FS) SetDebug(debug bool) {
 
 // get the Mode from a vfs Node
 func getMode(node os.FileInfo) uint32 {
-	Mode := node.Mode().Perm()
-	if node.IsDir() {
+	vfsMode := node.Mode()
+	Mode := vfsMode.Perm()
+	if vfsMode&os.ModeDir != 0 {
 		Mode |= fuse.S_IFDIR
+	} else if vfsMode&os.ModeSymlink != 0 {
+		Mode |= fuse.S_IFLNK
+	} else if vfsMode&os.ModeNamedPipe != 0 {
+		Mode |= fuse.S_IFIFO
 	} else {
 		Mode |= fuse.S_IFREG
 	}
 	return uint32(Mode)
 }
+
+// convert fuse mode to os.FileMode
+// func getFileMode(mode uint32) os.FileMode {
+// 	osMode := os.FileMode(0)
+// 	if mode&fuse.S_IFDIR != 0 {
+// 		mode ^= fuse.S_IFDIR
+// 		osMode |= os.ModeDir
+// 	} else if mode&fuse.S_IFREG != 0 {
+// 		mode ^= fuse.S_IFREG
+// 	} else if mode&fuse.S_IFLNK != 0 {
+// 		mode ^= fuse.S_IFLNK
+// 		osMode |= os.ModeSymlink
+// 	} else if mode&fuse.S_IFIFO != 0 {
+// 		mode ^= fuse.S_IFIFO
+// 		osMode |= os.ModeNamedPipe
+// 	}
+// 	osMode |= os.FileMode(mode)
+// 	return osMode
+// }
 
 // fill in attr from node
 func setAttr(node vfs.Node, attr *fuse.Attr) {

--- a/cmd/mount2/node.go
+++ b/cmd/mount2/node.go
@@ -227,7 +227,7 @@ type dirStream struct {
 // HasNext indicates if there are further entries. HasNext
 // might be called on already closed streams.
 func (ds *dirStream) HasNext() bool {
-	return ds.i < len(ds.nodes)
+	return ds.i < len(ds.nodes)+2
 }
 
 // Next retrieves the next entry. It is only called if HasNext
@@ -235,7 +235,22 @@ func (ds *dirStream) HasNext() bool {
 // indicate I/O errors
 func (ds *dirStream) Next() (de fuse.DirEntry, errno syscall.Errno) {
 	// defer log.Trace(nil, "")("de=%+v, errno=%v", &de, &errno)
-	fi := ds.nodes[ds.i]
+	if ds.i == 0 {
+		ds.i++
+		return fuse.DirEntry{
+			Mode: fuse.S_IFDIR,
+			Name: ".",
+			Ino:  0, // FIXME
+		}, 0
+	} else if ds.i == 1 {
+		ds.i++
+		return fuse.DirEntry{
+			Mode: fuse.S_IFDIR,
+			Name: "..",
+			Ino:  0, // FIXME
+		}, 0
+	}
+	fi := ds.nodes[ds.i-2]
 	de = fuse.DirEntry{
 		// Mode is the file's mode. Only the high bits (e.g. S_IFDIR)
 		// are considered.

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -16,6 +16,8 @@ const (
 	ModTimeNotSupported = 100 * 365 * 24 * time.Hour
 	// MaxLevel is a sentinel representing an infinite depth for listings
 	MaxLevel = math.MaxInt32
+	// The suffix added to a translated symbolic link
+	LinkSuffix = ".rclonelink"
 )
 
 // Globals

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -90,6 +90,13 @@ func (f *File) IsDir() bool {
 	return false
 }
 
+// IsSymlink returns true for symlinks when --links is enabled
+func (f *File) IsSymlink() bool {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.d.vfs.IsSymlink(f.leaf)
+}
+
 // Mode bits of the file or directory - satisfies Node interface
 func (f *File) Mode() (mode os.FileMode) {
 	f.mu.RLock()

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -101,9 +101,14 @@ func (f *File) IsSymlink() bool {
 func (f *File) Mode() (mode os.FileMode) {
 	f.mu.RLock()
 	defer f.mu.RUnlock()
-	mode = os.FileMode(f.d.vfs.Opt.FilePerms)
-	if f.appendMode {
-		mode |= os.ModeAppend
+	if f.IsSymlink() {
+		mode = os.FileMode(f.d.vfs.Opt.LinkPerms)
+	} else {
+		mode = os.FileMode(f.d.vfs.Opt.FilePerms)
+
+		if f.appendMode {
+			mode |= os.ModeAppend
+		}
 	}
 	return mode
 }

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -242,6 +242,11 @@ func New(f fs.Fs, opt *vfscommon.Options) *VFS {
 		fs.Logf(f, "--vfs-cache-mode writes or full is recommended for this remote as it can't stream")
 	}
 
+	// Warn if we handle symlinks
+	if vfs.Opt.Links {
+		fs.Logf(f, "Symlinks support enabled")
+	}
+
 	// Pin the Fs into the cache so that when we use cache.NewFs
 	// with the same remote string we get this one. The Pin is
 	// removed when the vfs is finalized

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -789,3 +789,19 @@ func (vfs *VFS) AddVirtual(remote string, size int64, isDir bool) (err error) {
 	dir.AddVirtual(leaf, size, false)
 	return nil
 }
+
+// IsSymlink returns true if remote ends with fs.LinkSuffix when --links is enabled
+func (vfs *VFS) IsSymlink(remote string) bool {
+	return vfs.Opt.Links && strings.HasSuffix(remote, fs.LinkSuffix)
+}
+
+// TrimSymlink returns true if remote ends with fs.LinkSuffix when --links is enabled
+// Also, if it's a link, it's trimmed from its fs.LinkSuffix
+func (vfs *VFS) TrimSymlink(remote string) (string, bool) {
+	if vfs.IsSymlink(remote) {
+		remote := strings.TrimSuffix(remote, fs.LinkSuffix)
+		return remote, true
+	}
+
+	return remote, false
+}

--- a/vfs/vfs.md
+++ b/vfs/vfs.md
@@ -288,6 +288,7 @@ read of the modification time takes a transaction.
     --no-modtime      Don't read/write the modification time (can speed things up).
     --no-seek         Don't allow seeking in files.
     --read-only       Only allow read-only access.
+    --links           Translate symlinks to/from regular files with a '.rclonelink' extension.
 
 Sometimes rclone is delivered reads or writes out of order. Rather
 than seeking rclone will wait a short time for the in sequence read or

--- a/vfs/vfscommon/options.go
+++ b/vfs/vfscommon/options.go
@@ -45,6 +45,12 @@ var OptionsInfo = fs.Options{{
 	Help:    "Only allow read-only access",
 	Groups:  "VFS",
 }, {
+	Name:     "links",
+	Default:  false,
+	Help:     "Translate symlinks to/from regular files with a '" + fs.LinkSuffix + "' extension",
+	Groups:   "VFS",
+	ShortOpt: "l",
+}, {
 	Name:    "vfs_cache_mode",
 	Default: CacheModeOff,
 	Help:    "Cache mode off|minimal|writes|full",
@@ -165,6 +171,7 @@ type Options struct {
 	NoSeek             bool          `config:"no_seek"`        // don't allow seeking if set
 	NoChecksum         bool          `config:"no_checksum"`    // don't check checksums if set
 	ReadOnly           bool          `config:"read_only"`      // if set VFS is read only
+	Links              bool          `config:"links"`          // if set interpret link files
 	NoModTime          bool          `config:"no_modtime"`     // don't read mod times for files
 	DirCacheTime       fs.Duration   `config:"dir_cache_time"` // how long to consider directory listing cache valid
 	Refresh            bool          `config:"vfs_refresh"`    // refreshes the directory listing recursively on start

--- a/vfs/vfscommon/options.go
+++ b/vfs/vfscommon/options.go
@@ -101,6 +101,11 @@ var OptionsInfo = fs.Options{{
 	Help:    "File permissions",
 	Groups:  "VFS",
 }, {
+	Name:    "link_perms",
+	Default: FileMode(0666),
+	Help:    "Link permissions",
+	Groups:  "VFS",
+}, {
 	Name:    "vfs_case_insensitive",
 	Default: runtime.GOOS == "windows" || runtime.GOOS == "darwin", // default to true on Windows and Mac, false otherwise,
 	Help:    "If a file name not found, find a case insensitive match",
@@ -181,6 +186,7 @@ type Options struct {
 	GID                uint32        `config:"gid"`
 	DirPerms           FileMode      `config:"dir_perms"`
 	FilePerms          FileMode      `config:"file_perms"`
+	LinkPerms          FileMode      `config:"link_perms"`
 	ChunkSize          fs.SizeSuffix `config:"vfs_read_chunk_size"`       // if > 0 read files in chunks
 	ChunkSizeLimit     fs.SizeSuffix `config:"vfs_read_chunk_size_limit"` // if > ChunkSize double the chunk size after each chunk until reached
 	ChunkStreams       int           `config:"vfs_read_chunk_streams"`    // Number of download streams to use
@@ -208,7 +214,11 @@ func (opt *Options) Init() {
 	// Mask the permissions with the umask
 	opt.DirPerms &= ^opt.Umask
 	opt.FilePerms &= ^opt.Umask
+	opt.LinkPerms &= ^opt.Umask
 
 	// Make sure directories are returned as directories
 	opt.DirPerms |= FileMode(os.ModeDir)
+
+	// Make sure links are returned as links
+	opt.LinkPerms |= FileMode(os.ModeSymlink)
 }

--- a/vfs/vfstest/file.go
+++ b/vfs/vfstest/file.go
@@ -78,10 +78,6 @@ func TestFileModTimeWithOpenWriters(t *testing.T) {
 func TestSymlinks(t *testing.T) {
 	run.skipIfNoFUSE(t)
 
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping test on Windows")
-	}
-
 	{
 		// VFS only implements os.Stat, which return information to target for symlinks, getting symlink information would require os.Lstat implementation.
 		// We will not bother to add Lstat implemented, but in the test we can just call os.Lstat which return the information needed when !useVFS

--- a/vfs/vfstest/file.go
+++ b/vfs/vfstest/file.go
@@ -101,10 +101,6 @@ func TestSymlinks(t *testing.T) {
 		// fs.Logf(nil, "LINK_FILE: %v, %v <-> %v, %v", lfl.Mode(), lfl.IsDir(), lf.Mode(), lf.IsDir())
 	}
 
-	if !run.useVFS {
-		t.Skip("Requires useVFS")
-	}
-
 	suffix := ""
 
 	if run.useVFS || !run.vfsOpt.Links {

--- a/vfs/vfstest/file.go
+++ b/vfs/vfstest/file.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -71,4 +72,278 @@ func TestFileModTimeWithOpenWriters(t *testing.T) {
 	assert.Equal(t, info.ModTime().Unix(), mtime.Unix())
 
 	run.rm(t, "cp-archive-test")
+}
+
+// TestSymlinks tests all the api of the VFS / Mount symlinks support
+func TestSymlinks(t *testing.T) {
+	run.skipIfNoFUSE(t)
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows")
+	}
+
+	{
+		// VFS only implements os.Stat, which return information to target for symlinks, getting symlink information would require os.Lstat implementation.
+		// We will not bother to add Lstat implemented, but in the test we can just call os.Lstat which return the information needed when !useVFS
+
+		// this is a link to a directory
+		// ldl, _ := os.Lstat("/tmp/kkk/link_dir")
+		// ld, _ := os.Stat("/tmp/kkk/link_dir")
+
+		// LINK_DIR: Lrwxrwxrwx, false <-> drwxr-xr-x, true
+		// fs.Logf(nil, "LINK_DIR: %v, %v <-> %v, %v", ldl.Mode(), ldl.IsDir(), ld.Mode(), ld.IsDir())
+
+		// This is a link to a regular file
+		// lfl, _ := os.Lstat("/tmp/kkk/link_file")
+		// lf, _ := os.Stat("/tmp/kkk/link_file")
+
+		// LINK_FILE: Lrwxrwxrwx, false <-> -rw-r--r--, false
+		// fs.Logf(nil, "LINK_FILE: %v, %v <-> %v, %v", lfl.Mode(), lfl.IsDir(), lf.Mode(), lf.IsDir())
+	}
+
+	if !run.useVFS {
+		t.Skip("Requires useVFS")
+	}
+
+	suffix := ""
+
+	if run.useVFS || !run.vfsOpt.Links {
+		suffix = fs.LinkSuffix
+	}
+
+	fs.Logf(nil, "Links: %v, useVFS: %v, suffix: %v", run.vfsOpt.Links, run.useVFS, suffix)
+
+	run.mkdir(t, "dir1")
+	run.mkdir(t, "dir1/sub1dir1")
+	run.createFile(t, "dir1/file1", "potato")
+
+	run.mkdir(t, "dir2")
+	run.mkdir(t, "dir2/sub1dir2")
+	run.createFile(t, "dir2/file1", "chicken")
+
+	run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+
+	// Link to a file
+	run.relativeSymlink(t, "dir1/file1", "dir1file1_link"+suffix)
+
+	run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|dir1file1_link"+suffix+" 10")
+
+	if run.vfsOpt.Links {
+		if run.useVFS {
+			run.checkMode(t, "dir1file1_link"+suffix, os.FileMode(run.vfsOpt.LinkPerms), os.FileMode(run.vfsOpt.LinkPerms))
+		} else {
+			run.checkMode(t, "dir1file1_link"+suffix, os.FileMode(run.vfsOpt.LinkPerms), os.FileMode(run.vfsOpt.FilePerms))
+		}
+	} else {
+		run.checkMode(t, "dir1file1_link"+suffix, os.FileMode(run.vfsOpt.FilePerms), os.FileMode(run.vfsOpt.FilePerms))
+	}
+
+	assert.Equal(t, "dir1/file1", run.readlink(t, "dir1file1_link"+suffix))
+
+	if !run.useVFS && run.vfsOpt.Links {
+		assert.Equal(t, "potato", run.readFile(t, "dir1file1_link"+suffix))
+
+		err := writeFile(run.path("dir1file1_link"+suffix), []byte("carrot"), 0600)
+		require.NoError(t, err)
+
+		assert.Equal(t, "carrot", run.readFile(t, "dir1file1_link"+suffix))
+		assert.Equal(t, "carrot", run.readFile(t, "dir1/file1"))
+	} else {
+		assert.Equal(t, "dir1/file1", run.readFile(t, "dir1file1_link"+suffix))
+	}
+
+	err := run.os.Rename(run.path("dir1file1_link"+suffix), run.path("dir1file1_link")+"_bla"+suffix)
+	require.NoError(t, err)
+
+	run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|dir1file1_link_bla"+suffix+" 10")
+
+	assert.Equal(t, "dir1/file1", run.readlink(t, "dir1file1_link_bla"+suffix))
+
+	run.rm(t, "dir1file1_link_bla"+suffix)
+
+	run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+
+	// Link to a dir
+	run.relativeSymlink(t, "dir1", "dir1_link"+suffix)
+
+	run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|dir1_link"+suffix+" 4")
+
+	if run.vfsOpt.Links {
+		if run.useVFS {
+			run.checkMode(t, "dir1_link"+suffix, os.FileMode(run.vfsOpt.LinkPerms), os.FileMode(run.vfsOpt.LinkPerms))
+		} else {
+			run.checkMode(t, "dir1_link"+suffix, os.FileMode(run.vfsOpt.LinkPerms), os.FileMode(run.vfsOpt.DirPerms))
+		}
+	} else {
+		run.checkMode(t, "dir1_link"+suffix, os.FileMode(run.vfsOpt.FilePerms), os.FileMode(run.vfsOpt.FilePerms))
+	}
+
+	assert.Equal(t, "dir1", run.readlink(t, "dir1_link"+suffix))
+
+	fh, err := run.os.OpenFile(run.path("dir1_link"+suffix), os.O_WRONLY, 0600)
+
+	if !run.useVFS && run.vfsOpt.Links {
+		require.Error(t, err)
+
+		dirLinksEntries := make(dirMap)
+		run.readLocal(t, dirLinksEntries, "dir1_link"+suffix)
+
+		assert.Equal(t, 2, len(dirLinksEntries))
+
+		dir1Entries := make(dirMap)
+		run.readLocal(t, dir1Entries, "dir1")
+
+		assert.Equal(t, 2, len(dir1Entries))
+	} else {
+		require.NoError(t, err)
+		// Don't care about the result, in some cache mode the file can't be opened for writing, so closing would trigger an err
+		_ = fh.Close()
+
+		assert.Equal(t, "dir1", run.readFile(t, "dir1_link"+suffix))
+	}
+
+	err = run.os.Rename(run.path("dir1_link"+suffix), run.path("dir1_link")+"_bla"+suffix)
+	require.NoError(t, err)
+
+	run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|dir1_link_bla"+suffix+" 4")
+
+	assert.Equal(t, "dir1", run.readlink(t, "dir1_link_bla"+suffix))
+
+	run.rm(t, "dir1_link_bla"+suffix) // run.rmdir works fine as well
+
+	run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+
+	// Corner case #1 - We do not allow creating regular and symlink files having the same name (ie, test.txt and test.txt.rclonelink)
+
+	// Symlink first, then regular
+	{
+		link1Name := "link1.txt" + suffix
+
+		run.relativeSymlink(t, "dir1/file1", link1Name)
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|link1.txt"+suffix+" 10")
+
+		fh, err = run.os.OpenFile(run.path("link1.txt"), os.O_WRONLY|os.O_CREATE, os.FileMode(run.vfsOpt.FilePerms))
+
+		// On real mount with links enabled, that open the symlink target as expected, else that fails to create a new file
+		if !run.useVFS && run.vfsOpt.Links {
+			assert.Equal(t, true, err == nil)
+			// Don't care about the result, in some cache mode the file can't be opened for writing, so closing would trigger an err
+			_ = fh.Close()
+		} else {
+			assert.Equal(t, true, err != nil)
+		}
+
+		run.rm(t, link1Name)
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+	}
+
+	// Regular first, then symlink
+	{
+		link1Name := "link1.txt" + suffix
+
+		run.createFile(t, "link1.txt", "")
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|link1.txt 0")
+
+		err = run.os.Symlink(".", run.path(link1Name))
+		assert.Equal(t, true, err != nil)
+
+		run.rm(t, "link1.txt")
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+	}
+
+	// Corner case #2 - We do not allow creating directory and symlink file having the same name (ie, test and test.rclonelink)
+
+	// Symlink first, then directory
+	{
+		link1Name := "link1" + suffix
+
+		run.relativeSymlink(t, ".", link1Name)
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|link1"+suffix+" 1")
+
+		err = run.os.Mkdir(run.path("link1"), os.FileMode(run.vfsOpt.DirPerms))
+		assert.Equal(t, true, err != nil)
+
+		run.rm(t, link1Name)
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+	}
+
+	// Directory first, then symlink
+	{
+		link1Name := "link1" + suffix
+
+		run.mkdir(t, "link1")
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|link1/")
+
+		err = run.os.Symlink(".", run.path(link1Name))
+		assert.Equal(t, true, err != nil)
+
+		run.rm(t, "link1")
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+	}
+
+	// Corner case #3 - We do not allow moving directory or file having the same name in a target (ie, test and test.rclonelink)
+
+	// Move symlink -> regular file
+	{
+		link1Name := "link1.txt" + suffix
+
+		run.relativeSymlink(t, ".", link1Name)
+		run.createFile(t, "dir1/link1.txt", "")
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|link1.txt"+suffix+" 1|dir1/link1.txt 0")
+
+		err = run.os.Rename(run.path(link1Name), run.path("dir1/"+link1Name))
+		assert.Equal(t, true, err != nil)
+
+		run.rm(t, link1Name)
+		run.rm(t, "dir1/link1.txt")
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+	}
+
+	// Move regular file -> symlink
+	{
+		link1Name := "link1.txt" + suffix
+
+		run.createFile(t, "link1.txt", "")
+		run.relativeSymlink(t, ".", "dir1/"+link1Name)
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|link1.txt 0|dir1/link1.txt"+suffix+" 1")
+
+		err = run.os.Rename(run.path("link1.txt"), run.path("dir1/link1.txt"))
+		assert.Equal(t, true, err != nil)
+
+		run.rm(t, "link1.txt")
+		run.rm(t, "dir1/"+link1Name)
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+	}
+
+	// Move symlink -> directory
+	{
+		link1Name := "link1" + suffix
+
+		run.relativeSymlink(t, ".", link1Name)
+		run.mkdir(t, "dir1/link1")
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|link1"+suffix+" 1|dir1/link1/")
+
+		err = run.os.Rename(run.path(link1Name), run.path("dir1/"+link1Name))
+		assert.Equal(t, true, err != nil)
+
+		run.rm(t, link1Name)
+		run.rm(t, "dir1/link1")
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+	}
+
+	// Move directory -> symlink
+	{
+		link1Name := "dir1/link1" + suffix
+
+		run.mkdir(t, "link1")
+		run.relativeSymlink(t, ".", link1Name)
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7|link1/|dir1/link1"+suffix+" 1")
+
+		err = run.os.Rename(run.path("link1"), run.path("dir1/link1"))
+		assert.Equal(t, true, err != nil)
+
+		run.rm(t, "link1")
+		run.rm(t, link1Name)
+		run.checkDir(t, "dir1/|dir1/sub1dir1/|dir1/file1 6|dir2/|dir2/sub1dir2/|dir2/file1 7")
+	}
 }

--- a/vfs/vfstest/fs.go
+++ b/vfs/vfstest/fs.go
@@ -49,12 +49,15 @@ func RunTests(t *testing.T, useVFS bool, minimumRequiredCacheMode vfscommon.Cach
 	tests := []struct {
 		cacheMode vfscommon.CacheMode
 		writeBack fs.Duration
+		links     bool
 	}{
 		{cacheMode: vfscommon.CacheModeOff},
+		{cacheMode: vfscommon.CacheModeOff, links: true},
 		{cacheMode: vfscommon.CacheModeMinimal},
 		{cacheMode: vfscommon.CacheModeWrites},
 		{cacheMode: vfscommon.CacheModeFull},
 		{cacheMode: vfscommon.CacheModeFull, writeBack: fs.Duration(100 * time.Millisecond)},
+		{cacheMode: vfscommon.CacheModeFull, writeBack: fs.Duration(100 * time.Millisecond), links: true},
 	}
 	for _, test := range tests {
 		if test.cacheMode < minimumRequiredCacheMode {
@@ -63,10 +66,14 @@ func RunTests(t *testing.T, useVFS bool, minimumRequiredCacheMode vfscommon.Cach
 		vfsOpt := vfscommon.Opt
 		vfsOpt.CacheMode = test.cacheMode
 		vfsOpt.WriteBack = test.writeBack
+		vfsOpt.Links = test.links
 		run = newRun(useVFS, &vfsOpt, mountFn)
 		what := fmt.Sprintf("CacheMode=%v", test.cacheMode)
 		if test.writeBack > 0 {
 			what += fmt.Sprintf(",WriteBack=%v", test.writeBack)
+		}
+		if test.links {
+			what += fmt.Sprintf(",Links=%v", test.links)
 		}
 		fs.Logf(nil, "Starting test run with %s", what)
 		ok := t.Run(what, func(t *testing.T) {
@@ -98,6 +105,7 @@ func RunTests(t *testing.T, useVFS bool, minimumRequiredCacheMode vfscommon.Cach
 			t.Run("TestWriteFileFsync", TestWriteFileFsync)
 			t.Run("TestWriteFileDup", TestWriteFileDup)
 			t.Run("TestWriteFileAppend", TestWriteFileAppend)
+			t.Run("TestSymlinks", TestSymlinks)
 		})
 		fs.Logf(nil, "Finished test run with %s (ok=%v)", what, ok)
 		run.Finalise()
@@ -213,10 +221,16 @@ func newDirMap(dirString string) (dm dirMap) {
 }
 
 // Returns a dirmap with only the files in
-func (dm dirMap) filesOnly() dirMap {
+func (dm dirMap) filesOnly(stripLinksSuffix bool) dirMap {
 	newDm := make(dirMap)
 	for name := range dm {
 		if !strings.HasSuffix(name, "/") {
+			if stripLinksSuffix {
+				index := strings.LastIndex(name, " ")
+				if index != -1 {
+					name = strings.TrimSuffix(name[0:index], fs.LinkSuffix) + name[index:]
+				}
+			}
 			newDm[name] = struct{}{}
 		}
 	}
@@ -236,7 +250,11 @@ func (r *Run) readLocal(t *testing.T, dir dirMap, filePath string) {
 			assert.Equal(t, os.FileMode(r.vfsOpt.DirPerms)&os.ModePerm, fi.Mode().Perm())
 		} else {
 			dir[fmt.Sprintf("%s %d", name, fi.Size())] = struct{}{}
-			assert.Equal(t, os.FileMode(r.vfsOpt.FilePerms)&os.ModePerm, fi.Mode().Perm())
+			if fi.Mode()&os.ModeSymlink != 0 {
+				assert.Equal(t, os.FileMode(r.vfsOpt.LinkPerms)&os.ModePerm, fi.Mode().Perm())
+			} else {
+				assert.Equal(t, os.FileMode(r.vfsOpt.FilePerms)&os.ModePerm, fi.Mode().Perm())
+			}
 		}
 	}
 }
@@ -271,7 +289,7 @@ func (r *Run) checkDir(t *testing.T, dirString string) {
 		remoteDm = make(dirMap)
 		r.readRemote(t, remoteDm, "")
 		// Ignore directories for remote compare
-		remoteOK = reflect.DeepEqual(dm.filesOnly(), remoteDm.filesOnly())
+		remoteOK = reflect.DeepEqual(dm.filesOnly(false), remoteDm.filesOnly(!r.useVFS && r.vfsOpt.Links))
 		fuseOK = reflect.DeepEqual(dm, localDm)
 		if remoteOK && fuseOK {
 			return
@@ -280,7 +298,7 @@ func (r *Run) checkDir(t *testing.T, dirString string) {
 		t.Logf("Sleeping for %v for list eventual consistency: %d/%d", sleep, i, retries)
 		time.Sleep(sleep)
 	}
-	assert.Equal(t, dm.filesOnly(), remoteDm.filesOnly(), "expected vs remote")
+	assert.Equal(t, dm.filesOnly(false), remoteDm.filesOnly(!r.useVFS && r.vfsOpt.Links), "expected vs remote")
 	assert.Equal(t, dm, localDm, "expected vs fuse mount")
 }
 
@@ -351,6 +369,53 @@ func (r *Run) rmdir(t *testing.T, filepath string) {
 	filepath = r.path(filepath)
 	err := r.os.Remove(filepath)
 	require.NoError(t, err)
+}
+
+func (r *Run) relativeSymlink(t *testing.T, oldname, newname string) {
+	newname = r.path(newname)
+	err := r.os.Symlink(oldname, newname)
+	// The native code path with Links disabled would check the created file is really a symlink
+	// In this case ensure the .rclonelink file was created by stating it.
+	if err != nil && !r.vfsOpt.Links {
+		_, eerr := r.os.Stat(newname)
+
+		if eerr == nil {
+			err = nil
+		}
+	}
+	require.NoError(t, err)
+}
+
+func (r *Run) checkMode(t *testing.T, name string, lexpected os.FileMode, expected os.FileMode) {
+	if r.useVFS {
+		info, err := run.os.Stat(run.path(name))
+		require.NoError(t, err)
+		assert.Equal(t, lexpected, info.Mode())
+		assert.Equal(t, expected, info.Mode())
+		assert.Equal(t, name, info.Name())
+	} else {
+		info, err := os.Lstat(run.path(name))
+		require.NoError(t, err)
+		assert.Equal(t, lexpected, info.Mode())
+		assert.Equal(t, name, info.Name())
+
+		info, err = run.os.Stat(run.path(name))
+		require.NoError(t, err)
+		assert.Equal(t, expected, info.Mode())
+		assert.Equal(t, name, info.Name())
+	}
+}
+
+func (r *Run) readlink(t *testing.T, name string) string {
+	result, err := r.os.Readlink(r.path(name))
+	// The native code path with Links disabled would check the file is really a symlink
+	// In this case read the existing .rclonelink file.
+	if err != nil && !r.vfsOpt.Links {
+		result = r.readFile(t, name)
+		err = nil
+	}
+	require.NoError(t, err)
+	return result
 }
 
 // TestMount checks that the Fs is mounted by seeing if the mountpoint

--- a/vfs/vfstest/os.go
+++ b/vfs/vfstest/os.go
@@ -22,6 +22,8 @@ type Oser interface {
 	Remove(name string) error
 	Rename(oldName, newName string) error
 	Stat(path string) (os.FileInfo, error)
+	Symlink(oldname, newname string) error
+	Readlink(name string) (s string, err error)
 }
 
 // realOs is an implementation of Oser backed by the "os" package
@@ -128,6 +130,16 @@ func (r realOs) Rename(oldName, newName string) error {
 // Stat
 func (r realOs) Stat(path string) (os.FileInfo, error) {
 	return os.Stat(path)
+}
+
+// Symlink
+func (r realOs) Symlink(oldname, newname string) error {
+	return os.Symlink(oldname, newname)
+}
+
+// Readlink
+func (r realOs) Readlink(name string) (s string, err error) {
+	return os.Readlink(name)
 }
 
 // Check interfaces


### PR DESCRIPTION
#### What is the purpose of this change?
Add mount / vfs symlink support

Please, note that it has only been tested with storj backend on linux.
Especially, macOS, windows were not tested.
Please do test those platforms and any other backends !!!

#### Was the change discussed in an issue or in the forum before?
https://github.com/rclone/rclone/issues/2975

#### Checklist
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

#### Notes
The whole work has been (trashed mostly) refactored. They were flaws in the previous implementation, especially trying to use truncated names in the vfs dir internal nodes  names which lead to inconsistency when it comes to push changes to the remotes.
For this reason, the refactoring went in 2 parts:

1. Add symlinks support in the VFS itself, in the form of always storing symlinks with the .rclonelink suffix, those being regular files.
The VFS Readlink and Symlink additions allow support for symlinks, even if the --links command line switch is not enabled, it's just a mater of creating a .rclonelink regular file with the target inside.
The only difference is that when --link is enabled, the VFS nodes Mode() would report the **os.ModeSymlink** flag hint.
This approach limit adding regressions in the VFS itself as there is no more names tweaking.
Some more checks were also added, to avoid to allow creating / moving files / links / directories names that would clash.
By example, the VFS must not be able to create in the same directory  something called **Hello.txt** and something called **Hello.txt.rclonelink**, this is because when using the mount operation with --links enabled, we would end up with both files claiming the same node name: **Hello.txt**.

2.  Add symlinks support in the mount backends, they are required to translate from the full vfs names into truncated names to the end user: **Test.rclonelink** would be seen as **Test**.
When --links command line switch is enabled, the file system will translate any ***.rclonelink** files into * links.
On the other hand, if --links is disabled, the symlinks will be seen as regular files, with their .rclonelink suffix which content contains the target file path.

Those changes comes with a rather big TestSymlinks unit test, which test all possible api and combinations.
The tests are ran for a VFS and each backends, with and without --links command line switch enabled, covering all possible scenarios.

I did run the tests successfully using this bash script:
```
#!/bin/bash -e

# Run the VFS tests in all subdirectories
pushd vfs
go test -tags cmount -v ./...
#go test -tags cmount -v -run TestFunctional
popd

# This test uses the tests in vfs/vfstest
pushd cmd/cmount
go test -tags cmount -v
popd

# This test uses the tests in vfs/vfstest
pushd cmd/mount
go test -v
popd

# This test uses the tests in vfs/vfstest
pushd cmd/mount2
go test -v
popd
```