### PR TITLE
SMB: Fix issue where spurious dot directory is created

### DIFF
--- a/backend/smb/smb.go
+++ b/backend/smb/smb.go
@@ -478,11 +478,15 @@ func (f *Fs) makeEntryRelative(share, _path, relative string, stat os.FileInfo) 
 }
 
 func (f *Fs) ensureDirectory(ctx context.Context, share, _path string) error {
+	dir := path.Dir(_path)
+	if dir == "." {
+		return nil
+	}
 	cn, err := f.getConnection(ctx, share)
 	if err != nil {
 		return err
 	}
-	err = cn.smbShare.MkdirAll(f.toSambaPath(path.Dir(_path)), 0o755)
+	err = cn.smbShare.MkdirAll(f.toSambaPath(dir), 0o755)
 	f.putConnection(&cn)
 	return err
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Given existing code line in the ensureDirectory function:

```
cn.smbShare.MkdirAll(f.toSambaPath(path.Dir(_path)), 0o755)
```

When uploading a file to the root of the share, _path here is empty string, then path.Dir will return "." (from its implicit call to path.Clean), toSambaPath will encode it to the Unicode wide equivalent, and the result is as described in the forum thread: A directory `．` is being created, in addition to the uploaded file.

I fixed this by checking for the "." and return from ensureDirectory before ever calling MkdirAll - assuming it is not necessary to call with empty string "".

(I've been thinking about the use of path.Clean/Join/Dir etc on remote paths in the backend implementations in general; if it is strictly speaking not the correct thing to do, i.e. the resolving of `.`, `..` and removal of `/`... but that's a topic for later)

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/smb-remote-creating-a-dir-named/34188

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
