### PR TITLE
Docs: add info about # of parallel checks for rclone check/cryptcheck

### DIFF
--- a/docs/content/commands/rclone_check.md
+++ b/docs/content/commands/rclone_check.md
@@ -52,6 +52,8 @@ you what happened to it. These are reminiscent of diff files.
 - `* path` means path was present in source and destination but different.
 - `! path` means there was an error reading or hashing the source or dest.
 
+The default number of parallel checks is N=8. See the [--checkers=N](/docs/#checkers-n) option
+for more information.
 
 ```
 rclone check source:path dest:path [flags]

--- a/docs/content/commands/rclone_cryptcheck.md
+++ b/docs/content/commands/rclone_cryptcheck.md
@@ -56,6 +56,8 @@ you what happened to it. These are reminiscent of diff files.
 - `* path` means path was present in source and destination but different.
 - `! path` means there was an error reading or hashing the source or dest.
 
+The default number of parallel checks is N=8. See the [--checkers=N](/docs/#checkers-n) option
+for more information.
 
 ```
 rclone cryptcheck remote:path cryptedremote:path [flags]


### PR DESCRIPTION
#### What is the purpose of this change?

-Mention default number of parallel checks when running rclone check/cryptcheck.
-Link documentation of option `--checkers` for detailed information.

#### Was the change discussed in an issue or in the forum before?

Dont know

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
