### PR TITLE
Avoid negative ETA values for very slow speeds

### DIFF
--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -269,7 +269,7 @@ func etaString(done, total int64, rate float64) string {
 	if d == etaMax {
 		return "-"
 	}
-	return fs.Duration(d).ReadableString()
+	return fs.Duration(d).ShortReadableString()
 }
 
 // percent returns a/b as a percentage rounded to the nearest integer

--- a/fs/accounting/stats_test.go
+++ b/fs/accounting/stats_test.go
@@ -29,7 +29,7 @@ func TestETA(t *testing.T) {
 		{size: 0, total: 15 * 86400, rate: 1.0, wantETA: 15 * 86400 * time.Second, wantOK: true, wantString: "2w1d"},
 		// Composite Custom String Cases
 		{size: 0, total: 1.5 * 86400, rate: 1.0, wantETA: 1.5 * 86400 * time.Second, wantOK: true, wantString: "1d12h"},
-		{size: 0, total: 95000, rate: 1.0, wantETA: 95000 * time.Second, wantOK: true, wantString: "1d2h23m20s"},
+		{size: 0, total: 95000, rate: 1.0, wantETA: 95000 * time.Second, wantOK: true, wantString: "1d2h23m"}, // Short format, if full it would be "1d2h23m20s"
 		// Standard Duration String Cases
 		{size: 0, total: 1, rate: 2.0, wantETA: 0, wantOK: true, wantString: "0s"},
 		{size: 0, total: 1, rate: 1.0, wantETA: time.Second, wantOK: true, wantString: "1s"},
@@ -47,7 +47,7 @@ func TestETA(t *testing.T) {
 		// Extreme Cases
 		{size: 0, total: (1 << 63) - 1, rate: 1.0, wantETA: (time.Duration((1<<63)-1) / time.Second) * time.Second, wantOK: true, wantString: "-"},
 		{size: 0, total: ((1 << 63) - 1) / int64(time.Second), rate: 1.0, wantETA: (time.Duration((1<<63)-1) / time.Second) * time.Second, wantOK: true, wantString: "-"},
-		{size: 0, total: ((1<<63)-1)/int64(time.Second) - 1, rate: 1.0, wantETA: (time.Duration((1<<63)-1)/time.Second - 1) * time.Second, wantOK: true, wantString: "292y24w3d23h47m15s"},
+		{size: 0, total: ((1<<63)-1)/int64(time.Second) - 1, rate: 1.0, wantETA: (time.Duration((1<<63)-1)/time.Second - 1) * time.Second, wantOK: true, wantString: "292y24w3d"}, // Short format, if full it would be "292y24w3d23h47m15s"
 		{size: 0, total: ((1<<63)-1)/int64(time.Second) - 1, rate: 0.1, wantETA: (time.Duration((1<<63)-1) / time.Second) * time.Second, wantOK: true, wantString: "-"},
 	} {
 		t.Run(fmt.Sprintf("size=%d/total=%d/rate=%f", test.size, test.total, test.rate), func(t *testing.T) {

--- a/fs/accounting/stats_test.go
+++ b/fs/accounting/stats_test.go
@@ -31,6 +31,9 @@ func TestETA(t *testing.T) {
 		{size: 0, total: 1.5 * 86400, rate: 1.0, wantETA: 1.5 * 86400 * time.Second, wantOK: true, wantString: "1d12h"},
 		{size: 0, total: 95000, rate: 1.0, wantETA: 95000 * time.Second, wantOK: true, wantString: "1d2h23m20s"},
 		// Standard Duration String Cases
+		{size: 0, total: 1, rate: 2.0, wantETA: 0, wantOK: true, wantString: "0s"},
+		{size: 0, total: 1, rate: 1.0, wantETA: time.Second, wantOK: true, wantString: "1s"},
+		{size: 0, total: 1, rate: 0.5, wantETA: 2 * time.Second, wantOK: true, wantString: "2s"},
 		{size: 0, total: 100, rate: 1.0, wantETA: 100 * time.Second, wantOK: true, wantString: "1m40s"},
 		{size: 50, total: 100, rate: 1.0, wantETA: 50 * time.Second, wantOK: true, wantString: "50s"},
 		{size: 100, total: 100, rate: 1.0, wantETA: 0 * time.Second, wantOK: true, wantString: "0s"},
@@ -41,10 +44,15 @@ func TestETA(t *testing.T) {
 		{size: 10, total: 20, rate: 0.0, wantETA: 0, wantOK: false, wantString: "-"},
 		{size: 10, total: 20, rate: -1.0, wantETA: 0, wantOK: false, wantString: "-"},
 		{size: 0, total: 0, rate: 1.0, wantETA: 0, wantOK: false, wantString: "-"},
+		// Extreme Cases
+		{size: 0, total: (1 << 63) - 1, rate: 1.0, wantETA: (time.Duration((1<<63)-1) / time.Second) * time.Second, wantOK: true, wantString: "-"},
+		{size: 0, total: ((1 << 63) - 1) / int64(time.Second), rate: 1.0, wantETA: (time.Duration((1<<63)-1) / time.Second) * time.Second, wantOK: true, wantString: "-"},
+		{size: 0, total: ((1<<63)-1)/int64(time.Second) - 1, rate: 1.0, wantETA: (time.Duration((1<<63)-1)/time.Second - 1) * time.Second, wantOK: true, wantString: "292y24w3d23h47m15s"},
+		{size: 0, total: ((1<<63)-1)/int64(time.Second) - 1, rate: 0.1, wantETA: (time.Duration((1<<63)-1) / time.Second) * time.Second, wantOK: true, wantString: "-"},
 	} {
 		t.Run(fmt.Sprintf("size=%d/total=%d/rate=%f", test.size, test.total, test.rate), func(t *testing.T) {
 			gotETA, gotOK := eta(test.size, test.total, test.rate)
-			assert.Equal(t, test.wantETA, gotETA)
+			assert.Equal(t, int64(test.wantETA), int64(gotETA))
 			assert.Equal(t, test.wantOK, gotOK)
 			gotString := etaString(test.size, test.total, test.rate)
 			assert.Equal(t, test.wantString, gotString)

--- a/fs/parseduration_test.go
+++ b/fs/parseduration_test.go
@@ -108,38 +108,44 @@ func TestDurationString(t *testing.T) {
 
 func TestDurationReadableString(t *testing.T) {
 	for _, test := range []struct {
-		negative bool
-		in       time.Duration
-		want     string
+		negative  bool
+		in        time.Duration
+		wantLong  string
+		wantShort string
 	}{
 		// Edge Cases
-		{false, time.Duration(DurationOff), "off"},
+		{false, time.Duration(DurationOff), "off", "off"},
 		// Base Cases
-		{false, time.Duration(0), "0s"},
-		{true, time.Millisecond, "1ms"},
-		{true, time.Second, "1s"},
-		{true, time.Minute, "1m"},
-		{true, (3 * time.Minute) / 2, "1m30s"},
-		{true, time.Hour, "1h"},
-		{true, time.Hour * 24, "1d"},
-		{true, time.Hour * 24 * 7, "1w"},
-		{true, time.Hour * 24 * 365, "1y"},
+		{false, time.Duration(0), "0s", "0s"},
+		{true, time.Millisecond, "1ms", "1ms"},
+		{true, time.Second, "1s", "1s"},
+		{true, time.Minute, "1m", "1m"},
+		{true, (3 * time.Minute) / 2, "1m30s", "1m30s"},
+		{true, time.Hour, "1h", "1h"},
+		{true, time.Hour * 24, "1d", "1d"},
+		{true, time.Hour * 24 * 7, "1w", "1w"},
+		{true, time.Hour * 24 * 365, "1y", "1y"},
 		// Composite Cases
-		{true, time.Hour + 2*time.Minute + 3*time.Second, "1h2m3s"},
-		{true, time.Hour * 24 * (365 + 14), "1y2w"},
-		{true, time.Hour*24*4 + time.Hour*3 + time.Minute*2 + time.Second, "4d3h2m1s"},
-		{true, time.Hour * 24 * (365*3 + 7*2 + 1), "3y2w1d"},
-		{true, time.Hour*24*(365*3+7*2+1) + time.Hour*2 + time.Second, "3y2w1d2h1s"},
-		{true, time.Hour*24*(365*3+7*2+1) + time.Second, "3y2w1d1s"},
-		{true, time.Hour*24*(365+7*2+3) + time.Hour*4 + time.Minute*5 + time.Second*6 + time.Millisecond*7, "1y2w3d4h5m6s7ms"},
+		{true, time.Hour + 2*time.Minute + 3*time.Second, "1h2m3s", "1h2m3s"},
+		{true, time.Hour * 24 * (365 + 14), "1y2w", "1y2w"},
+		{true, time.Hour*24*4 + time.Hour*3 + time.Minute*2 + time.Second, "4d3h2m1s", "4d3h2m"},
+		{true, time.Hour * 24 * (365*3 + 7*2 + 1), "3y2w1d", "3y2w1d"},
+		{true, time.Hour*24*(365*3+7*2+1) + time.Hour*2 + time.Second, "3y2w1d2h1s", "3y2w1d"},
+		{true, time.Hour*24*(365*3+7*2+1) + time.Second, "3y2w1d1s", "3y2w1d"},
+		{true, time.Hour*24*(365+7*2+3) + time.Hour*4 + time.Minute*5 + time.Second*6 + time.Millisecond*7, "1y2w3d4h5m6s7ms", "1y2w3d"},
+		{true, time.Duration(DurationOff) / time.Millisecond * time.Millisecond, "292y24w3d23h47m16s853ms", "292y24w3d"}, // Should have been 854ms but some precision are lost with floating point calculations
 	} {
 		got := Duration(test.in).ReadableString()
-		assert.Equal(t, test.want, got)
+		assert.Equal(t, test.wantLong, got)
+		got = Duration(test.in).ShortReadableString()
+		assert.Equal(t, test.wantShort, got)
 
 		// Test Negative Case
 		if test.negative {
 			got = Duration(-test.in).ReadableString()
-			assert.Equal(t, "-"+test.want, got)
+			assert.Equal(t, "-"+test.wantLong, got)
+			got = Duration(-test.in).ShortReadableString()
+			assert.Equal(t, "-"+test.wantShort, got)
 		}
 	}
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Part 1: Integer overflow would lead to ETA such as "-255y7w4h11m22s966ms", as reported in #6381. Now the value will be clipped at the maximum "292y24w3d23h47m16s", and it will be shown as "-".
- I would like to show the Unicode symbol for infinity, "∞", for this situation, but I'm worried it will cause issues in some consoles (especially Windows, with code page nightmare etc). Don't know if there are any other comparable uses of Unicode symbols in output from rclone? Tree command probably, but maybe that is a somewhat unconventional command with limited use, compared to the stats output, so less important with compatibility. Maybe "**" could serve as an ascii version of the infinity symbol, or perhaps it will look a bit "noisy". I landed on just showing "-", which is the same as already used for any unknown/invalid/completed ETA.

Part 2: As suggested in the issue, it does not make much sense to report hours, minutes, and even seconds when the duration is  several years. I've changed to show a shorter ETA string, at most 3 significant parts: "292y24w3d", "24w3d23h", "3d23h47m", "23h47m16s". This means when ETA is days or more, then precision will be sacrificed, but anything within 24 hours will be full precision (hours, minute, second - eta is only second precision).

#### Was the change discussed in an issue or in the forum before?

#6381

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
