### PR TITLE
copy: Don't print sensitive values from environment variables when running rclone

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -162,11 +162,13 @@ func init() {
 				Help:  "Get AWS credentials from the environment (env vars or IAM).",
 			}},
 		}, {
-			Name: "access_key_id",
-			Help: "AWS Access Key ID.\n\nLeave blank for anonymous access or runtime credentials.",
+			Name:       "access_key_id",
+			Help:       "AWS Access Key ID.\n\nLeave blank for anonymous access or runtime credentials.",
+			IsPassword: true,
 		}, {
-			Name: "secret_access_key",
-			Help: "AWS Secret Access Key (password).\n\nLeave blank for anonymous access or runtime credentials.",
+			Name:       "secret_access_key",
+			Help:       "AWS Secret Access Key (password).\n\nLeave blank for anonymous access or runtime credentials.",
+			IsPassword: true,
 		}, {
 			// References:
 			// 1. https://docs.aws.amazon.com/general/latest/gr/rande.html

--- a/fs/config/util/sanitize.go
+++ b/fs/config/util/sanitize.go
@@ -1,0 +1,11 @@
+package util
+
+// SanitizeSensitiveValue replaces a logged value with a non-sensitive value if the value is deemed sensitive for
+// logging purposes
+func SanitizeSensitiveValue(value string, isPassword bool) string {
+	if isPassword {
+		return "<sensitive value>"
+	}
+
+	return value
+}

--- a/fs/configmap_test.go
+++ b/fs/configmap_test.go
@@ -1,0 +1,70 @@
+package fs
+
+import (
+	"bytes"
+	"github.com/stretchr/testify/assert"
+	"io"
+	"log"
+	"os"
+	"testing"
+)
+
+func setupLogging() {
+	globalConfig = &ConfigInfo{
+		LogLevel: LogLevelDebug,
+	}
+}
+
+func captureLogging(print func()) string {
+	// keep backup of the real stdout
+	old := log.Default().Writer()
+	r, w, _ := os.Pipe()
+	log.Default().SetOutput(w)
+
+	print()
+
+	outC := make(chan string)
+
+	// send stdout to channel
+	go func() {
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		outC <- buf.String()
+	}()
+
+	// restore
+	w.Close()
+	log.Default().SetOutput(old)
+	return <-outC
+}
+
+const Value = "MY_VALUE"
+const Section = "s3"
+
+func TestConfigEnvVarsNotLoggingSensitiveValues(t *testing.T) {
+	setupLogging()
+
+	fsInfo := &RegInfo{
+		Options: []Option{
+			{Name: "access_key_id", IsPassword: true},
+			{Name: "region"},
+		},
+	}
+
+	cev := configEnvVars{Section, fsInfo}
+
+	for _, option := range fsInfo.Options {
+		err := os.Setenv(ConfigToEnv(Section, option.Name), Value)
+		assert.NoError(t, err)
+
+		logMessage := captureLogging(func() {
+			cev.Get(option.Name)
+		})
+
+		if option.IsPassword {
+			assert.NotContains(t, logMessage, Value)
+		} else {
+			assert.Contains(t, logMessage, Value)
+		}
+	}
+}

--- a/fs/fs_test.go
+++ b/fs/fs_test.go
@@ -333,7 +333,7 @@ func TestOptionGetters(t *testing.T) {
 	// set up getters
 
 	// A configmap.Getter to read from the environment RCLONE_CONFIG_backend_option_name
-	configEnvVarsGetter := configEnvVars("local")
+	configEnvVarsGetter := configEnvVars{"local", fsInfo}
 
 	// A configmap.Getter to read from the environment RCLONE_option_name
 	optionEnvVarsGetter := optionEnvVars{fsInfo}


### PR DESCRIPTION
#### What is the purpose of this change?

When running `rclone` with some configuration options set via environment variables, `rclone` will log sensitive values.  For example, if I run this command that runs `rclone` in docker, it will log my s3 access key id and secret key:

```
# docker run -it --rm \
  -e RCLONE_CONFIG_S3_REGION="us-east-2" \
  -e RCLONE_CONFIG_S3_ACCESS_KEY_ID="<REDACTED>" \
  -e RCLONE_CONFIG_S3_SECRET_ACCESS_KEY="<REDACTED>" \
  -e RCLONE_CONFIG_S3_TYPE="s3" \
  -e RCLONE_CONFIG_S3_PROVIDER="aws" \
  -e RCLONE_CONFIG_S3_ENV_AUTH="false" \
  -e RCLONE_VERBOSE=2 \
  rclone-copy s3://rtr-data-models/stage/models/happy/v1.0/1652196245 /mnt/models
2022/08/04 13:38:28 DEBUG : rclone: Version "v1.57.0" starting with parameters ["rclone" "copy" "s3://rtr-data-models/stage/models/happy/v1.0/1652196245" "/mnt/models"]
2022/08/04 13:38:28 DEBUG : Creating backend with remote "s3://rtr-data-models/stage/models/happy/v1.0/1652196245"
2022/08/04 13:38:28 DEBUG : Setting type="s3" for "s3" from environment variable RCLONE_CONFIG_S3_TYPE
2022/08/04 13:38:28 DEBUG : Setting provider="aws" for "s3" from environment variable RCLONE_CONFIG_S3_PROVIDER
2022/08/04 13:38:28 DEBUG : Setting env_auth="false" for "s3" from environment variable RCLONE_CONFIG_S3_ENV_AUTH
2022/08/04 13:38:28 DEBUG : Setting access_key_id="<REDACTED>" for "s3" from environment variable RCLONE_CONFIG_S3_ACCESS_KEY_ID
2022/08/04 13:38:28 DEBUG : Setting secret_access_key="<REDACTED>" for "s3" from environment variable RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
2022/08/04 13:38:28 DEBUG : Setting region="us-east-2" for "s3" from environment variable RCLONE_CONFIG_S3_REGION
2022/08/04 13:38:28 DEBUG : Setting region="us-east-2" for "s3" from environment variable RCLONE_CONFIG_S3_REGION
2022/08/04 13:38:28 DEBUG : Setting region="us-east-2" for "s3" from environment variable RCLONE_CONFIG_S3_REGION
2022/08/04 13:38:28 DEBUG : s3: detected overridden config - adding "{TrI48}" suffix to name
2022/08/04 13:38:28 DEBUG : Setting provider="aws" for "s3" from environment variable RCLONE_CONFIG_S3_PROVIDER
2022/08/04 13:38:28 DEBUG : Setting env_auth="false" for "s3" from environment variable RCLONE_CONFIG_S3_ENV_AUTH
2022/08/04 13:38:28 DEBUG : Setting access_key_id="<REDACTED>" for "s3" from environment variable RCLONE_CONFIG_S3_ACCESS_KEY_ID
2022/08/04 13:38:28 DEBUG : Setting secret_access_key="<REDACTED>" for "s3" from environment variable RCLONE_CONFIG_S3_SECRET_ACCESS_KEY
2022/08/04 13:38:28 DEBUG : Setting region="us-east-2" for "s3" from environment variable RCLONE_CONFIG_S3_REGION
2022/08/04 13:38:28 NOTICE: Config file "/config/rclone/rclone.conf" not found - using defaults
2022/08/04 13:38:29 DEBUG : fs cache: renaming cache item "s3://rtr-data-models/stage/models/happy/v1.0/1652196245" to be canonical "s3{TrI48}:rtr-data-models/stage/models/happy/v1.0/165219624
5"
2022/08/04 13:38:29 DEBUG : Creating backend with remote "/mnt/models"
2022/08/04 13:38:29 DEBUG : Local file system at /mnt/models: Waiting for checks to finish
2022/08/04 13:38:29 DEBUG : Local file system at /mnt/models: Waiting for transfers to finish
2022/08/04 13:38:29 DEBUG : 1/variables/variables.index: md5 = 7a60f2aa9a3abc2ef37a923f01e77a4c OK
2022/08/04 13:38:29 INFO  : 1/variables/variables.index: Copied (new)
2022/08/04 13:38:29 DEBUG : 1/saved_model.pb: md5 = a96abbefdc7d40a65ec48aed89723476 OK
2022/08/04 13:38:29 INFO  : 1/saved_model.pb: Copied (new)
2022/08/04 13:38:31 INFO  : 1/variables/variables.data-00000-of-00001: Copied (new)
2022/08/04 13:38:31 INFO  :
Transferred:       83.144 MiB / 83.144 MiB, 100%, 41.075 MiB/s, ETA 0s
Transferred:            3 / 3, 100%
Elapsed time:         2.3s

2022/08/04 13:38:31 DEBUG : 13 go routines active
```

It would be nice to be able to run `rclone` with full verbose mode and not log sensitive values.  This PR is a step in that direction, it checks whether a given option we read from an environment value is marked `IsPassword`, and then sanitizes the output accordingly.

#### Was the change discussed in an issue or in the forum before?

It isn't an issue yet in the rclone repo, but it originally came up in another repo as an issue: https://github.com/SeldonIO/seldon-core/issues/4247

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
