### PR TITLE
docs: show only significant parts of version number in version introduced label

### DIFF
--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -1,7 +1,7 @@
 ---
 title: "Bisync"
 description: "Bidirectional cloud sync solution in rclone"
-versionIntroduced: "v1.58.0"
+versionIntroduced: "v1.58"
 ---
 
 ## Getting started {#getting-started}

--- a/docs/content/chunker.md
+++ b/docs/content/chunker.md
@@ -1,7 +1,7 @@
 ---
 title: "Chunker"
 description: "Split-chunking overlay remote"
-versionIntroduced: "v1.50.0"
+versionIntroduced: "v1.50"
 status: Beta
 ---
 

--- a/docs/content/combine.md
+++ b/docs/content/combine.md
@@ -1,7 +1,7 @@
 ---
 title: "Combine"
 description: "Combine several remotes into one"
-versionIntroduced: "v1.59.0"
+versionIntroduced: "v1.59"
 ---
 
 # {{< icon "fa fa-folder-plus" >}} Combine

--- a/docs/content/compress.md
+++ b/docs/content/compress.md
@@ -1,7 +1,7 @@
 ---
 title: "Compress"
 description: "Compression Remote"
-versionIntroduced: "v1.54.0"
+versionIntroduced: "v1.54"
 status: Experimental
 ---
 

--- a/docs/content/docker.md
+++ b/docs/content/docker.md
@@ -1,7 +1,7 @@
 ---
 title: "Docker Volume Plugin"
 description: "Docker Volume Plugin"
-versionIntroduced: "v1.56.0"
+versionIntroduced: "v1.56"
 ---
 
 # Docker Volume Plugin

--- a/docs/content/fichier.md
+++ b/docs/content/fichier.md
@@ -1,7 +1,7 @@
 ---
 title: "1Fichier"
 description: "Rclone docs for 1Fichier"
-versionIntroduced: "v1.49.0"
+versionIntroduced: "v1.49"
 ---
 
 # {{< icon "fa fa-archive" >}} 1Fichier

--- a/docs/content/filefabric.md
+++ b/docs/content/filefabric.md
@@ -1,7 +1,7 @@
 ---
 title: "Enterprise File Fabric"
 description: "Rclone docs for the Enterprise File Fabric backend"
-versionIntroduced: "v1.54.0"
+versionIntroduced: "v1.54"
 ---
 
 # {{< icon "fa fa-cloud" >}} Enterprise File Fabric

--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -1,7 +1,7 @@
 ---
 title: "Google Photos"
 description: "Rclone docs for Google Photos"
-versionIntroduced: "v1.49.0"
+versionIntroduced: "v1.49"
 ---
 
 # {{< icon "fa fa-images" >}} Google Photos

--- a/docs/content/gui.md
+++ b/docs/content/gui.md
@@ -1,7 +1,7 @@
 ---
 title: "GUI"
 description: "Web based Graphical User Interface"
-versionIntroduced: "v1.49.0"
+versionIntroduced: "v1.49"
 ---
 
 # GUI (Experimental)

--- a/docs/content/hasher.md
+++ b/docs/content/hasher.md
@@ -1,7 +1,7 @@
 ---
 title: "Hasher"
 description: "Better checksums for other remotes"
-versionIntroduced: "v1.57.0"
+versionIntroduced: "v1.57"
 status: Experimental
 ---
 

--- a/docs/content/hdfs.md
+++ b/docs/content/hdfs.md
@@ -1,7 +1,7 @@
 ---
 title: "HDFS Remote"
 description: "Remote for Hadoop Distributed Filesystem"
-versionIntroduced: "v1.54.0"
+versionIntroduced: "v1.54"
 ---
 
 # {{< icon "fa fa-globe" >}} HDFS

--- a/docs/content/hidrive.md
+++ b/docs/content/hidrive.md
@@ -1,7 +1,7 @@
 ---
 title: "HiDrive"
 description: "Rclone docs for HiDrive"
-versionIntroduced: "v1.59.0"
+versionIntroduced: "v1.59"
 ---
 
 # {{< icon "fa fa-cloud" >}} HiDrive

--- a/docs/content/internetarchive.md
+++ b/docs/content/internetarchive.md
@@ -1,7 +1,7 @@
 ---
 title: "Internet Archive"
 description: "Rclone docs for Internet Archive"
-versionIntroduced: "v1.59.0"
+versionIntroduced: "v1.59"
 ---
 
 # {{< icon "fa fa-archive" >}} Internet Archive

--- a/docs/content/koofr.md
+++ b/docs/content/koofr.md
@@ -1,7 +1,7 @@
 ---
 title: "Koofr"
 description: "Rclone docs for Koofr"
-versionIntroduced: "v1.47.0"
+versionIntroduced: "v1.47"
 ---
 
 # {{< icon "fa fa-suitcase" >}} Koofr

--- a/docs/content/mailru.md
+++ b/docs/content/mailru.md
@@ -1,7 +1,7 @@
 ---
 title: "Mailru"
 description: "Mail.ru Cloud"
-versionIntroduced: "v1.50.0"
+versionIntroduced: "v1.50"
 ---
 
 # {{< icon "fas fa-at" >}} Mail.ru Cloud

--- a/docs/content/memory.md
+++ b/docs/content/memory.md
@@ -1,7 +1,7 @@
 ---
 title: "Memory"
 description: "Rclone docs for Memory backend"
