### PR TITLE
Add global flag '--color'

### DIFF
--- a/cmd/tree/tree.go
+++ b/cmd/tree/tree.go
@@ -61,7 +61,6 @@ func init() {
 	flags.StringVarP(cmdFlags, &sort, "sort", "", "", "Select sort: name,version,size,mtime,ctime")
 	// Graphics
 	flags.BoolVarP(cmdFlags, &opts.NoIndent, "noindent", "", false, "Don't print indentation lines")
-	flags.BoolVarP(cmdFlags, &opts.Colorize, "color", "C", false, "Turn colorization on always")
 }
 
 var commandDefinition = &cobra.Command{
@@ -113,6 +112,7 @@ For a more interactive navigation of the remote see the
 		opts.SizeSort = sort == "size"
 		ci := fs.GetConfig(context.Background())
 		opts.UnitSize = ci.HumanReadable
+		opts.Colorize = ci.TerminalColorMode != fs.TerminalColorModeNever
 		if opts.DeepLevel == 0 {
 			opts.DeepLevel = ci.MaxDepth
 		}

--- a/docs/content/commands/rclone_tree.md
+++ b/docs/content/commands/rclone_tree.md
@@ -48,7 +48,6 @@ rclone tree remote:path [flags]
 
 ```
   -a, --all             All files are listed (list . files too)
-  -C, --color           Turn colorization on always
   -d, --dirs-only       List directories only
       --dirsfirst       List directories before files (-U disables)
       --full-path       Print the full path prefix for each file

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -823,6 +823,16 @@ quicker than without the `--checksum` flag.
 When using this flag, rclone won't update mtimes of remote files if
 they are incorrect as it would normally.
 
+### --color WHEN ###
+
+Specifiy when colors (and other ANSI codes) should be added to the output.
+
+`AUTO` (default) only allows ANSI codes when the output is a terminal
+
+`NEVER` never allow ANSI codes
+
+`ALWAYS` always add ANSI codes, regardless of the output format (terminal or file)
+
 ### --compare-dest=DIR ###
 
 When using `sync`, `copy` or `move` DIR is checked in addition to the
@@ -1820,16 +1830,6 @@ and `TMP` and `TEMP` on Windows.
 
 You can use the [config paths](/commands/rclone_config_paths/)
 command to see the current value.
-
-### --terminal-color-mode MODE ###
-
-Specifiy how colors (and other ANSI codes) should be handled in when printing output.
-
-`AUTO` (default) only allows ANSI codes when the output is a terminal
-
-`NEVER` never allow ANSI codes
-
-`ALWAYS` always add ANSI codes, regardless of the output format (terminal or file)
 
 ### --tpslimit float ###
 

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1821,6 +1821,16 @@ and `TMP` and `TEMP` on Windows.
 You can use the [config paths](/commands/rclone_config_paths/)
 command to see the current value.
 
+### --terminal-color-mode MODE ###
+
+Specifiy how colors (and other ANSI codes) should be handled in when printing output.
+
+`AUTO` (default) only allows ANSI codes when the output is a terminal
+
+`NEVER` never allow ANSI codes
+
+`ALWAYS` always add ANSI codes, regardless of the output format (terminal or file)
+
 ### --tpslimit float ###
 
 Limit transactions per second to this number. Default is 0 which is

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -151,6 +151,7 @@ These flags are available for every command.
       --syslog                               Use Syslog for logging
       --syslog-facility string               Facility for syslog, e.g. KERN,USER,... (default "DAEMON")
       --temp-dir string                      Directory rclone will use for temporary files (default "/tmp")
+      --terminal-color-mode                  Mode for colors (and other ANSI codes) in terminal output AUTO|ALWAYS|NEVER (default AUTO)
       --timeout duration                     IO idle timeout (default 5m0s)
       --tpslimit float                       Limit HTTP transactions per second to this
       --tpslimit-burst int                   Max burst of transactions for --tpslimit (default 1)

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -27,6 +27,7 @@ These flags are available for every command.
   -c, --checksum                             Skip based on checksum (if available) & size, not mod-time & size
       --client-cert string                   Client SSL certificate (PEM) for mutual TLS auth
       --client-key string                    Client SSL private key (PEM) for mutual TLS auth
+      --color                                Define when colors (and other ANSI codes) should be shown AUTO|ALWAYS|NEVER (default AUTO)
       --compare-dest stringArray             Include additional comma separated server-side paths during comparison
       --config string                        Config file (default "$HOME/.config/rclone/rclone.conf")
       --contimeout duration                  Connect timeout (default 1m0s)
@@ -151,7 +152,6 @@ These flags are available for every command.
       --syslog                               Use Syslog for logging
       --syslog-facility string               Facility for syslog, e.g. KERN,USER,... (default "DAEMON")
       --temp-dir string                      Directory rclone will use for temporary files (default "/tmp")
-      --terminal-color-mode                  Mode for colors (and other ANSI codes) in terminal output AUTO|ALWAYS|NEVER (default AUTO)
       --timeout duration                     IO idle timeout (default 5m0s)
       --tpslimit float                       Limit HTTP transactions per second to this
       --tpslimit-burst int                   Max burst of transactions for --tpslimit (default 1)

--- a/fs/config.go
+++ b/fs/config.go
@@ -142,6 +142,7 @@ type ConfigInfo struct {
 	DisableHTTPKeepAlives   bool
 	Metadata                bool
 	ServerSideAcrossConfigs bool
+	TerminalColorMode       TerminalColorMode
 }
 
 // NewConfig creates a new config with everything set to the default

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -142,6 +142,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &ci.DisableHTTPKeepAlives, "disable-http-keep-alives", "", ci.DisableHTTPKeepAlives, "Disable HTTP keep-alives and use each connection once.")
 	flags.BoolVarP(flagSet, &ci.Metadata, "metadata", "M", ci.Metadata, "If set, preserve metadata when copying objects")
 	flags.BoolVarP(flagSet, &ci.ServerSideAcrossConfigs, "server-side-across-configs", "", ci.ServerSideAcrossConfigs, "Allow server-side operations (e.g. copy) to work across different configs")
+	flags.FVarP(flagSet, &ci.TerminalColorMode, "terminal-color-mode", "", "Color mode for the terminal AUTO|NEVER|ALWAYS")
 }
 
 // ParseHeaders converts the strings passed in via the header flags into HTTPOptions

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -142,7 +142,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &ci.DisableHTTPKeepAlives, "disable-http-keep-alives", "", ci.DisableHTTPKeepAlives, "Disable HTTP keep-alives and use each connection once.")
 	flags.BoolVarP(flagSet, &ci.Metadata, "metadata", "M", ci.Metadata, "If set, preserve metadata when copying objects")
 	flags.BoolVarP(flagSet, &ci.ServerSideAcrossConfigs, "server-side-across-configs", "", ci.ServerSideAcrossConfigs, "Allow server-side operations (e.g. copy) to work across different configs")
-	flags.FVarP(flagSet, &ci.TerminalColorMode, "terminal-color-mode", "", "Color mode for the terminal AUTO|NEVER|ALWAYS")
+	flags.FVarP(flagSet, &ci.TerminalColorMode, "color", "", "When to show colors (and other ANSI codes) AUTO|NEVER|ALWAYS")
 }
 
 // ParseHeaders converts the strings passed in via the header flags into HTTPOptions

--- a/fs/terminalcolormode.go
+++ b/fs/terminalcolormode.go
@@ -1,0 +1,51 @@
+package fs
+
+import (
+	"fmt"
+	"strings"
+)
+
+type TerminalColorMode byte
+
+const (
+	TerminalColorModeAuto TerminalColorMode = iota
+	TerminalColorModeNever
+	TerminalColorModeAlways
+)
+
+var terminalColorModeToString = []string{
+	TerminalColorModeAuto:   "AUTO",
+	TerminalColorModeNever:  "NEVER",
+	TerminalColorModeAlways: "ALWAYS",
+}
+
+func (m TerminalColorMode) String() string {
+	if m >= TerminalColorMode(len(terminalColorModeToString)) {
+		return fmt.Sprintf("TerminalColorMode(%d)", m)
+	}
+	return terminalColorModeToString[m]
+}
+
+func (m *TerminalColorMode) Set(s string) error {
+	for n, name := range terminalColorModeToString {
+		if s != "" && name == strings.ToUpper(s) {
+			*m = TerminalColorMode(n)
+			return nil
+		}
+	}
+	return fmt.Errorf("unknown terminal color mode %q", s)
+}
+
+func (m TerminalColorMode) Type() string {
+	return "string"
+}
+
+func (m *TerminalColorMode) UnmarshalJSON(in []byte) error {
+	return UnmarshalJSONFlag(in, m, func(i int64) error {
+		if i < 0 || i >= int64(len(terminalColorModeToString)) {
+			return fmt.Errorf("out of range terminal color mode %d", i)
+		}
+		*m = (TerminalColorMode)(i)
+		return nil
+	})
+}

--- a/fs/terminalcolormode.go
+++ b/fs/terminalcolormode.go
@@ -5,8 +5,10 @@ import (
 	"strings"
 )
 
+// TerminalColorMode describes how ANSI codes should be handled
 type TerminalColorMode byte
 
+// TerminalColorMode constants
 const (
 	TerminalColorModeAuto TerminalColorMode = iota
 	TerminalColorModeNever
@@ -19,6 +21,7 @@ var terminalColorModeToString = []string{
 	TerminalColorModeAlways: "ALWAYS",
 }
 
+// String converts a TerminalColorMode to a string
 func (m TerminalColorMode) String() string {
 	if m >= TerminalColorMode(len(terminalColorModeToString)) {
 		return fmt.Sprintf("TerminalColorMode(%d)", m)
@@ -26,6 +29,7 @@ func (m TerminalColorMode) String() string {
 	return terminalColorModeToString[m]
 }
 
+// Set a TerminalColorMode
 func (m *TerminalColorMode) Set(s string) error {
 	for n, name := range terminalColorModeToString {
 		if s != "" && name == strings.ToUpper(s) {
@@ -36,10 +40,12 @@ func (m *TerminalColorMode) Set(s string) error {
 	return fmt.Errorf("unknown terminal color mode %q", s)
 }
 
+// Type of TerminalColorMode
 func (m TerminalColorMode) Type() string {
 	return "string"
 }
 
+// UnmarshalJSON converts a string/integer in JSON to a TerminalColorMode
 func (m *TerminalColorMode) UnmarshalJSON(in []byte) error {
 	return UnmarshalJSONFlag(in, m, func(i int64) error {
 		if i < 0 || i >= int64(len(terminalColorModeToString)) {

--- a/fs/terminalcolormode_test.go
+++ b/fs/terminalcolormode_test.go
@@ -1,0 +1,74 @@
+package fs
+
+import (
+	"encoding/json"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerminalColorModeString(t *testing.T) {
+	for _, test := range []struct {
+		in   TerminalColorMode
+		want string
+	}{
+		{TerminalColorModeAuto, "AUTO"},
+		{TerminalColorModeAlways, "ALWAYS"},
+		{TerminalColorModeNever, "NEVER"},
+		{36, "TerminalColorMode(36)"},
+	} {
+		tcm := test.in
+		assert.Equal(t, test.want, tcm.String(), test.in)
+	}
+}
+
+func TestTerminalColorModeSet(t *testing.T) {
+	for _, test := range []struct {
+		in          string
+		want        TerminalColorMode
+		expectError bool
+	}{
+		{"auto", TerminalColorModeAuto, false},
+		{"ALWAYS", TerminalColorModeAlways, false},
+		{"Never", TerminalColorModeNever, false},
+		{"INVALID", 0, true},
+	} {
+		tcm := TerminalColorMode(0)
+		err := tcm.Set(test.in)
+		if test.expectError {
+			require.Error(t, err, test.in)
+		} else {
+			require.NoError(t, err, test.in)
+		}
+		assert.Equal(t, test.want, tcm, test.in)
+	}
+}
+
+func TestTerminalColorModeUnmarshalJSON(t *testing.T) {
+	for _, test := range []struct {
+		in          string
+		want        TerminalColorMode
+		expectError bool
+	}{
+		{`"auto"`, TerminalColorModeAuto, false},
+		{`"ALWAYS"`, TerminalColorModeAlways, false},
+		{`"Never"`, TerminalColorModeNever, false},
+		{`"Invalid"`, 0, true},
+		{strconv.Itoa(int(TerminalColorModeAuto)), TerminalColorModeAuto, false},
+		{strconv.Itoa(int(TerminalColorModeAlways)), TerminalColorModeAlways, false},
+		{strconv.Itoa(int(TerminalColorModeNever)), TerminalColorModeNever, false},
+		{`99`, 0, true},
+		{`-99`, 0, true},
+	} {
+		var tcm TerminalColorMode
+		err := json.Unmarshal([]byte(test.in), &tcm)
+		if test.expectError {
+			require.Error(t, err, test.in)
+		} else {
+			require.NoError(t, err, test.in)
+		}
+		assert.Equal(t, test.want, tcm, test.in)
+	}
+}

--- a/lib/terminal/terminal.go
+++ b/lib/terminal/terminal.go
@@ -3,12 +3,14 @@
 package terminal
 
 import (
+	"context"
 	"io"
 	"os"
 	"runtime"
 	"sync"
 
 	colorable "github.com/mattn/go-colorable"
+	"github.com/rclone/rclone/fs"
 )
 
 // VT100 codes
@@ -73,13 +75,21 @@ var (
 // Start the terminal - must be called before use
 func Start() {
 	once.Do(func() {
+		ci := fs.GetConfig(context.Background())
+
 		f := os.Stdout
 		if !IsTerminal(int(f.Fd())) {
-			// If stdout not a tty then remove escape codes
-			Out = colorable.NewNonColorable(f)
+			// If stdout is not a tty, remove escape codes EXCEPT if terminal color mode equals "ALWAYS"
+			if ci.TerminalColorMode == fs.TerminalColorModeAlways {
+				Out = colorable.NewColorable(f)
+			} else {
+				Out = colorable.NewNonColorable(f)
+			}
 		} else if runtime.GOOS == "windows" && os.Getenv("TERM") != "" {
 			// If TERM is set just use stdout
 			Out = f
+		} else if ci.TerminalColorMode == fs.TerminalColorModeNever {
+			Out = colorable.NewNonColorable(f)
 		} else {
 			Out = colorable.NewColorable(f)
 		}


### PR DESCRIPTION
#### What is the purpose of this change?

This PR adds a new global flag `--terminal-color-mode` which allows you to change the way ANSI codes are handled in output. This is similar to the `-color` flag for many UNIX commands (grep, ls...).

Currently, rclone only adds ANSI codes to output if target file descriptor is an actual terminal. With this new flag, the behavior can be changed by using one of the following modes:

- `AUTO` (default) = current behaviour => only add ANSI codes when the output medium is an actual terminal
- `ALWAYS` => always add ANSI codes, even to normal files
- `NEVER` => never add ANSI codes

I am still not sure if this is the best name for the flag. Maybe just `--terminal-color` or `--color` is better?

#### Was the change discussed in an issue or in the forum before?

This has been discussed by someone else on the forum 2 years ago:
https://forum.rclone.org/t/specifying-preservation-of-ansi-codes-in-rclone-output/17305

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
**Remark**: no tests for the terminal part itself, since I am not sure how to test this...
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)