### PR TITLE
version: fix reported os/kernel version for windows

### DIFF
--- a/lib/buildinfo/osversion_windows.go
+++ b/lib/buildinfo/osversion_windows.go
@@ -1,7 +1,6 @@
 package buildinfo
 
 import (
-	"fmt"
 	"regexp"
 	"strings"
 	"unsafe"
@@ -32,10 +31,10 @@ func GetOSVersion() (osVersion, osKernel string) {
 			}
 		}
 
-		// Simplify kernel output: `RELEASE.BUILD Build BUILD` -> `RELEASE.BUILD`
-		match := regexp.MustCompile(`^([\d\.]+?\.)(\d+) Build (\d+)$`).FindStringSubmatch(osKernel)
+		// Simplify kernel output: `MAJOR.MINOR.BUILD.REVISION Build BUILD.REVISION` -> `MAJOR.MINOR.BUILD.REVISION`
+		match := regexp.MustCompile(`^(\d+\.\d+\.(\d+\.\d+)) Build (\d+\.\d+)$`).FindStringSubmatch(osKernel)
 		if len(match) == 4 && match[2] == match[3] {
-			osKernel = match[1] + match[2]
+			osKernel = match[1]
 		}
 	}
 
@@ -51,11 +50,6 @@ func GetOSVersion() (osVersion, osKernel string) {
 		if friendlyName != "" {
 			osVersion += " " + friendlyName
 		}
-	}
-
-	updateRevision := getRegistryVersionInt("UBR")
-	if osKernel != "" && updateRevision != 0 {
-		osKernel += fmt.Sprintf(".%d", updateRevision)
 	}
 
 	if arch, err := host.KernelArch(); err == nil && arch != "" {


### PR DESCRIPTION
#### What is the purpose of this change?

I just noticed the os/kernel output from rclone version command has become verbose and repetitive:

```
rclone v1.62.2
- os/version: Microsoft Windows 10 Enterprise 22H2 (64 bit)
- os/kernel: 10.0.19045.2728 Build 19045.2728.2728 (x86_64)
```

Found the reason is the external gopsutil library started to include the UBR (Update Build Revision) in the kernel version string that we use, since version [3.22.12](https://github.com/shirou/gopsutil/releases/tag/v3.22.12).

This PR removes our own code for retrieving and appending the UBR value, and also fixes the parsing of the kernel version to simplify it to pure 4 part numeric string as before. Seems safe to assume the output string is always in format `MAJOR.MINOR.BUILD.REVISION Build BUILD.REVISION`, see: https://github.com/shirou/gopsutil/blob/10f213c448609a6ea9ff3acce5634e7da8b7d334/host/host_windows.go#L218-L220

Result is now:
```
rclone v1.62.2
- os/version: Microsoft Windows 10 Enterprise 22H2 (64 bit)
- os/kernel: 10.0.19045.2728 (x86_64)
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
