### PR TITLE
dlna: specify SSDP interface names from command line

### DIFF
--- a/cmd/serve/dlna/dlna_test.go
+++ b/cmd/serve/dlna/dlna_test.go
@@ -35,7 +35,9 @@ const (
 func startServer(t *testing.T, f fs.Fs) {
 	opt := dlnaflags.DefaultOpt
 	opt.ListenAddr = testBindAddress
-	dlnaServer = newServer(f, &opt)
+	var err error
+	dlnaServer, err = newServer(f, &opt)
+	assert.NoError(t, err)
 	assert.NoError(t, dlnaServer.Serve())
 	baseURL = "http://" + dlnaServer.HTTPConn.Addr().String()
 }

--- a/cmd/serve/dlna/dlna_util.go
+++ b/cmd/serve/dlna/dlna_util.go
@@ -47,11 +47,15 @@ func listInterfaces() []net.Interface {
 
 	var active []net.Interface
 	for _, intf := range ifs {
-		if intf.Flags&net.FlagUp != 0 && intf.Flags&net.FlagMulticast != 0 && intf.MTU > 0 {
+		if isAppropriatelyConfigured(intf) {
 			active = append(active, intf)
 		}
 	}
 	return active
+}
+
+func isAppropriatelyConfigured(intf net.Interface) bool {
+	return intf.Flags&net.FlagUp != 0 && intf.Flags&net.FlagMulticast != 0 && intf.MTU > 0
 }
 
 func didlLite(chardata string) string {

--- a/cmd/serve/dlna/dlnaflags/dlnaflags.go
+++ b/cmd/serve/dlna/dlnaflags/dlnaflags.go
@@ -23,16 +23,18 @@ logging of all UPNP traffic.
 
 // Options is the type for DLNA serving options.
 type Options struct {
-	ListenAddr   string
-	FriendlyName string
-	LogTrace     bool
+	ListenAddr     string
+	FriendlyName   string
+	LogTrace       bool
+	InterfaceNames []string
 }
 
 // DefaultOpt contains the defaults options for DLNA serving.
 var DefaultOpt = Options{
-	ListenAddr:   ":7879",
-	FriendlyName: "",
-	LogTrace:     false,
+	ListenAddr:     ":7879",
+	FriendlyName:   "",
+	LogTrace:       false,
+	InterfaceNames: []string{},
 }
 
 // Opt contains the options for DLNA serving.
@@ -45,6 +47,7 @@ func addFlagsPrefix(flagSet *pflag.FlagSet, prefix string, Opt *Options) {
 	flags.StringVarP(flagSet, &Opt.ListenAddr, prefix+"addr", "", Opt.ListenAddr, "The ip:port or :port to bind the DLNA http server to")
 	flags.StringVarP(flagSet, &Opt.FriendlyName, prefix+"name", "", Opt.FriendlyName, "Name of DLNA server")
 	flags.BoolVarP(flagSet, &Opt.LogTrace, prefix+"log-trace", "", Opt.LogTrace, "Enable trace logging of SOAP traffic")
+	flags.StringArrayVarP(flagSet, &Opt.InterfaceNames, prefix+"interface", "", Opt.InterfaceNames, "The interface to use for SSDP (repeat as necessary)")
 }
 
 // AddFlags add the command line flags for DLNA serving.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
Enabling a user to specify the interfaces used for DLNA (SSDP). This is especially useful when serving DLNA on a machine with many virtual network interfaces (for example when also running Kubernetes) for which you don't wish to advertise DLNA.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