-versionIntroduced: "v1.51.0"
+versionIntroduced: "v1.51"
 ---
 
 # {{< icon "fas fa-memory" >}} Memory

--- a/docs/content/netstorage.md
+++ b/docs/content/netstorage.md
@@ -1,7 +1,7 @@
 ---
 title: "Akamai Netstorage"
 description: "Rclone docs for Akamai NetStorage"
-versionIntroduced: "v1.58.0"
+versionIntroduced: "v1.58"
 ---
 
 # {{< icon "fas fa-database" >}} Akamai NetStorage

--- a/docs/content/oracleobjectstorage.md
+++ b/docs/content/oracleobjectstorage.md
@@ -1,7 +1,7 @@
 ---
 title: "Oracle Object Storage"
 description: "Rclone docs for Oracle Object Storage"
-versionIntroduced: "v1.60.0"
+versionIntroduced: "v1.60"
 ---
 
 # {{< icon "fa fa-cloud" >}} Oracle Object Storage

--- a/docs/content/premiumizeme.md
+++ b/docs/content/premiumizeme.md
@@ -1,7 +1,7 @@
 ---
 title: "premiumize.me"
 description: "Rclone docs for premiumize.me"
-versionIntroduced: "v1.49.0"
+versionIntroduced: "v1.49"
 ---
 
 # {{< icon "fa fa-user" >}} premiumize.me

--- a/docs/content/putio.md
+++ b/docs/content/putio.md
@@ -1,7 +1,7 @@
 ---
 title: "put.io"
 description: "Rclone docs for put.io"
-versionIntroduced: "v1.49.0"
+versionIntroduced: "v1.49"
 ---
 
 # {{< icon "fas fa-parking" >}} put.io

--- a/docs/content/seafile.md
+++ b/docs/content/seafile.md
@@ -1,7 +1,7 @@
 ---
 title: "Seafile"
 description: "Seafile"
-versionIntroduced: "v1.52.0"
+versionIntroduced: "v1.52"
 ---
 
 # {{< icon "fa fa-server" >}} Seafile

--- a/docs/content/sharefile.md
+++ b/docs/content/sharefile.md
@@ -1,7 +1,7 @@
 ---
 title: "Citrix ShareFile"
 description: "Rclone docs for Citrix ShareFile"
-versionIntroduced: "v1.50.0"
+versionIntroduced: "v1.50"
 ---
 
 # {{< icon "fas fa-share-square" >}} Citrix ShareFile

--- a/docs/content/sia.md
+++ b/docs/content/sia.md
@@ -1,7 +1,7 @@
 ---
 title: "Sia"
 description: "Remote for Sia Decentralized Cloud"
-versionIntroduced: "v1.57.0"
+versionIntroduced: "v1.57"
 date: "2019-10-02"
 ---
 

--- a/docs/content/smb.md
+++ b/docs/content/smb.md
@@ -1,7 +1,7 @@
 ---
 title: "SMB / CIFS"
 description: "Rclone docs for SMB backend"
-versionIntroduced: "v1.60.0"
+versionIntroduced: "v1.60"
 ---
 
 # {{< icon "fa fa-server" >}} SMB

--- a/docs/content/storj.md
+++ b/docs/content/storj.md
@@ -1,7 +1,7 @@
 ---
 title: "Storj"
 description: "Rclone docs for Storj"
-versionIntroduced: "v1.52.0"
+versionIntroduced: "v1.52"
 ---
 
 # {{< icon "fas fa-dove" >}} Storj

--- a/docs/content/sugarsync.md
+++ b/docs/content/sugarsync.md
@@ -1,7 +1,7 @@
 ---
 title: "SugarSync"
 description: "Rclone docs for SugarSync"
-versionIntroduced: "v1.51.0"
+versionIntroduced: "v1.51"
 ---
 
 # {{< icon "fas fa-dove" >}} SugarSync

--- a/docs/content/tardigrade.md
+++ b/docs/content/tardigrade.md
@@ -1,7 +1,7 @@
 ---
 title: "Tardigrade"
 description: "Rclone docs for Tardigrade"
-versionIntroduced: "v1.52.0"
+versionIntroduced: "v1.52"
 ---
 
 # {{< icon "fas fa-dove" >}} Tardigrade

--- a/docs/content/uptobox.md
+++ b/docs/content/uptobox.md
@@ -1,7 +1,7 @@
 ---
 title: "Uptobox"
 description: "Rclone docs for Uptobox"
-versionIntroduced: "v1.56.0"
+versionIntroduced: "v1.56"
 ---
 
 # {{< icon "fa fa-archive" >}} Uptobox

--- a/docs/content/zoho.md
+++ b/docs/content/zoho.md
@@ -1,7 +1,7 @@
 ---
 title: "Zoho"
 description: "Zoho WorkDrive"
-versionIntroduced: "v1.54.0"
+versionIntroduced: "v1.54"
 ---
 
 # {{< icon "fas fa-folder" >}} Zoho Workdrive


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

With current version of official docs, after the 1.61 release, there is a bit of a mix in the version number formats used in the newly introduced version badges. E.g. the Box backend has "v1.38" (two parts) while 1Fichier has "v1.49.0" (three parts). This PR makes them consistent by removing the trailing ".0" parts. My thinking is that it looks a bit better this way, that the looks of the full "v1.49.0" label is a tiny bit more on the technical side, if you see what I mean...? But if you have a strong opinion the other way, that's fine too, my primary goal is consistency here. (Sorry for not noticing before the release, really should have seen this in tip.rclone.org). 


#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
