### PR TITLE
build: fix condition for manual workflow run

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,12 +15,14 @@ on:
   workflow_dispatch:
     inputs:
       manual:
+        description: Manual run (bypass default conditions)
+        type: boolean
         required: true
         default: true
 
 jobs:
   build:
-    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual }}
+    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual == 'true' }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -218,7 +220,7 @@ jobs:
         if: matrix.deploy && github.head_ref == '' && github.repository == 'rclone/rclone'
 
   lint:
-    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual }}
+    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual == 'true' }}
     timeout-minutes: 30
     name: "lint"
     runs-on: ubuntu-latest
@@ -247,7 +249,7 @@ jobs:
         run: govulncheck ./...
 
   android:
-    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual }}
+    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual == 'true' }}
     timeout-minutes: 30
     name: "android-all"
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What is the purpose of this change?

This fixes the the input property `manual` in the `inputs` context of our GitHub workflow. It was introduced in #5275, see that for background.

The first change is only a small improvement: Added a `description` property, which shows a more human-readable label in the "Run workflow" dialog, and added a `type` property with value "boolean" which makes GitHub present it as a checkbox, instead of a regular text box with the text "true" set by default.

Furthermore I discovered that the value is not really a boolean, even after I added the "type: boolean" property. It is in reality always a string - either the string 'true' or the string 'false'. But this means a condition `if: ${{ github.event.inputs.manual }}` will always be met, because any non-empty string is treated as boolean true, even the string 'false'!


#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
