### PR TITLE
azureblob: allow emulator account/key override

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -595,7 +595,15 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	)
 	switch {
 	case opt.UseEmulator:
-		credential, err := azblob.NewSharedKeyCredential(emulatorAccount, emulatorAccountKey)
+		var actualEmulatorAccount = emulatorAccount
+		if opt.Account != "" {
+			actualEmulatorAccount = opt.Account
+		}
+		var actualEmulatorKey = emulatorAccountKey
+		if opt.Key != "" {
+			actualEmulatorKey = opt.Key
+		}
+		credential, err := azblob.NewSharedKeyCredential(actualEmulatorAccount, actualEmulatorKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse credentials: %w", err)
 		}

--- a/docs/content/azureblob.md
+++ b/docs/content/azureblob.md
@@ -530,6 +530,6 @@ See [List of backends that do not support rclone about](https://rclone.org/overv
 
 You can run rclone with storage emulator (usually _azurite_).
 
-To do this, just set up a new remote with `rclone config` following instructions described in introduction and set `use_emulator` config as `true`. You do not need to provide default account name neither an account key. But you can override them in the _account_ and _key_ options. (Prior to v1.60 they were hard coded to _azurite_'s `devstoreaccount1`.)
+To do this, just set up a new remote with `rclone config` following instructions described in introduction and set `use_emulator` config as `true`. You do not need to provide default account name neither an account key. But you can override them in the _account_ and _key_ options. (Prior to v1.61 they were hard coded to _azurite_'s `devstoreaccount1`.)
 
 Also, if you want to access a storage emulator instance running on a different machine, you can override _Endpoint_ parameter in advanced settings, setting it to `http(s)://<host>:<port>/devstoreaccount1` (e.g. `http://10.254.2.5:10000/devstoreaccount1`).

--- a/docs/content/azureblob.md
+++ b/docs/content/azureblob.md
@@ -164,7 +164,7 @@ Here are the Standard options specific to azureblob (Microsoft Azure Blob Storag
 
 Storage Account Name.
 
-Leave blank to use SAS URL or Emulator.
+Leave blank to use SAS URL.
 
 Properties:
 
@@ -198,7 +198,7 @@ Properties:
 
 Storage Account Key.
 
-Leave blank to use SAS URL or Emulator.
+Leave blank to use SAS URL.
 
 Properties:
 
@@ -245,6 +245,8 @@ Properties:
 Uses local storage emulator if provided as 'true'.
 
 Leave blank if using real azure storage endpoint.
+
+Provide `account`, `key`, and `endpoint` if desired to override their _azurite_ defaults.
 
 Properties:
 
@@ -528,6 +530,6 @@ See [List of backends that do not support rclone about](https://rclone.org/overv
 
 You can run rclone with storage emulator (usually _azurite_).
 
-To do this, just set up a new remote with `rclone config` following instructions described in introduction and set `use_emulator` config as `true`. You do not need to provide default account name neither an account key.
+To do this, just set up a new remote with `rclone config` following instructions described in introduction and set `use_emulator` config as `true`. You do not need to provide default account name neither an account key. But you can override them in the _account_ and _key_ options. (Prior to v1.60 they were hard coded to _azurite_'s `devstoreaccount1`.)
 
 Also, if you want to access a storage emulator instance running on a different machine, you can override _Endpoint_ parameter in advanced settings, setting it to `http(s)://<host>:<port>/devstoreaccount1` (e.g. `http://10.254.2.5:10000/devstoreaccount1`).


### PR DESCRIPTION
#### What is the purpose of this change?

In #3285 support for `azureblob` was added. In #6290 the option was added to override the endpoint. This adds the option to override the account name and key also.

Note: this could be regarded backwards incompatible. E.g. for people who keep their production credentials in the config but only switch `use_emulator` on and off. In which case an attempt would be made to authorize with the emulator with wrong credentials.

#### Was the change discussed in an issue or in the forum before?

I couldn't find any mentions of it.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
