### PR TITLE
serve: allow unix socket on serve

### DIFF
--- a/docs/content/commands/rclone_serve_http.md
+++ b/docs/content/commands/rclone_serve_http.md
@@ -28,7 +28,8 @@ control the stats printing.
 Use `--addr` to specify which IP address and port the server should
 listen on, eg `--addr 1.2.3.4:8000` or `--addr :8080` to listen to all
 IPs.  By default it only listens on localhost.  You can use port
-:0 to let the OS choose an available port.
+:0 to let the OS choose an available port. 
+You can prefix the address with `unix:` to listen on a unix domain (e.g. `--addr unix:/tmp/rclone.sock`).
 
 If you set `--addr` to listen on a public or LAN accessible IP address
 then using Authentication is advised - see the next section for info.

--- a/docs/content/commands/rclone_serve_webdav.md
+++ b/docs/content/commands/rclone_serve_webdav.md
@@ -34,6 +34,7 @@ Use `--addr` to specify which IP address and port the server should
 listen on, e.g. `--addr 1.2.3.4:8000` or `--addr :8080` to
 listen to all IPs.  By default it only listens on localhost.  You can use port
 :0 to let the OS choose an available port.
+You can prefix the address with `unix:` to listen on a unix domain (e.g. `--addr unix:/tmp/rclone.sock`).
 
 If you set `--addr` to listen on a public or LAN accessible IP address
 then using Authentication is advised - see the next section for info.

--- a/lib/http/http.go
+++ b/lib/http/http.go
@@ -358,7 +358,22 @@ func start() error {
 
 	var err error
 	var l net.Listener
-	l, err = net.Listen("tcp", defaultServerOptions.ListenAddr)
+
+	if strings.HasPrefix(defaultServerOptions.ListenAddr, "unix:") {
+		socketFile := defaultServerOptions.ListenAddr[5:]
+
+		// Cleanup socket file if already existing
+		if _, err := os.Stat(socketFile); err == nil {
+			if err := os.Remove(socketFile); err != nil {
+				return err
+			}
+		}
+
+		l, err = net.Listen("unix", socketFile)
+	} else {
+		l, err = net.Listen("tcp", defaultServerOptions.ListenAddr)
+	}
+
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

I am running a WebDav server using Rclone and want to pass to my Caddy server a unix socket instead using a random local port

#### Was the change discussed in an issue or in the forum before?

Nope

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
