### PR TITLE
azureblob: support service principals using the EnvironmentCredential scheme

### DIFF
--- a/backend/azureblob/azureblob_test.go
+++ b/backend/azureblob/azureblob_test.go
@@ -7,6 +7,7 @@ package azureblob
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/rclone/rclone/fs"
@@ -42,7 +43,11 @@ func TestServicePrincipalFileSuccess(t *testing.T) {
     "tenant": "my active directory tenant ID"
 }
 `
-	tokenRefresher, err := newServicePrincipalTokenRefresher(ctx, []byte(credentials))
+	var spCredentials servicePrincipalCredentials
+	jerr := json.Unmarshal([]byte(credentials), &spCredentials)
+	assert.Nil(t, jerr)
+
+	tokenRefresher, err := newServicePrincipalTokenRefresher(ctx, spCredentials)
 	if assert.NoError(t, err) {
 		assert.NotNil(t, tokenRefresher)
 	}
@@ -57,7 +62,11 @@ func TestServicePrincipalFileFailure(t *testing.T) {
     "tenant": "my active directory tenant ID"
 }
 `
-	_, err := newServicePrincipalTokenRefresher(ctx, []byte(credentials))
+	var spCredentials servicePrincipalCredentials
+	jerr := json.Unmarshal([]byte(credentials), &spCredentials)
+	assert.Nil(t, jerr)
+
+	_, err := newServicePrincipalTokenRefresher(ctx, spCredentials)
 	assert.Error(t, err)
 	assert.EqualError(t, err, "error creating service principal token: parameter 'secret' cannot be empty")
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Add support for inferring the Azure Service Principal identity and secret from environment variables as per [EnvironmentCredential](https://learn.microsoft.com/en-us/dotnet/api/azure.identity.environmentcredential?view=azure-dotnet).   I find myself using `rclone` in a context where `EnvironmentCredential`s are already available for other reasons and it seems silly to go write a JSON file just to use the values therein.

Are there additional tests you'd like to see for this feature?

#### Was the change discussed in an issue or in the forum before?

No, sorry.

#### Checklist

I believe the ticked boxes are correct, but please be gentle if I've missed something.

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
