### PR TITLE
Clean absolute paths in local backend

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1400,29 +1400,26 @@ func (o *Object) writeMetadata(metadata fs.Metadata) (err error) {
 }
 
 func cleanRootPath(s string, noUNC bool, enc encoder.MultiEncoder) string {
-	if runtime.GOOS == "windows" {
-		if !filepath.IsAbs(s) && !strings.HasPrefix(s, "\\") {
+	if runtime.GOOS != "windows" || !strings.HasPrefix(s, "\\") {
+		if !filepath.IsAbs(s) {
 			s2, err := filepath.Abs(s)
 			if err == nil {
 				s = s2
 			}
+		} else {
+			s = filepath.Clean(s)
 		}
+	}
+	if runtime.GOOS == "windows" {
 		s = filepath.ToSlash(s)
 		vol := filepath.VolumeName(s)
 		s = vol + enc.FromStandardPath(s[len(vol):])
 		s = filepath.FromSlash(s)
-
 		if !noUNC {
 			// Convert to UNC
 			s = file.UNCPath(s)
 		}
 		return s
-	}
-	if !filepath.IsAbs(s) {
-		s2, err := filepath.Abs(s)
-		if err == nil {
-			s = s2
-		}
 	}
 	s = enc.FromStandardPath(s)
 	return s


### PR DESCRIPTION
#### What is the purpose of this change?

In existing version, relative paths are made absolute with `filepath.Abs`, which implicitely performs a `filepath.Clean` which eliminates path elements such as `..`. But paths that are already absolute are not cleaned, which means a path element `..` will be kept and encoded according to backend encoding.

This PR adds a call to `filepath.Clean` for absolute paths, making it more consistent.

Windows paths with prefix `\\` are excluded from this, they were already excluded from `filepath.Abs` in existing version, as UNC paths cannot be relative (this is documented) nor contain "relative" path elements (undocumented, but at least the `dir` command such as `dir \\?\C:\Some\Path\..\OtherPath` errors with "The filename, directory name, or volume label syntax is incorrect", and also, in any case, this means using `\\?` prefix can be used as workaround in case the Clean/Abs leads to problems).

#### Was the change discussed in an issue or in the forum before?

Fixes #6493

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
