### PR TITLE
test: replace defer cleanup with `t.Cleanup`

### DIFF
--- a/backend/cache/cache_internal_test.go
+++ b/backend/cache/cache_internal_test.go
@@ -101,14 +101,12 @@ func TestMain(m *testing.M) {
 
 func TestInternalListRootAndInnerRemotes(t *testing.T) {
 	id := fmt.Sprintf("tilrair%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, true, true, nil)
 
 	// Instantiate inner fs
 	innerFolder := "inner"
 	runInstance.mkdir(t, rootFs, innerFolder)
-	rootFs2, boltDb2 := runInstance.newCacheFs(t, remoteName, id+"/"+innerFolder, true, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs2, boltDb2)
+	rootFs2, _ := runInstance.newCacheFs(t, remoteName, id+"/"+innerFolder, true, true, nil)
 
 	runInstance.writeObjectString(t, rootFs2, "one", "content")
 	listRoot, err := runInstance.list(t, rootFs, "")
@@ -225,8 +223,7 @@ func TestInternalVfsCache(t *testing.T) {
 
 func TestInternalObjWrapFsFound(t *testing.T) {
 	id := fmt.Sprintf("tiowff%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, true, true, nil)
 
 	cfs, err := runInstance.getCacheFs(rootFs)
 	require.NoError(t, err)
@@ -258,8 +255,7 @@ func TestInternalObjWrapFsFound(t *testing.T) {
 
 func TestInternalObjNotFound(t *testing.T) {
 	id := fmt.Sprintf("tionf%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, false, true, nil)
 
 	obj, err := rootFs.NewObject(context.Background(), "404")
 	require.Error(t, err)
@@ -269,8 +265,7 @@ func TestInternalObjNotFound(t *testing.T) {
 func TestInternalCachedWrittenContentMatches(t *testing.T) {
 	testy.SkipUnreliable(t)
 	id := fmt.Sprintf("ticwcm%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, false, true, nil)
 
 	cfs, err := runInstance.getCacheFs(rootFs)
 	require.NoError(t, err)
@@ -297,8 +292,7 @@ func TestInternalDoubleWrittenContentMatches(t *testing.T) {
 		t.Skip("Skip test on windows/386")
 	}
 	id := fmt.Sprintf("tidwcm%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, false, true, nil)
 
 	// write the object
 	runInstance.writeRemoteString(t, rootFs, "one", "one content")
@@ -316,8 +310,7 @@ func TestInternalDoubleWrittenContentMatches(t *testing.T) {
 func TestInternalCachedUpdatedContentMatches(t *testing.T) {
 	testy.SkipUnreliable(t)
 	id := fmt.Sprintf("ticucm%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, false, true, nil)
 	var err error
 
 	// create some rand test data
@@ -346,8 +339,7 @@ func TestInternalCachedUpdatedContentMatches(t *testing.T) {
 func TestInternalWrappedWrittenContentMatches(t *testing.T) {
 	id := fmt.Sprintf("tiwwcm%v", time.Now().Unix())
 	vfsflags.Opt.DirCacheTime = time.Second
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, true, true, nil)
 	if runInstance.rootIsCrypt {
 		t.Skip("test skipped with crypt remote")
 	}
@@ -377,8 +369,7 @@ func TestInternalWrappedWrittenContentMatches(t *testing.T) {
 func TestInternalLargeWrittenContentMatches(t *testing.T) {
 	id := fmt.Sprintf("tilwcm%v", time.Now().Unix())
 	vfsflags.Opt.DirCacheTime = time.Second
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, true, true, nil)
 	if runInstance.rootIsCrypt {
 		t.Skip("test skipped with crypt remote")
 	}
@@ -404,8 +395,7 @@ func TestInternalLargeWrittenContentMatches(t *testing.T) {
 
 func TestInternalWrappedFsChangeNotSeen(t *testing.T) {
 	id := fmt.Sprintf("tiwfcns%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, false, true, nil)
 
 	cfs, err := runInstance.getCacheFs(rootFs)
 	require.NoError(t, err)
@@ -459,8 +449,7 @@ func TestInternalWrappedFsChangeNotSeen(t *testing.T) {
 
 func TestInternalMoveWithNotify(t *testing.T) {
 	id := fmt.Sprintf("timwn%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, false, true, nil)
 	if !runInstance.wrappedIsExternal {
 		t.Skipf("Not external")
 	}
@@ -546,8 +535,7 @@ func TestInternalMoveWithNotify(t *testing.T) {
 
 func TestInternalNotifyCreatesEmptyParts(t *testing.T) {
 	id := fmt.Sprintf("tincep%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil)
 	if !runInstance.wrappedIsExternal {
 		t.Skipf("Not external")
 	}
@@ -633,8 +621,7 @@ func TestInternalNotifyCreatesEmptyParts(t *testing.T) {
 
 func TestInternalChangeSeenAfterDirCacheFlush(t *testing.T) {
 	id := fmt.Sprintf("ticsadcf%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, false, true, nil)
 
 	cfs, err := runInstance.getCacheFs(rootFs)
 	require.NoError(t, err)
@@ -666,8 +653,7 @@ func TestInternalChangeSeenAfterDirCacheFlush(t *testing.T) {
 
 func TestInternalCacheWrites(t *testing.T) {
 	id := "ticw"
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, map[string]string{"writes": "true"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, map[string]string{"writes": "true"})
 
 	cfs, err := runInstance.getCacheFs(rootFs)
 	require.NoError(t, err)
@@ -688,8 +674,7 @@ func TestInternalMaxChunkSizeRespected(t *testing.T) {
 		t.Skip("Skip test on windows/386")
 	}
 	id := fmt.Sprintf("timcsr%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil, map[string]string{"workers": "1"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, map[string]string{"workers": "1"})
 
 	cfs, err := runInstance.getCacheFs(rootFs)
 	require.NoError(t, err)
@@ -724,8 +709,7 @@ func TestInternalMaxChunkSizeRespected(t *testing.T) {
 func TestInternalExpiredEntriesRemoved(t *testing.T) {
 	id := fmt.Sprintf("tieer%v", time.Now().Unix())
 	vfsflags.Opt.DirCacheTime = time.Second * 4 // needs to be lower than the defined
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true, map[string]string{"info_age": "5s"}, nil)
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, true, true, nil)
 	cfs, err := runInstance.getCacheFs(rootFs)
 	require.NoError(t, err)
 
@@ -762,9 +746,7 @@ func TestInternalBug2117(t *testing.T) {
 	vfsflags.Opt.DirCacheTime = time.Second * 10
 
 	id := fmt.Sprintf("tib2117%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true, nil,
-		map[string]string{"info_age": "72h", "chunk_clean_interval": "15m"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, false, true, map[string]string{"info_age": "72h", "chunk_clean_interval": "15m"})
 
 	if runInstance.rootIsCrypt {
 		t.Skipf("skipping crypt")
@@ -865,7 +847,7 @@ func (r *run) encryptRemoteIfNeeded(t *testing.T, remote string) string {
 	return enc
 }
 
-func (r *run) newCacheFs(t *testing.T, remote, id string, needRemote, purge bool, cfg map[string]string, flags map[string]string) (fs.Fs, *cache.Persistent) {
+func (r *run) newCacheFs(t *testing.T, remote, id string, needRemote, purge bool, flags map[string]string) (fs.Fs, *cache.Persistent) {
 	fstest.Initialise()
 	remoteExists := false
 	for _, s := range config.FileSections() {
@@ -958,10 +940,15 @@ func (r *run) newCacheFs(t *testing.T, remote, id string, needRemote, purge bool
 	}
 	err = f.Mkdir(context.Background(), "")
 	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		runInstance.cleanupFs(t, f)
+	})
+
 	return f, boltDb
 }
 
-func (r *run) cleanupFs(t *testing.T, f fs.Fs, b *cache.Persistent) {
+func (r *run) cleanupFs(t *testing.T, f fs.Fs) {
 	err := f.Features().Purge(context.Background(), "")
 	require.NoError(t, err)
 	cfs, err := r.getCacheFs(f)

--- a/backend/cache/cache_upload_test.go
+++ b/backend/cache/cache_upload_test.go
@@ -21,10 +21,8 @@ import (
 
 func TestInternalUploadTempDirCreated(t *testing.T) {
 	id := fmt.Sprintf("tiutdc%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, false, true,
-		nil,
+	runInstance.newCacheFs(t, remoteName, id, false, true,
 		map[string]string{"tmp_upload_path": path.Join(runInstance.tmpUploadDir, id)})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
 	_, err := os.Stat(path.Join(runInstance.tmpUploadDir, id))
 	require.NoError(t, err)
@@ -63,9 +61,7 @@ func testInternalUploadQueueOneFile(t *testing.T, id string, rootFs fs.Fs, boltD
 func TestInternalUploadQueueOneFileNoRest(t *testing.T) {
 	id := fmt.Sprintf("tiuqofnr%v", time.Now().Unix())
 	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true,
-		nil,
 		map[string]string{"tmp_upload_path": path.Join(runInstance.tmpUploadDir, id), "tmp_wait_time": "0s"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
 	testInternalUploadQueueOneFile(t, id, rootFs, boltDb)
 }
@@ -73,19 +69,15 @@ func TestInternalUploadQueueOneFileNoRest(t *testing.T) {
 func TestInternalUploadQueueOneFileWithRest(t *testing.T) {
 	id := fmt.Sprintf("tiuqofwr%v", time.Now().Unix())
 	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true,
-		nil,
 		map[string]string{"tmp_upload_path": path.Join(runInstance.tmpUploadDir, id), "tmp_wait_time": "1m"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
 	testInternalUploadQueueOneFile(t, id, rootFs, boltDb)
 }
 
 func TestInternalUploadMoveExistingFile(t *testing.T) {
 	id := fmt.Sprintf("tiumef%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true,
-		nil,
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, true, true,
 		map[string]string{"tmp_upload_path": path.Join(runInstance.tmpUploadDir, id), "tmp_wait_time": "3s"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
 	err := rootFs.Mkdir(context.Background(), "one")
 	require.NoError(t, err)
@@ -119,10 +111,8 @@ func TestInternalUploadMoveExistingFile(t *testing.T) {
 
 func TestInternalUploadTempPathCleaned(t *testing.T) {
 	id := fmt.Sprintf("tiutpc%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true,
-		nil,
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, true, true,
 		map[string]string{"cache-tmp-upload-path": path.Join(runInstance.tmpUploadDir, id), "cache-tmp-wait-time": "5s"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
 	err := rootFs.Mkdir(context.Background(), "one")
 	require.NoError(t, err)
@@ -162,10 +152,8 @@ func TestInternalUploadTempPathCleaned(t *testing.T) {
 
 func TestInternalUploadQueueMoreFiles(t *testing.T) {
 	id := fmt.Sprintf("tiuqmf%v", time.Now().Unix())
-	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true,
-		nil,
+	rootFs, _ := runInstance.newCacheFs(t, remoteName, id, true, true,
 		map[string]string{"tmp_upload_path": path.Join(runInstance.tmpUploadDir, id), "tmp_wait_time": "1s"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
 	err := rootFs.Mkdir(context.Background(), "test")
 	require.NoError(t, err)
@@ -213,9 +201,7 @@ func TestInternalUploadQueueMoreFiles(t *testing.T) {
 func TestInternalUploadTempFileOperations(t *testing.T) {
 	id := "tiutfo"
 	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true,
-		nil,
 		map[string]string{"tmp_upload_path": path.Join(runInstance.tmpUploadDir, id), "tmp_wait_time": "1h"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
 	boltDb.PurgeTempUploads()
 
@@ -343,9 +329,7 @@ func TestInternalUploadTempFileOperations(t *testing.T) {
 func TestInternalUploadUploadingFileOperations(t *testing.T) {
 	id := "tiuufo"
 	rootFs, boltDb := runInstance.newCacheFs(t, remoteName, id, true, true,
-		nil,
 		map[string]string{"tmp_upload_path": path.Join(runInstance.tmpUploadDir, id), "tmp_wait_time": "1h"})
-	defer runInstance.cleanupFs(t, rootFs, boltDb)
 
 	boltDb.PurgeTempUploads()
 

--- a/backend/local/local_internal_test.go
+++ b/backend/local/local_internal_test.go
@@ -33,7 +33,6 @@ func TestMain(m *testing.M) {
 // Test copy with source file that's updating
 func TestUpdatingCheck(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	filePath := "sub dir/local test"
 	r.WriteFile(filePath, "content", time.Now())
 
@@ -78,7 +77,6 @@ func TestUpdatingCheck(t *testing.T) {
 func TestSymlink(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	f := r.Flocal.(*Fs)
 	dir := f.root
 
@@ -177,7 +175,6 @@ func TestSymlinkError(t *testing.T) {
 func TestHashOnUpdate(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	const filePath = "file.txt"
 	when := time.Now()
 	r.WriteFile(filePath, "content", when)
@@ -208,7 +205,6 @@ func TestHashOnUpdate(t *testing.T) {
 func TestHashOnDelete(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	const filePath = "file.txt"
 	when := time.Now()
 	r.WriteFile(filePath, "content", when)
@@ -237,7 +233,6 @@ func TestHashOnDelete(t *testing.T) {
 func TestMetadata(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	const filePath = "metafile.txt"
 	when := time.Now()
 	const dayLength = len("2001-01-01")
@@ -372,7 +367,6 @@ func TestMetadata(t *testing.T) {
 func TestFilter(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	when := time.Now()
 	r.WriteFile("included", "included file", when)
 	r.WriteFile("excluded", "excluded file", when)

--- a/cmd/touch/touch_test.go
+++ b/cmd/touch/touch_test.go
@@ -28,7 +28,6 @@ func TestMain(m *testing.M) {
 
 func TestTouchOneFile(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	err := Touch(context.Background(), r.Fremote, "newFile")
 	require.NoError(t, err)
@@ -38,7 +37,6 @@ func TestTouchOneFile(t *testing.T) {
 
 func TestTouchWithNoCreateFlag(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	notCreateNewFile = true
 	err := Touch(context.Background(), r.Fremote, "newFile")
@@ -50,7 +48,6 @@ func TestTouchWithNoCreateFlag(t *testing.T) {
 
 func TestTouchWithTimestamp(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	timeAsArgument = "060102"
 	srcFileName := "oldFile"
@@ -61,7 +58,6 @@ func TestTouchWithTimestamp(t *testing.T) {
 
 func TestTouchWithLongerTimestamp(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	timeAsArgument = "2006-01-02T15:04:05"
 	srcFileName := "oldFile"
@@ -72,7 +68,6 @@ func TestTouchWithLongerTimestamp(t *testing.T) {
 
 func TestTouchUpdateTimestamp(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	srcFileName := "a"
 	content := "aaa"
@@ -87,7 +82,6 @@ func TestTouchUpdateTimestamp(t *testing.T) {
 
 func TestTouchUpdateTimestampWithCFlag(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	srcFileName := "a"
 	content := "aaa"
@@ -104,7 +98,6 @@ func TestTouchUpdateTimestampWithCFlag(t *testing.T) {
 
 func TestTouchCreateMultipleDirAndFile(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	longPath := "a/b/c.txt"
 	err := Touch(context.Background(), r.Fremote, longPath)
@@ -115,7 +108,6 @@ func TestTouchCreateMultipleDirAndFile(t *testing.T) {
 
 func TestTouchEmptyName(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	err := Touch(context.Background(), r.Fremote, "")
 	require.NoError(t, err)
@@ -124,7 +116,6 @@ func TestTouchEmptyName(t *testing.T) {
 
 func TestTouchEmptyDir(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	err := r.Fremote.Mkdir(context.Background(), "a")
 	require.NoError(t, err)
@@ -135,7 +126,6 @@ func TestTouchEmptyDir(t *testing.T) {
 
 func TestTouchDirWithFiles(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	err := r.Fremote.Mkdir(context.Background(), "a")
 	require.NoError(t, err)
@@ -148,7 +138,6 @@ func TestTouchDirWithFiles(t *testing.T) {
 
 func TestRecursiveTouchDirWithFiles(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	err := r.Fremote.Mkdir(context.Background(), "a/b/c")
 	require.NoError(t, err)

--- a/cmdtest/cmdtest_test.go
+++ b/cmdtest/cmdtest_test.go
@@ -111,13 +111,6 @@ func createTestEnvironment(t *testing.T) {
 var testFolder string
 var testConfig string
 
-// removeTestEnvironment removes the test environment created by createTestEnvironment
-func removeTestEnvironment(t *testing.T) {
-	// Remove temporary folder with all contents
-	err := os.RemoveAll(testFolder)
-	require.NoError(t, err)
-}
-
 // createTestFile creates the file testFolder/name
 func createTestFile(name string, t *testing.T) string {
 	err := os.WriteFile(testFolder+"/"+name, []byte("content_of_"+name), 0666)
@@ -146,19 +139,18 @@ func createSimpleTestData(t *testing.T) string {
 	createTestFolder("testdata/folderB", t)
 	createTestFile("testdata/folderB/fileB1.txt", t)
 	createTestFile("testdata/folderB/fileB2.txt", t)
-	return testFolder + "/testdata"
-}
 
-// removeSimpleTestData removes the test data created by createSimpleTestData
-func removeSimpleTestData(t *testing.T) {
-	err := os.RemoveAll(testFolder + "/testdata")
-	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := os.RemoveAll(testFolder + "/testdata")
+		require.NoError(t, err)
+	})
+
+	return testFolder + "/testdata"
 }
 
 // TestCmdTest demonstrates and verifies the test functions for end-to-end testing of rclone
 func TestCmdTest(t *testing.T) {
 	createTestEnvironment(t)
-	defer removeTestEnvironment(t)
 
 	// Test simple call and output from rclone
 	out, err := rclone("version")
@@ -213,7 +205,6 @@ func TestCmdTest(t *testing.T) {
 
 	// Test creation of simple test data
 	createSimpleTestData(t)
-	defer removeSimpleTestData(t)
 
 	// Test access to config file and simple test data
 	out, err = rclone("lsl", "myLocal:"+testFolder)

--- a/cmdtest/environment_test.go
+++ b/cmdtest/environment_test.go
@@ -17,10 +17,8 @@ import (
 func TestEnvironmentVariables(t *testing.T) {
 
 	createTestEnvironment(t)
-	defer removeTestEnvironment(t)
 
 	testdataPath := createSimpleTestData(t)
-	defer removeSimpleTestData(t)
 
 	// Non backend flags
 	// =================

--- a/fs/cache/cache_test.go
+++ b/fs/cache/cache_test.go
@@ -16,7 +16,7 @@ var (
 	errSentinel = errors.New("an error")
 )
 
-func mockNewFs(t *testing.T) (func(), func(ctx context.Context, path string) (fs.Fs, error)) {
+func mockNewFs(t *testing.T) func(ctx context.Context, path string) (fs.Fs, error) {
 	called = 0
 	create := func(ctx context.Context, path string) (f fs.Fs, err error) {
 		assert.Equal(t, 0, called)
@@ -32,15 +32,12 @@ func mockNewFs(t *testing.T) (func(), func(ctx context.Context, path string) (fs
 		t.Fatalf("Unknown path %q", path)
 		panic("unreachable")
 	}
-	cleanup := func() {
-		Clear()
-	}
-	return cleanup, create
+	t.Cleanup(Clear)
+	return create
 }
 
 func TestGet(t *testing.T) {
-	cleanup, create := mockNewFs(t)
-	defer cleanup()
+	create := mockNewFs(t)
 
 	assert.Equal(t, 0, Entries())
 
@@ -56,8 +53,7 @@ func TestGet(t *testing.T) {
 }
 
 func TestGetFile(t *testing.T) {
-	cleanup, create := mockNewFs(t)
-	defer cleanup()
+	create := mockNewFs(t)
 
 	assert.Equal(t, 0, Entries())
 
@@ -82,8 +78,7 @@ func TestGetFile(t *testing.T) {
 }
 
 func TestGetFile2(t *testing.T) {
-	cleanup, create := mockNewFs(t)
-	defer cleanup()
+	create := mockNewFs(t)
 
 	assert.Equal(t, 0, Entries())
 
@@ -108,8 +103,7 @@ func TestGetFile2(t *testing.T) {
 }
 
 func TestGetError(t *testing.T) {
-	cleanup, create := mockNewFs(t)
-	defer cleanup()
+	create := mockNewFs(t)
 
 	assert.Equal(t, 0, Entries())
 
@@ -121,8 +115,7 @@ func TestGetError(t *testing.T) {
 }
 
 func TestPut(t *testing.T) {
-	cleanup, create := mockNewFs(t)
-	defer cleanup()
+	create := mockNewFs(t)
 
 	f := mockfs.NewFs(context.Background(), "mock", "/alien")
 
@@ -151,8 +144,7 @@ func TestPut(t *testing.T) {
 }
 
 func TestPin(t *testing.T) {
-	cleanup, create := mockNewFs(t)
-	defer cleanup()
+	create := mockNewFs(t)
 
 	// Test pinning and unpinning nonexistent
 	f := mockfs.NewFs(context.Background(), "mock", "/alien")
@@ -167,8 +159,7 @@ func TestPin(t *testing.T) {
 }
 
 func TestClearConfig(t *testing.T) {
-	cleanup, create := mockNewFs(t)
-	defer cleanup()
+	create := mockNewFs(t)
 
 	assert.Equal(t, 0, Entries())
 
@@ -183,8 +174,7 @@ func TestClearConfig(t *testing.T) {
 }
 
 func TestClear(t *testing.T) {
-	cleanup, create := mockNewFs(t)
-	defer cleanup()
+	create := mockNewFs(t)
 
 	// Create something
 	_, err := GetFn(context.Background(), "mock:/", create)
@@ -198,8 +188,7 @@ func TestClear(t *testing.T) {
 }
 
 func TestEntries(t *testing.T) {
-	cleanup, create := mockNewFs(t)
-	defer cleanup()
+	create := mockNewFs(t)
 
 	assert.Equal(t, 0, Entries())
 

--- a/fs/march/march_test.go
+++ b/fs/march/march_test.go
@@ -170,7 +170,6 @@ func TestMarch(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("TestMarch-%s", test.what), func(t *testing.T) {
 			r := fstest.NewRun(t)
-			defer r.Finalise()
 
 			var srcOnly []fstest.Item
 			var dstOnly []fstest.Item
@@ -242,7 +241,6 @@ func TestMarchNoTraverse(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("TestMarch-%s", test.what), func(t *testing.T) {
 			r := fstest.NewRun(t)
-			defer r.Finalise()
 
 			var srcOnly []fstest.Item
 			var match []fstest.Item

--- a/fs/operations/check_test.go
+++ b/fs/operations/check_test.go
@@ -24,7 +24,6 @@ import (
 
 func testCheck(t *testing.T, checkFunction func(ctx context.Context, opt *operations.CheckOpt) error) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	ctx := context.Background()
 	ci := fs.GetConfig(ctx)
 
@@ -279,7 +278,6 @@ func TestCheckEqualReaders(t *testing.T) {
 
 func TestParseSumFile(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	ctx := context.Background()
 
 	const sumFile = "test.sum"
@@ -342,7 +340,6 @@ func testCheckSum(t *testing.T, download bool) {
 
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	subRemote := r.FremoteName
 	if !strings.HasSuffix(subRemote, ":") {

--- a/fs/operations/dedupe_test.go
+++ b/fs/operations/dedupe_test.go
@@ -45,7 +45,6 @@ func skipIfNoModTime(t *testing.T, f fs.Fs) {
 
 func TestDeduplicateInteractive(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 	skipIfNoHash(t, r.Fremote)
 
@@ -62,7 +61,6 @@ func TestDeduplicateInteractive(t *testing.T) {
 
 func TestDeduplicateSkip(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 	haveHash := r.Fremote.Hashes().GetOne() != hash.None
 
@@ -84,7 +82,6 @@ func TestDeduplicateSkip(t *testing.T) {
 
 func TestDeduplicateSizeOnly(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 	ctx := context.Background()
 	ci := fs.GetConfig(ctx)
@@ -107,7 +104,6 @@ func TestDeduplicateSizeOnly(t *testing.T) {
 
 func TestDeduplicateFirst(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
 	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
@@ -136,7 +132,6 @@ func TestDeduplicateFirst(t *testing.T) {
 
 func TestDeduplicateNewest(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 	skipIfNoModTime(t, r.Fremote)
 
@@ -153,7 +148,6 @@ func TestDeduplicateNewest(t *testing.T) {
 
 func TestDeduplicateNewestByHash(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfNoHash(t, r.Fremote)
 	skipIfNoModTime(t, r.Fremote)
 	contents := random.String(100)
@@ -172,7 +166,6 @@ func TestDeduplicateNewestByHash(t *testing.T) {
 
 func TestDeduplicateOldest(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
 	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
@@ -188,7 +181,6 @@ func TestDeduplicateOldest(t *testing.T) {
 
 func TestDeduplicateLargest(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
 	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
@@ -204,7 +196,6 @@ func TestDeduplicateLargest(t *testing.T) {
 
 func TestDeduplicateSmallest(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
 	file1 := r.WriteUncheckedObject(context.Background(), "one", "This is one", t1)
@@ -220,7 +211,6 @@ func TestDeduplicateSmallest(t *testing.T) {
 
 func TestDeduplicateRename(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	skipIfCantDedupe(t, r.Fremote)
 
 	file1 := r.WriteUncheckedObject(context.Background(), "one.txt", "This is one", t1)
@@ -260,7 +250,6 @@ func TestDeduplicateRename(t *testing.T) {
 // doesn't have enough tools to make it easy
 func TestMergeDirs(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	mergeDirs := r.Fremote.Features().MergeDirs
 	if mergeDirs == nil {

--- a/fs/operations/listdirsorted_test.go
+++ b/fs/operations/listdirsorted_test.go
@@ -16,7 +16,6 @@ import (
 // which can't be tested there due to import loops.
 func TestListDirSorted(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ctx := context.Background()
 	fi := filter.GetConfig(ctx)

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -37,7 +37,6 @@ func compareListJSONItem(t *testing.T, a, b *operations.ListJSONItem, precision 
 func TestListJSON(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "file1", "file1", t1)
 	file2 := r.WriteBoth(ctx, "sub/file2", "sub/file2", t2)
 
@@ -245,7 +244,6 @@ func TestListJSON(t *testing.T) {
 func TestStatJSON(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "file1", "file1", t1)
 	file2 := r.WriteBoth(ctx, "sub/file2", "sub/file2", t2)
 

--- a/fs/operations/multithread_test.go
+++ b/fs/operations/multithread_test.go
@@ -106,7 +106,6 @@ func TestMultithreadCalculateChunks(t *testing.T) {
 
 func TestMultithreadCopy(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	ctx := context.Background()
 
 	for _, test := range []struct {

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -65,7 +65,6 @@ func TestMain(m *testing.M) {
 func TestMkdir(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	err := operations.Mkdir(ctx, r.Fremote, "")
 	require.NoError(t, err)
@@ -78,7 +77,6 @@ func TestMkdir(t *testing.T) {
 func TestLsd(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "sub dir/hello world", "hello world", t1)
 
 	r.CheckRemoteItems(t, file1)
@@ -93,7 +91,6 @@ func TestLsd(t *testing.T) {
 func TestLs(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 
@@ -111,7 +108,6 @@ func TestLsWithFilesFrom(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 
@@ -143,7 +139,6 @@ func TestLsWithFilesFrom(t *testing.T) {
 func TestLsLong(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 
@@ -186,7 +181,6 @@ func TestLsLong(t *testing.T) {
 func TestHashSums(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 
@@ -392,7 +386,6 @@ func TestCount(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 	file3 := r.WriteBoth(ctx, "sub dir/potato3", "hello", t2)
@@ -416,7 +409,6 @@ func TestDelete(t *testing.T) {
 	fi.Opt.MaxSize = 60
 	ctx = filter.ReplaceConfig(ctx, fi)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "small", "1234567890", t2)                                                                                           // 10 bytes
 	file2 := r.WriteObject(ctx, "medium", "------------------------------------------------------------", t1)                                        // 60 bytes
 	file3 := r.WriteObject(ctx, "large", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1) // 100 bytes
@@ -457,7 +449,6 @@ func TestRetry(t *testing.T) {
 func TestCat(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "file1", "ABCDEFGHIJ", t1)
 	file2 := r.WriteBoth(ctx, "file2", "012345678", t2)
 
@@ -488,7 +479,6 @@ func TestCat(t *testing.T) {
 func TestPurge(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRunIndividual(t) // make new container (azureblob has delayed mkdir after rmdir)
-	defer r.Finalise()
 	r.Mkdir(ctx, r.Fremote)
 
 	// Make some files and dirs
@@ -561,7 +551,6 @@ func TestPurge(t *testing.T) {
 func TestRmdirsNoLeaveRoot(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	r.Mkdir(ctx, r.Fremote)
 
 	// Make some files and dirs we expect to keep
@@ -642,7 +631,6 @@ func TestRmdirsNoLeaveRoot(t *testing.T) {
 func TestRmdirsLeaveRoot(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	r.Mkdir(ctx, r.Fremote)
 
 	r.ForceMkdir(ctx, r.Fremote)
@@ -682,7 +670,6 @@ func TestRmdirsWithFilter(t *testing.T) {
 	require.NoError(t, fi.AddRule("+ /A1/B1/**"))
 	require.NoError(t, fi.AddRule("- *"))
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	r.Mkdir(ctx, r.Fremote)
 
 	r.ForceMkdir(ctx, r.Fremote)
@@ -720,7 +707,6 @@ func TestCopyURL(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	contents := "file contents\n"
 	file1 := r.WriteFile("file1", contents, t1)
@@ -835,7 +821,6 @@ func TestCopyURLToWriter(t *testing.T) {
 func TestMoveFile(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	file1 := r.WriteFile("file1", "file1 contents", t1)
 	r.CheckLocalItems(t, file1)
@@ -866,7 +851,6 @@ func TestMoveFileWithIgnoreExisting(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("file1", "file1 contents", t1)
 	r.CheckLocalItems(t, file1)
 
@@ -891,7 +875,6 @@ func TestMoveFileWithIgnoreExisting(t *testing.T) {
 func TestCaseInsensitiveMoveFile(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	if !r.Fremote.Features().CaseInsensitive {
 		return
 	}
@@ -928,7 +911,6 @@ func TestMoveFileBackupDir(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	if !operations.CanServerSideMove(r.Fremote) {
 		t.Skip("Skipping test as remote does not support server-side move or copy")
 	}
@@ -951,7 +933,6 @@ func TestMoveFileBackupDir(t *testing.T) {
 func TestCopyFile(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	file1 := r.WriteFile("file1", "file1 contents", t1)
 	r.CheckLocalItems(t, file1)
@@ -979,7 +960,6 @@ func TestCopyFileBackupDir(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	if !operations.CanServerSideMove(r.Fremote) {
 		t.Skip("Skipping test as remote does not support server-side move or copy")
 	}
@@ -1004,7 +984,6 @@ func TestCopyFileCompareDest(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.CompareDest = []string{r.FremoteName + "/CompareDest"}
 	fdst, err := fs.NewFs(ctx, r.FremoteName+"/dst")
@@ -1083,7 +1062,6 @@ func TestCopyFileCopyDest(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if r.Fremote.Features().Copy == nil {
 		t.Skip("Skipping test as remote does not support server-side copy")
@@ -1457,7 +1435,6 @@ func TestListFormat(t *testing.T) {
 func TestDirMove(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	r.Mkdir(ctx, r.Fremote)
 
@@ -1538,7 +1515,6 @@ func TestDirMove(t *testing.T) {
 
 func TestGetFsInfo(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	f := r.Fremote
 	info := operations.GetFsInfo(f)
@@ -1559,7 +1535,7 @@ func TestGetFsInfo(t *testing.T) {
 func TestRcat(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
-	check := func(withChecksum, ignoreChecksum bool) {
+	check := func(t *testing.T, withChecksum, ignoreChecksum bool) {
 		ci.CheckSum, ci.IgnoreChecksum = withChecksum, ignoreChecksum
 
 		var prefix string
@@ -1573,7 +1549,6 @@ func TestRcat(t *testing.T) {
 		}
 
 		r := fstest.NewRun(t)
-		defer r.Finalise()
 
 		if *fstest.SizeLimit > 0 && int64(ci.StreamingUploadCutoff) > *fstest.SizeLimit {
 			savedCutoff := ci.StreamingUploadCutoff
@@ -1606,14 +1581,13 @@ func TestRcat(t *testing.T) {
 		withChecksum := (i & 1) != 0
 		ignoreChecksum := (i & 2) != 0
 		t.Run(fmt.Sprintf("withChecksum=%v,ignoreChecksum=%v", withChecksum, ignoreChecksum), func(t *testing.T) {
-			check(withChecksum, ignoreChecksum)
+			check(t, withChecksum, ignoreChecksum)
 		})
 	}
 }
 
 func TestRcatMetadata(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if !r.Fremote.Features().UserMetadata {
 		t.Skip("Skipping as destination doesn't support user metadata")
@@ -1670,7 +1644,6 @@ func TestRcatMetadata(t *testing.T) {
 func TestRcatSize(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	const body = "------------------------------------------------------------"
 	file1 := r.WriteFile("potato1", body, t1)
@@ -1696,7 +1669,6 @@ func TestRcatSize(t *testing.T) {
 
 func TestRcatSizeMetadata(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if !r.Fremote.Features().UserMetadata {
 		t.Skip("Skipping as destination doesn't support user metadata")
@@ -1750,7 +1722,6 @@ func TestCopyFileMaxTransfer(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	defer accounting.Stats(ctx).ResetCounters()
 
 	const sizeCutoff = 2048
@@ -1817,7 +1788,6 @@ func TestCopyFileMaxTransfer(t *testing.T) {
 func TestTouchDir(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if r.Fremote.Precision() == fs.ModTimeNotSupported {
 		t.Skip("Skipping test as remote does not support modtime")

--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -35,7 +35,6 @@ func rcNewRun(t *testing.T, method string) (*fstest.Run, *rc.Call) {
 // operations/about: Return the space used on the remote
 func TestRcAbout(t *testing.T) {
 	r, call := rcNewRun(t, "operations/about")
-	defer r.Finalise()
 	r.Mkdir(context.Background(), r.Fremote)
 
 	// Will get an error if remote doesn't support About
@@ -58,7 +57,6 @@ func TestRcAbout(t *testing.T) {
 // operations/cleanup: Remove trashed files in the remote or path
 func TestRcCleanup(t *testing.T) {
 	r, call := rcNewRun(t, "operations/cleanup")
-	defer r.Finalise()
 
 	in := rc.Params{
 		"fs": r.LocalName,
@@ -72,7 +70,6 @@ func TestRcCleanup(t *testing.T) {
 // operations/copyfile: Copy a file from source remote to destination remote
 func TestRcCopyfile(t *testing.T) {
 	r, call := rcNewRun(t, "operations/copyfile")
-	defer r.Finalise()
 	file1 := r.WriteFile("file1", "file1 contents", t1)
 	r.Mkdir(context.Background(), r.Fremote)
 	r.CheckLocalItems(t, file1)
@@ -96,7 +93,6 @@ func TestRcCopyfile(t *testing.T) {
 // operations/copyurl: Copy the URL to the object
 func TestRcCopyurl(t *testing.T) {
 	r, call := rcNewRun(t, "operations/copyurl")
-	defer r.Finalise()
 	contents := "file1 contents\n"
 	file1 := r.WriteFile("file1", contents, t1)
 	r.Mkdir(context.Background(), r.Fremote)
@@ -159,7 +155,6 @@ func TestRcCopyurl(t *testing.T) {
 // operations/delete: Remove files in the path
 func TestRcDelete(t *testing.T) {
 	r, call := rcNewRun(t, "operations/delete")
-	defer r.Finalise()
 
 	file1 := r.WriteObject(context.Background(), "small", "1234567890", t2)                                                                                           // 10 bytes
 	file2 := r.WriteObject(context.Background(), "medium", "------------------------------------------------------------", t1)                                        // 60 bytes
@@ -179,7 +174,6 @@ func TestRcDelete(t *testing.T) {
 // operations/deletefile: Remove the single file pointed to
 func TestRcDeletefile(t *testing.T) {
 	r, call := rcNewRun(t, "operations/deletefile")
-	defer r.Finalise()
 
 	file1 := r.WriteObject(context.Background(), "small", "1234567890", t2)                                                    // 10 bytes
 	file2 := r.WriteObject(context.Background(), "medium", "------------------------------------------------------------", t1) // 60 bytes
@@ -199,7 +193,6 @@ func TestRcDeletefile(t *testing.T) {
 // operations/list: List the given remote and path in JSON format.
 func TestRcList(t *testing.T) {
 	r, call := rcNewRun(t, "operations/list")
-	defer r.Finalise()
 
 	file1 := r.WriteObject(context.Background(), "a", "a", t1)
 	file2 := r.WriteObject(context.Background(), "subdir/b", "bb", t2)
@@ -264,7 +257,6 @@ func TestRcList(t *testing.T) {
 // operations/stat: Stat the given remote and path in JSON format.
 func TestRcStat(t *testing.T) {
 	r, call := rcNewRun(t, "operations/stat")
-	defer r.Finalise()
 
 	file1 := r.WriteObject(context.Background(), "subdir/a", "a", t1)
 
@@ -318,7 +310,6 @@ func TestRcStat(t *testing.T) {
 func TestRcMkdir(t *testing.T) {
 	ctx := context.Background()
 	r, call := rcNewRun(t, "operations/mkdir")
-	defer r.Finalise()
 	r.Mkdir(context.Background(), r.Fremote)
 
 	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{}, []string{}, fs.GetModifyWindow(ctx, r.Fremote))
@@ -337,7 +328,6 @@ func TestRcMkdir(t *testing.T) {
 // operations/movefile: Move a file from source remote to destination remote
 func TestRcMovefile(t *testing.T) {
 	r, call := rcNewRun(t, "operations/movefile")
-	defer r.Finalise()
 	file1 := r.WriteFile("file1", "file1 contents", t1)
 	r.Mkdir(context.Background(), r.Fremote)
 	r.CheckLocalItems(t, file1)
@@ -362,7 +352,6 @@ func TestRcMovefile(t *testing.T) {
 func TestRcPurge(t *testing.T) {
 	ctx := context.Background()
 	r, call := rcNewRun(t, "operations/purge")
-	defer r.Finalise()
 	file1 := r.WriteObject(context.Background(), "subdir/file1", "subdir/file1 contents", t1)
 
 	fstest.CheckListingWithPrecision(t, r.Fremote, []fstest.Item{file1}, []string{"subdir"}, fs.GetModifyWindow(ctx, r.Fremote))
@@ -382,7 +371,6 @@ func TestRcPurge(t *testing.T) {
 func TestRcRmdir(t *testing.T) {
 	ctx := context.Background()
 	r, call := rcNewRun(t, "operations/rmdir")
-	defer r.Finalise()
 	r.Mkdir(context.Background(), r.Fremote)
 	assert.NoError(t, r.Fremote.Mkdir(context.Background(), "subdir"))
 
@@ -403,7 +391,6 @@ func TestRcRmdir(t *testing.T) {
 func TestRcRmdirs(t *testing.T) {
 	ctx := context.Background()
 	r, call := rcNewRun(t, "operations/rmdirs")
-	defer r.Finalise()
 	r.Mkdir(context.Background(), r.Fremote)
 	assert.NoError(t, r.Fremote.Mkdir(context.Background(), "subdir"))
 	assert.NoError(t, r.Fremote.Mkdir(context.Background(), "subdir/subsubdir"))
@@ -439,7 +426,6 @@ func TestRcRmdirs(t *testing.T) {
 // operations/size: Count the number of bytes and files in remote
 func TestRcSize(t *testing.T) {
 	r, call := rcNewRun(t, "operations/size")
-	defer r.Finalise()
 	file1 := r.WriteObject(context.Background(), "small", "1234567890", t2)                                                           // 10 bytes
 	file2 := r.WriteObject(context.Background(), "subdir/medium", "------------------------------------------------------------", t1) // 60 bytes
 	file3 := r.WriteObject(context.Background(), "subdir/subsubdir/large", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1)  // 50 bytes
@@ -460,7 +446,6 @@ func TestRcSize(t *testing.T) {
 // operations/publiclink: Create or retrieve a public link to the given file or folder.
 func TestRcPublicLink(t *testing.T) {
 	r, call := rcNewRun(t, "operations/publiclink")
-	defer r.Finalise()
 	in := rc.Params{
 		"fs":     r.FremoteName,
 		"remote": "",
@@ -475,7 +460,6 @@ func TestRcPublicLink(t *testing.T) {
 // operations/fsinfo: Return information about the remote
 func TestRcFsInfo(t *testing.T) {
 	r, call := rcNewRun(t, "operations/fsinfo")
-	defer r.Finalise()
 	in := rc.Params{
 		"fs": r.FremoteName,
 	}
@@ -502,7 +486,6 @@ func TestRcFsInfo(t *testing.T) {
 // operations/uploadfile : Tests if upload file succeeds
 func TestUploadFile(t *testing.T) {
 	r, call := rcNewRun(t, "operations/uploadfile")
-	defer r.Finalise()
 	ctx := context.Background()
 
 	testFileName := "test.txt"
@@ -558,7 +541,6 @@ func TestUploadFile(t *testing.T) {
 // operations/command: Runs a backend command
 func TestRcCommand(t *testing.T) {
 	r, call := rcNewRun(t, "backend/command")
-	defer r.Finalise()
 	in := rc.Params{
 		"fs":      r.FremoteName,
 		"command": "noop",

--- a/fs/rc/webgui/rc_test.go
+++ b/fs/rc/webgui/rc_test.go
@@ -2,7 +2,6 @@ package webgui
 
 import (
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -22,7 +21,7 @@ func init() {
 	rcflags.Opt.WebUI = true
 }
 
-func setCacheDir(t *testing.T) string {
+func setCacheDir(t *testing.T) {
 	cacheDir := t.TempDir()
 	PluginsPath = filepath.Join(cacheDir, "plugins")
 	pluginsConfigPath = filepath.Join(cacheDir, "config")
@@ -30,11 +29,6 @@ func setCacheDir(t *testing.T) string {
 	loadedPlugins = newPlugins(availablePluginsJSONPath)
 	err := loadedPlugins.readFromFile()
 	assert.Nil(t, err)
-	return cacheDir
-}
-
-func cleanCacheDir(t *testing.T, cacheDir string) {
-	_ = os.RemoveAll(cacheDir)
 }
 
 func addPlugin(t *testing.T) {
@@ -88,8 +82,7 @@ func removePlugin(t *testing.T) {
 //}
 
 func TestAddPlugin(t *testing.T) {
-	cacheDir := setCacheDir(t)
-	defer cleanCacheDir(t, cacheDir)
+	setCacheDir(t)
 
 	addPlugin(t)
 	_, ok := loadedPlugins.LoadedPlugins[testPluginKey]
@@ -101,8 +94,7 @@ func TestAddPlugin(t *testing.T) {
 }
 
 func TestListPlugins(t *testing.T) {
-	cacheDir := setCacheDir(t)
-	defer cleanCacheDir(t, cacheDir)
+	setCacheDir(t)
 
 	addPlugin := rc.Calls.Get("pluginsctl/listPlugins")
 	assert.NotNil(t, addPlugin)
@@ -117,8 +109,7 @@ func TestListPlugins(t *testing.T) {
 }
 
 func TestRemovePlugin(t *testing.T) {
-	cacheDir := setCacheDir(t)
-	defer cleanCacheDir(t, cacheDir)
+	setCacheDir(t)
 
 	addPlugin(t)
 	removePluginCall := rc.Calls.Get("pluginsctl/removePlugin")

--- a/fs/sync/rc_test.go
+++ b/fs/sync/rc_test.go
@@ -26,7 +26,6 @@ func rcNewRun(t *testing.T, method string) (*fstest.Run, *rc.Call) {
 // sync/copy: copy a directory from source remote to destination remote
 func TestRcCopy(t *testing.T) {
 	r, call := rcNewRun(t, "sync/copy")
-	defer r.Finalise()
 	r.Mkdir(context.Background(), r.Fremote)
 
 	file1 := r.WriteBoth(context.Background(), "file1", "file1 contents", t1)
@@ -51,7 +50,6 @@ func TestRcCopy(t *testing.T) {
 // sync/move: move a directory from source remote to destination remote
 func TestRcMove(t *testing.T) {
 	r, call := rcNewRun(t, "sync/move")
-	defer r.Finalise()
 	r.Mkdir(context.Background(), r.Fremote)
 
 	file1 := r.WriteBoth(context.Background(), "file1", "file1 contents", t1)
@@ -76,7 +74,6 @@ func TestRcMove(t *testing.T) {
 // sync/sync: sync a directory from source remote to destination remote
 func TestRcSync(t *testing.T) {
 	r, call := rcNewRun(t, "sync/sync")
-	defer r.Finalise()
 	r.Mkdir(context.Background(), r.Fremote)
 
 	file1 := r.WriteBoth(context.Background(), "file1", "file1 contents", t1)

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -41,7 +41,6 @@ func TestCopyWithDryRun(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
 	r.Mkdir(ctx, r.Fremote)
 
@@ -57,7 +56,6 @@ func TestCopyWithDryRun(t *testing.T) {
 func TestCopy(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
 	r.Mkdir(ctx, r.Fremote)
 
@@ -71,7 +69,6 @@ func TestCopy(t *testing.T) {
 func TestCopyMissingDirectory(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	r.Mkdir(ctx, r.Fremote)
 
 	nonExistingFs, err := fs.NewFs(ctx, "/non-existing")
@@ -88,7 +85,6 @@ func TestCopyNoTraverse(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.NoTraverse = true
 
@@ -106,7 +102,6 @@ func TestCopyCheckFirst(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.CheckFirst = true
 
@@ -124,7 +119,6 @@ func TestSyncNoTraverse(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.NoTraverse = true
 
@@ -143,7 +137,6 @@ func TestCopyWithDepth(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
 	file2 := r.WriteFile("hello world2", "hello world2", t2)
 
@@ -162,7 +155,6 @@ func testCopyWithFilesFrom(t *testing.T, noTraverse bool) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("potato2", "hello world", t1)
 	file2 := r.WriteFile("hello world2", "hello world2", t2)
 
@@ -190,7 +182,6 @@ func TestCopyWithFilesFromAndNoTraverse(t *testing.T) { testCopyWithFilesFrom(t,
 func TestCopyEmptyDirectories(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
 	err := operations.Mkdir(ctx, r.Flocal, "sub dir2")
 	require.NoError(t, err)
@@ -215,7 +206,6 @@ func TestCopyEmptyDirectories(t *testing.T) {
 func TestMoveEmptyDirectories(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
 	err := operations.Mkdir(ctx, r.Flocal, "sub dir2")
 	require.NoError(t, err)
@@ -240,7 +230,6 @@ func TestMoveEmptyDirectories(t *testing.T) {
 func TestSyncEmptyDirectories(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
 	err := operations.Mkdir(ctx, r.Flocal, "sub dir2")
 	require.NoError(t, err)
@@ -265,7 +254,6 @@ func TestSyncEmptyDirectories(t *testing.T) {
 func TestServerSideCopy(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "sub dir/hello world", "hello world", t1)
 	r.CheckRemoteItems(t, file1)
 
@@ -285,7 +273,6 @@ func TestServerSideCopy(t *testing.T) {
 func TestCopyAfterDelete(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "sub dir/hello world", "hello world", t1)
 	r.CheckLocalItems(t)
 	r.CheckRemoteItems(t, file1)
@@ -304,7 +291,6 @@ func TestCopyAfterDelete(t *testing.T) {
 func TestCopyRedownload(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "sub dir/hello world", "hello world", t1)
 	r.CheckRemoteItems(t, file1)
 
@@ -322,7 +308,6 @@ func TestSyncBasedOnCheckSum(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	ci.CheckSum = true
 
 	file1 := r.WriteFile("check sum", "-", t1)
@@ -357,7 +342,6 @@ func TestSyncSizeOnly(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	ci.SizeOnly = true
 
 	file1 := r.WriteFile("sizeonly", "potato", t1)
@@ -392,7 +376,6 @@ func TestSyncIgnoreSize(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	ci.IgnoreSize = true
 
 	file1 := r.WriteFile("ignore-size", "contents", t1)
@@ -424,7 +407,6 @@ func TestSyncIgnoreTimes(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "existing", "potato", t1)
 	r.CheckRemoteItems(t, file1)
 
@@ -454,7 +436,6 @@ func TestSyncIgnoreExisting(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("existing", "potato", t1)
 
 	ci.IgnoreExisting = true
@@ -479,7 +460,6 @@ func TestSyncIgnoreErrors(t *testing.T) {
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
 	ci.IgnoreErrors = true
-	defer r.Finalise()
 	file1 := r.WriteFile("a/potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteObject(ctx, "b/potato", "SMALLER BUT SAME DATE", t2)
 	file3 := r.WriteBoth(ctx, "c/non empty space", "AhHa!", t2)
@@ -541,7 +521,6 @@ func TestSyncAfterChangingModtimeOnly(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("empty space", "-", t2)
 	file2 := r.WriteObject(ctx, "empty space", "-", t1)
 
@@ -571,7 +550,6 @@ func TestSyncAfterChangingModtimeOnlyWithNoUpdateModTime(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if r.Fremote.Hashes().Count() == 0 {
 		t.Logf("Can't check this if no hashes supported")
@@ -597,7 +575,6 @@ func TestSyncAfterChangingModtimeOnlyWithNoUpdateModTime(t *testing.T) {
 func TestSyncDoesntUpdateModtime(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	if fs.GetModifyWindow(ctx, r.Fremote) == fs.ModTimeNotSupported {
 		t.Skip("Can't run this test on fs which doesn't support mod time")
 	}
@@ -622,7 +599,6 @@ func TestSyncDoesntUpdateModtime(t *testing.T) {
 func TestSyncAfterAddingAFile(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "empty space", "-", t2)
 	file2 := r.WriteFile("potato", "------------------------------------------------------------", t3)
 
@@ -639,7 +615,6 @@ func TestSyncAfterAddingAFile(t *testing.T) {
 func TestSyncAfterChangingFilesSizeOnly(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteObject(ctx, "potato", "------------------------------------------------------------", t3)
 	file2 := r.WriteFile("potato", "smaller but same date", t3)
 	r.CheckRemoteItems(t, file1)
@@ -657,7 +632,6 @@ func TestSyncAfterChangingFilesSizeOnly(t *testing.T) {
 func TestSyncAfterChangingContentsOnly(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	var file1 fstest.Item
 	if r.Fremote.Precision() == fs.ModTimeNotSupported {
 		t.Logf("ModTimeNotSupported so forcing file to be a different size")
@@ -681,7 +655,6 @@ func TestSyncAfterRemovingAFileAndAddingAFileDryRun(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteObject(ctx, "potato", "SMALLER BUT SAME DATE", t2)
 	file3 := r.WriteBoth(ctx, "empty space", "-", t2)
@@ -699,7 +672,6 @@ func TestSyncAfterRemovingAFileAndAddingAFileDryRun(t *testing.T) {
 // Sync after removing a file and adding a file
 func testSyncAfterRemovingAFileAndAddingAFile(ctx context.Context, t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteObject(ctx, "potato", "SMALLER BUT SAME DATE", t2)
 	file3 := r.WriteBoth(ctx, "empty space", "-", t2)
@@ -720,7 +692,6 @@ func TestSyncAfterRemovingAFileAndAddingAFile(t *testing.T) {
 // Sync after removing a file and adding a file
 func testSyncAfterRemovingAFileAndAddingAFileSubDir(ctx context.Context, t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("a/potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteObject(ctx, "b/potato", "SMALLER BUT SAME DATE", t2)
 	file3 := r.WriteBoth(ctx, "c/non empty space", "AhHa!", t2)
@@ -788,7 +759,6 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDir(t *testing.T) {
 func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("a/potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteObject(ctx, "b/potato", "SMALLER BUT SAME DATE", t2)
 	file3 := r.WriteBoth(ctx, "c/non empty space", "AhHa!", t2)
@@ -882,7 +852,6 @@ func TestCopyDeleteBefore(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.DeleteMode = fs.DeleteModeBefore
 
@@ -903,7 +872,6 @@ func TestCopyDeleteBefore(t *testing.T) {
 func TestSyncWithExclude(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1)
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 	file3 := r.WriteFile("enormous", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1) // 100 bytes
@@ -932,7 +900,6 @@ func TestSyncWithExclude(t *testing.T) {
 func TestSyncWithExcludeAndDeleteExcluded(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteBoth(ctx, "potato2", "------------------------------------------------------------", t1) // 60 bytes
 	file2 := r.WriteBoth(ctx, "empty space", "-", t2)
 	file3 := r.WriteBoth(ctx, "enormous", "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", t1) // 100 bytes
@@ -963,7 +930,6 @@ func TestSyncWithUpdateOlder(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	if fs.GetModifyWindow(ctx, r.Fremote) == fs.ModTimeNotSupported {
 		t.Skip("Can't run this test on fs which doesn't support mod time")
 	}
@@ -1009,7 +975,6 @@ func testSyncWithMaxDuration(t *testing.T, cutoffMode fs.CutoffMode) {
 		t.Skip("Skipping test on non local remote")
 	}
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	maxDuration := 250 * time.Millisecond
 	ci.MaxDuration = maxDuration
@@ -1063,7 +1028,6 @@ func TestSyncWithTrackRenames(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.TrackRenames = true
 	defer func() {
@@ -1135,7 +1099,6 @@ func TestSyncWithTrackRenamesStrategyModtime(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.TrackRenames = true
 	ci.TrackRenamesStrategy = "modtime"
@@ -1171,7 +1134,6 @@ func TestSyncWithTrackRenamesStrategyLeaf(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.TrackRenames = true
 	ci.TrackRenamesStrategy = "leaf"
@@ -1285,7 +1247,6 @@ func testServerSideMove(ctx context.Context, t *testing.T, r *fstest.Run, withFi
 func TestMoveWithDeleteEmptySrcDirs(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
 	file2 := r.WriteFile("nested/sub dir/file", "nested", t1)
 	r.Mkdir(ctx, r.Fremote)
@@ -1305,7 +1266,6 @@ func TestMoveWithDeleteEmptySrcDirs(t *testing.T) {
 func TestMoveWithoutDeleteEmptySrcDirs(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
 	file2 := r.WriteFile("nested/sub dir/file", "nested", t1)
 	r.Mkdir(ctx, r.Fremote)
@@ -1329,7 +1289,6 @@ func TestMoveWithIgnoreExisting(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	file1 := r.WriteFile("existing", "potato", t1)
 	file2 := r.WriteFile("existing-b", "tomato", t1)
 
@@ -1380,7 +1339,6 @@ func TestMoveWithIgnoreExisting(t *testing.T) {
 func TestServerSideMove(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	testServerSideMove(ctx, t, r, false, false)
 }
 
@@ -1388,7 +1346,6 @@ func TestServerSideMove(t *testing.T) {
 func TestServerSideMoveWithFilter(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	fi, err := filter.NewFilter(nil)
 	require.NoError(t, err)
@@ -1402,7 +1359,6 @@ func TestServerSideMoveWithFilter(t *testing.T) {
 func TestServerSideMoveDeleteEmptySourceDirs(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	testServerSideMove(ctx, t, r, false, true)
 }
 
@@ -1410,7 +1366,6 @@ func TestServerSideMoveDeleteEmptySourceDirs(t *testing.T) {
 func TestServerSideMoveOverlap(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if r.Fremote.Features().DirMove != nil {
 		t.Skip("Skipping test as remote supports DirMove")
@@ -1441,7 +1396,6 @@ func TestServerSideMoveOverlap(t *testing.T) {
 func TestSyncOverlap(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	subRemoteName := r.FremoteName + "/rclone-sync-test"
 	FremoteSync, err := fs.NewFs(ctx, subRemoteName)
@@ -1463,7 +1417,6 @@ func TestSyncOverlap(t *testing.T) {
 func TestSyncOverlapWithFilter(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	fi, err := filter.NewFilter(nil)
 	require.NoError(t, err)
@@ -1521,7 +1474,6 @@ func TestSyncCompareDest(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.CompareDest = []string{r.FremoteName + "/CompareDest"}
 
@@ -1637,7 +1589,6 @@ func TestSyncMultipleCompareDest(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	precision := fs.GetModifyWindow(ctx, r.Fremote, r.Flocal)
 
 	ci.CompareDest = []string{r.FremoteName + "/pre-dest1", r.FremoteName + "/pre-dest2"}
@@ -1669,7 +1620,6 @@ func TestSyncCopyDest(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if r.Fremote.Features().Copy == nil {
 		t.Skip("Skipping test as remote does not support server-side copy")
@@ -1771,7 +1721,6 @@ func testSyncBackupDir(t *testing.T, backupDir string, suffix string, suffixKeep
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if !operations.CanServerSideMove(r.Fremote) {
 		t.Skip("Skipping test as remote does not support server-side move")
@@ -1869,7 +1818,6 @@ func testSyncSuffix(t *testing.T, suffix string, suffixKeepExtension bool) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if !operations.CanServerSideMove(r.Fremote) {
 		t.Skip("Skipping test as remote does not support server-side move")
@@ -1957,7 +1905,6 @@ func TestSyncUTFNorm(t *testing.T) {
 	}
 
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	// Two strings with different unicode normalization (from OS X)
 	Encoding1 := "Testêé"
@@ -1988,7 +1935,6 @@ func TestSyncImmutable(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	ci.Immutable = true
 
@@ -2022,7 +1968,6 @@ func TestSyncIgnoreCase(t *testing.T) {
 	ctx := context.Background()
 	ctx, ci := fs.AddConfig(ctx)
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	// Only test if filesystems are case sensitive
 	if r.Fremote.Features().CaseInsensitive || r.Flocal.Features().CaseInsensitive {
@@ -2056,7 +2001,6 @@ func TestMaxTransfer(t *testing.T) {
 
 	test := func(t *testing.T, cutoff fs.CutoffMode) {
 		r := fstest.NewRun(t)
-		defer r.Finalise()
 		ci.CutoffMode = cutoff
 
 		if r.Fremote.Name() != "local" {
@@ -2098,7 +2042,6 @@ func testSyncConcurrent(t *testing.T, subtest string) {
 	ci.Transfers = NTRANSFERS
 
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 	stats := accounting.GlobalStats()
 
 	itemsBefore := []fstest.Item{}

--- a/fstest/run.go
+++ b/fstest/run.go
@@ -178,6 +178,7 @@ func newRunIndividual(t *testing.T, individual bool) *Run {
 	r.Logf = t.Logf
 	r.Fatalf = t.Fatalf
 	r.Logf("Remote %q, Local %q, Modify Window %q", r.Fremote, r.Flocal, fs.GetModifyWindow(ctx, r.Fremote))
+	t.Cleanup(r.Finalise)
 	return r
 }
 
@@ -186,8 +187,6 @@ func newRunIndividual(t *testing.T, individual bool) *Run {
 //
 // r.Flocal is an empty local Fs
 // r.Fremote is an empty remote Fs
-//
-// Finalise() will tidy them away when done.
 func NewRun(t *testing.T) *Run {
 	return newRunIndividual(t, *Individual)
 }

--- a/vfs/dir_handle_test.go
+++ b/vfs/dir_handle_test.go
@@ -11,8 +11,7 @@ import (
 )
 
 func TestDirHandleMethods(t *testing.T) {
-	_, _, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	_, _, dir, _ := dirCreate(t)
 
 	h, err := dir.Open(os.O_RDONLY)
 	require.NoError(t, err)
@@ -38,8 +37,7 @@ func TestDirHandleMethods(t *testing.T) {
 }
 
 func TestDirHandleReaddir(t *testing.T) {
-	r, vfs, cleanup := newTestVFS(t)
-	defer cleanup()
+	r, vfs := newTestVFS(t)
 
 	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2- contents", t2)
@@ -93,8 +91,7 @@ func TestDirHandleReaddir(t *testing.T) {
 }
 
 func TestDirHandleReaddirnames(t *testing.T) {
-	_, _, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	_, _, dir, _ := dirCreate(t)
 
 	fh, err := dir.Open(os.O_RDONLY)
 	require.NoError(t, err)

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func dirCreate(t *testing.T) (r *fstest.Run, vfs *VFS, dir *Dir, item fstest.Item, cleanup func()) {
-	r, vfs, cleanup = newTestVFS(t)
+func dirCreate(t *testing.T) (r *fstest.Run, vfs *VFS, dir *Dir, item fstest.Item) {
+	r, vfs = newTestVFS(t)
 
 	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
 	r.CheckRemoteItems(t, file1)
@@ -25,12 +25,11 @@ func dirCreate(t *testing.T) (r *fstest.Run, vfs *VFS, dir *Dir, item fstest.Ite
 	require.NoError(t, err)
 	require.True(t, node.IsDir())
 
-	return r, vfs, node.(*Dir), file1, cleanup
+	return r, vfs, node.(*Dir), file1
 }
 
 func TestDirMethods(t *testing.T) {
-	_, vfs, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	_, vfs, dir, _ := dirCreate(t)
 
 	// String
 	assert.Equal(t, "dir/", dir.String())
@@ -81,8 +80,7 @@ func TestDirMethods(t *testing.T) {
 }
 
 func TestDirForgetAll(t *testing.T) {
-	_, vfs, dir, file1, cleanup := dirCreate(t)
-	defer cleanup()
+	_, vfs, dir, file1 := dirCreate(t)
 
 	// Make sure / and dir are in cache
 	_, err := vfs.Stat(file1.Path)
@@ -109,8 +107,7 @@ func TestDirForgetAll(t *testing.T) {
 }
 
 func TestDirForgetPath(t *testing.T) {
-	_, vfs, dir, file1, cleanup := dirCreate(t)
-	defer cleanup()
+	_, vfs, dir, file1 := dirCreate(t)
 
 	// Make sure / and dir are in cache
 	_, err := vfs.Stat(file1.Path)
@@ -141,8 +138,7 @@ func TestDirForgetPath(t *testing.T) {
 }
 
 func TestDirWalk(t *testing.T) {
-	r, vfs, _, file1, cleanup := dirCreate(t)
-	defer cleanup()
+	r, vfs, _, file1 := dirCreate(t)
 
 	file2 := r.WriteObject(context.Background(), "fil/a/b/c", "super long file", t1)
 	r.CheckRemoteItems(t, file1, file2)
@@ -210,8 +206,7 @@ func TestDirWalk(t *testing.T) {
 }
 
 func TestDirSetModTime(t *testing.T) {
-	_, vfs, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	_, vfs, dir, _ := dirCreate(t)
 
 	err := dir.SetModTime(t1)
 	require.NoError(t, err)
@@ -227,8 +222,7 @@ func TestDirSetModTime(t *testing.T) {
 }
 
 func TestDirStat(t *testing.T) {
-	_, _, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	_, _, dir, _ := dirCreate(t)
 
 	node, err := dir.Stat("file1")
 	require.NoError(t, err)
@@ -253,8 +247,7 @@ func checkListing(t *testing.T, dir *Dir, want []string) {
 }
 
 func TestDirReadDirAll(t *testing.T) {
-	r, vfs, cleanup := newTestVFS(t)
-	defer cleanup()
+	r, vfs := newTestVFS(t)
 
 	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2- contents", t2)
@@ -334,8 +327,7 @@ func TestDirReadDirAll(t *testing.T) {
 }
 
 func TestDirOpen(t *testing.T) {
-	_, _, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	_, _, dir, _ := dirCreate(t)
 
 	fd, err := dir.Open(os.O_RDONLY)
 	require.NoError(t, err)
@@ -348,8 +340,7 @@ func TestDirOpen(t *testing.T) {
 }
 
 func TestDirCreate(t *testing.T) {
-	_, vfs, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	_, vfs, dir, _ := dirCreate(t)
 
 	file, err := dir.Create("potato", os.O_WRONLY|os.O_CREATE)
 	require.NoError(t, err)
@@ -388,8 +379,7 @@ func TestDirCreate(t *testing.T) {
 }
 
 func TestDirMkdir(t *testing.T) {
-	r, vfs, dir, file1, cleanup := dirCreate(t)
-	defer cleanup()
+	r, vfs, dir, file1 := dirCreate(t)
 
 	_, err := dir.Mkdir("file1")
 	assert.Error(t, err)
@@ -410,8 +400,7 @@ func TestDirMkdir(t *testing.T) {
 }
 
 func TestDirMkdirSub(t *testing.T) {
-	r, vfs, dir, file1, cleanup := dirCreate(t)
-	defer cleanup()
+	r, vfs, dir, file1 := dirCreate(t)
 
 	_, err := dir.Mkdir("file1")
 	assert.Error(t, err)
@@ -436,8 +425,7 @@ func TestDirMkdirSub(t *testing.T) {
 }
 
 func TestDirRemove(t *testing.T) {
-	r, vfs, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	r, vfs, dir, _ := dirCreate(t)
 
 	// check directory is there
 	node, err := vfs.Stat("dir")
@@ -476,8 +464,7 @@ func TestDirRemove(t *testing.T) {
 }
 
 func TestDirRemoveAll(t *testing.T) {
-	r, vfs, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	r, vfs, dir, _ := dirCreate(t)
 
 	// Remove the directory and contents
 	err := dir.RemoveAll()
@@ -498,8 +485,7 @@ func TestDirRemoveAll(t *testing.T) {
 }
 
 func TestDirRemoveName(t *testing.T) {
-	r, vfs, dir, _, cleanup := dirCreate(t)
-	defer cleanup()
+	r, vfs, dir, _ := dirCreate(t)
 
 	err := dir.RemoveName("file1")
 	require.NoError(t, err)
@@ -518,8 +504,7 @@ func TestDirRemoveName(t *testing.T) {
 }
 
 func TestDirRename(t *testing.T) {
-	r, vfs, dir, file1, cleanup := dirCreate(t)
-	defer cleanup()
+	r, vfs, dir, file1 := dirCreate(t)
 
 	features := r.Fremote.Features()
 	if features.DirMove == nil && features.Move == nil && features.Copy == nil {

--- a/vfs/file_test.go
+++ b/vfs/file_test.go
@@ -17,11 +17,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func fileCreate(t *testing.T, mode vfscommon.CacheMode) (r *fstest.Run, vfs *VFS, fh *File, item fstest.Item, cleanup func()) {
+func fileCreate(t *testing.T, mode vfscommon.CacheMode) (r *fstest.Run, vfs *VFS, fh *File, item fstest.Item) {
 	opt := vfscommon.DefaultOpt
 	opt.CacheMode = mode
 	opt.WriteBack = writeBackDelay
-	r, vfs, cleanup = newTestVFSOpt(t, &opt)
+	r, vfs = newTestVFSOpt(t, &opt)
 
 	file1 := r.WriteObject(context.Background(), "dir/file1", "file1 contents", t1)
 	r.CheckRemoteItems(t, file1)
@@ -30,12 +30,11 @@ func fileCreate(t *testing.T, mode vfscommon.CacheMode) (r *fstest.Run, vfs *VFS
 	require.NoError(t, err)
 	require.True(t, node.Mode().IsRegular())
 
-	return r, vfs, node.(*File), file1, cleanup
+	return r, vfs, node.(*File), file1
 }
 
 func TestFileMethods(t *testing.T) {
-	r, vfs, file, _, cleanup := fileCreate(t, vfscommon.CacheModeOff)
-	defer cleanup()
+	r, vfs, file, _ := fileCreate(t, vfscommon.CacheModeOff)
 
 	// String
 	assert.Equal(t, "dir/file1", file.String())
@@ -92,8 +91,7 @@ func testFileSetModTime(t *testing.T, cacheMode vfscommon.CacheMode, open bool, 
 	if !canSetModTimeValue {
 		t.Skip("can't set mod time")
 	}
-	r, vfs, file, file1, cleanup := fileCreate(t, cacheMode)
-	defer cleanup()
+	r, vfs, file, file1 := fileCreate(t, cacheMode)
 	if !canSetModTime(t, r) {
 		t.Skip("can't set mod time")
 	}
@@ -176,8 +174,7 @@ func fileCheckContents(t *testing.T, file *File) {
 }
 
 func TestFileOpenRead(t *testing.T) {
-	_, _, file, _, cleanup := fileCreate(t, vfscommon.CacheModeOff)
-	defer cleanup()
+	_, _, file, _ := fileCreate(t, vfscommon.CacheModeOff)
 
 	fileCheckContents(t, file)
 }
@@ -229,8 +226,7 @@ func TestFileOpenReadUnknownSize(t *testing.T) {
 }
 
 func TestFileOpenWrite(t *testing.T) {
-	_, vfs, file, _, cleanup := fileCreate(t, vfscommon.CacheModeOff)
-	defer cleanup()
+	_, vfs, file, _ := fileCreate(t, vfscommon.CacheModeOff)
 
 	fd, err := file.openWrite(os.O_WRONLY | os.O_TRUNC)
 	require.NoError(t, err)
@@ -249,8 +245,7 @@ func TestFileOpenWrite(t *testing.T) {
 }
 
 func TestFileRemove(t *testing.T) {
-	r, vfs, file, _, cleanup := fileCreate(t, vfscommon.CacheModeOff)
-	defer cleanup()
+	r, vfs, file, _ := fileCreate(t, vfscommon.CacheModeOff)
 
 	err := file.Remove()
 	require.NoError(t, err)
@@ -263,8 +258,7 @@ func TestFileRemove(t *testing.T) {
 }
 
 func TestFileRemoveAll(t *testing.T) {
-	r, vfs, file, _, cleanup := fileCreate(t, vfscommon.CacheModeOff)
-	defer cleanup()
+	r, vfs, file, _ := fileCreate(t, vfscommon.CacheModeOff)
 
 	err := file.RemoveAll()
 	require.NoError(t, err)
@@ -277,8 +271,7 @@ func TestFileRemoveAll(t *testing.T) {
 }
 
 func TestFileOpen(t *testing.T) {
-	_, _, file, _, cleanup := fileCreate(t, vfscommon.CacheModeOff)
-	defer cleanup()
+	_, _, file, _ := fileCreate(t, vfscommon.CacheModeOff)
 
 	fd, err := file.Open(os.O_RDONLY)
 	require.NoError(t, err)
@@ -303,8 +296,7 @@ func TestFileOpen(t *testing.T) {
 }
 
 func testFileRename(t *testing.T, mode vfscommon.CacheMode, inCache bool, forceCache bool) {
-	r, vfs, file, item, cleanup := fileCreate(t, mode)
-	defer cleanup()
+	r, vfs, file, item := fileCreate(t, mode)
 
 	if !operations.CanServerSideMove(r.Fremote) {
 		t.Skip("skip as can't rename files")

--- a/vfs/rc_test.go
+++ b/vfs/rc_test.go
@@ -12,14 +12,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func rcNewRun(t *testing.T, method string) (r *fstest.Run, vfs *VFS, cleanup func(), call *rc.Call) {
+func rcNewRun(t *testing.T, method string) (r *fstest.Run, vfs *VFS, call *rc.Call) {
 	if *fstest.RemoteName != "" {
 		t.Skip("Skipping test on non local remote")
 	}
-	r, vfs, cleanup = newTestVFS(t)
+	r, vfs = newTestVFS(t)
 	call = rc.Calls.Get(method)
 	assert.NotNil(t, call)
-	return r, vfs, cleanup, call
+	return r, vfs, call
 }
 
 func TestRcGetVFS(t *testing.T) {
@@ -29,8 +29,7 @@ func TestRcGetVFS(t *testing.T) {
 	assert.Contains(t, err.Error(), "no VFS active")
 	assert.Nil(t, vfs)
 
-	r, vfs2, cleanup := newTestVFS(t)
-	defer cleanup()
+	r, vfs2 := newTestVFS(t)
 
 	vfs, err = getVFS(in)
 	require.NoError(t, err)
@@ -65,8 +64,7 @@ func TestRcGetVFS(t *testing.T) {
 }
 
 func TestRcForget(t *testing.T) {
-	r, vfs, cleanup, call := rcNewRun(t, "vfs/forget")
-	defer cleanup()
+	r, vfs, call := rcNewRun(t, "vfs/forget")
 	_, _ = r, vfs
 	in := rc.Params{"fs": fs.ConfigString(r.Fremote)}
 	out, err := call.Fn(context.Background(), in)
@@ -78,8 +76,7 @@ func TestRcForget(t *testing.T) {
 }
 
 func TestRcRefresh(t *testing.T) {
-	r, vfs, cleanup, call := rcNewRun(t, "vfs/refresh")
-	defer cleanup()
+	r, vfs, call := rcNewRun(t, "vfs/refresh")
 	_, _ = r, vfs
 	in := rc.Params{"fs": fs.ConfigString(r.Fremote)}
 	out, err := call.Fn(context.Background(), in)
@@ -93,8 +90,7 @@ func TestRcRefresh(t *testing.T) {
 }
 
 func TestRcPollInterval(t *testing.T) {
-	r, vfs, cleanup, call := rcNewRun(t, "vfs/poll-interval")
-	defer cleanup()
+	r, vfs, call := rcNewRun(t, "vfs/poll-interval")
 	_ = vfs
 	if r.Fremote.Features().ChangeNotify == nil {
 		t.Skip("ChangeNotify not supported")
@@ -106,8 +102,7 @@ func TestRcPollInterval(t *testing.T) {
 }
 
 func TestRcList(t *testing.T) {
-	r, vfs, cleanup, call := rcNewRun(t, "vfs/list")
-	defer cleanup()
+	r, vfs, call := rcNewRun(t, "vfs/list")
 	_ = vfs
 
 	out, err := call.Fn(context.Background(), nil)
@@ -121,8 +116,7 @@ func TestRcList(t *testing.T) {
 }
 
 func TestRcStats(t *testing.T) {
-	r, vfs, cleanup, call := rcNewRun(t, "vfs/stats")
-	defer cleanup()
+	r, vfs, call := rcNewRun(t, "vfs/stats")
 	out, err := call.Fn(context.Background(), nil)
 	require.NoError(t, err)
 	assert.Equal(t, fs.ConfigString(r.Fremote), out["fs"])

--- a/vfs/read_test.go
+++ b/vfs/read_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 // Open a file for write
-func readHandleCreate(t *testing.T) (r *fstest.Run, vfs *VFS, fh *ReadFileHandle, cleanup func()) {
-	r, vfs, cleanup = newTestVFS(t)
+func readHandleCreate(t *testing.T) (r *fstest.Run, vfs *VFS, fh *ReadFileHandle) {
+	r, vfs = newTestVFS(t)
 
 	file1 := r.WriteObject(context.Background(), "dir/file1", "0123456789abcdef", t1)
 	r.CheckRemoteItems(t, file1)
@@ -23,7 +23,7 @@ func readHandleCreate(t *testing.T) (r *fstest.Run, vfs *VFS, fh *ReadFileHandle
 	fh, ok := h.(*ReadFileHandle)
 	require.True(t, ok)
 
-	return r, vfs, fh, cleanup
+	return r, vfs, fh
 }
 
 // read data from the string
@@ -37,8 +37,7 @@ func readString(t *testing.T, fh *ReadFileHandle, n int) string {
 }
 
 func TestReadFileHandleMethods(t *testing.T) {
-	_, _, fh, cleanup := readHandleCreate(t)
-	defer cleanup()
+	_, _, fh := readHandleCreate(t)
 
 	// String
 	assert.Equal(t, "dir/file1 (r)", fh.String())
@@ -80,8 +79,7 @@ func TestReadFileHandleMethods(t *testing.T) {
 }
 
 func TestReadFileHandleSeek(t *testing.T) {
-	_, _, fh, cleanup := readHandleCreate(t)
-	defer cleanup()
+	_, _, fh := readHandleCreate(t)
 
 	assert.Equal(t, "0", readString(t, fh, 1))
 
@@ -123,8 +121,7 @@ func TestReadFileHandleSeek(t *testing.T) {
 }
 
 func TestReadFileHandleReadAt(t *testing.T) {
-	_, _, fh, cleanup := readHandleCreate(t)
-	defer cleanup()
+	_, _, fh := readHandleCreate(t)
 
 	// read from start
 	buf := make([]byte, 1)
@@ -179,8 +176,7 @@ func TestReadFileHandleReadAt(t *testing.T) {
 }
 
 func TestReadFileHandleFlush(t *testing.T) {
-	_, _, fh, cleanup := readHandleCreate(t)
-	defer cleanup()
+	_, _, fh := readHandleCreate(t)
 
 	// Check Flush does nothing if read not called
 	err := fh.Flush()
@@ -208,8 +204,7 @@ func TestReadFileHandleFlush(t *testing.T) {
 }
 
 func TestReadFileHandleRelease(t *testing.T) {
-	_, _, fh, cleanup := readHandleCreate(t)
-	defer cleanup()
+	_, _, fh := readHandleCreate(t)
 
 	// Check Release does nothing if file not read from
 	err := fh.Release()

--- a/vfs/vfs_case_test.go
+++ b/vfs/vfs_case_test.go
@@ -13,7 +13,6 @@ import (
 
 func TestCaseSensitivity(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	if r.Fremote.Features().CaseInsensitive {
 		t.Skip("Can't test case sensitivity - this remote is officially not case-sensitive")

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -46,18 +46,17 @@ func cleanupVFS(t *testing.T, vfs *VFS) {
 }
 
 // Create a new VFS
-func newTestVFSOpt(t *testing.T, opt *vfscommon.Options) (r *fstest.Run, vfs *VFS, cleanup func()) {
+func newTestVFSOpt(t *testing.T, opt *vfscommon.Options) (r *fstest.Run, vfs *VFS) {
 	r = fstest.NewRun(t)
 	vfs = New(r.Fremote, opt)
-	cleanup = func() {
+	t.Cleanup(func() {
 		cleanupVFS(t, vfs)
-		r.Finalise()
-	}
-	return r, vfs, cleanup
+	})
+	return r, vfs
 }
 
 // Create a new VFS with default options
-func newTestVFS(t *testing.T) (r *fstest.Run, vfs *VFS, cleanup func()) {
+func newTestVFS(t *testing.T) (r *fstest.Run, vfs *VFS) {
 	return newTestVFSOpt(t, nil)
 }
 
@@ -136,7 +135,7 @@ func TestVFSNew(t *testing.T) {
 
 	checkActiveCacheEntries(0)
 
-	r, vfs, cleanup := newTestVFS(t)
+	r, vfs := newTestVFS(t)
 
 	// Check making a VFS with nil options
 	var defaultOpt = vfscommon.DefaultOpt
@@ -158,7 +157,7 @@ func TestVFSNew(t *testing.T) {
 
 	checkActiveCacheEntries(1)
 
-	cleanup()
+	cleanupVFS(t, vfs)
 
 	checkActiveCacheEntries(0)
 }
@@ -169,8 +168,7 @@ func TestVFSNewWithOpts(t *testing.T) {
 	opt.DirPerms = 0777
 	opt.FilePerms = 0666
 	opt.Umask = 0002
-	_, vfs, cleanup := newTestVFSOpt(t, &opt)
-	defer cleanup()
+	_, vfs := newTestVFSOpt(t, &opt)
 
 	assert.Equal(t, os.FileMode(0775)|os.ModeDir, vfs.Opt.DirPerms)
 	assert.Equal(t, os.FileMode(0664), vfs.Opt.FilePerms)
@@ -178,8 +176,7 @@ func TestVFSNewWithOpts(t *testing.T) {
 
 // TestRoot checks root directory is present and correct
 func TestVFSRoot(t *testing.T) {
-	_, vfs, cleanup := newTestVFS(t)
-	defer cleanup()
+	_, vfs := newTestVFS(t)
 
 	root, err := vfs.Root()
 	require.NoError(t, err)
@@ -189,8 +186,7 @@ func TestVFSRoot(t *testing.T) {
 }
 
 func TestVFSStat(t *testing.T) {
-	r, vfs, cleanup := newTestVFS(t)
-	defer cleanup()
+	r, vfs := newTestVFS(t)
 
 	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
@@ -225,8 +221,7 @@ func TestVFSStat(t *testing.T) {
 }
 
 func TestVFSStatParent(t *testing.T) {
-	r, vfs, cleanup := newTestVFS(t)
-	defer cleanup()
+	r, vfs := newTestVFS(t)
 
 	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
@@ -258,8 +253,7 @@ func TestVFSStatParent(t *testing.T) {
 }
 
 func TestVFSOpenFile(t *testing.T) {
-	r, vfs, cleanup := newTestVFS(t)
-	defer cleanup()
+	r, vfs := newTestVFS(t)
 
 	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
 	file2 := r.WriteObject(context.Background(), "dir/file2", "file2 contents", t2)
@@ -293,8 +287,7 @@ func TestVFSOpenFile(t *testing.T) {
 }
 
 func TestVFSRename(t *testing.T) {
-	r, vfs, cleanup := newTestVFS(t)
-	defer cleanup()
+	r, vfs := newTestVFS(t)
 
 	features := r.Fremote.Features()
 	if features.Move == nil && features.Copy == nil {
@@ -322,8 +315,7 @@ func TestVFSRename(t *testing.T) {
 }
 
 func TestVFSStatfs(t *testing.T) {
-	r, vfs, cleanup := newTestVFS(t)
-	defer cleanup()
+	r, vfs := newTestVFS(t)
 
 	// pre-conditions
 	assert.Nil(t, vfs.usage)

--- a/vfs/vfscache/cache_test.go
+++ b/vfs/vfscache/cache_test.go
@@ -81,7 +81,7 @@ func addVirtual(remote string, size int64, isDir bool) error {
 	return nil
 }
 
-func newTestCacheOpt(t *testing.T, opt vfscommon.Options) (r *fstest.Run, c *Cache, cleanup func()) {
+func newTestCacheOpt(t *testing.T, opt vfscommon.Options) (r *fstest.Run, c *Cache) {
 	r = fstest.NewRun(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -90,18 +90,17 @@ func newTestCacheOpt(t *testing.T, opt vfscommon.Options) (r *fstest.Run, c *Cac
 	c, err := New(ctx, r.Fremote, &opt, addVirtual)
 	require.NoError(t, err)
 
-	cleanup = func() {
+	t.Cleanup(func() {
 		err := c.CleanUp()
 		require.NoError(t, err)
 		assertPathNotExist(t, c.root)
 		cancel()
-		r.Finalise()
-	}
+	})
 
-	return r, c, cleanup
+	return r, c
 }
 
-func newTestCache(t *testing.T) (r *fstest.Run, c *Cache, cleanup func()) {
+func newTestCache(t *testing.T) (r *fstest.Run, c *Cache) {
 	opt := vfscommon.DefaultOpt
 
 	// Disable the cache cleaner as it interferes with these tests
@@ -114,8 +113,7 @@ func newTestCache(t *testing.T) (r *fstest.Run, c *Cache, cleanup func()) {
 }
 
 func TestCacheNew(t *testing.T) {
-	r, c, cleanup := newTestCache(t)
-	defer cleanup()
+	r, c := newTestCache(t)
 
 	assert.Contains(t, c.root, "vfs")
 	assert.Contains(t, c.fcache.Root(), filepath.Base(r.Fremote.Root()))
@@ -191,8 +189,7 @@ func TestCacheNew(t *testing.T) {
 }
 
 func TestCacheOpens(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	assert.Equal(t, []string(nil), itemAsString(c))
 	potato := c.Item("potato")
@@ -240,8 +237,7 @@ func TestCacheOpens(t *testing.T) {
 
 // test the open, createItemDir, purge, close, purge sequence
 func TestCacheOpenMkdir(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	// open
 	potato := c.Item("sub/potato")
@@ -288,8 +284,7 @@ func TestCacheOpenMkdir(t *testing.T) {
 }
 
 func TestCachePurgeOld(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	// Test funcs
 	c.purgeOld(-10 * time.Second)
@@ -342,8 +337,7 @@ func TestCachePurgeOld(t *testing.T) {
 }
 
 func TestCachePurgeOverQuota(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	// Test funcs
 
@@ -428,8 +422,7 @@ func TestCachePurgeOverQuota(t *testing.T) {
 
 // test reset clean files
 func TestCachePurgeClean(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 	contents, obj, potato1 := newFile(t, r, c, "existing")
 	_ = contents
 
@@ -491,8 +484,7 @@ func TestCachePurgeClean(t *testing.T) {
 }
 
 func TestCacheInUse(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	assert.False(t, c.InUse("potato"))
 
@@ -510,8 +502,7 @@ func TestCacheInUse(t *testing.T) {
 }
 
 func TestCacheDirtyItem(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	assert.Nil(t, c.DirtyItem("potato"))
 
@@ -530,8 +521,7 @@ func TestCacheDirtyItem(t *testing.T) {
 }
 
 func TestCacheExistsAndRemove(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	assert.False(t, c.Exists("potato"))
 
@@ -554,8 +544,7 @@ func TestCacheExistsAndRemove(t *testing.T) {
 }
 
 func TestCacheRename(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	// setup
 
@@ -611,8 +600,7 @@ func TestCacheCleaner(t *testing.T) {
 	opt := vfscommon.DefaultOpt
 	opt.CachePollInterval = 10 * time.Millisecond
 	opt.CacheMaxAge = 20 * time.Millisecond
-	_, c, cleanup := newTestCacheOpt(t, opt)
-	defer cleanup()
+	_, c := newTestCacheOpt(t, opt)
 
 	time.Sleep(2 * opt.CachePollInterval)
 
@@ -634,8 +622,7 @@ func TestCacheCleaner(t *testing.T) {
 }
 
 func TestCacheSetModTime(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	t1 := time.Date(2010, 1, 2, 3, 4, 5, 9, time.UTC)
 
@@ -653,8 +640,7 @@ func TestCacheSetModTime(t *testing.T) {
 }
 
 func TestCacheTotaInUse(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	assert.Equal(t, int(0), c.TotalInUse())
 
@@ -681,8 +667,7 @@ func TestCacheTotaInUse(t *testing.T) {
 }
 
 func TestCacheDump(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	out := (*Cache)(nil).Dump()
 	assert.Equal(t, "Cache: <nil>\n", out)
@@ -703,8 +688,7 @@ func TestCacheDump(t *testing.T) {
 }
 
 func TestCacheStats(t *testing.T) {
-	_, c, cleanup := newTestCache(t)
-	defer cleanup()
+	_, c := newTestCache(t)
 
 	out := c.Stats()
 	assert.Equal(t, int64(0), out["bytesUsed"])

--- a/vfs/vfscache/downloaders/downloaders_test.go
+++ b/vfs/vfscache/downloaders/downloaders_test.go
@@ -75,7 +75,6 @@ func (item *testItem) WriteAtNoOverwrite(b []byte, off int64) (n int, skipped in
 
 func TestDownloaders(t *testing.T) {
 	r := fstest.NewRun(t)
-	defer r.Finalise()
 
 	var (
 		ctx    = context.Background()

--- a/vfs/vfscache/item_test.go
+++ b/vfs/vfscache/item_test.go
@@ -23,7 +23,7 @@ import (
 
 var zeroes = string(make([]byte, 100))
 
-func newItemTestCache(t *testing.T) (r *fstest.Run, c *Cache, cleanup func()) {
+func newItemTestCache(t *testing.T) (r *fstest.Run, c *Cache) {
 	opt := vfscommon.DefaultOpt
 
 	// Disable the cache cleaner as it interferes with these tests
@@ -61,8 +61,7 @@ func newFile(t *testing.T, r *fstest.Run, c *Cache, remote string) (contents str
 }
 
 func TestItemExists(t *testing.T) {
-	_, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	_, c := newItemTestCache(t)
 	item, _ := c.get("potato")
 
 	assert.False(t, item.Exists())
@@ -75,8 +74,7 @@ func TestItemExists(t *testing.T) {
 }
 
 func TestItemGetSize(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 	item, _ := c.get("potato")
 	require.NoError(t, item.Open(nil))
 
@@ -97,8 +95,7 @@ func TestItemGetSize(t *testing.T) {
 }
 
 func TestItemDirty(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 	item, _ := c.get("potato")
 	require.NoError(t, item.Open(nil))
 
@@ -122,8 +119,7 @@ func TestItemDirty(t *testing.T) {
 }
 
 func TestItemSync(t *testing.T) {
-	_, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	_, c := newItemTestCache(t)
 	item, _ := c.get("potato")
 
 	require.Error(t, item.Sync())
@@ -136,8 +132,7 @@ func TestItemSync(t *testing.T) {
 }
 
 func TestItemTruncateNew(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 	item, _ := c.get("potato")
 
 	require.Error(t, item.Truncate(0))
@@ -164,8 +159,7 @@ func TestItemTruncateNew(t *testing.T) {
 }
 
 func TestItemTruncateExisting(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 
 	contents, obj, item := newFile(t, r, c, "existing")
 
@@ -184,8 +178,7 @@ func TestItemTruncateExisting(t *testing.T) {
 }
 
 func TestItemReadAt(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 
 	contents, obj, item := newFile(t, r, c, "existing")
 	buf := make([]byte, 10)
@@ -219,8 +212,7 @@ func TestItemReadAt(t *testing.T) {
 }
 
 func TestItemWriteAtNew(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 	item, _ := c.get("potato")
 	buf := make([]byte, 10)
 
@@ -251,8 +243,7 @@ func TestItemWriteAtNew(t *testing.T) {
 }
 
 func TestItemWriteAtExisting(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 
 	contents, obj, item := newFile(t, r, c, "existing")
 
@@ -276,8 +267,7 @@ func TestItemWriteAtExisting(t *testing.T) {
 }
 
 func TestItemLoadMeta(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 
 	contents, obj, item := newFile(t, r, c, "existing")
 	_ = contents
@@ -305,8 +295,7 @@ func TestItemLoadMeta(t *testing.T) {
 }
 
 func TestItemReload(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 
 	contents, obj, item := newFile(t, r, c, "existing")
 	_ = contents
@@ -350,8 +339,7 @@ func TestItemReload(t *testing.T) {
 }
 
 func TestItemReloadRemoteGone(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 
 	contents, obj, item := newFile(t, r, c, "existing")
 	_ = contents
@@ -394,8 +382,7 @@ func TestItemReloadRemoteGone(t *testing.T) {
 }
 
 func TestItemReloadCacheStale(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 
 	contents, obj, item := newFile(t, r, c, "existing")
 
@@ -450,8 +437,7 @@ func TestItemReloadCacheStale(t *testing.T) {
 }
 
 func TestItemReadWrite(t *testing.T) {
-	r, c, cleanup := newItemTestCache(t)
-	defer cleanup()
+	r, c := newItemTestCache(t)
 	const (
 		size     = 50*1024*1024 + 123
 		fileName = "large"

--- a/vfs/write_test.go
+++ b/vfs/write_test.go
@@ -17,20 +17,19 @@ import (
 )
 
 // Open a file for write
-func writeHandleCreate(t *testing.T) (r *fstest.Run, vfs *VFS, fh *WriteFileHandle, cleanup func()) {
-	r, vfs, cleanup = newTestVFS(t)
+func writeHandleCreate(t *testing.T) (r *fstest.Run, vfs *VFS, fh *WriteFileHandle) {
+	r, vfs = newTestVFS(t)
 
 	h, err := vfs.OpenFile("file1", os.O_WRONLY|os.O_CREATE, 0777)
 	require.NoError(t, err)
 	fh, ok := h.(*WriteFileHandle)
 	require.True(t, ok)
 
-	return r, vfs, fh, cleanup
+	return r, vfs, fh
 }
 
 func TestWriteFileHandleMethods(t *testing.T) {
-	r, vfs, fh, cleanup := writeHandleCreate(t)
-	defer cleanup()
+	r, vfs, fh := writeHandleCreate(t)
 
 	// String
 	assert.Equal(t, "file1 (w)", fh.String())
@@ -132,8 +131,7 @@ func TestWriteFileHandleMethods(t *testing.T) {
 }
 
 func TestWriteFileHandleWriteAt(t *testing.T) {
-	r, vfs, fh, cleanup := writeHandleCreate(t)
-	defer cleanup()
+	r, vfs, fh := writeHandleCreate(t)
 
 	// Preconditions
 	assert.Equal(t, int64(0), fh.offset)
@@ -177,8 +175,7 @@ func TestWriteFileHandleWriteAt(t *testing.T) {
 }
 
 func TestWriteFileHandleFlush(t *testing.T) {
-	_, vfs, fh, cleanup := writeHandleCreate(t)
-	defer cleanup()
+	_, vfs, fh := writeHandleCreate(t)
 
 	// Check Flush already creates file for unwritten handles, without closing it
 	err := fh.Flush()
@@ -210,8 +207,7 @@ func TestWriteFileHandleFlush(t *testing.T) {
 }
 
 func TestWriteFileHandleRelease(t *testing.T) {
-	_, _, fh, cleanup := writeHandleCreate(t)
-	defer cleanup()
+	_, _, fh := writeHandleCreate(t)
 
 	// Check Release closes file
 	err := fh.Release()
@@ -258,8 +254,7 @@ func canSetModTime(t *testing.T, r *fstest.Run) bool {
 
 // tests mod time on open files
 func TestWriteFileModTimeWithOpenWriters(t *testing.T) {
-	r, vfs, fh, cleanup := writeHandleCreate(t)
-	defer cleanup()
+	r, vfs, fh := writeHandleCreate(t)
 
 	if !canSetModTime(t, r) {
 		t.Skip("can't set mod time")
@@ -286,8 +281,7 @@ func TestWriteFileModTimeWithOpenWriters(t *testing.T) {
 }
 
 func testFileReadAt(t *testing.T, n int) {
-	_, vfs, fh, cleanup := writeHandleCreate(t)
-	defer cleanup()
+	_, vfs, fh := writeHandleCreate(t)
 
 	contents := []byte(random.String(n))
 	if n != 0 {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

This PR replaces `defer cleanup()` calls with `t.Cleanup` in tests. The main reason for using `t.Cleanup` is to simplify the resource creation and cleanup logic during a test in a test helper function, for example:

```go
func createTestResource(t *testing.T) *resource {
	resource, cleanup := createResource()

	t.Cleanup(func() {
		cleanup()
	})

	return resource
}

func TestFoo(t *testing.T) {
	resource := createTestResource(t)
	// do things with resource...
}
```
In this way, we can focus on the test logic without cluttering the code with repeated cleanup calls.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
