### PR TITLE
Add case insensitive alphabet option to base32768 encoding.

### DIFF
--- a/backend/crypt/cipher.go
+++ b/backend/crypt/cipher.go
@@ -161,6 +161,8 @@ func NewNameEncoding(s string) (enc fileNameEncoding, err error) {
 		enc = base64.RawURLEncoding
 	case "base32768":
 		enc = base32768.SafeEncoding
+	case "base32768ci":
+		enc = base32768.SafeEncodingCI
 	default:
 		err = fmt.Errorf("unknown file name encoding mode %q", s)
 	}

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -138,7 +138,11 @@ length and if it's case sensitive.`,
 				},
 				{
 					Value: "base32768",
-					Help:  "Encode using base32768. Suitable if your remote counts UTF-16 or\nUnicode codepoint instead of UTF-8 byte length. (Eg. Onedrive)",
+					Help:  "Encode using base32768. Suitable if your remote counts UTF-16 or\nUnicode codepoint instead of UTF-8 byte length.",
+				},
+				{
+					Value: "base32768ci",
+					Help:  "Encode using base32768 with case insensitive alphabet. Suitable eg. for Onedrive.",
 				},
 			},
 			Advanced: true,

--- a/backend/crypt/crypt_test.go
+++ b/backend/crypt/crypt_test.go
@@ -95,6 +95,28 @@ func TestStandardBase32768(t *testing.T) {
 	})
 }
 
+func TestStandardBase32768Ci(t *testing.T) {
+	if *fstest.RemoteName != "" {
+		t.Skip("Skipping as -remote set")
+	}
+	tempdir := filepath.Join(os.TempDir(), "rclone-crypt-test-standard")
+	name := "TestCrypt"
+	fstests.Run(t, &fstests.Opt{
+		RemoteName: name + ":",
+		NilObject:  (*crypt.Object)(nil),
+		ExtraConfig: []fstests.ExtraConfigItem{
+			{Name: name, Key: "type", Value: "crypt"},
+			{Name: name, Key: "remote", Value: tempdir},
+			{Name: name, Key: "password", Value: obscure.MustObscure("potato")},
+			{Name: name, Key: "filename_encryption", Value: "standard"},
+			{Name: name, Key: "filename_encoding", Value: "base32768ci"},
+		},
+		UnimplementableFsMethods:     []string{"OpenWriterAt"},
+		UnimplementableObjectMethods: []string{"MimeType"},
+		QuickTestOK:                  true,
+	})
+}
+
 // TestOff runs integration tests against the remote
 func TestOff(t *testing.T) {
 	if *fstest.RemoteName != "" {

--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -377,10 +377,10 @@ cloud storage provider.
 An experimental advanced option `filename_encoding` is now provided to
 address this problem to a certain degree.
 For cloud storage systems with case sensitive file names (e.g. Google Drive),
-`base64` can be used to reduce file name length. 
+`base64` can be used to reduce file name length.
 For cloud storage systems using UTF-16 to store file names internally
-(e.g. OneDrive), `base32768` can be used to drastically reduce
-file name length. 
+(e.g. OneDrive), `base32768` or case insensitive version `base32768ci`
+can be used to drastically reduce file name length.
 
 An alternative, future rclone file name encryption mode may tolerate
 backend provider path length limits.
@@ -585,8 +585,10 @@ Properties:
         - Encode using base64. Suitable for case sensitive remote.
     - "base32768"
         - Encode using base32768. Suitable if your remote counts UTF-16 or
-        - Unicode codepoint instead of UTF-8 byte length. (Eg. Onedrive)
-
+        - Unicode codepoint instead of UTF-8 byte length.
+    - "base32768ci"
+	- Encode using base32768 with case insensitive alphabet.
+	- Suitable eg. for Onedrive."
 ### Metadata
 
 Any metadata supported by the underlying remote is read and written.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.2.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.6.1
 	github.com/Azure/go-ntlmssp v0.0.0-20221128193559-754e69321358
-	github.com/Max-Sum/base32768 v0.0.0-20191205131208-7937843c71d5
+	github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd
 	github.com/Unknwon/goconfig v1.0.0
 	github.com/a8m/tree v0.0.0-20230208161321-36ae24ddad15
 	github.com/aalpar/deheap v0.0.0-20210914013432-0cc84d79dec3

--- a/go.sum
+++ b/go.sum
@@ -55,6 +55,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/Max-Sum/base32768 v0.0.0-20191205131208-7937843c71d5 h1:w/vNc+SQRYKGWBHeDrzvvNttHwZEbSAP0kmTdORl4OI=
 github.com/Max-Sum/base32768 v0.0.0-20191205131208-7937843c71d5/go.mod h1:C8yoIfvESpM3GD07OCHU7fqI7lhwyZ2Td1rbNbTAhnc=
+github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd h1:nzE1YQBdx1bq9IlZinHa+HVffy+NmVRoKr+wHN8fpLE=
+github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd/go.mod h1:C8yoIfvESpM3GD07OCHU7fqI7lhwyZ2Td1rbNbTAhnc=
 github.com/Microsoft/go-winio v0.5.2 h1:a9IhgEQBCUEk6QCdml9CiJGhAws+YwffDHEMp1VMrpA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/ProtonMail/go-crypto v0.0.0-20230109192245-7efeeb08f296 h1:865LKksDklBvemmkvQ2TO6yArI12PChQJn9R/2S8ov0=


### PR DESCRIPTION
Fix for https://github.com/rclone/rclone/issues/6803

#### What is the purpose of this change?

Add case insensitive alphabet option (base32768ci) to base32768 encoding.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/6803

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
