### PR TITLE
vfs: add refresh flag

### DIFF
--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -232,10 +232,24 @@ func New(f fs.Fs, opt *vfscommon.Options) *VFS {
 	// removed when the vfs is finalized
 	cache.PinUntilFinalized(f, vfs)
 
+	// Refresh the dircache if required
+	if vfs.Opt.Refresh {
+		go vfs.refresh()
+	}
+
 	// This can take some time so do it after the Pin
 	vfs.SetCacheMode(vfs.Opt.CacheMode)
 
 	return vfs
+}
+
+// refresh the directory cache for all directories
+func (vfs *VFS) refresh() {
+	fs.Debugf(vfs.f, "Refreshing VFS directory cache")
+	err := vfs.root.readDirTree()
+	if err != nil {
+		fs.Errorf(vfs.f, "Error refreshing VFS directory cache: %v", err)
+	}
 }
 
 // Stats returns info about the VFS

--- a/vfs/vfscommon/options.go
+++ b/vfs/vfscommon/options.go
@@ -15,6 +15,7 @@ type Options struct {
 	ReadOnly           bool          // if set VFS is read only
 	NoModTime          bool          // don't read mod times for files
 	DirCacheTime       time.Duration // how long to consider directory listing cache valid
+	Refresh            bool          // refreshes the directory listing recursively on start
 	PollInterval       time.Duration
 	Umask              int
 	UID                uint32
@@ -44,6 +45,7 @@ var DefaultOpt = Options{
 	NoChecksum:         false,
 	NoSeek:             false,
 	DirCacheTime:       5 * 60 * time.Second,
+	Refresh:            false,
 	PollInterval:       time.Minute,
 	ReadOnly:           false,
 	Umask:              0,

--- a/vfs/vfsflags/vfsflags.go
+++ b/vfs/vfsflags/vfsflags.go
@@ -22,6 +22,7 @@ func AddFlags(flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &Opt.NoChecksum, "no-checksum", "", Opt.NoChecksum, "Don't compare checksums on up/download", "VFS")
 	flags.BoolVarP(flagSet, &Opt.NoSeek, "no-seek", "", Opt.NoSeek, "Don't allow seeking in files", "VFS")
 	flags.DurationVarP(flagSet, &Opt.DirCacheTime, "dir-cache-time", "", Opt.DirCacheTime, "Time to cache directory entries for", "VFS")
+	flags.BoolVarP(flagSet, &Opt.Refresh, "vfs-refresh", "", Opt.Refresh, "Refreshes the directory cache recursively on start", "VFS")
 	flags.DurationVarP(flagSet, &Opt.PollInterval, "poll-interval", "", Opt.PollInterval, "Time to wait between polling for changes, must be smaller than dir-cache-time and only on supported remotes (set 0 to disable)", "VFS")
 	flags.BoolVarP(flagSet, &Opt.ReadOnly, "read-only", "", Opt.ReadOnly, "Only allow read-only access", "VFS")
 	flags.FVarP(flagSet, &Opt.CacheMode, "vfs-cache-mode", "", "Cache mode off|minimal|writes|full", "VFS")


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Add vfs/refesh recursive=true flag so it can run w/o needing rc on mount.

#### Was the change discussed in an issue or in the forum before?

closes #6830 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
