### PR TITLE
serve: trigger systemd notify for restic

### DIFF
--- a/cmd/serve/restic/restic.go
+++ b/cmd/serve/restic/restic.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	sysdnotify "github.com/iguanesolutions/go-systemd/v5/notify"
+
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/chi/v5/middleware"
 	"github.com/rclone/rclone/cmd"
@@ -177,7 +179,17 @@ with a path of ` + "`/<username>/`" + `.
 				return nil
 			}
 			fs.Logf(s.f, "Serving restic REST API on %s", s.URLs())
+
+			if err := sysdnotify.Ready(); err != nil {
+				fs.Logf(s.f, "failed to notify ready to systemd: %v", err)
+			}
+
 			s.Wait()
+
+			if err := sysdnotify.Stopping(); err != nil {
+				fs.Logf(s.f, "failed to notify stopping to systemd: %v", err)
+			}
+
 			return nil
 		})
 	},


### PR DESCRIPTION
#### What is the purpose of this change?

I would like to react for systemd notify hooks to savely build my backup scripts.

I have an Restic Service + Restic Timer and they start Rclone before they run. I want to make it safe that the Restic API is ready before the Restic process itself starts. Therefore I want to use `Type=notify` on my Rclone.


#### Was the change discussed in an issue or in the forum before?

Nope

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
