### PR TITLE
Enable console virtual terminal sequences processing (ANSI/VT100 colors)

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -401,9 +401,15 @@ func initConfig() {
 	// Start accounting
 	accounting.Start(ctx)
 
-	// Hide console window
+	// Configure console
 	if ci.NoConsole {
+		// Hide the console window
 		terminal.HideConsole()
+	} else {
+		// Enable color support on stdout if possible.
+		// This enables virtual terminal processing on Windows 10,
+		// adding native support for ANSI/VT100 escape sequences.
+		terminal.EnableColorsStdout()
 	}
 
 	// Load filters

--- a/cmd/tree/tree.go
+++ b/cmd/tree/tree.go
@@ -18,6 +18,7 @@ import (
 	"github.com/rclone/rclone/fs/dirtree"
 	"github.com/rclone/rclone/fs/log"
 	"github.com/rclone/rclone/fs/walk"
+	"github.com/rclone/rclone/lib/terminal"
 	"github.com/spf13/cobra"
 )
 
@@ -100,22 +101,26 @@ For a more interactive navigation of the remote see the
 	RunE: func(command *cobra.Command, args []string) error {
 		cmd.CheckArgs(1, 1, command, args)
 		fsrc := cmd.NewFsSrc(args)
-		outFile := os.Stdout
+		ci := fs.GetConfig(context.Background())
+		var outFile io.Writer
 		if outFileName != "" {
 			var err error
 			outFile, err = os.Create(outFileName)
 			if err != nil {
 				return fmt.Errorf("failed to create output file: %w", err)
 			}
+			opts.Colorize = false
+		} else {
+			terminal.Start()
+			outFile = terminal.Out
+			opts.Colorize = true
 		}
 		opts.VerSort = opts.VerSort || sort == "version"
 		opts.ModSort = opts.ModSort || sort == "mtime"
 		opts.CTimeSort = opts.CTimeSort || sort == "ctime"
 		opts.NameSort = sort == "name"
 		opts.SizeSort = sort == "size"
-		ci := fs.GetConfig(context.Background())
 		opts.UnitSize = ci.HumanReadable
-		opts.Colorize = ci.TerminalColorMode != fs.TerminalColorModeNever
 		if opts.DeepLevel == 0 {
 			opts.DeepLevel = ci.MaxDepth
 		}

--- a/lib/terminal/terminal.go
+++ b/lib/terminal/terminal.go
@@ -111,3 +111,14 @@ func Write(out []byte) {
 	Start()
 	_, _ = Out.Write(out)
 }
+
+// EnableColorsStdout enable colors if possible.
+// This enables virtual terminal processing on Windows 10 console,
+// adding native support for VT100 escape codes. When this terminal
+// package is used for output, the result is that the colorable library
+// don't have to decode the escapes and explicitely write text with color
+// formatting to the console using Windows API functions, but can simply
+// relay everything to stdout.
+func EnableColorsStdout() {
+	_ = colorable.EnableColorsStdout(nil)
+}


### PR DESCRIPTION
On Windows this makes sure console mode `ENABLE_VIRTUAL_TERMINAL_PROCESSING` is enabled on the rclone process, by using `GetConsoleMode`/`SetConsoleMode` functions from Windows API. This mode is default in many cases, e.g. when using the Windows Terminal application, but in other cases it relies on a registry setting:
```
[HKEY_CURRENT_USER\Console]
"VirtualTerminalLevel"=dword:00000001
```

(I'm still confused as to exactly how this works; when it is default enabled and not, as can be seen from the discussions in the linked PR and forum thread, but seems certain that it is not always enabled by default and therefore it is better to set it explicitly on the process).

Since rclone version 1.61.0 the tree command uses ANSI color sequences in output by default, and this lead to issues in some terminals that were not handling these (see links below).

Background:
- https://learn.microsoft.com/windows/console/console-virtual-terminal-sequences
- https://ss64.com/nt/syntax-ansi.html

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

#6668
#6591
https://forum.rclone.org/t/error-with-build-v1-61-1-tree-command-panic-runtime-error-invalid-memory-address-or-nil-pointer-dereference/35922

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
