### PR TITLE
lib/oauthutil: don't retry for probably fatal errors

### DIFF
--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -204,6 +204,37 @@ func (ts *TokenSource) reReadToken() (changed bool) {
 	return changed
 }
 
+type retrieveErrResponse struct {
+	Error string `json:"error"`
+}
+
+// If err is nil or an error other than fatal OAuth errors, returns err itself.
+// Otherwise returns a more user-friendly error.
+func maybeWrapOAuthError(err error, remoteName string) (newErr error) {
+	newErr = err
+	if rErr, ok := err.(*oauth2.RetrieveError); ok {
+		if rErr.Response.StatusCode == 400 || rErr.Response.StatusCode == 401 {
+			fs.Debugf(remoteName, "got fatal oauth error: %v", rErr)
+			var resp retrieveErrResponse
+			if err = json.Unmarshal(rErr.Body, &resp); err != nil {
+				newErr = fmt.Errorf("(can't decode error info) - try refreshing token with \"rclone config reconnect %s:\"", remoteName)
+				return
+			}
+			var suggestion string
+			switch resp.Error {
+			case "invalid_client", "unauthorized_client", "unsupported_grant_type", "invalid_scope":
+				suggestion = fmt.Sprintf("if you're using your own client id/secret, make sure they're properly set up following the docs")
+			case "invalid_grant":
+				fallthrough
+			default:
+				suggestion = fmt.Sprintf("maybe token expired? - try refreshing with \"rclone config reconnect %s:\"", remoteName)
+			}
+			newErr = fmt.Errorf("%s: %s", resp.Error, suggestion)
+		}
+	}
+	return
+}
+
 // Token returns a token or an error.
 // Token must be safe for concurrent use by multiple goroutines.
 // The returned Token must not be modified.
@@ -218,15 +249,6 @@ func (ts *TokenSource) Token() (*oauth2.Token, error) {
 		changed = false
 	)
 	const maxTries = 5
-
-	shouldRetry := func(err error) bool {
-		if rErr, ok := err.(*oauth2.RetrieveError); ok {
-			if rErr.Response.StatusCode == 400 || rErr.Response.StatusCode == 401 {
-				return false
-			}
-		}
-		return true
-	}
 
 	// Try getting the token a few times
 	for i := 1; i <= maxTries; i++ {
@@ -248,14 +270,18 @@ func (ts *TokenSource) Token() (*oauth2.Token, error) {
 		}
 
 		token, err = ts.tokenSource.Token()
-		if err == nil || !shouldRetry(err) {
+		if err == nil {
+			break
+		}
+		if newErr := maybeWrapOAuthError(err, ts.name); newErr != err {
+			err = newErr // Fatal OAuth error
 			break
 		}
 		fs.Debugf(ts.name, "Token refresh failed try %d/%d: %v", i, maxTries, err)
 		time.Sleep(1 * time.Second)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("couldn't fetch token - maybe it has expired? - refresh with \"rclone config reconnect %s:\": %w", ts.name, err)
+		return nil, fmt.Errorf("couldn't fetch token: %w", err)
 	}
 	changed = changed || (*token != *ts.token)
 	ts.token = token


### PR DESCRIPTION
According to the OAuth2 RFC (https://www.rfc-editor.org/rfc/rfc6749#section-5.2), the server should return a 400 (or maybe sometimes 401) for a list of unrecoverable errors, such as expired refresh tokens. Rclone shouldn't still make 5 attempts to get a token in those cases. @ncw do you see any potential problem with this?

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~
- [ ] ~~I have added documentation for the changes if appropriate.~~
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
