### PR TITLE
[doc] Fix character that was incorrectly interpreted as markdown

### DIFF
--- a/docs/content/local.md
+++ b/docs/content/local.md
@@ -428,8 +428,8 @@ Properties:
 Don't check to see if the files change during upload.
 
 Normally rclone checks the size and modification time of files as they
-are being uploaded and aborts with a message which starts "can't copy
-- source file is being updated" if the file changes during upload.
+are being uploaded and aborts with a message which starts "can't copy - 
+source file is being updated" if the file changes during upload.
 
 However on some file systems this modification time check may fail (e.g.
 [Glusterfs #2206](https://github.com/rclone/rclone/issues/2206)) so this


### PR DESCRIPTION

#### What is the purpose of this change?
Before, the documentation for this option looked like this:
![image](https://user-images.githubusercontent.com/550823/200206013-7236ad41-e4d5-4328-b871-65fe8435a461.png)

The bullet point was not intended.

This fixes it.
Preview on github:
![image](https://user-images.githubusercontent.com/550823/200206073-29d177f4-3b14-4158-9987-d2c587923039.png)


#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
