### PR TITLE
drive: Make --drive-stop-on-upload-limit to respond to storageQuotaExceeded

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -761,7 +761,7 @@ func (f *Fs) shouldRetry(ctx context.Context, err error) (bool, error) {
 			} else if f.opt.StopOnDownloadLimit && reason == "downloadQuotaExceeded" {
 				fs.Errorf(f, "Received download limit error: %v", err)
 				return false, fserrors.FatalError(err)
-			} else if f.opt.StopOnUploadLimit && reason == "quotaExceeded" {
+			} else if f.opt.StopOnUploadLimit && (reason == "quotaExceeded" || reason == "storageQuotaExceeded") {
 				fs.Errorf(f, "Received upload limit error: %v", err)
 				return false, fserrors.FatalError(err)
 			} else if f.opt.StopOnUploadLimit && reason == "teamDriveFileLimitExceeded" {

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -243,6 +243,15 @@ func (f *Fs) InternalTestShouldRetry(t *testing.T) {
 	quotaExceededRetry, quotaExceededError := f.shouldRetry(ctx, &generic403)
 	assert.False(t, quotaExceededRetry)
 	assert.Equal(t, quotaExceededError, expectedQuotaError)
+
+	sqEItem := googleapi.ErrorItem{
+		Reason: "storageQuotaExceeded",
+	}
+	generic403.Errors[0] = sqEItem
+	expectedStorageQuotaError := fserrors.FatalError(&generic403)
+	storageQuotaExceededRetry, storageQuotaExceededError := f.shouldRetry(ctx, &generic403)
+	assert.False(t, storageQuotaExceededRetry)
+	assert.Equal(t, storageQuotaExceededError, expectedStorageQuotaError)
 }
 
 func (f *Fs) InternalTestDocumentImport(t *testing.T) {


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Before this change, if a "--drive-stop-on-upload-limit" was set, rclone would not stop the upload if a "storageQuotaExceeded" error occurred.

This fix now checks for the "storageQuotaExceeded" error and "--drive-stop-on-upload-limit", and fails fast.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
https://forum.rclone.org/t/google-drive-add-ability-to-stop-on-storagequotaexceeded/36290

Command:
```sh
rclone copy my-drive1:Test.mkv my-drive2: -P --drive-stop-on-upload-limit
```

*Before*
```
2023-03-06 16:49:31 ERROR : Test.mkv: Failed to copy: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
2023-03-06 16:49:31 ERROR : Attempt 1/3 failed with 1 errors and: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
2023-03-06 16:49:34 ERROR : Test.mkv: Failed to copy: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
2023-03-06 16:49:34 ERROR : Attempt 2/3 failed with 1 errors and: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
2023-03-06 16:49:37 ERROR : Test.mkv: Failed to copy: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
2023-03-06 16:49:37 ERROR : Attempt 3/3 failed with 1 errors and: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Errors:                 1 (retrying may help)
Elapsed time:        11.2s
2023/03/06 16:49:37 Failed to copy: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
```

*After*
```
2023-03-06 17:27:46 ERROR : Google drive root '': Received upload limit error: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
2023-03-06 17:27:46 ERROR : Test.mkv: Failed to copy: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
2023-03-06 17:27:46 ERROR : Fatal error received - not attempting retries
Transferred:              0 B / 0 B, -, 0 B/s, ETA -
Errors:                 1 (fatal error encountered)
Elapsed time:         4.6s
2023/03/06 17:27:46 Failed to copy: googleapi: Error 403: The user's Drive storage quota has been exceeded., storageQuotaExceeded
```

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
