### PR TITLE
Update parent dir modtime on vfs actions

### DIFF
--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -923,6 +923,10 @@ func (d *Dir) Create(name string, flags int) (*File, error) {
 	if d.vfs.Opt.ReadOnly {
 		return nil, EROFS
 	}
+	if err = d.SetModTime(time.Now()); err != nil {
+		fs.Errorf(d, "Dir.Create failed to set modtime on parent dir: %v", err)
+		return nil, err
+	}
 	// This gets added to the directory when the file is opened for write
 	return newFile(d, d.Path(), nil, name), nil
 }
@@ -957,6 +961,10 @@ func (d *Dir) Mkdir(name string) (*Dir, error) {
 	fsDir := fs.NewDir(path, time.Now())
 	dir := newDir(d.vfs, d.f, d, fsDir)
 	d.addObject(dir)
+	if err = d.SetModTime(time.Now()); err != nil {
+		fs.Errorf(d, "Dir.Mkdir failed to set modtime on parent dir: %v", err)
+		return nil, err
+	}
 	// fs.Debugf(path, "Dir.Mkdir OK")
 	return dir, nil
 }
@@ -1026,6 +1034,10 @@ func (d *Dir) RemoveName(name string) error {
 	node, err := d.stat(name)
 	if err != nil {
 		fs.Errorf(d, "Dir.Remove error: %v", err)
+		return err
+	}
+	if err = d.SetModTime(time.Now()); err != nil {
+		fs.Errorf(d, "Dir.Remove failed to set modtime on parent dir: %v", err)
 		return err
 	}
 	return node.Remove()
@@ -1098,6 +1110,10 @@ func (d *Dir) Rename(oldName, newName string, destDir *Dir) error {
 	// Show moved - delete from old dir and add to new
 	d.delObject(oldName)
 	destDir.addObject(oldNode)
+	if err = d.SetModTime(time.Now()); err != nil {
+		fs.Errorf(d, "Dir.Rename failed to set modtime on parent dir: %v", err)
+		return err
+	}
 
 	// fs.Debugf(newPath, "Dir.Rename renamed from %q", oldPath)
 	// fs.Debugf(d, "AFTER\n%s", d.dump())

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -343,9 +343,12 @@ func TestDirOpen(t *testing.T) {
 func TestDirCreate(t *testing.T) {
 	_, vfs, dir, _ := dirCreate(t)
 
+	origModTime := dir.ModTime()
+	time.Sleep(100 * time.Millisecond) // for low rez Windows timers
 	file, err := dir.Create("potato", os.O_WRONLY|os.O_CREATE)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), file.Size())
+	assert.True(t, dir.ModTime().After(origModTime))
 
 	fd, err := file.Open(os.O_WRONLY | os.O_CREATE)
 	require.NoError(t, err)
@@ -385,8 +388,11 @@ func TestDirMkdir(t *testing.T) {
 	_, err := dir.Mkdir("file1")
 	assert.Error(t, err)
 
+	origModTime := dir.ModTime()
+	time.Sleep(100 * time.Millisecond) // for low rez Windows timers
 	sub, err := dir.Mkdir("sub")
 	assert.NoError(t, err)
+	assert.True(t, dir.ModTime().After(origModTime))
 
 	// check the vfs
 	checkListing(t, dir, []string{"file1,14,false", "sub,0,true"})
@@ -488,8 +494,11 @@ func TestDirRemoveAll(t *testing.T) {
 func TestDirRemoveName(t *testing.T) {
 	r, vfs, dir, _ := dirCreate(t)
 
+	origModTime := dir.ModTime()
+	time.Sleep(100 * time.Millisecond) // for low rez Windows timers
 	err := dir.RemoveName("file1")
 	require.NoError(t, err)
+	assert.True(t, dir.ModTime().After(origModTime))
 	checkListing(t, dir, []string(nil))
 	root, err := vfs.Root()
 	require.NoError(t, err)
@@ -538,8 +547,11 @@ func TestDirRename(t *testing.T) {
 	dir = node.(*Dir)
 
 	// Rename a file
+	origModTime := dir.ModTime()
+	time.Sleep(100 * time.Millisecond) // for low rez Windows timers
 	err = dir.Rename("file1", "file2", root)
 	assert.NoError(t, err)
+	assert.True(t, dir.ModTime().After(origModTime))
 	checkListing(t, root, []string{"dir2,0,true", "file2,14,false"})
 	checkListing(t, dir, []string{"file3,15,false"})
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

I noticed that when doing actions on files/directories in a rclone mounted directory that the modtime on the parent directory was never updated. [lf](https://github.com/gokcehan/lf) relies on this information to know when to refresh a directory, but as it was never updated, any changes to files would not show up. [ranger](https://github.com/ranger/ranger) seems to have the same problem.

This PR replicates the normal unix behavior (same as sshfs) which is to update the modtime of the parent directory when creating/renaming/removing files/directories.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
