### PR TITLE
vfs: fix directory cache serving stale data

### DIFF
--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -760,6 +760,7 @@ func (d *Dir) _readDirFromEntries(entries fs.DirEntries, dirTree dirtree.DirTree
 			dir := node.(*Dir)
 			dir.mu.Lock()
 			dir.modTime = item.ModTime(context.TODO())
+			dir.entry = item
 			if dirTree != nil {
 				err = dir._readDirFromDirTree(dirTree, when)
 				if err != nil {


### PR DESCRIPTION
The VFS directory cache layer didn't update directory properties like the last modified time at all, as the new objects were not used. The same problem is already solved for files, implement the same solution for directories.

Fixes #6335

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
