### PR TITLE
docker volume plugin restoreState: skip fs option if empty - fixes #6769

### DIFF
--- a/cmd/serve/docker/options.go
+++ b/cmd/serve/docker/options.go
@@ -60,12 +60,14 @@ func (vol *Volume) applyOptions(volOpt VolOpts) error {
 		case "":
 			continue
 		case "remote", "fs":
-			p, err := fspath.Parse(str)
-			if err != nil || p.Name == ":" {
-				return fmt.Errorf("cannot parse path %q: %w", str, err)
+			if str != "" {
+				p, err := fspath.Parse(str)
+				if err != nil || p.Name == ":" {
+					return fmt.Errorf("cannot parse path %q: %w", str, err)
+				}
+				fsName, fsPath, fsOpt = p.Name, p.Path, p.Config
+				vol.Fs = str
 			}
-			fsName, fsPath, fsOpt = p.Name, p.Path, p.Config
-			vol.Fs = str
 		case "type":
 			fsType = str
 			vol.Type = str


### PR DESCRIPTION
#### What is the purpose of this change?

Upon remount an empty fs option leeds to a parsing error and thus does not recreate the volume after docker restart

#### Was the change discussed in an issue or in the forum before?

rclone volume plugin does not remount crypt volume on docker restart #6769

I have checked that in case the fs option is passed, the value must be != ""

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [n/a] I have added tests for all changes in this PR if appropriate.
- [n/a] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
