### PR TITLE
FAQ: clarify fixes for name resolution errors

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -190,9 +190,14 @@ If you are using `systemd-resolved` (default on Arch Linux), ensure it
 is at version 233 or higher. Previous releases contain a bug which
 causes not all domains to be resolved properly.
 
-Additionally with the `GODEBUG=netdns=` environment variable the Go
-resolver decision can be influenced. This also allows to resolve certain
-issues with DNS resolution. See the [name resolution section in the go docs](https://golang.org/pkg/net/#hdr-Name_Resolution).
+The Go resolver decision can be influenced with the `GODEBUG=netdns=...`
+environment variable. This also allows to resolve certain issues with
+DNS resolution. On Windows or MacOS systems, try forcing use of the
+internal Go resolver by setting `GODEBUG=netdns=go` at runtime. On
+other systems (Linux, \*BSD, etc) try forcing use of the system
+name resolver by setting `GODEBUG=netdns=cgo` (and recompile rclone
+from source with CGO enabled if necessary). See the
+[name resolution section in the go docs](https://golang.org/pkg/net/#hdr-Name_Resolution).
 
 ### The total size reported in the stats for a sync is wrong and keeps changing
 


### PR DESCRIPTION
On Linux systems rclone builds with cgo but uses the internal Go resolver for DNS by default. Update the FAQ to suggest use of GODEBUG=netdns=cgo if there are name resolution problems on Linux/BSD (with CGO_ENABLED rebuild from source if necessary), or try GODEBUG=netdns=go on Windows/MacOS. See Issue#683.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Improves documentation for fixing name resolution errors.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

Discussed in Issue#683.

#### Checklist

- [ x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [n/a ] I have added tests for all changes in this PR if appropriate.
- [x ] I have added documentation for the changes if appropriate.
- [x ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)
