### PR TITLE
Update s3.go

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2791,6 +2791,7 @@ func setQuirks(opt *Options) {
 		useMultipartEtag = false // untested
 	case "IDrive":
 		virtualHostStyle = false
+		useMultipartEtag = false //Etag calculated by Idrive e2 for the encrypted bucket is different from the one calculated by rclone.
 	case "IONOS":
 		// listObjectsV2 supported - https://api.ionos.com/docs/s3/#Basic-Operations-get-Bucket-list-type-2
 		virtualHostStyle = false


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Setting default value of useMultipartEtag  false for idrive. It seems like Md5 calculated by Idrive e2 for the encrypted bucket is different from the one calculated by rclone. Probably it's considering encrypted data only to calculate Md5.


#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/issues-with-idrive-e2-corrupted-transfers/36085

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
