### PR TITLE
oracle-object-storage: expose the storage_tier option in config

### DIFF
--- a/backend/oracleobjectstorage/options.go
+++ b/backend/oracleobjectstorage/options.go
@@ -124,6 +124,22 @@ func newOptions() []fs.Option {
 			Help:  "Use the default profile",
 		}},
 	}, {
+		// Mapping from here: https://github.com/oracle/oci-go-sdk/blob/master/objectstorage/storage_tier.go
+		Name:     "storage_tier",
+		Help:     "The storage class to use when storing new objects in storage. https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/understandingstoragetiers.htm",
+		Default:  "Standard",
+		Advanced: true,
+		Examples: []fs.OptionExample{{
+			Value: "Standard",
+			Help:  "Standard storage tier, this is the default tier",
+		}, {
+			Value: "InfrequentAccess",
+			Help:  "InfrequentAccess storage tier",
+		}, {
+			Value: "Archive",
+			Help:  "Archive storage tier",
+		}},
+	}, {
 		Name: "upload_cutoff",
 		Help: `Cutoff for switching to chunked upload.
 

--- a/docs/content/oracleobjectstorage.md
+++ b/docs/content/oracleobjectstorage.md
@@ -290,6 +290,24 @@ Properties:
 
 Here are the Advanced options specific to oracleobjectstorage (Oracle Cloud Infrastructure Object Storage).
 
+#### --oos-storage-tier
+
+The storage class to use when storing new objects in storage. https://docs.oracle.com/en-us/iaas/Content/Object/Concepts/understandingstoragetiers.htm
+
+Properties:
+
+- Config:      storage_tier
+- Env Var:     RCLONE_OOS_STORAGE_TIER
+- Type:        string
+- Default:     "Standard"
+- Examples:
+    - "Standard"
+        - Standard storage tier, this is the default tier
+    - "InfrequentAccess"
+        - InfrequentAccess storage tier
+    - "Archive"
+        - Archive storage tier
+
 #### --oos-upload-cutoff
 
 Cutoff for switching to chunked upload.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Support for storage_tier is already there. This just exposes it in the config. 
-->

#### Was the change discussed in an issue or in the forum before?
yes. Fixes #6588 
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X ] I have added tests for all changes in this PR if appropriate.
- [X ] I have added documentation for the changes if appropriate.
- [X ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ X] I'm done, this Pull Request is ready for review :-)
