### PR TITLE
s3: add Qiniu KODO quirks virtualHostStyle is false

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2973,6 +2973,7 @@ func setQuirks(opt *Options) {
 	case "Qiniu":
 		useMultipartEtag = false
 		urlEncodeListings = false
+		virtualHostStyle = false
 	case "GCS":
 		// Google break request Signature by mutating accept-encoding HTTP header
 		// https://github.com/rclone/rclone/issues/6670


### PR DESCRIPTION
#### What is the purpose of this change?
When I use the s3 backend of Qiniu provider, setting `force_path_style` does not work, it always use virtual-host style. I need to modify the processing for Qiniu in setQuirks in rclone.


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
