### PR TITLE
dlna: fix SOAP action header parsing - fixes #6354

### DIFF
--- a/cmd/serve/dlna/dlna.go
+++ b/cmd/serve/dlna/dlna.go
@@ -186,7 +186,7 @@ func (s *server) rootDescHandler(w http.ResponseWriter, r *http.Request) {
 // Handle a service control HTTP request.
 func (s *server) serviceControlHandler(w http.ResponseWriter, r *http.Request) {
 	soapActionString := r.Header.Get("SOAPACTION")
-	soapAction, err := parseActionHTTPHeader(soapActionString)
+	soapAction, err := upnp.ParseActionHTTPHeader(soapActionString)
 	if err != nil {
 		serveError(s, w, "Could not parse SOAPACTION header", err)
 		return

--- a/cmd/serve/dlna/dlna_test.go
+++ b/cmd/serve/dlna/dlna_test.go
@@ -119,6 +119,8 @@ func TestContentDirectoryBrowseMetadata(t *testing.T) {
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	body, err := ioutil.ReadAll(resp.Body)
 	require.NoError(t, err)
+	// should contain an appropriate URN
+	require.Contains(t, string(body), "urn:schemas-upnp-org:service:ContentDirectory:1")
 	// expect a <container> element
 	require.Contains(t, string(body), html.EscapeString("<container "))
 	require.NotContains(t, string(body), html.EscapeString("<item "))

--- a/cmd/serve/dlna/dlna_util.go
+++ b/cmd/serve/dlna/dlna_util.go
@@ -3,7 +3,6 @@ package dlna
 import (
 	"crypto/md5"
 	"encoding/xml"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -12,9 +11,6 @@ import (
 	"net/http/httptest"
 	"net/http/httputil"
 	"os"
-	"regexp"
-	"strconv"
-	"strings"
 
 	"github.com/anacrolix/dms/soap"
 	"github.com/anacrolix/dms/upnp"
@@ -87,36 +83,6 @@ func marshalSOAPResponse(sa upnp.SoapAction, args map[string]string) []byte {
 	}
 	return []byte(fmt.Sprintf(`<u:%[1]sResponse xmlns:u="%[2]s">%[3]s</u:%[1]sResponse>`,
 		sa.Action, sa.ServiceURN.String(), mustMarshalXML(soapArgs)))
-}
-
-var serviceURNRegexp = regexp.MustCompile(`:service:(\w+):(\d+)$`)
-
-func parseServiceType(s string) (ret upnp.ServiceURN, err error) {
-	matches := serviceURNRegexp.FindStringSubmatch(s)
-	if matches == nil {
-		err = errors.New(s)
-		return
-	}
-	if len(matches) != 3 {
-		log.Panicf("Invalid serviceURNRegexp ?")
-	}
-	ret.Type = matches[1]
-	ret.Version, err = strconv.ParseUint(matches[2], 0, 0)
-	return
-}
-
-func parseActionHTTPHeader(s string) (ret upnp.SoapAction, err error) {
-	if s[0] != '"' || s[len(s)-1] != '"' {
-		return
-	}
-	s = s[1 : len(s)-1]
-	hashIndex := strings.LastIndex(s, "#")
-	if hashIndex == -1 {
-		return
-	}
-	ret.Action = s[hashIndex+1:]
-	ret.ServiceURN, err = parseServiceType(s[:hashIndex])
-	return
 }
 
 type loggingResponseWriter struct {


### PR DESCRIPTION
#### What is the purpose of this change?

[Changes](https://github.com/anacrolix/dms/commit/3d402bc95f0bde7d353e23cf4f3c5e4fdc37c9ec#diff-835dd4c4999146276b07a369231a91c13111bdf55266e5cd245e5d2e33a3b24aL13-R36) in [anacrolix/dms](https://github.com/anacrolix/dms) changed `upnp.ServiceURN` to include a namespace identifier. This identifier was previously hardcoded, but is now parsed out of the URN. The old SOAP action header parsing logic was duplicated in rclone and did not handle this field. Resulting responses included a URN with an empty namespace identifier, breaking clients.

#### Was the change discussed in an issue or in the forum before?

See #6354

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
