### PR TITLE
docs: Added note on Box API rate limits

### DIFF
--- a/docs/content/box.md
+++ b/docs/content/box.md
@@ -464,6 +464,8 @@ Reverse Solidus).
 
 Box only supports filenames up to 255 characters in length.
 
+Box has [API rate limits](https://developer.box.com/guides/api-calls/permissions-and-errors/rate-limits/) that sometimes reduce the speed of rclone.
+
 `rclone about` is not supported by the Box backend. Backends without
 this capability cannot determine free space for an rclone mount or
 use policy `mfs` (most free space) as a member of an rclone union


### PR DESCRIPTION
#### What is the purpose of this change?

Add note about Box API rate limits with reference to Box description of the limits,

#### Was the change discussed in an issue or in the forum before?

Yes, here:

https://forum.rclone.org/t/rclone-smb-to-box/34818/9

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
