### PR TITLE
docs/content: Fix link in bisync doc

### DIFF
--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -16,7 +16,7 @@ versionIntroduced: "v1.58"
 - For successive sync runs, leave off the `--resync` flag.
 - Consider using a [filters file](#filtering) for excluding
   unnecessary files and directories from the sync.
-- Consider setting up the [--check-access](#check-access-option) feature
+- Consider setting up the [--check-access](#check-access) feature
   for safety.
 - On Linux, consider setting up a [crontab entry](#cron). bisync can
   safely run in concurrent cron jobs thanks to lock files it maintains.


### PR DESCRIPTION
#### What is the purpose of this change?

Improve documentation by fixing a broken anchor link.

#check-access-option does not exist in bisync.md; #check-access does.

#### Was the change discussed in an issue or in the forum before?

Negative

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
