### PR TITLE
crypt: fix for unencrypted directory names on case insensitive remotes

### DIFF
--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -235,7 +235,7 @@ func NewFs(ctx context.Context, name, rpath string, m configmap.Mapper) (fs.Fs, 
 	// the features here are ones we could support, and they are
 	// ANDed with the ones from wrappedFs
 	f.features = (&fs.Features{
-		CaseInsensitive:         cipher.NameEncryptionMode() == NameEncryptionOff,
+		CaseInsensitive:         !cipher.dirNameEncrypt || cipher.NameEncryptionMode() == NameEncryptionOff,
 		DuplicateFiles:          true,
 		ReadMimeType:            false, // MimeTypes not supported with crypt
 		WriteMimeType:           false,

--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -455,6 +455,7 @@ Properties:
     - "off"
         - Don't encrypt the file names.
         - Adds a ".bin" extension only.
+        - May cause problems on [case insensitive](/overview/#case-insensitive) [storage systems](/overview/#features) like OneDrive, Dropbox, Windows, OSX and SMB.
 
 #### --crypt-directory-name-encryption
 
@@ -473,6 +474,7 @@ Properties:
         - Encrypt directory names.
     - "false"
         - Don't encrypt directory names, leave them intact.
+        - May cause problems on [case insensitive](/overview/#case-insensitive) [storage systems](/overview/#features) like OneDrive, Dropbox, Windows, OSX and SMB.
 
 #### --crypt-password
 


### PR DESCRIPTION
#### What is the purpose of this change?

rclone sync erroneously deleted folders renamed to a different case on crypts where directory name encryption was disabled and the underlying remote was case insensitive.

Example: Renaming the folder Test to tEST before a sync to a crypt having remote=OneDrive:crypt and directory_name_encryption=false could result in the folder and all its content being deleted. The following sync would correctly create the tEST folder and upload all of the content.

Additional tests have revealed other potential issues when using filename_encryption=off or directory_name_encryption=false on case insensitive remotes. The documentation has been updated to warn about potential problems when using these combinations.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/chaning-directory-case-makes-rclone-lose-it/35268

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
