### PR TITLE
Making SetModTime less scary by printing as Debugf.

### DIFF
--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -1098,7 +1098,7 @@ func (o *Object) ModTime(ctx context.Context) time.Time {
 // SetModTime sets the modification time of the object
 func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
 	if !o.fs.fSetTime {
-		fs.Errorf(o.fs, "SetModTime is not supported")
+		fs.Debugf(o.fs, "SetModTime is not supported")
 		return nil
 	}
 	c, err := o.fs.getFtpConnection(ctx)


### PR DESCRIPTION
#### What is the purpose of this change?

Changed "SetModTime not supported" feature to print out the information from `Errorf` to `Debugf`.
Functionality was given before, so the message could be considered more of a warning.

It was / is observed with different ftp implementations - confirmed with the implementation of `FRITZ!Box 7530 - FRITZ!OS:7.51-104920 BETA`

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/ftp-fritz-box-setmodtime-is-not-supported/37781

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
