### PR TITLE
docs: clarify that X-Amz-Meta-Md5chksum is really a base64-encoded he…

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -384,10 +384,7 @@ the same format as is required for `Content-MD5`).  You can use base64 -d and he
 
     echo 'VWTGdNx3LyXQDfA0e2Edxw==' | base64 -d | hexdump
 
-or use native commands to verify:
-
-    rclone check            # hashes the local file and compares against X-Amz-Meta-Md5chksum
-    rclone check --download # downloads the entire file from S3 to check against local file
+or you can use `rclone check` to verify the hashes are OK.
 
 For large objects, calculating this hash can take some time so the
 addition of this hash can be disabled with `--s3-disable-checksum`.


### PR DESCRIPTION
…x value and give example of how to decode the value stored in X-Amz-Meta-Md5chksum

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
To clarify how to decode the value stored in X-Amz-Meta-Md5chksum for S3 metadata
-->

#### Was the change discussed in an issue or in the forum before?

<!--
[Link issues and relevant forum posts here.](https://forum.rclone.org/t/help-me-figure-out-how-to-verify-backup-accuracy-and-completeness-on-s3/37632/11)
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
