### PR TITLE
build: avoid running workflow twice for pull requests with branch on main repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ on:
 
 jobs:
   build:
-    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual == 'true' }}
+    if: ${{ github.event.inputs.manual == 'true' || (github.repository == 'rclone/rclone' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)) }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
@@ -220,7 +220,7 @@ jobs:
         if: matrix.deploy && github.head_ref == '' && github.repository == 'rclone/rclone'
 
   lint:
-    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual == 'true' }}
+    if: ${{ github.event.inputs.manual == 'true' || (github.repository == 'rclone/rclone' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)) }}
     timeout-minutes: 30
     name: "lint"
     runs-on: ubuntu-latest
@@ -249,7 +249,7 @@ jobs:
         run: govulncheck ./...
 
   android:
-    if: ${{ github.repository == 'rclone/rclone' || github.event.inputs.manual == 'true' }}
+    if: ${{ github.event.inputs.manual == 'true' || (github.repository == 'rclone/rclone' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name)) }}
     timeout-minutes: 30
     name: "android-all"
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What is the purpose of this change?

Currently, when pushing a branch to upstream rclone/rclone and making a pull request from that (instead of from a branch pushed to my own fork), which has the advantage of publishing beta binaries, the same github workflow runs twice - once for the branch push and once for the pull request.

Using the trick from here:

https://wildwolf.name/github-actions-how-to-avoid-running-the-same-workflow-multiple-times/

The condition is getting a bit long, unfortunately, but to break down the change: The existing condition
```
github.repository == 'rclone/rclone'
```
is extended
```
github.repository == 'rclone/rclone' && 
```
with a condition that it is not a pull request (i.e. it is branch push):
```
(github.event_name != 'pull_request'
```
or, if it is a pull request, then it is not from a branch on the same repo:
```

|| github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name))
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
