### PR TITLE
Config file save improvements

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -952,15 +952,9 @@ To reduce risk of corrupting an existing configuration file, rclone
 will not write directly to it when saving changes. Instead it will
 first write to a new, temporary, file. If a configuration file already
 existed, it will (on Unix systems) try to mirror its permissions to
-the new file. Then it will rename the existing file by adding suffix
-".old" to its name (e.g. `rclone.conf.old`), if a file with the same
-name already exists it will simply be replaced. Next, rclone will rename
-the new file to the correct name, before finally cleaning up by deleting
-the original file now which has now ".old" suffix to its name. Note that
-one side-effect of this is that if you happen to have a file in the same
-directory and with the same name as your configuration file, but with
-suffix ".old", then rclone will end up deleting this file next time it
-updates its configuration file!
+the new file. Then it will rename the existing file to a temporary
+name as backup. Next, rclone will rename the new file to the correct name,
+before finally cleaning up by deleting the backup file.
 
 ### --contimeout=TIME ###
 

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -956,6 +956,14 @@ the new file. Then it will rename the existing file to a temporary
 name as backup. Next, rclone will rename the new file to the correct name,
 before finally cleaning up by deleting the backup file.
 
+If the configuration file path used by rclone is a symbolic link, then
+this will be evaluated and rclone will write to the resolved path, instead
+of overwriting the symbolic link. Temporary files used in the process
+(described above) will be written to the same parent directory as that
+of the resolved configuration file, but if this directory is also a
+symbolic link it will not be resolved and the temporary files will be
+written to the location of the directory symbolic link.
+
 ### --contimeout=TIME ###
 
 Set the connection timeout. This should be in go time format which


### PR DESCRIPTION
#### What is the purpose of this change?

See commit messages and issues linked from those.

The following example should also illustrate the changes.

Given symbolic link:
```
tempconfig.txt -> tempconfig/temp/tempconfig.txt
```
Then:
```
./rclone -vv config create yyy local --config=tempconfig.txt
2023/04/04 16:42:36 DEBUG : rclone: Version "v1.63.0-DEV" starting with parameters ["./rclone" "-vv" "config" "create" "yyy" "local" "--config=tempconfig.txt"]
2023/04/04 16:42:36 DEBUG : Using config file from "/home/user/projects/rclone/tempconfig.txt"
2023/04/04 16:42:36 DEBUG : yyy: config in: state="", result=""
2023/04/04 16:42:36 DEBUG : yyy: config out: out=<nil>, err=<nil>
2023/04/04 16:42:36 DEBUG : Saving config file: /home/user/projects/rclone/tempconfig.txt
2023/04/04 16:42:36 DEBUG : Config path resolved to: tempconfig/temp/tempconfig.txt
2023/04/04 16:42:36 DEBUG : Writing new config to temporary file: tempconfig/temp/tempconfig.txt740963405
2023/04/04 16:42:36 DEBUG : Moving existing config to temporary file: tempconfig/temp/tempconfig.txt.old1388108941
2023/04/04 16:42:36 DEBUG : Moving temporary file with new config to real config path: tempconfig/temp/tempconfig.txt
[yyy]
type = local
2023/04/04 16:42:36 DEBUG : rclone: Version "v1.63.0-DEV" finishing with parameters ["./rclone" "-vv" "config" "create" "yyy" "local" "--config=tempconfig.txt"]
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
