### PR TITLE
Stricter check for remote names with leading/trailing space

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -3431,7 +3431,7 @@ func (f *Fs) Command(ctx context.Context, name string, arg []string, opt map[str
 		if err != nil {
 			return nil, err
 		}
-		re := regexp.MustCompile(`[^\w_. -]+`)
+		re := regexp.MustCompile(`[^\w\p{L}\p{N}. -]+`)
 		if _, ok := opt["config"]; ok {
 			lines := []string{}
 			upstreams := []string{}

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -338,9 +338,17 @@ Will get their own names
 ### Valid remote names
 
 Remote names are case sensitive, and must adhere to the following rules:
- - May only contain `0`-`9`, `A`-`Z`, `a`-`z`, `_`, `-`, `.` and space.
+ - May contain number, letter, `_`, `-`, `.` and space.
  - May not start with `-` or space.
  - May not end with space.
+
+Starting with rclone version 1.61, any Unicode numbers and letters are allowed,
+while in older versions it was limited to plain ASCII (0-9, A-Z, a-z). If you use
+the same rclone configuration from different shells, which may be configured with
+different character encoding, you must be cautious to use characters that are
+possible to write in all of them. This is mostly a problem on Windows, where
+the console traditionally uses a non-Unicode character set - defined
+by the so-called "code page".
 
 Quoting and the shell
 ---------------------

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -340,6 +340,7 @@ Will get their own names
 Remote names are case sensitive, and must adhere to the following rules:
  - May only contain `0`-`9`, `A`-`Z`, `a`-`z`, `_`, `-`, `.` and space.
  - May not start with `-` or space.
+ - May not end with space.
 
 Quoting and the shell
 ---------------------

--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	configNameRe = `[\w. -]+`
-	remoteNameRe = `^(:?` + configNameRe + `)`
+	remoteNameRe = `(:?` + configNameRe + `)`
 )
 
 var (

--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	configNameRe = `[\w.-]+(?: +[\w.-]+)*`
+	configNameRe = `[\w\p{L}\p{N}.-]+(?: +[\w\p{L}\p{N}.-]+)*`
 )
 
 var (
-	errInvalidCharacters = errors.New("config name contains invalid characters - may only contain `0-9`, `A-Z`, `a-z`, `_`, `-`, `.` and space, while not start or end with space")
+	errInvalidCharacters = errors.New("config name contains invalid characters - may only contain numbers, letters, `_`, `-`, `.` and space, while not start or end with space")
 	errCantBeEmpty       = errors.New("can't use empty string as a path")
 	errCantStartWithDash = errors.New("config name starts with `-`")
 	errBadConfigParam    = errors.New("config parameters may only contain `0-9`, `A-Z`, `a-z` and `_`")

--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	configNameRe = `[\w. -]+`
-	remoteNameRe = `:?` + configNameRe
 )
 
 var (
@@ -35,7 +34,7 @@ var (
 	configNameMatcher = regexp.MustCompile(`^` + configNameRe + `$`)
 
 	// remoteNameMatcher is a pattern to match an rclone remote name at the start of a config
-	remoteNameMatcher = regexp.MustCompile(`^` + remoteNameRe + `(?::$|,)`)
+	remoteNameMatcher = regexp.MustCompile(`^:?` + configNameRe + `(?::$|,)`)
 )
 
 // CheckConfigName returns an error if configName is invalid

--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -17,7 +17,7 @@ const (
 )
 
 var (
-	errInvalidCharacters = errors.New("config name contains invalid characters - may only contain `0-9`, `A-Z`, `a-z`, `_`, `-`, `.` and space")
+	errInvalidCharacters = errors.New("config name contains invalid characters - may only contain `0-9`, `A-Z`, `a-z`, `_`, `-`, `.` and space, while not start or end with space")
 	errCantBeEmpty       = errors.New("can't use empty string as a path")
 	errCantStartWithDash = errors.New("config name starts with `-`")
 	errBadConfigParam    = errors.New("config parameters may only contain `0-9`, `A-Z`, `a-z` and `_`")

--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	configNameRe = `[\w_. -]+`
+	configNameRe = `[\w. -]+`
 	remoteNameRe = `^(:?` + configNameRe + `)`
 )
 

--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	configNameRe = `[\w. -]+`
-	remoteNameRe = `(:?` + configNameRe + `)`
+	remoteNameRe = `:?` + configNameRe
 )
 
 var (
@@ -35,7 +35,7 @@ var (
 	configNameMatcher = regexp.MustCompile(`^` + configNameRe + `$`)
 
 	// remoteNameMatcher is a pattern to match an rclone remote name at the start of a config
-	remoteNameMatcher = regexp.MustCompile(`^` + remoteNameRe + `(:$|,)`)
+	remoteNameMatcher = regexp.MustCompile(`^` + remoteNameRe + `(?::$|,)`)
 )
 
 // CheckConfigName returns an error if configName is invalid

--- a/fs/fspath/path.go
+++ b/fs/fspath/path.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	configNameRe = `[\w. -]+`
+	configNameRe = `[\w.-]+(?: +[\w.-]+)*`
 )
 
 var (

--- a/fs/fspath/path_test.go
+++ b/fs/fspath/path_test.go
@@ -38,9 +38,9 @@ func TestCheckConfigName(t *testing.T) {
 		{"..", nil},
 		{".r.e.m.o.t.e.", nil},
 		{"rem ote", nil},
-		{"remote ", nil},
-		{" remote", nil},
-		{" remote ", nil},
+		{"remote ", errInvalidCharacters},
+		{" remote", errInvalidCharacters},
+		{" remote ", errInvalidCharacters},
 	} {
 		got := CheckConfigName(test.in)
 		assert.Equal(t, test.want, got, test.in)
@@ -60,9 +60,9 @@ func TestCheckRemoteName(t *testing.T) {
 		{".r.e.m.o.t.e.:", nil},
 		{"-r-emote-:", nil},
 		{"rem ote:", nil},
-		{"remote :", nil},
-		{" remote:", nil},
-		{" remote :", nil},
+		{"remote :", errInvalidCharacters},
+		{" remote:", errInvalidCharacters},
+		{" remote :", errInvalidCharacters},
 		{"", errInvalidCharacters},
 		{"rem:ote", errInvalidCharacters},
 		{"rem:ote:", errInvalidCharacters},
@@ -226,26 +226,14 @@ func TestParse(t *testing.T) {
 				Path:         "/path/to/file",
 			},
 		}, {
-			in: "remote :/path/to/file",
-			wantParsed: Parsed{
-				ConfigString: "remote ",
-				Name:         "remote ",
-				Path:         "/path/to/file",
-			},
+			in:      "remote :/path/to/file",
+			wantErr: errInvalidCharacters,
 		}, {
-			in: " remote:/path/to/file",
-			wantParsed: Parsed{
-				ConfigString: " remote",
-				Name:         " remote",
-				Path:         "/path/to/file",
-			},
+			in:      " remote:/path/to/file",
+			wantErr: errInvalidCharacters,
 		}, {
-			in: " remote :/path/to/file",
-			wantParsed: Parsed{
-				ConfigString: " remote ",
-				Name:         " remote ",
-				Path:         "/path/to/file",
-			},
+			in:      " remote :/path/to/file",
+			wantErr: errInvalidCharacters,
 		}, {
 			in:      "rem#ote:/path/to/file",
 			wantErr: errInvalidCharacters,
@@ -482,9 +470,9 @@ func TestSplitFs(t *testing.T) {
 		{"rem.ote:potato/sausage", "rem.ote:", "potato/sausage", nil},
 
 		{"rem ote:", "rem ote:", "", nil},
-		{"remote :", "remote :", "", nil},
-		{" remote:", " remote:", "", nil},
-		{" remote :", " remote :", "", nil},
+		{"remote :", "", "", errInvalidCharacters},
+		{" remote:", "", "", errInvalidCharacters},
+		{" remote :", "", "", errInvalidCharacters},
 
 		{".:", ".:", "", nil},
 		{"..:", "..:", "", nil},
@@ -539,9 +527,9 @@ func TestSplit(t *testing.T) {
 		{"rem.ote:potato/sausage", "rem.ote:potato/", "sausage", nil},
 
 		{"rem ote:", "rem ote:", "", nil},
-		{"remote :", "remote :", "", nil},
-		{" remote:", " remote:", "", nil},
-		{" remote :", " remote :", "", nil},
+		{"remote :", "", "", errInvalidCharacters},
+		{" remote:", "", "", errInvalidCharacters},
+		{" remote :", "", "", errInvalidCharacters},
 
 		{".:", ".:", "", nil},
 		{"..:", "..:", "", nil},

--- a/fs/fspath/path_test.go
+++ b/fs/fspath/path_test.go
@@ -23,6 +23,7 @@ func TestCheckConfigName(t *testing.T) {
 		want error
 	}{
 		{"remote", nil},
+		{"REMOTE", nil},
 		{"", errInvalidCharacters},
 		{":remote:", errInvalidCharacters},
 		{"remote:", errInvalidCharacters},
@@ -38,6 +39,8 @@ func TestCheckConfigName(t *testing.T) {
 		{"..", nil},
 		{".r.e.m.o.t.e.", nil},
 		{"rem ote", nil},
+		{"blåbær", nil},
+		{"chữ Quốc ngữ", nil},
 		{"remote ", errInvalidCharacters},
 		{" remote", errInvalidCharacters},
 		{" remote ", errInvalidCharacters},
@@ -53,6 +56,7 @@ func TestCheckRemoteName(t *testing.T) {
 		want error
 	}{
 		{":remote:", nil},
+		{":REMOTE:", nil},
 		{":s3:", nil},
 		{"remote:", nil},
 		{".:", nil},
@@ -60,6 +64,8 @@ func TestCheckRemoteName(t *testing.T) {
 		{".r.e.m.o.t.e.:", nil},
 		{"-r-emote-:", nil},
 		{"rem ote:", nil},
+		{"blåbær:", nil},
+		{"chữ Quốc ngữ:", nil},
 		{"remote :", errInvalidCharacters},
 		{" remote:", errInvalidCharacters},
 		{" remote :", errInvalidCharacters},

--- a/fs/fspath/path_test.go
+++ b/fs/fspath/path_test.go
@@ -58,6 +58,7 @@ func TestCheckRemoteName(t *testing.T) {
 		{".:", nil},
 		{"..:", nil},
 		{".r.e.m.o.t.e.:", nil},
+		{"-r-emote-:", nil},
 		{"rem ote:", nil},
 		{"remote :", nil},
 		{" remote:", nil},

--- a/fs/fspath/path_test.go
+++ b/fs/fspath/path_test.go
@@ -37,6 +37,10 @@ func TestCheckConfigName(t *testing.T) {
 		{".", nil},
 		{"..", nil},
 		{".r.e.m.o.t.e.", nil},
+		{"rem ote", nil},
+		{"remote ", nil},
+		{" remote", nil},
+		{" remote ", nil},
 	} {
 		got := CheckConfigName(test.in)
 		assert.Equal(t, test.want, got, test.in)
@@ -54,6 +58,10 @@ func TestCheckRemoteName(t *testing.T) {
 		{".:", nil},
 		{"..:", nil},
 		{".r.e.m.o.t.e.:", nil},
+		{"rem ote:", nil},
+		{"remote :", nil},
+		{" remote:", nil},
+		{" remote :", nil},
 		{"", errInvalidCharacters},
 		{"rem:ote", errInvalidCharacters},
 		{"rem:ote:", errInvalidCharacters},
@@ -207,6 +215,34 @@ func TestParse(t *testing.T) {
 			wantParsed: Parsed{
 				ConfigString: "rem.ote",
 				Name:         "rem.ote",
+				Path:         "/path/to/file",
+			},
+		}, {
+			in: "rem ote:/path/to/file",
+			wantParsed: Parsed{
+				ConfigString: "rem ote",
+				Name:         "rem ote",
+				Path:         "/path/to/file",
+			},
+		}, {
+			in: "remote :/path/to/file",
+			wantParsed: Parsed{
+				ConfigString: "remote ",
+				Name:         "remote ",
+				Path:         "/path/to/file",
+			},
+		}, {
+			in: " remote:/path/to/file",
+			wantParsed: Parsed{
+				ConfigString: " remote",
+				Name:         " remote",
+				Path:         "/path/to/file",
+			},
+		}, {
+			in: " remote :/path/to/file",
+			wantParsed: Parsed{
+				ConfigString: " remote ",
+				Name:         " remote ",
 				Path:         "/path/to/file",
 			},
 		}, {
@@ -444,6 +480,11 @@ func TestSplitFs(t *testing.T) {
 		{"remote:potato/sausage", "remote:", "potato/sausage", nil},
 		{"rem.ote:potato/sausage", "rem.ote:", "potato/sausage", nil},
 
+		{"rem ote:", "rem ote:", "", nil},
+		{"remote :", "remote :", "", nil},
+		{" remote:", " remote:", "", nil},
+		{" remote :", " remote :", "", nil},
+
 		{".:", ".:", "", nil},
 		{"..:", "..:", "", nil},
 		{".:potato/sausage", ".:", "potato/sausage", nil},
@@ -495,6 +536,11 @@ func TestSplit(t *testing.T) {
 		{"remote:/potato/potato", "remote:/potato/", "potato", nil},
 		{"remote:potato/sausage", "remote:potato/", "sausage", nil},
 		{"rem.ote:potato/sausage", "rem.ote:potato/", "sausage", nil},
+
+		{"rem ote:", "rem ote:", "", nil},
+		{"remote :", "remote :", "", nil},
+		{" remote:", " remote:", "", nil},
+		{" remote :", " remote :", "", nil},
 
 		{".:", ".:", "", nil},
 		{"..:", "..:", "", nil},


### PR DESCRIPTION
#### What is the purpose of this change?

This started as a documentation task; to add a statement that remote names may not *end* with space. This triggered more investigations, to verify that this is really always the case, and then one thing lead to another... First fixed/simplified the remote/config name regex by removing superfluous elements, unnecessary capture groups etc. Then extended it to explicitly match only when no leading/trailing space, so that an error is reported in the same way as when illegal characters are used.

Normally the remote names from config are trimmed (`strings.TrimSpace`) early on, and will never contain leading/trailing space when matched against the changed regex. This is the case when using interactive command line (config ui) and when the remote names are read/parsed from the config file. I.e. there will e no change to these uses. One place I found it will make a difference is rc, as illustrated below - which is using rclone without this PR:

```
rclone rcd --rc-no-auth
rclone rc config/create "name=   space   " type=local parameters="{}"
	{}
rclone rc config/listremotes
	{
		"remotes": [
			"   space   "
		]
	}
rclone rc config/get "name=   space   "
	{
		"type": "local"
	}
rclone listremotes
	space:
rclone lsd space:
	-1 2022-09-16 16:59:13        -1 .git
	-1 2022-01-26 14:50:08        -1 .github
	-1 2022-08-17 07:39:15        -1 backend
	-1 2022-09-14 13:29:43        -1 bin
	-1 2022-08-30 13:16:45        -1 cmd

```

Maybe not a very realistic example? And one could say that rcd(?) instead could also do `strings.TrimSpace` on the remote name. But that was not really my point. My point with this PR was primarily to improve the code and documentation according to the fact that rclone does not/should not/have never (?) supported remote names with trailing (or leading) space.

Note:
- The changes to a single line of regex (more or less) are currently spread across several commits, to carefully document each individual change leading to the end result.

#### Was the change discussed in an issue or in the forum before?

Not really. But the following discussion is what made me look into the handling of space characters in remote names:

https://forum.rclone.org/t/sync-to-onedrive-personal-lands-file-in-localfilesystem-but-not-in-onedrive/32956

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
