### PR TITLE
pikpak: add validity check when using a media link

### DIFF
--- a/backend/pikpak/api/types.go
+++ b/backend/pikpak/api/types.go
@@ -227,9 +227,10 @@ type Media struct {
 		Duration   int64  `json:"duration,omitempty"`
 		BitRate    int    `json:"bit_rate,omitempty"`
 		FrameRate  int    `json:"frame_rate,omitempty"`
-		VideoCodec string `json:"video_codec,omitempty"`
-		AudioCodec string `json:"audio_codec,omitempty"`
-		VideoType  string `json:"video_type,omitempty"`
+		VideoCodec string `json:"video_codec,omitempty"` // "h264", "hevc"
+		AudioCodec string `json:"audio_codec,omitempty"` // "pcm_bluray", "aac"
+		VideoType  string `json:"video_type,omitempty"`  // "mpegts"
+		HdrType    string `json:"hdr_type,omitempty"`
 	} `json:"video,omitempty"`
 	Link           *Link         `json:"link,omitempty"`
 	NeedMoreQuota  bool          `json:"need_more_quota,omitempty"`


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Before this change:

The Pikpak backend would always download the first media item whenever possible, regardless of whether or not it was linked to the original contents. This could lead to users downloading the wrong file, e.g. transcoded media.

Now:

We check the validity of a media link using the `fid` parameter in the link URL. This ensures that users always download the correct file object.

#### Was the change discussed in an issue or in the forum before?

Closes #6992 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
