### PR TITLE
cmd/ncdu: refactor redraw handling

### DIFF
--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -81,7 +81,7 @@ the remote you can also use the [size](/commands/rclone_size/) command.
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			return NewUI(fsrc).Show()
+			return NewUI(fsrc).Run()
 		})
 	},
 }
@@ -353,7 +353,7 @@ func (u *UI) hasEmptyDir() bool {
 }
 
 // Draw the current screen
-func (u *UI) Draw() error {
+func (u *UI) Draw() {
 	ctx := context.Background()
 	w, h := u.s.Size()
 	u.dirListHeight = h - 3
@@ -489,8 +489,6 @@ func (u *UI) Draw() error {
 	if u.showBox {
 		u.Box()
 	}
-	u.s.Show()
-	return nil
 }
 
 // Move the cursor this many spaces adjusting the viewport as necessary
@@ -900,8 +898,8 @@ func NewUI(f fs.Fs) *UI {
 	}
 }
 
-// Show shows the user interface
-func (u *UI) Show() error {
+// Run shows the user interface
+func (u *UI) Run() error {
 	var err error
 	u.s, err = tcell.NewScreen()
 	if err != nil {
@@ -924,10 +922,6 @@ func (u *UI) Show() error {
 	// Main loop, waiting for events and channels
 outer:
 	for {
-		err := u.Draw()
-		if err != nil {
-			return fmt.Errorf("draw failed: %w", err)
-		}
 		select {
 		case root := <-rootChan:
 			u.root = root
@@ -938,16 +932,14 @@ outer:
 			}
 			u.listing = false
 		case <-updated:
-			// redraw
 			// TODO: might want to limit updates per second
 			u.sortCurrentDir()
 		case ev := <-events:
 			switch ev := ev.(type) {
 			case *tcell.EventResize:
-				if u.root != nil {
-					u.sortCurrentDir() // redraw
-				}
+				u.Draw()
 				u.s.Sync()
+				continue // don't draw again
 			case *tcell.EventKey:
 				var c rune
 				if k := ev.Key(); k == tcell.KeyRune {
@@ -1026,11 +1018,15 @@ outer:
 				// Refresh the screen. Not obvious what key to map
 				// this onto, but ^L is a common choice.
 				case key(tcell.KeyCtrlL):
+					u.Draw()
 					u.s.Sync()
+					continue // don't draw again
 				}
 			}
 		}
-		// listen to key presses, etc.
+
+		u.Draw()
+		u.s.Show()
 	}
 	return nil
 }


### PR DESCRIPTION
#### What is the purpose of this change?

It refactors the handling of our `Draw` function, the tcell `Screen.Show` and `Screen.Sync` functions, the tcell resize event and the tcell `Ctrl-L` keyboard event.

This change should make it smoother and changes more instantaneous.

This also renames the `ncdu.Show` function to `ncdu.Run`, to reduce confusion with `Screen.Show`.

#### Was the change discussed in an issue or in the forum before?

n/a

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
