### PR TITLE
docs: clarify backends that use --no-update-modtime flag

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1576,6 +1576,11 @@ files if they are incorrect as it would normally.
 This can be used if the remote is being synced with another tool also
 (e.g. the Google Drive client).
 
+Currently only implemented for Openstack Swift, Oracle Object Storage,
+Amazon S3, and Microsoft Azure Blob Storage. If specified with other
+backends - even those that [support ModTime](/overview/) -
+the flag is silently ignored.
+
 ### --order-by string ###
 
 The `--order-by` flag controls the order in which files in the backlog


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

The --no-update-modtime flag is supported by a only a couple of backends, even though many of the backends support modtime writing. Since the flag gets silently ignored, which ones support it should be made clear to users.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
