### PR TITLE
swift: Retry segment deletion manually if bulk deletion fails

### DIFF
--- a/backend/swift/swift.go
+++ b/backend/swift/swift.go
@@ -1318,14 +1318,23 @@ func (o *Object) removeSegmentsLargeObject(ctx context.Context, containerSegment
 	if containerSegments == nil || len(containerSegments) <= 0 {
 		return nil
 	}
+	var err error = nil
 	for container, segments := range containerSegments {
-		_, err := o.fs.c.BulkDelete(ctx, container, segments)
-		if err != nil {
-			fs.Debugf(o, "Failed to delete bulk segments %v", err)
-			return err
+		_, e := o.fs.c.BulkDelete(ctx, container, segments)
+		if e != nil {
+			fs.Debugf(o, "Failed to delete bulk segments: %v", e)
+			for _, segment := range segments {
+				e := o.fs.c.ObjectDelete(ctx, container, segment)
+				if e != nil {
+					fs.Debugf(o, "Failed to delete manual segment: %s, %s, %v", container, segment, e)
+					if err == nil {
+						err = e
+					}
+				}
+			}
 		}
 	}
-	return nil
+	return err
 }
 
 func (o *Object) getSegmentsDlo(ctx context.Context) (segmentsContainer string, prefix string, err error) {


### PR DESCRIPTION
Bulk deletion could be unavailable (no bulk middleware in swift pipeline).

Fixes: #6549

#### What is the purpose of this change?

Fix segment deletion if bulk middleware is unavailable.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
