### PR TITLE
rc: Fix mount/listmounts not returning the full Fs entered in mount/mount

### DIFF
--- a/cmd/mountlib/rc.go
+++ b/cmd/mountlib/rc.go
@@ -258,7 +258,7 @@ func listMountsRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
 	for _, k := range keys {
 		m := liveMounts[k]
 		info := MountInfo{
-			Fs:         m.Fs.Name(),
+			Fs:         fs.ConfigString(m.Fs),
 			MountPoint: m.MountPoint,
 			MountedOn:  m.MountedOn,
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

`mount/listmounts` currently only returns the remote name in `Fs`:

```bash
rclone rc mount/mount fs=remote0:photos mountPoint=/home/username/mounts/remote0
```

```json
{
    "Fs": "remote0",
    "MountPoint": "/home/username/mounts/remote0",
    "MountedOn": "2022-10-16T00:46:33.351736924"
}
```
expected behaviour 
    
```json
{
    "Fs": "remote0:photos",
    "MountPoint": "/home/username/mounts/remote0",
    "MountedOn": "2022-10-16T00:46:33.351736924"
}
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
https://github.com/rclone/rclone/pull/6499

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
