### PR TITLE
add env auth to drive provider

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -202,7 +202,7 @@ func init() {
 					m.Set("root_folder_id", "appDataFolder")
 				}
 
-				if opt.ServiceAccountFile == "" && opt.ServiceAccountCredentials == "" {
+				if opt.ServiceAccountFile == "" && opt.ServiceAccountCredentials == "" && !opt.EnvAuth {
 					return oauthutil.ConfigOut("teamdrive", &oauthutil.Options{
 						OAuth2Config: driveConfig,
 					})
@@ -598,6 +598,18 @@ resource key is no needed.
 			// Encode invalid UTF-8 bytes as json doesn't handle them properly.
 			// Don't encode / as it's a valid name character in drive.
 			Default: encoder.EncodeInvalidUtf8,
+		}, {
+			Name:     "env_auth",
+			Help:     "Get IAM credentials from runtime (environment variables or instance meta data if no env vars).\n\nOnly applies if service_account_file and service_account_credentials is blank.",
+			Default:  false,
+			Advanced: true,
+			Examples: []fs.OptionExample{{
+				Value: "false",
+				Help:  "Enter credentials in the next step.",
+			}, {
+				Value: "true",
+				Help:  "Get GCP IAM credentials from the environment (env vars or IAM).",
+			}},
 		}}...),
 	})
 
@@ -654,6 +666,7 @@ type Options struct {
 	SkipDanglingShortcuts     bool                 `config:"skip_dangling_shortcuts"`
 	ResourceKey               string               `config:"resource_key"`
 	Enc                       encoder.MultiEncoder `config:"encoding"`
+	EnvAuth                   bool                 `config:"env_auth"`
 }
 
 // Fs represents a remote drive server
@@ -1121,6 +1134,12 @@ func createOAuthClient(ctx context.Context, opt *Options, name string, m configm
 		oAuthClient, err = getServiceAccountClient(ctx, opt, []byte(opt.ServiceAccountCredentials))
 		if err != nil {
 			return nil, fmt.Errorf("failed to create oauth client from service account: %w", err)
+		}
+	} else if opt.EnvAuth {
+		scopes := driveScopes(opt.Scope)
+		oAuthClient, err = google.DefaultClient(ctx, scopes...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create client from environment: %w", err)
 		}
 	} else {
 		oAuthClient, _, err = oauthutil.NewClientWithBaseClient(ctx, name, m, driveConfig, getClient(ctx, opt))


### PR DESCRIPTION
What is the purpose of this change?

This change provides the ability to pass env_auth as a parameter to the drive provider. This enables the provider to pull IAM credentials from the environment or instance metadata. Previously if no auth method was given it would default to requesting oauth.
Was the change discussed in an issue or in the forum before?

As requested [Can google drive work with application default credentials?](https://forum.rclone.org/t/can-google-drive-work-with-application-default-credentials/36107).

This needs more testing by someone who uses drive api more extensively. 

[x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md?rgh-link-date=2023-03-04T05%3A19%3A33Z#submitting-a-new-feature-or-bug-fix).
[]I  have added tests for all changes in this PR if appropriate.
[x] I have added documentation for the changes if appropriate.
[x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md?rgh-link-date=2023-03-04T05%3A19%3A33Z#commit-messages).
[] I'm done, this Pull Request is ready for review :-)