### PR TITLE
Ncdu improvements

### DIFF
--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -692,13 +692,17 @@ func (ds *ncduSort) Less(i, j int) bool {
 			return iAvgSize < jAvgSize
 		}
 		// if avgSize is equal, sort by size
-		return iattrs.Size < jattrs.Size
+		if iattrs.Size != jattrs.Size {
+			return iattrs.Size < jattrs.Size
+		}
 	case ds.u.sortByAverageSize > 0:
 		if iAvgSize != jAvgSize {
 			return iAvgSize > jAvgSize
 		}
 		// if avgSize is equal, sort by size
-		return iattrs.Size > jattrs.Size
+		if iattrs.Size != jattrs.Size {
+			return iattrs.Size > jattrs.Size
+		}
 	}
 	// if everything equal, sort by name
 	return iname < jname


### PR DESCRIPTION
#### What is the purpose of this change?

Some smaller improvements to ncdu. The biggest being added support for showing modification times.

Modification times can now be togled with `m` and sorted with `M`, like the [original ncdu](https://dev.yorhel.nl/ncdu) tool. Time format is the same as when testing ncdu 1.17 (on Fedora and Alpine): "2006-01-02 15:04:05 -0700". One downside of this format is that it contains spaces, while other fields like count and size in the output are separated by space.

Example output, with everything (size, count, average and modified time) shown:

```
     153        1       153 2021-04-15 18:11:40 +0200 [          ] /i18n
21.252Ki       23       946 2021-04-15 18:11:40 +0200 [          ] /layouts
 3.019Mi       28 110.402Ki 2021-04-15 18:11:40 +0200 [##########] /static
     757                    2021-08-31 09:56:44 +0200 [          ]  config.json
 3.677Ki                    2022-08-15 07:36:44 +0200 [          ]  README.md
 1.657Mi      158  10.737Ki 2022-11-04 11:30:06 +0100 [#####     ] /content   
```
        
(Originally also adjusted how empty directories are displayed, making them shown with count and average size as value 0 instead of blank, so that blank in these columns are only for files, but discovered that the original ncdu version tested above shows them like rclone ncdu did before, so dropped these changes for consistency - assuming this ncdu version is representative).

#### Was the change discussed in an issue or in the forum before?

Fixes #6537

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
