### PR TITLE
sftp: check for directory existence if mkdir fails

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -1171,6 +1171,11 @@ func (f *Fs) mkdir(ctx context.Context, dirPath string) error {
 	err = c.sftpClient.Mkdir(dirPath)
 	f.putSftpConnection(&c, err)
 	if err != nil {
+		ok, _ := f.dirExists(ctx, dirPath)
+		if ok {
+			fs.LogPrintf(fs.LogLevelWarning, f, "directory %q exists after Mkdir is attempted", dirPath)
+			return nil
+		}
 		return fmt.Errorf("mkdir %q failed: %w", dirPath, err)
 	}
 	return nil

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -1171,9 +1171,8 @@ func (f *Fs) mkdir(ctx context.Context, dirPath string) error {
 	err = c.sftpClient.Mkdir(dirPath)
 	f.putSftpConnection(&c, err)
 	if err != nil {
-		ok, _ := f.dirExists(ctx, dirPath)
-		if ok {
-			fs.LogPrintf(fs.LogLevelWarning, f, "directory %q exists after Mkdir is attempted", dirPath)
+		if os.IsExist(err) {
+			fs.Debugf(f, "directory %q exists after Mkdir is attempted", dirPath)
 			return nil
 		}
 		return fmt.Errorf("mkdir %q failed: %w", dirPath, err)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This checks directory existence if mkdir operation fails.
Race condition happens very often when an union remote points to the same (physical) directory, and directory creation is needed.
As servers find the directory that others are created, you get "Failure" errors and unfortunate files will be skipped.

Although it looks it's patched for the FTP backend, but SFTP is not.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
