### PR TITLE
docs: Describe connection strings in alias backend

### DIFF
--- a/docs/content/alias.md
+++ b/docs/content/alias.md
@@ -23,6 +23,11 @@ Invoking `rclone mkdir backup:../desktop` is exactly the same as invoking
 The empty path is not allowed as a remote. To alias the current directory
 use `.` instead.
 
+The target remote can also be a [connection string](/docs/#connection-strings). 
+This can be used to modify the config of a remote for different uses, e.g.
+the alias  `myDriveTrash` with the target remote `myDrive,trashed_only:` 
+can be used to only show the trashed files in `myDrive`.
+
 ## Configuration
 
 Here is an example of how to make an alias called `remote` for local folder.


### PR DESCRIPTION
#### What is the purpose of this change?

To make users aware of the possibility of using connection strings in the alias backend.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/crypt-alias-with-different-password-password2/33506/14

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
