### PR TITLE
Add rc call config/setpassword to set password of config file

### DIFF
--- a/docs/content/rc.md
+++ b/docs/content/rc.md
@@ -624,6 +624,14 @@ Parameters:
 
 **Authentication is required for this call.**
 
+### config/setpassword: Set the password of the config file {#config-setpassword}
+
+Parameters:
+
+- password - password of the config file to use
+
+**Authentication is required for this call.**
+
 ### config/update: update the config for a remote. {#config-update}
 
 This takes the following parameters:

--- a/fs/config/crypt.go
+++ b/fs/config/crypt.go
@@ -288,9 +288,20 @@ func SetConfigPassword(password string) error {
 	return nil
 }
 
-// ClearConfigPassword sets the current the password to empty
+// ClearConfigPassword sets the current password to empty
 func ClearConfigPassword() {
 	configKey = nil
+}
+
+// SetOrClearConfigPassword will set the configKey to the hash of
+// the password. If the password passed is an empty string,
+// then the current password will be set to empty.
+func SetOrClearConfigPassword(password string) error {
+	if password == "" {
+		ClearConfigPassword()
+		return nil
+	}
+	return SetConfigPassword(password)
 }
 
 // changeConfigPassword will query the user twice

--- a/fs/config/crypt_test.go
+++ b/fs/config/crypt_test.go
@@ -14,6 +14,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testLoadingEncryptedConfig(t *testing.T) {
+	err := config.Data().Load()
+	require.NoError(t, err)
+	sections := config.Data().GetSectionList()
+	var expect = []string{"nounc", "unc"}
+	assert.Equal(t, expect, sections)
+
+	keys := config.Data().GetKeyList("nounc")
+	expect = []string{"type", "nounc"}
+	assert.Equal(t, expect, keys)
+}
+
 func TestConfigLoadEncrypted(t *testing.T) {
 	var err error
 	oldConfigPath := config.GetConfigPath()
@@ -26,15 +38,7 @@ func TestConfigLoadEncrypted(t *testing.T) {
 	// Set correct password
 	err = config.SetConfigPassword("asdf")
 	require.NoError(t, err)
-	err = config.Data().Load()
-	require.NoError(t, err)
-	sections := config.Data().GetSectionList()
-	var expect = []string{"nounc", "unc"}
-	assert.Equal(t, expect, sections)
-
-	keys := config.Data().GetKeyList("nounc")
-	expect = []string{"type", "nounc"}
-	assert.Equal(t, expect, keys)
+	testLoadingEncryptedConfig(t)
 }
 
 func TestConfigLoadEncryptedWithValidPassCommand(t *testing.T) {

--- a/fs/config/rc.go
+++ b/fs/config/rc.go
@@ -241,3 +241,27 @@ func rcSetPath(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	err = SetConfigPath(path)
 	return nil, err
 }
+
+func init() {
+	rc.Add(rc.Call{
+		Path:         "config/setpassword",
+		Fn:           rcSetPassword,
+		Title:        "Set the password to the config file",
+		AuthRequired: true,
+		Help: `
+Parameters:
+
+- password - password of the config file to use
+`,
+	})
+}
+
+// Set the config file password
+func rcSetPassword(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+	password, err := in.GetString("password")
+	if err != nil {
+		return nil, err
+	}
+	err = SetOrClearConfigPassword(password)
+	return nil, err
+}

--- a/fs/config/rc_test.go
+++ b/fs/config/rc_test.go
@@ -171,3 +171,29 @@ func TestRcSetPath(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, oldPath, config.GetConfigPath())
 }
+
+func TestRcSetPassword(t *testing.T) {
+	encryptedConfigPath := "./testdata/encrypted.conf"
+	oldConfigPath := config.GetConfigPath()
+	call := rc.Calls.Get("config/setpath")
+	assert.NotNil(t, call)
+	in := rc.Params{
+		"path": encryptedConfigPath,
+	}
+	_, err := call.Fn(context.Background(), in)
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, config.SetConfigPath(oldConfigPath))
+		config.ClearConfigPassword()
+	}()
+
+	call = rc.Calls.Get("config/setpassword")
+	assert.NotNil(t, call)
+	in = rc.Params{
+		"password": "asdf",
+	}
+	_, err = call.Fn(context.Background(), in)
+	require.NoError(t, err)
+
+	testLoadingEncryptedConfig(t)
+}


### PR DESCRIPTION
#### What is the purpose of this change?

This PR aims to support [Rcd With Encrypted Config File - Help and Support - rclone forum](https://forum.rclone.org/t/rcd-with-encrypted-config-file/11222).

#### Was the change discussed in an issue or in the forum before?
[rc: add new api for switching config file · Issue #3437 · rclone/rclone](https://github.com/rclone/rclone/issues/3437)
[rc: add config/upload by terorie · Pull Request #3657 · rclone/rclone](https://github.com/rclone/rclone/pull/3657)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
