### PR TITLE
install.sh: fix arm-v7 download

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -106,6 +106,9 @@ case "$OS_type" in
   aarch64|arm64)
     OS_type='arm64'
     ;;
+  armv7*)
+    OS_type='arm-v7'
+    ;;
   arm*)
     OS_type='arm'
     ;;


### PR DESCRIPTION
#### What is the purpose of this change?

To download the correct executable om armv7 (E.g. RPi 2 Model B)

#### Was the change discussed in an issue or in the forum before?

The observation:
https://forum.rclone.org/t/out-of-memory-after-moving-to-rpi-8gb-and-ssd/33521/8

This initially proposed solution:
https://forum.rclone.org/t/out-of-memory-after-moving-to-rpi-8gb-and-ssd/33521/19

The decision to match everything starting with armv7
https://forum.rclone.org/t/out-of-memory-after-moving-to-rpi-8gb-and-ssd/33521/27

#### Tests

The modification was tested on Ubuntu with different hardcoded settings of OS_type.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
