### PR TITLE
docs: update drive.md create client-id instructions

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -1508,9 +1508,15 @@ to the next step; if not, click on "CONFIGURE CONSENT SCREEN" button
 (near the top right corner of the right panel), then select "External"
 and click on "CREATE"; on the next screen, enter an "Application name"
 ("rclone" is OK); enter "User Support Email" (your own email is OK); 
-enter "Developer Contact Email" (your own email is OK); then click on "Save" (all other data is optional). 
-Click again on "Credentials" on the left panel to go back to the 
-"Credentials" screen.
+enter "Developer Contact Email" (your own email is OK); then click on
+"Save" (all other data is optional). You will also have to add some scopes,
+including `.../auth/docs` and `.../auth/drive` in order to be able to edit,
+create and delete files with RClone. You may also want to include the
+`../auth/drive.metadata.readonly` scope. After adding scopes, click
+"Save and continue" to add test users. Be sure to add your own account to
+the test users. Once you've added yourself as a test user and saved the
+changes, click again on "Credentials" on the left panel to go back to
+the "Credentials" screen.
 
    (PS: if you are a GSuite user, you could also select "Internal" instead
 of "External" above, but this will restrict API use to Google Workspace 
@@ -1523,24 +1529,24 @@ then select "OAuth client ID".
 
 8. It will show you a client ID and client secret. Make a note of these.
    
-   (If you selected "External" at Step 5 continue to "Publish App" in the Steps 9 and 10. 
+   (If you selected "External" at Step 5 continue to Step 9. 
    If you chose "Internal" you don't need to publish and can skip straight to
    Step 11.)
 
-9. Go to "Oauth consent screen" and press "Publish App"
+9. Go to "Oauth consent screen" and confirm that your intended email is shown
+     as a test user, and that "Publishing status" is shown as "Testing".
 
-10. Click "OAuth consent screen", then click "PUBLISH APP" button and 
-confirm, or add your account under "Test users".
+10. Provide the noted client ID and client secret to rclone.
 
-11. Provide the noted client ID and client secret to rclone.
-
-Be aware that, due to the "enhanced security" recently introduced by
-Google, you are theoretically expected to "submit your app for verification"
-and then wait a few weeks(!) for their response; in practice, you can go right
-ahead and use the client ID and client secret with rclone, the only issue will
-be a very scary confirmation screen shown when you connect via your browser 
-for rclone to be able to get its token-id (but as this only happens during 
-the remote configuration, it's not such a big deal). 
+Be aware that, due to the "enhanced security" introduced by Google, you are
+theoretically expected to "submit your app for verification" and then wait a
+few weeks(!) for their response; in practice, if you keep your app in testing,
+then you can go right ahead and use the client ID and client secret with rclone,
+the only issue will be a very scary confirmation screen shown when you connect
+via your browser for rclone to be able to get its token-id (but as this only
+happens during the remote configuration, it's not such a big deal). Because we
+anticipate that we will be the only user on this client-id, testing should be
+sufficient for most use cases.
 
 (Thanks to @balazer on github for these instructions.)
 


### PR DESCRIPTION
* Updates OAuth consent screen instructions to include adding scopes for backup purposes (create, edit and delete files).
* Updates instructions to keep app in testing mode (appropriate for most users). The previous instructions suggested this, but we don't need to "publish" the app at all in order to proceed with this step.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Updates some documentation surrounding creating a user client-id and some makes changes to accommodate differences I encountered on the OAuth Consent screen flow.
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
No, but happy to make changes as required.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
