### PR TITLE
ftp: Improve performance of findItem

### DIFF
--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -676,7 +676,11 @@ func (f *Fs) findItem(ctx context.Context, remote string) (entry *ftp.Entry, err
 		entry, err := c.GetEntry(f.opt.Enc.FromStandardPath(remote))
 		f.putFtpConnection(&c, err)
 		if err != nil {
-			return nil, translateErrorFile(err)
+			err = translateErrorFile(err)
+			if err == fs.ErrorObjectNotFound {
+				return nil, nil
+			}
+			return nil, err
 		}
 		if entry != nil {
 			f.entryToStandard(entry)

--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -666,13 +666,28 @@ func (f *Fs) findItem(ctx context.Context, remote string) (entry *ftp.Entry, err
 			Time: time.Now(),
 		}, nil
 	}
-	dir := path.Dir(fullPath)
-	base := path.Base(fullPath)
 
 	c, err := f.getFtpConnection(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("findItem: %w", err)
 	}
+
+	// returns TRUE if MLST is supported which is required to call GetEntry
+	if c.IsTimePreciseInList() {
+		entry, err := c.GetEntry(fullPath)
+		f.putFtpConnection(&c, err)
+		if err != nil {
+			return nil, translateErrorFile(err)
+		}
+		if entry != nil {
+			f.entryToStandard(entry)
+		}
+		return entry, nil
+	}
+
+	dir := path.Dir(fullPath)
+	base := path.Base(fullPath)
+
 	files, err := c.List(f.dirFromStandardPath(dir))
 	f.putFtpConnection(&c, err)
 	if err != nil {
@@ -857,32 +872,18 @@ func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, opt
 // getInfo reads the FileInfo for a path
 func (f *Fs) getInfo(ctx context.Context, remote string) (fi *FileInfo, err error) {
 	// defer fs.Trace(remote, "")("fi=%v, err=%v", &fi, &err)
-	dir := path.Dir(remote)
-	base := path.Base(remote)
-
-	c, err := f.getFtpConnection(ctx)
+	file, err := f.findItem(ctx, remote)
 	if err != nil {
-		return nil, fmt.Errorf("getInfo: %w", err)
-	}
-	files, err := c.List(f.dirFromStandardPath(dir))
-	f.putFtpConnection(&c, err)
-	if err != nil {
-		return nil, translateErrorFile(err)
-	}
-
-	for i := range files {
-		file := files[i]
-		f.entryToStandard(file)
-		if file.Name == base {
-			info := &FileInfo{
-				Name:    remote,
-				Size:    file.Size,
-				ModTime: file.Time,
-				precise: f.fLstTime,
-				IsDir:   file.Type == ftp.EntryTypeFolder,
-			}
-			return info, nil
+		return nil, err
+	} else if file != nil {
+		info := &FileInfo{
+			Name:    remote,
+			Size:    file.Size,
+			ModTime: file.Time,
+			precise: f.fLstTime,
+			IsDir:   file.Type == ftp.EntryTypeFolder,
 		}
+		return info, nil
 	}
 	return nil, fs.ErrorObjectNotFound
 }

--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -673,7 +673,7 @@ func (f *Fs) findItem(ctx context.Context, remote string) (entry *ftp.Entry, err
 
 	// returns TRUE if MLST is supported which is required to call GetEntry
 	if c.IsTimePreciseInList() {
-		entry, err := c.GetEntry(remote)
+		entry, err := c.GetEntry(f.opt.Enc.FromStandardPath(remote))
 		f.putFtpConnection(&c, err)
 		if err != nil {
 			return nil, translateErrorFile(err)


### PR DESCRIPTION
#### What is the purpose of this change?

Use a more efficient way to lookup a single FTP item when supported by the remote server.

#### Was the change discussed in an issue or in the forum before?

Here: https://forum.rclone.org/t/ftp-does-not-play-well-with-files-from/31158

And https://github.com/rclone/rclone/issues/6225

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
