### PR TITLE
cmd: fix typos found by codespell

### DIFF
--- a/cmd/bisync/testdata/test_check_access_filters/scenario.txt
+++ b/cmd/bisync/testdata/test_check_access_filters/scenario.txt
@@ -3,8 +3,8 @@ test check-access-filters
 # NOTE: Include Other tests may result in listing diffs due to rclone processing order change. False fail.
 #
 # Tests are done in two phases:
-#  - EXCLUDE OTHER tests check that RCLONE_TEST files are only found in the explicity included directories
-#  - INCLUDE OTHER tesss check that RCLONE_TEST files are found in all directories not explicity excluded
+#  - EXCLUDE OTHER tests check that RCLONE_TEST files are only found in the explicitly included directories
+#  - INCLUDE OTHER tesss check that RCLONE_TEST files are found in all directories not explicitly excluded
 #
 # Each phase checks that:
 #  - missing RCLONE_TEST files in don't care directories don't cause failures

--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -142,7 +142,7 @@ match.  It doesn't alter the source or destination.
 
 For the [crypt](/crypt/) remote there is a dedicated command,
 [cryptcheck](/commands/rclone_cryptcheck/), that are able to check
-the checksums of the crypted files.
+the checksums of the encrypted files.
 
 If you supply the |--size-only| flag, it will only compare the sizes not
 the hashes as well.  Use this for a quick check.

--- a/cmd/cryptcheck/cryptcheck.go
+++ b/cmd/cryptcheck/cryptcheck.go
@@ -22,11 +22,11 @@ func init() {
 
 var commandDefinition = &cobra.Command{
 	Use:   "cryptcheck remote:path cryptedremote:path",
-	Short: `Cryptcheck checks the integrity of a crypted remote.`,
+	Short: `Cryptcheck checks the integrity of an encrypted remote.`,
 	Long: `
 rclone cryptcheck checks a remote against a [crypted](/crypt/) remote.
 This is the equivalent of running rclone [check](/commands/rclone_check/),
-but able to check the checksums of the crypted remote.
+but able to check the checksums of the encrypted remote.
 
 For it to work the underlying remote of the cryptedremote must support
 some kind of checksum.
@@ -56,7 +56,7 @@ After it has run it will log the status of the encryptedremote:.
 	},
 }
 
-// cryptCheck checks the integrity of a crypted remote
+// cryptCheck checks the integrity of an encrypted remote
 func cryptCheck(ctx context.Context, fdst, fsrc fs.Fs) error {
 	// Check to see fcrypt is a crypt
 	fcrypt, ok := fdst.(*crypt.Fs)

--- a/cmd/serve/sftp/sftp.go
+++ b/cmd/serve/sftp/sftp.go
@@ -108,7 +108,7 @@ which can lead to "corrupted on transfer" errors. This is the case because
 the client chooses indiscriminately which server to send commands to while
 the servers all have different views of the state of the filing system.
 
-The "restrict" in authorized_keys prevents SHA1SUMs and MD5SUMs from beeing
+The "restrict" in authorized_keys prevents SHA1SUMs and MD5SUMs from being
 used. Omitting "restrict" and using  ` + "`--sftp-path-override`" + ` to enable
 checksumming is possible but less secure and you could use the SFTP server
 provided by OpenSSH in this case.

--- a/cmd/test/test.go
+++ b/cmd/test/test.go
@@ -16,7 +16,7 @@ var Command = &cobra.Command{
 	Short: `Run a test command`,
 	Long: `Rclone test is used to run test commands.
 
-Select which test comand you want with the subcommand, eg
+Select which test command you want with the subcommand, eg
 
     rclone test memory remote:
 

--- a/cmd/touch/touch.go
+++ b/cmd/touch/touch.go
@@ -138,7 +138,7 @@ func Touch(ctx context.Context, f fs.Fs, remote string) error {
 	file, err := f.NewObject(ctx, remote)
 	if err != nil {
 		if errors.Is(err, fs.ErrorObjectNotFound) {
-			// Touching non-existant path, possibly creating it as new file
+			// Touching non-existent path, possibly creating it as new file
 			if remote == "" {
 				fs.Logf(f, "Not touching empty directory")
 				return nil


### PR DESCRIPTION
#### What is the purpose of this change?

Fix typos found by [codespell](https://github.com/codespell-project/codespell).

I have left out two suggestions:
* `synching` → `syncing` (too intrusive so I feel it would need a merge request of its own)
* a few occurrences of `crypted` → `encrypted` (they would have changed the command)

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
