### PR TITLE
Add misspell linter to build pipeline

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - gosimple
     - stylecheck
     - unused
+    - misspell
     #- prealloc
     #- maligned
   disable-all: true

--- a/fs/config/configfile/configfile.go
+++ b/fs/config/configfile/configfile.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/Unknwon/goconfig"
+	"github.com/Unknwon/goconfig" //nolint:misspell // Don't include misspell when running golangci-lint
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/lib/file"


### PR DESCRIPTION
#### What is the purpose of this change?

Testing the `misspell` linter in golangci-lint: Activates the spell-checking linter `misspell` available with golangci-lint, and fixes reported issues on current codebase, as well as exclude comment in one one place where there is a false positive.

> According to docs, by default it only checks comments in .go files, and must be configured to check entire source files for it to detect errors in strings. But the golangci-lint integration is always checking entire source ("Treat Go source files as a plain text by misspell: it allows detecting issues in strings, variable names, etc.", [ref](https://github.com/golangci/golangci-lint/blob/master/CHANGELOG.md#june-2019)). Strings are way more important than comments, at least in rclone, to get all the help texts correct, which are also used for generated documentation. And also the user documentation .md files are important. It would be easy for us to enable misspell, and it would be helpful enough, although quite limited results. Also; latest commit in the github repo is from 2018 so probably not much hope for improvements..
(https://github.com/rclone/rclone/pull/6380#issuecomment-1222129251)

Did not configure US or UK locale, which means it uses "a neutral variety of English":

> Setting locale to US will correct the British spelling of 'colour' to 'color'. Default is to use a neutral variety of English.
(https://golangci-lint.run/usage/linters/#misspell)

Is this something we want? Would be annoying if it constantly "red flags" pull requests due to false positives or trifles (*is that a word? Google translate says so!*), though first impression is that it is quite "relaxed". Also, as mentioned in quote above; last commit is from 2018 so there is a a risk it will be deprecated in golangci-lint soon, as `deadcode`, `structcheck` and `varcheck` recently was - two of them also hadn't had a commit since 2018.

There are other alternatives which might be better, but the main advantage of `misspell` is that it is the only one included with golangci-lint. See #6380 for one alternative, and some related comments.

See also #6387, which changes and adds several other linters - but not misspell.

#### Was the change discussed in an issue or in the forum before?

#6380

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
