### PR TITLE
Added cache cleaner for directories

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ issues:
   exclude-rules:
 
     - linters:
-      - staticcheck
+        - staticcheck
       text: 'SA1019: "github.com/rclone/rclone/cmd/serve/httplib" is deprecated'
 
 run:
@@ -54,3 +54,6 @@ linters-settings:
     # Only enable the checks performed by the staticcheck stand-alone tool,
     # as documented here: https://staticcheck.io/docs/configuration/options/#checks
     checks: ["all", "-ST1000", "-ST1003", "-ST1016", "-ST1020", "-ST1021", "-ST1022", "-ST1023"]
+  govet:
+    enable:
+      - atomicalign

--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -22,21 +22,19 @@ import (
 
 // Dir represents a directory entry
 type Dir struct {
-	vfs   *VFS   // read only
-	inode uint64 // read only: inode number
-	f     fs.Fs  // read only
-
-	mu      sync.RWMutex // protects the following
-	parent  *Dir         // parent, nil for root
-	path    string
-	entry   fs.Directory
-	read    time.Time         // time directory entry last read
-	items   map[string]Node   // directory entries - can be empty but not nil
-	virtual map[string]vState // virtual directory entries - may be nil
-	sys     atomic.Value      // user defined info to be attached here
-
-	modTimeMu sync.Mutex // protects the following
 	modTime   time.Time
+	read      time.Time // time directory entry last read
+	entry     fs.Directory
+	f         fs.Fs             // read only
+	sys       atomic.Value      // user defined info to be attached here
+	virtual   map[string]vState // virtual directory entries - may be nil
+	parent    *Dir              // parent, nil for root
+	items     map[string]Node   // directory entries - can be empty but not nil
+	vfs       *VFS              // read only
+	path      string
+	inode     uint64       // inode number: read only
+	mu        sync.RWMutex // protects the directory attributes
+	modTimeMu sync.Mutex   // protects the modTime
 }
 
 //go:generate stringer -type=vState

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -36,21 +36,19 @@ import (
 
 // File represents a file
 type File struct {
-	inode uint64 // inode number - read only
-	size  int64  // size of file - read and written with atomic int64 - must be 64 bit aligned
-
-	muRW sync.Mutex // synchronize RWFileHandle.openPending(), RWFileHandle.close() and File.Remove
-
-	mu               sync.RWMutex                    // protects the following
-	d                *Dir                            // parent directory
-	dPath            string                          // path of parent directory. NB dir rename means all Files are flushed
-	o                fs.Object                       // NB o may be nil if file is being written
-	leaf             string                          // leaf name of the object
-	writers          []Handle                        // writers for this file
-	virtualModTime   *time.Time                      // modtime for backends with Precision == fs.ModTimeNotSupported
 	pendingModTime   time.Time                       // will be applied once o becomes available, i.e. after file was written
-	pendingRenameFun func(ctx context.Context) error // will be run/renamed after all writers close
+	o                fs.Object                       // NB o may be nil if file is being written
 	sys              atomic.Value                    // user defined info to be attached here
+	d                *Dir                            // parent directory
+	pendingRenameFun func(ctx context.Context) error // will be run/renamed after all writers close
+	virtualModTime   *time.Time                      // modtime for backends with Precision == fs.ModTimeNotSupported
+	leaf             string                          // leaf name of the object
+	dPath            string                          // path of parent directory. NB dir rename means all Files are flushed
+	writers          []Handle                        // writers for this file
+	inode            uint64                          // inode number - read only
+	size             int64                           // size of file - read and written with atomic int64 - must be 64 bit aligned
+	mu               sync.RWMutex                    // protects the file attributes
+	muRW             sync.Mutex                      // synchronize RWFileHandle.openPending(), RWFileHandle.close() and File.Remove
 	nwriters         int32                           // len(writers) which is read/updated with atomic
 	appendMode       bool                            // file was opened with O_APPEND
 }

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -36,17 +36,17 @@ import (
 
 // File represents a file
 type File struct {
+	inode            uint64                          // inode number - read only
+	size             int64                           // size of file - read and written with atomic int64 - must be 64 bit aligned
 	pendingModTime   time.Time                       // will be applied once o becomes available, i.e. after file was written
 	o                fs.Object                       // NB o may be nil if file is being written
 	sys              atomic.Value                    // user defined info to be attached here
-	d                *Dir                            // parent directory
 	pendingRenameFun func(ctx context.Context) error // will be run/renamed after all writers close
-	virtualModTime   *time.Time                      // modtime for backends with Precision == fs.ModTimeNotSupported
+	d                *Dir                            // parent directory
+	virtualModTime   *time.Time                      // mod time for backends with Precision == fs.ModTimeNotSupported
 	leaf             string                          // leaf name of the object
 	dPath            string                          // path of parent directory. NB dir rename means all Files are flushed
 	writers          []Handle                        // writers for this file
-	inode            uint64                          // inode number - read only
-	size             int64                           // size of file - read and written with atomic int64 - must be 64 bit aligned
 	mu               sync.RWMutex                    // protects the file attributes
 	muRW             sync.Mutex                      // synchronize RWFileHandle.openPending(), RWFileHandle.close() and File.Remove
 	nwriters         int32                           // len(writers) which is read/updated with atomic


### PR DESCRIPTION
Signed-off-by: Anagh Kumar Baranwal <6824881+darthShadow@users.noreply.github.com>

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Added a cache cleaner for the VFS directories that runs in a goroutine and exectues after `2 * DirCacheTime`.

#### Was the change discussed in an issue or in the forum before?

N/A

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
