### PR TITLE
rc: add FsRoot to mount/listmounts output

### DIFF
--- a/cmd/mountlib/rc.go
+++ b/cmd/mountlib/rc.go
@@ -241,6 +241,7 @@ Eg
 // MountInfo is a transitional structure for json marshaling
 type MountInfo struct {
 	Fs         string    `json:"Fs"`
+	FsRoot     string    `json:"FsRoot"`
 	MountPoint string    `json:"MountPoint"`
 	MountedOn  time.Time `json:"MountedOn"`
 }
@@ -259,6 +260,7 @@ func listMountsRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
 		m := liveMounts[k]
 		info := MountInfo{
 			Fs:         m.Fs.Name(),
+			FsRoot:     m.Fs.Root(),
 			MountPoint: m.MountPoint,
 			MountedOn:  m.MountedOn,
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

`mount/listmounts` currently only returns `Fs` which is just the name of the remote:

```bash
rclone rc mount/mount fs=remote0:photos mountPoint=/home/username/mounts/remote0
```

```json
{
    "Fs": "remote0",
    "MountPoint": "/home/username/mounts/remote0",
    "MountedOn": "2022-10-16T00:46:33.351736924"
}
```

This PR adds `FsRoot` which will allow consumers to recreate the `Fs` entered in the `mount/mount` call:
    
```json
{
    "Fs": "remote0",
    "FsRoot": "photos",
    "MountPoint": "/home/username/mounts/remote0",
    "MountedOn": "2022-10-16T00:46:33.351736924"
}
```
This was done to prevent potential breaking changes but if you want me to make another PR so that `Fs` returns the full path, just let me know.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
negative

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
