### PR TITLE
sia: switch to renterd

### DIFF
--- a/backend/sia/api/types.go
+++ b/backend/sia/api/types.go
@@ -1,23 +1,13 @@
 // Package api provides types used by the Sia API.
 package api
 
-import (
-	"strings"
-	"time"
-)
+import "strings"
 
-// DirectoriesResponse is the response for https://sia.tech/docs/#renter-dir-siapath-get
-type DirectoriesResponse struct {
-	Directories []DirectoryInfo `json:"directories"`
-	Files       []FileInfo      `json:"files"`
+type FileInfo struct {
+	Name string `json:"name"`
+	Size uint64 `json:"size"`
 }
 
-// FilesResponse is the response for https://sia.tech/docs/#renter-files-get
-type FilesResponse struct {
-	Files []FileInfo `json:"files"`
-}
-
-// FileResponse is the response for https://sia.tech/docs/#renter-file-siapath-get
 type ObjectResponse struct {
 	Object ObjectInfo `json:"object"`
 }
@@ -28,60 +18,6 @@ type ObjectInfo struct {
 
 type Slab struct {
 	Length uint64 `json:"Length"`
-}
-
-// FileInfo is used in https://sia.tech/docs/#renter-files-get
-type FileInfo struct {
-	AccessTime       time.Time `json:"accesstime"`
-	Available        bool      `json:"available"`
-	ChangeTime       time.Time `json:"changetime"`
-	CipherType       string    `json:"ciphertype"`
-	CreateTime       time.Time `json:"createtime"`
-	Expiration       uint64    `json:"expiration"`
-	Filesize         uint64    `json:"filesize"`
-	Health           float64   `json:"health"`
-	LocalPath        string    `json:"localpath"`
-	MaxHealth        float64   `json:"maxhealth"`
-	MaxHealthPercent float64   `json:"maxhealthpercent"`
-	ModTime          time.Time `json:"modtime"`
-	NumStuckChunks   uint64    `json:"numstuckchunks"`
-	OnDisk           bool      `json:"ondisk"`
-	Recoverable      bool      `json:"recoverable"`
-	Redundancy       float64   `json:"redundancy"`
-	Renewing         bool      `json:"renewing"`
-	SiaPath          string    `json:"siapath"`
-	Stuck            bool      `json:"stuck"`
-	StuckHealth      float64   `json:"stuckhealth"`
-	UploadedBytes    uint64    `json:"uploadedbytes"`
-	UploadProgress   float64   `json:"uploadprogress"`
-}
-
-// DirectoryInfo is used in https://sia.tech/docs/#renter-dir-siapath-get
-type DirectoryInfo struct {
-	AggregateHealth              float64   `json:"aggregatehealth"`
-	AggregateLastHealthCheckTime time.Time `json:"aggregatelasthealthchecktime"`
-	AggregateMaxHealth           float64   `json:"aggregatemaxhealth"`
-	AggregateMaxHealthPercentage float64   `json:"aggregatemaxhealthpercentage"`
-	AggregateMinRedundancy       float64   `json:"aggregateminredundancy"`
-	AggregateMostRecentModTime   time.Time `json:"aggregatemostrecentmodtime"`
-	AggregateNumFiles            uint64    `json:"aggregatenumfiles"`
-	AggregateNumStuckChunks      uint64    `json:"aggregatenumstuckchunks"`
-	AggregateNumSubDirs          uint64    `json:"aggregatenumsubdirs"`
-	AggregateSize                uint64    `json:"aggregatesize"`
-	AggregateStuckHealth         float64   `json:"aggregatestuckhealth"`
-
-	Health              float64   `json:"health"`
-	LastHealthCheckTime time.Time `json:"lasthealthchecktime"`
-	MaxHealthPercentage float64   `json:"maxhealthpercentage"`
-	MaxHealth           float64   `json:"maxhealth"`
-	MinRedundancy       float64   `json:"minredundancy"`
-	MostRecentModTime   time.Time `json:"mostrecentmodtime"`
-	NumFiles            uint64    `json:"numfiles"`
-	NumStuckChunks      uint64    `json:"numstuckchunks"`
-	NumSubDirs          uint64    `json:"numsubdirs"`
-	SiaPath             string    `json:"siapath"`
-	Size                uint64    `json:"size"`
-	StuckHealth         float64   `json:"stuckhealth"`
 }
 
 // Error contains an error message per https://sia.tech/docs/#error

--- a/backend/sia/api/types.go
+++ b/backend/sia/api/types.go
@@ -18,8 +18,16 @@ type FilesResponse struct {
 }
 
 // FileResponse is the response for https://sia.tech/docs/#renter-file-siapath-get
-type FileResponse struct {
-	File FileInfo `json:"file"`
+type ObjectResponse struct {
+	Object ObjectInfo `json:"object"`
+}
+
+type ObjectInfo struct {
+	Slabs []Slab `json:"Slabs"`
+}
+
+type Slab struct {
+	Length uint64 `json:"Length"`
 }
 
 // FileInfo is used in https://sia.tech/docs/#renter-files-get

--- a/backend/sia/api/types.go
+++ b/backend/sia/api/types.go
@@ -16,6 +16,14 @@ type ObjectInfo struct {
 	Slabs []Slab `json:"Slabs"`
 }
 
+func (o *ObjectInfo) Size() int64 {
+	size := int64(0)
+	for _, slab := range o.Slabs {
+		size += int64(slab.Length)
+	}
+	return size
+}
+
 type Slab struct {
 	Length uint64 `json:"Length"`
 }

--- a/backend/sia/sia.go
+++ b/backend/sia/sia.go
@@ -4,7 +4,6 @@ package sia
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -37,26 +36,25 @@ const (
 func init() {
 	fs.Register(&fs.RegInfo{
 		Name:        "sia",
-		Description: "Sia Decentralized Cloud",
+		Description: "Sia Decentralized Cloud (renterd)",
 		NewFs:       NewFs,
 		Options: []fs.Option{{
 			Name: "api_url",
-			Help: `Sia daemon API URL, like http://sia.daemon.host:9980.
+			Help: `renterd API URL, like http://renterd.host:9980.
 
-Note that siad must run with --disable-api-security to open API port for other hosts (not recommended).
-Keep default if Sia daemon runs on localhost.`,
+Keep default if renterd runs on localhost.`,
 			Default: "http://127.0.0.1:9980",
 		}, {
 			Name: "api_password",
-			Help: `Sia Daemon API Password.
+			Help: `renterd API password.
 
 Can be found in the apipassword file located in HOME/.sia/ or in the daemon directory.`,
 			IsPassword: true,
 		}, {
 			Name: "user_agent",
-			Help: `Siad User Agent
+			Help: `renterd User Agent
 
-Sia daemon requires the 'Sia-Agent' user agent by default for security`,
+renterd requires the 'Sia-Agent' user agent by default for security`,
 			Default:  "Sia-Agent",
 			Advanced: true,
 		}, {
@@ -159,7 +157,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	var resp *http.Response
 	opts := rest.Opts{
 		Method:  "GET",
-		Path:    path.Join("/renter/stream/", o.fs.root, o.fs.opt.Enc.FromStandardPath(o.remote)),
+		Path:    path.Join("/api/worker/objects/", o.fs.root, o.fs.opt.Enc.FromStandardPath(o.remote)),
 		Options: optionsFixed,
 	}
 	err = o.fs.pacer.Call(func() (bool, error) {
@@ -177,13 +175,12 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	size := src.Size()
 	var resp *http.Response
 	opts := rest.Opts{
-		Method:        "POST",
-		Path:          path.Join("/renter/uploadstream/", o.fs.opt.Enc.FromStandardPath(path.Join(o.fs.root, o.remote))),
+		Method:        "PUT",
+		Path:          path.Join("/api/worker/objects/", o.fs.opt.Enc.FromStandardPath(path.Join(o.fs.root, o.remote))),
 		Body:          in,
 		ContentLength: &size,
 		Parameters:    url.Values{},
 	}
-	opts.Parameters.Set("force", "true")
 
 	err = o.fs.pacer.Call(func() (bool, error) {
 		resp, err = o.fs.srv.Call(ctx, &opts)
@@ -201,8 +198,8 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 func (o *Object) Remove(ctx context.Context) (err error) {
 	var resp *http.Response
 	opts := rest.Opts{
-		Method: "POST",
-		Path:   path.Join("/renter/delete/", o.fs.opt.Enc.FromStandardPath(path.Join(o.fs.root, o.remote))),
+		Method: "DELETE",
+		Path:   path.Join("/api/bus/objects/", o.fs.opt.Enc.FromStandardPath(path.Join(o.fs.root, o.remote))),
 	}
 	err = o.fs.pacer.Call(func() (bool, error) {
 		resp, err = o.fs.srv.Call(ctx, &opts)
@@ -216,10 +213,10 @@ func (o *Object) Remove(ctx context.Context) (err error) {
 func (o *Object) readMetaData(ctx context.Context) (err error) {
 	opts := rest.Opts{
 		Method: "GET",
-		Path:   path.Join("/renter/file/", o.fs.opt.Enc.FromStandardPath(path.Join(o.fs.root, o.remote))),
+		Path:   path.Join("/api/bus/objects/", o.fs.opt.Enc.FromStandardPath(path.Join(o.fs.root, o.remote))),
 	}
 
-	var result api.FileResponse
+	var result api.ObjectResponse
 	var resp *http.Response
 	err = o.fs.pacer.Call(func() (bool, error) {
 		resp, err = o.fs.srv.CallJSON(ctx, &opts, nil, &result)
@@ -230,8 +227,7 @@ func (o *Object) readMetaData(ctx context.Context) (err error) {
 		return err
 	}
 
-	o.size = int64(result.File.Filesize)
-	o.modTime = result.File.ModTime
+	o.size = int64(result.Object.Slabs[0].Length)
 
 	return nil
 }
@@ -268,13 +264,22 @@ func (f *Fs) Features() *fs.Features {
 
 // List files and directories in a directory
 func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err error) {
-	dirPrefix := f.opt.Enc.FromStandardPath(path.Join(f.root, dir)) + "/"
+	dirPrefix := "/" + f.opt.Enc.FromStandardPath(path.Join(f.root, dir)) + "/"
 
-	var result api.DirectoriesResponse
+	if dirPrefix == "//" {
+		dirPrefix = "/"
+	}
+
+	rootDirPrefix := "/" + f.root + "/"
+	if rootDirPrefix == "//" {
+		rootDirPrefix = "/"
+	}
+
+	var result []string
 	var resp *http.Response
 	opts := rest.Opts{
 		Method: "GET",
-		Path:   path.Join("/renter/dir/", dirPrefix) + "/",
+		Path:   path.Join("/api/worker/objects/", dirPrefix) + "/",
 	}
 
 	err = f.pacer.Call(func() (bool, error) {
@@ -286,21 +291,25 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 		return nil, err
 	}
 
-	for _, directory := range result.Directories {
-		if directory.SiaPath+"/" == dirPrefix {
+	for _, object := range result {
+		if object == "/" {
 			continue
 		}
+		if object == dirPrefix {
+			continue
+		}
+		if strings.HasSuffix(object, "/") {
+			d := fs.NewDir(f.opt.Enc.ToStandardPath(strings.TrimSuffix(strings.TrimPrefix(object, rootDirPrefix), "/")), time.Time{})
+			entries = append(entries, d)
+		} else {
+			o := &Object{fs: f,
+				remote: f.opt.Enc.ToStandardPath(strings.TrimPrefix(object, rootDirPrefix)),
+				// TODO file size missing
+				// size: int64(0),
+			}
+			entries = append(entries, o)
+		}
 
-		d := fs.NewDir(f.opt.Enc.ToStandardPath(strings.TrimPrefix(directory.SiaPath, f.opt.Enc.FromStandardPath(f.root)+"/")), directory.MostRecentModTime)
-		entries = append(entries, d)
-	}
-
-	for _, file := range result.Files {
-		o := &Object{fs: f,
-			remote:  f.opt.Enc.ToStandardPath(strings.TrimPrefix(file.SiaPath, f.opt.Enc.FromStandardPath(f.root)+"/")),
-			modTime: file.ModTime,
-			size:    int64(file.Filesize)}
-		entries = append(entries, o)
 	}
 
 	return entries, nil
@@ -362,11 +371,10 @@ func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, opt
 func (f *Fs) Mkdir(ctx context.Context, dir string) (err error) {
 	var resp *http.Response
 	opts := rest.Opts{
-		Method:     "POST",
-		Path:       path.Join("/renter/dir/", f.opt.Enc.FromStandardPath(path.Join(f.root, dir))),
+		Method:     "PUT",
+		Path:       path.Join("/api/worker/objects/", f.opt.Enc.FromStandardPath(path.Join(f.root, dir))) + "/",
 		Parameters: url.Values{},
 	}
-	opts.Parameters.Set("action", "create")
 
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.Call(ctx, &opts)
@@ -385,27 +393,26 @@ func (f *Fs) Rmdir(ctx context.Context, dir string) (err error) {
 	var resp *http.Response
 	opts := rest.Opts{
 		Method: "GET",
-		Path:   path.Join("/renter/dir/", f.opt.Enc.FromStandardPath(path.Join(f.root, dir))),
+		Path:   path.Join("/api/worker/objects/", f.opt.Enc.FromStandardPath(path.Join(f.root, dir))) + "/",
 	}
 
-	var result api.DirectoriesResponse
+	var result []string
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.CallJSON(ctx, &opts, nil, &result)
 		return f.shouldRetry(resp, err)
 	})
 
-	if len(result.Directories) == 0 {
+	if len(result) == 0 {
 		return fs.ErrorDirNotFound
-	} else if len(result.Files) > 0 || len(result.Directories) > 1 {
+	} else if len(result) > 1 {
 		return fs.ErrorDirectoryNotEmpty
 	}
 
 	opts = rest.Opts{
-		Method:     "POST",
-		Path:       path.Join("/renter/dir/", f.opt.Enc.FromStandardPath(path.Join(f.root, dir))),
+		Method:     "DELETE",
+		Path:       path.Join("/api/bus/objects/", f.opt.Enc.FromStandardPath(path.Join(f.root, dir))) + "/",
 		Parameters: url.Values{},
 	}
-	opts.Parameters.Set("action", "delete")
 
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.Call(ctx, &opts)
@@ -464,7 +471,8 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	if root != "" && !rootIsDir {
-		// Check to see if the root actually an existing file
+		// TODO Check if root is file
+		/* // Check to see if the root actually an existing file
 		remote := path.Base(root)
 		f.root = path.Dir(root)
 		if f.root == "." {
@@ -480,7 +488,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 			return nil, err
 		}
 		// return an error with an fs which points to the parent
-		return f, fs.ErrorIsFile
+		return f, fs.ErrorIsFile */
 	}
 
 	return f, nil

--- a/backend/sia/sia.go
+++ b/backend/sia/sia.go
@@ -458,27 +458,6 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		f.srv.SetUserPass("", opt.APIPassword)
 	}
 
-	if root != "" && !rootIsDir {
-		// TODO Check if root is file
-		/* // Check to see if the root actually an existing file
-		remote := path.Base(root)
-		f.root = path.Dir(root)
-		if f.root == "." {
-			f.root = ""
-		}
-		_, err := f.NewObject(ctx, remote)
-		if err != nil {
-			if errors.Is(err, fs.ErrorObjectNotFound) || errors.Is(err, fs.ErrorNotAFile) {
-				// File doesn't exist so return old f
-				f.root = root
-				return f, nil
-			}
-			return nil, err
-		}
-		// return an error with an fs which points to the parent
-		return f, fs.ErrorIsFile */
-	}
-
 	return f, nil
 }
 

--- a/backend/sia/sia.go
+++ b/backend/sia/sia.go
@@ -429,7 +429,6 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return nil, err
 	}
 
-	rootIsDir := strings.HasSuffix(root, "/")
 	root = strings.Trim(root, "/")
 
 	f := &Fs{


### PR DESCRIPTION
#### What is the purpose of this change?

The current Sia integration in rclone uses the **siad** API (https://github.com/SiaFoundation/siad).

The Sia Foundation is working on a new next-generation Sia renter called **renterd** (https://github.com/SiaFoundation/renterd). This PR changes the Sia backend to support the new renterd API. 

Changing the implementation would break existing rclone setups still using siad, so it might make sense to instead create a new backend or add a migration process. I'm open for suggestions.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
