### PR TITLE
backend: allow specifying SSH host key algorithms to use for sftp

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -370,6 +370,20 @@ Example:
     umac-64-etm@openssh.com umac-128-etm@openssh.com hmac-sha2-256-etm@openssh.com
 `,
 			Advanced: true,
+		}, {
+			Name:    "host_key_algorithms",
+			Default: fs.SpaceSepList{},
+			Help: `Space separated list of host key algorithms, ordered by preference.
+
+At least one must match with server configuration. This can be checked for example using ssh -Q HostKeyAlgorithms.
+
+Note: This can affect the outcome of key negotiation with the server even if server host key validation is not enabled.
+
+Example:
+
+    ssh-ed25519 ssh-rsa ssh-dss
+`,
+			Advanced: true,
 		}},
 	}
 	fs.Register(fsi)
@@ -408,6 +422,7 @@ type Options struct {
 	Ciphers                 fs.SpaceSepList `config:"ciphers"`
 	KeyExchange             fs.SpaceSepList `config:"key_exchange"`
 	MACs                    fs.SpaceSepList `config:"macs"`
+	HostKeyAlgorithms       fs.SpaceSepList `config:"host_key_algorithms"`
 }
 
 // Fs stores the interface to the remote SFTP files
@@ -738,6 +753,10 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 		Timeout:         f.ci.ConnectTimeout,
 		ClientVersion:   "SSH-2.0-" + f.ci.UserAgent,
+	}
+
+	if len(opt.HostKeyAlgorithms) != 0 {
+		sshConfig.HostKeyAlgorithms = []string(opt.HostKeyAlgorithms)
 	}
 
 	if opt.KnownHostsFile != "" {


### PR DESCRIPTION
#### What is the purpose of this change?

Add an option `host_key_algorithms` to the SFTP backend such that you can specify `--sftp-host-key-algorithms` as a list of SSH host key algorithms in preference order. For example:

```
--sftp-host-key-algorithms ssh-ed25519,ssh-rsa
```

This can be useful when working with hosts that have a non-standard SSH implementation or when you have a particular preference for a type of SSH host keys.

#### Was the change discussed in an issue or in the forum before?

Yes but not by me.

I found this [forum thread](https://forum.rclone.org/t/simple-sftp-connection-fails-with-eof/35065/5) and I have the same issue with the SFTP backend against a Remarkable running dropbear SSH. While I agree with comments by `ncw` in that thread that this is potentially an issue on the server side I would much prefer a client side fix given that the server side is a proprietary solution. I think that this change is a reasonable one to allow us (`Silver7845` from the forum and myself) to work around the issue without being too specific to the problem we have - there is no change in behaviour unless specifying the new option and there are other reasons why a user may wish to specify a specific list of SSH host key algorithms.

With this change (and using the example option from above) I can connect to the Remarkable device just fine.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

##### Tests

I did not add any tests because there does not seem to be anywhere in this folder to fit this in. If I have got that wrong please let me know and I will do my best to get something added.