### PR TITLE
swift: add dirctory marker support #3453

### DIFF
--- a/backend/swift/swift_test.go
+++ b/backend/swift/swift_test.go
@@ -28,6 +28,17 @@ func TestIntegration(t *testing.T) {
 	})
 }
 
+// TestIntegrationWithDirectoryMarkers runs integration tests against the remote with directory markers enabled
+func TestIntegrationWithDirectoryMarkers(t *testing.T) {
+	fstests.Run(t, &fstests.Opt{
+		RemoteName: "TestSwiftAIO:",
+		NilObject:  (*Object)(nil),
+		ExtraConfig: []fstests.ExtraConfigItem{
+			{Name: "TestSwiftAIO", Key: "directory_markers", Value: "true"},
+		},
+	})
+}
+
 func (f *Fs) SetUploadChunkSize(cs fs.SizeSuffix) (fs.SizeSuffix, error) {
 	return f.setUploadChunkSize(cs)
 }

--- a/fstest/test_all/config.yaml
+++ b/fstest/test_all/config.yaml
@@ -278,6 +278,9 @@ backends:
    remote:   "TestSwiftAIO:"
    fastlist: true
  - backend:  "swift"
+   remote:   "TestSwiftAIO,directory_markers:"
+   fastlist: true
+ - backend:  "swift"
    remote:   "TestSwift:"
    fastlist: true
  # - backend:  "swift"

--- a/fstest/testserver/init.d/TestSwiftAIO
+++ b/fstest/testserver/init.d/TestSwiftAIO
@@ -7,9 +7,15 @@ NAME=swift-aio
 . $(dirname "$0")/docker.bash
 
 start() {
+    # When running the second set of integration tests against SwiftAIO, we need to wait for the first run to stop.
+    if docker inspect ${NAME} >/dev/null 2>&1; then
+        echo "Waiting for the previous run to stop..."
+        sleep 3
+    fi
+
     docker run --rm -d --name ${NAME} \
            bouncestorage/swift-aio
-    
+
     echo type=swift
     echo env_auth=false
     echo user=test:tester


### PR DESCRIPTION
#### What is the purpose of this change?

Support --swift-directory-markers .

I also included a change to `TestSwiftAIO` to allow retries. That fixes occasional errors because the `swift-aio` container wasn't cleaned up properly between the first and the second integration test runs.

Please let me know if I miss anything. Thanks!

#### Was the change discussed in an issue or in the forum before?

#3453 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
