### PR TITLE
Improve MkdirAll on Windows for non-existent network host

### DIFF
--- a/lib/file/mkdir_windows.go
+++ b/lib/file/mkdir_windows.go
@@ -11,8 +11,9 @@ import (
 
 // MkdirAll creates a directory named path, along with any necessary parents.
 //
-// Improves os.MkdirAll by avoiding trying to create a folder \\? when the
-// volume of a given extended length path does not exist.
+// Improves os.MkdirAll by avoiding trying to create a folder `\\?` when the
+// volume of a given extended length path does not exist, and `\\?\UNC` when
+// a network host name does not exist.
 //
 // Based on source code from golang's os.MkdirAll
 // (https://github.com/golang/go/blob/master/src/os/path.go)
@@ -37,7 +38,6 @@ func MkdirAll(path string, perm os.FileMode) error {
 	}
 	if i > 0 {
 		path = path[:i]
-
 		if path == filepath.VolumeName(path) {
 			// Make reference to a drive's root directory include the trailing slash.
 			// In extended-length form without trailing slash ("\\?\C:"), os.Stat
@@ -53,10 +53,12 @@ func MkdirAll(path string, perm os.FileMode) error {
 				j--
 			}
 			if j > 1 {
-				// Create parent.
-				err = MkdirAll(path[:j-1], perm)
-				if err != nil {
-					return err
+				if path[:j-1] != `\\?\UNC` {
+					// Create parent.
+					err = MkdirAll(path[:j-1], perm)
+					if err != nil {
+						return err
+					}
 				}
 			}
 		}


### PR DESCRIPTION
#### What is the purpose of this change?

When copying to network path `\\Server\Share`, and the Server does not exist, then instead of reporting the error as

`mkdir \\?\UNC: The filename, directory name, or volume label syntax is incorrect.`

... which is not so informative, and a little confusing. Instead, report it as:

`mkdir \\?\UNC\Server: The specified path is invalid.`

This builds on the previously  custom variant of os.MkdirAll, introduced with #5401. Rclone transforms `\\Server\Share` into extended-length format `\\?\UNC\Server\Share`. When Server does not exist, then with standard os.MkdirAll it would fail with `mkdir \\?: The filename, directory name, or volume label syntax is incorrect.`. The mentioned PR changed this to `mkdir \\?\UNC: The filename, directory name, or volume label syntax is incorrect.`, which is still not very informative (reason is the code relies on `filename.VolumeName`, and it is not aware of extended-length network paths and therefore returns `\\?\UNC` - which is *not* a volume name!). This PR adds a small extra to improve this. 

I'm not so much worried about the error description, "The specified path is invalid" or "The filename, directory name, or volume label syntax is incorrect", I'm more interested in getting the path reported being something the user can relate to. And then the error description more or less is what it is, without introducing too much additional logic compared to os.MkdirAll.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/use-rclone-to-copy-file-to-list-of-remote-computers-locations/31998

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
