### PR TITLE
rcd: fix regular expression error when folder name contain square brackets

### DIFF
--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -384,7 +384,7 @@ func (s *Server) serveRemote(w http.ResponseWriter, r *http.Request, path string
 }
 
 // Match URLS of the form [fs]/remote
-var fsMatch = regexp.MustCompile(`^\[(.*?)\](.*)$`)
+var fsMatch = regexp.MustCompile(`^\[(.*)](\/.*)`)
 
 func (s *Server) handleGet(w http.ResponseWriter, r *http.Request, path string) {
 	// Look to see if this has an fs in the path


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Fixed object not found error when folder/file name contain square brackets.
<img width="1085" alt="Screenshot_20230224_125538" src="https://user-images.githubusercontent.com/30148130/221014928-faf00fc9-6ef6-45db-af2c-93807a0f146c.png">

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
No
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)