### PR TITLE
fs: fix typos found by codespell

### DIFF
--- a/fs/accounting/transfer.go
+++ b/fs/accounting/transfer.go
@@ -192,7 +192,7 @@ func (tr *Transfer) Snapshot() TransferSnapshot {
 // rcStats returns stats for the transfer suitable for the rc
 func (tr *Transfer) rcStats() rc.Params {
 	return rc.Params{
-		"name": tr.remote, // no locking needed to access thess
+		"name": tr.remote, // no locking needed to access this
 		"size": tr.size,
 	}
 }

--- a/fs/backend_config.go
+++ b/fs/backend_config.go
@@ -376,7 +376,7 @@ func configAll(ctx context.Context, name string, m configmap.Mapper, ri *RegInfo
 	//
 	//     *all-ACTION,NUMBER,ADVANCED
 	//
-	// Where NUMBER is the curent state, ADVANCED is a flag true or false
+	// Where NUMBER is the current state, ADVANCED is a flag true or false
 	// to say whether we are asking about advanced config and
 	// ACTION is what the state should be doing next.
 	stateParams, state := StatePop(in.State)

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -789,7 +789,7 @@ func TestCopyURL(t *testing.T) {
 	headerFilename := "headerfilename.txt"
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if status != 0 {
-			http.Error(w, "an error ocurred", status)
+			http.Error(w, "an error occurred", status)
 		}
 		if nameHeader {
 			w.Header().Set("Content-Disposition", `attachment; filename="folder\`+headerFilename+`"`)
@@ -863,7 +863,7 @@ func TestCopyURLToWriter(t *testing.T) {
 	status := 0
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if status != 0 {
-			http.Error(w, "an error ocurred", status)
+			http.Error(w, "an error occurred", status)
 			return
 		}
 		_, err := w.Write([]byte(contents))
@@ -1694,7 +1694,7 @@ func TestRcatMetadata(t *testing.T) {
 		gotMeta, err := fs.GetMetadata(ctx, o)
 		require.NoError(t, err)
 		// Check the specific user data we set is set
-		// Likey there will be other values
+		// Likely there will be other values
 		assert.Equal(t, "value", gotMeta["key"])
 		assert.Equal(t, "potato", gotMeta["sausage"])
 
@@ -1781,7 +1781,7 @@ func TestRcatSizeMetadata(t *testing.T) {
 		gotMeta, err := fs.GetMetadata(ctx, o)
 		require.NoError(t, err)
 		// Check the specific user data we set is set
-		// Likey there will be other values
+		// Likely there will be other values
 		assert.Equal(t, "value", gotMeta["key"])
 		assert.Equal(t, "potato", gotMeta["sausage"])
 	}

--- a/fs/rc/rc.go
+++ b/fs/rc/rc.go
@@ -1,7 +1,7 @@
 // Package rc implements a remote control server and registry for rclone
 //
 // To register your internal calls, call rc.Add(path, function).  Your
-// function should take ane return a Param.  It can also return an
+// function should take and return a Param.  It can also return an
 // error.  Use rc.NewError to wrap an existing error along with an
 // http response type if another response other than 500 internal
 // error is required on error.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix typos found by [codespell](https://github.com/codespell-project/codespell).

Not sure about the `thess` → `these` and `Likey` → `Likely` changes. Please double-check.

By the way, codespell suggested to change `Unknwon` → `Unknown` here:
https://github.com/rclone/rclone/blob/3b4a57dab954fbbaecf692f1814e9372e7692c95/fs/config/configfile/configfile.go#L12
I haven't changed anything, of course, but I thought I'd mention that https://github.com/Unknwon/goconfig reads:
> **IMPORTANT**
> 
> - This library is under bug fix only mode, which means no more features will be added.
> - I'm continuing working on better Go code with a different library: [ini](https://github.com/go-ini/ini).

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
