### PR TITLE
fs: allow setting a write buffer for multithread

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1511,6 +1511,25 @@ if you are reading and writing to an OS X filing system this will be
 
 This command line flag allows you to override that computed default.
 
+### --multi-thread-write-buffer-size=SIZE ###
+
+When downloading with multiple threads, rclone will buffer SIZE bytes in
+memory before writing to disk for each thread.
+
+This can improve performance if the underlying filesystem does not deal
+well with a lot of small writes in different positions of the file, so
+if you see downloads being limited by disk write speed, you might want
+to experiment with different values. Specially for magnetic drives and
+remote file systems a higher value can be useful.
+
+Nevertheless, the default of `128k` should be fine for almost all use
+cases, so before changing it ensure that network is not really your
+bottleneck.
+
+As a final hint, size is not the only factor: block size (or similar
+concept) can have an impact. In one case, we observed that exact
+multiples of 16k performed much better than other values.
+
 ### --multi-thread-cutoff=SIZE ###
 
 When downloading files to the local backend above this size, rclone

--- a/fs/config.go
+++ b/fs/config.go
@@ -51,101 +51,102 @@ var (
 
 // ConfigInfo is filesystem config options
 type ConfigInfo struct {
-	LogLevel                LogLevel
-	StatsLogLevel           LogLevel
-	UseJSONLog              bool
-	DryRun                  bool
-	Interactive             bool
-	CheckSum                bool
-	SizeOnly                bool
-	IgnoreTimes             bool
-	IgnoreExisting          bool
-	IgnoreErrors            bool
-	ModifyWindow            time.Duration
-	Checkers                int
-	Transfers               int
-	ConnectTimeout          time.Duration // Connect timeout
-	Timeout                 time.Duration // Data channel timeout
-	ExpectContinueTimeout   time.Duration
-	Dump                    DumpFlags
-	InsecureSkipVerify      bool // Skip server certificate verification
-	DeleteMode              DeleteMode
-	MaxDelete               int64
-	MaxDeleteSize           SizeSuffix
-	TrackRenames            bool   // Track file renames.
-	TrackRenamesStrategy    string // Comma separated list of strategies used to track renames
-	LowLevelRetries         int
-	UpdateOlder             bool // Skip files that are newer on the destination
-	NoGzip                  bool // Disable compression
-	MaxDepth                int
-	IgnoreSize              bool
-	IgnoreChecksum          bool
-	IgnoreCaseSync          bool
-	NoTraverse              bool
-	CheckFirst              bool
-	NoCheckDest             bool
-	NoUnicodeNormalization  bool
-	NoUpdateModTime         bool
-	DataRateUnit            string
-	CompareDest             []string
-	CopyDest                []string
-	BackupDir               string
-	Suffix                  string
-	SuffixKeepExtension     bool
-	UseListR                bool
-	BufferSize              SizeSuffix
-	BwLimit                 BwTimetable
-	BwLimitFile             BwTimetable
-	TPSLimit                float64
-	TPSLimitBurst           int
-	BindAddr                net.IP
-	DisableFeatures         []string
-	UserAgent               string
-	Immutable               bool
-	AutoConfirm             bool
-	StreamingUploadCutoff   SizeSuffix
-	StatsFileNameLength     int
-	AskPassword             bool
-	PasswordCommand         SpaceSepList
-	UseServerModTime        bool
-	MaxTransfer             SizeSuffix
-	MaxDuration             time.Duration
-	CutoffMode              CutoffMode
-	MaxBacklog              int
-	MaxStatsGroups          int
-	StatsOneLine            bool
-	StatsOneLineDate        bool   // If we want a date prefix at all
-	StatsOneLineDateFormat  string // If we want to customize the prefix
-	ErrorOnNoTransfer       bool   // Set appropriate exit code if no files transferred
-	Progress                bool
-	ProgressTerminalTitle   bool
-	Cookie                  bool
-	UseMmap                 bool
-	CaCert                  []string // Client Side CA
-	ClientCert              string   // Client Side Cert
-	ClientKey               string   // Client Side Key
-	MultiThreadCutoff       SizeSuffix
-	MultiThreadStreams      int
-	MultiThreadSet          bool   // whether MultiThreadStreams was set (set in fs/config/configflags)
-	OrderBy                 string // instructions on how to order the transfer
-	UploadHeaders           []*HTTPOption
-	DownloadHeaders         []*HTTPOption
-	Headers                 []*HTTPOption
-	MetadataSet             Metadata // extra metadata to write when uploading
-	RefreshTimes            bool
-	NoConsole               bool
-	TrafficClass            uint8
-	FsCacheExpireDuration   time.Duration
-	FsCacheExpireInterval   time.Duration
-	DisableHTTP2            bool
-	HumanReadable           bool
-	KvLockTime              time.Duration // maximum time to keep key-value database locked by process
-	DisableHTTPKeepAlives   bool
-	Metadata                bool
-	ServerSideAcrossConfigs bool
-	TerminalColorMode       TerminalColorMode
-	DefaultTime             Time // time that directories with no time should display
-	Inplace                 bool // Download directly to destination file instead of atomic download to temp/rename
+	LogLevel                   LogLevel
+	StatsLogLevel              LogLevel
+	UseJSONLog                 bool
+	DryRun                     bool
+	Interactive                bool
+	CheckSum                   bool
+	SizeOnly                   bool
+	IgnoreTimes                bool
+	IgnoreExisting             bool
+	IgnoreErrors               bool
+	ModifyWindow               time.Duration
+	Checkers                   int
+	Transfers                  int
+	ConnectTimeout             time.Duration // Connect timeout
+	Timeout                    time.Duration // Data channel timeout
+	ExpectContinueTimeout      time.Duration
+	Dump                       DumpFlags
+	InsecureSkipVerify         bool // Skip server certificate verification
+	DeleteMode                 DeleteMode
+	MaxDelete                  int64
+	MaxDeleteSize              SizeSuffix
+	TrackRenames               bool   // Track file renames.
+	TrackRenamesStrategy       string // Comma separated list of strategies used to track renames
+	LowLevelRetries            int
+	UpdateOlder                bool // Skip files that are newer on the destination
+	NoGzip                     bool // Disable compression
+	MaxDepth                   int
+	IgnoreSize                 bool
+	IgnoreChecksum             bool
+	IgnoreCaseSync             bool
+	NoTraverse                 bool
+	CheckFirst                 bool
+	NoCheckDest                bool
+	NoUnicodeNormalization     bool
+	NoUpdateModTime            bool
+	DataRateUnit               string
+	CompareDest                []string
+	CopyDest                   []string
+	BackupDir                  string
+	Suffix                     string
+	SuffixKeepExtension        bool
+	UseListR                   bool
+	BufferSize                 SizeSuffix
+	MultiThreadWriteBufferSize SizeSuffix
+	BwLimit                    BwTimetable
+	BwLimitFile                BwTimetable
+	TPSLimit                   float64
+	TPSLimitBurst              int
+	BindAddr                   net.IP
+	DisableFeatures            []string
+	UserAgent                  string
+	Immutable                  bool
+	AutoConfirm                bool
+	StreamingUploadCutoff      SizeSuffix
+	StatsFileNameLength        int
+	AskPassword                bool
+	PasswordCommand            SpaceSepList
+	UseServerModTime           bool
+	MaxTransfer                SizeSuffix
+	MaxDuration                time.Duration
+	CutoffMode                 CutoffMode
+	MaxBacklog                 int
+	MaxStatsGroups             int
+	StatsOneLine               bool
+	StatsOneLineDate           bool   // If we want a date prefix at all
+	StatsOneLineDateFormat     string // If we want to customize the prefix
+	ErrorOnNoTransfer          bool   // Set appropriate exit code if no files transferred
+	Progress                   bool
+	ProgressTerminalTitle      bool
+	Cookie                     bool
+	UseMmap                    bool
+	CaCert                     []string // Client Side CA
+	ClientCert                 string   // Client Side Cert
+	ClientKey                  string   // Client Side Key
+	MultiThreadCutoff          SizeSuffix
+	MultiThreadStreams         int
+	MultiThreadSet             bool   // whether MultiThreadStreams was set (set in fs/config/configflags)
+	OrderBy                    string // instructions on how to order the transfer
+	UploadHeaders              []*HTTPOption
+	DownloadHeaders            []*HTTPOption
+	Headers                    []*HTTPOption
+	MetadataSet                Metadata // extra metadata to write when uploading
+	RefreshTimes               bool
+	NoConsole                  bool
+	TrafficClass               uint8
+	FsCacheExpireDuration      time.Duration
+	FsCacheExpireInterval      time.Duration
+	DisableHTTP2               bool
+	HumanReadable              bool
+	KvLockTime                 time.Duration // maximum time to keep key-value database locked by process
+	DisableHTTPKeepAlives      bool
+	Metadata                   bool
+	ServerSideAcrossConfigs    bool
+	TerminalColorMode          TerminalColorMode
+	DefaultTime                Time // time that directories with no time should display
+	Inplace                    bool // Download directly to destination file instead of atomic download to temp/rename
 }
 
 // NewConfig creates a new config with everything set to the default
@@ -170,6 +171,7 @@ func NewConfig() *ConfigInfo {
 	c.MaxDepth = -1
 	c.DataRateUnit = "bytes"
 	c.BufferSize = SizeSuffix(16 << 20)
+	c.MultiThreadWriteBufferSize = SizeSuffix(128 * 1024)
 	c.UserAgent = "rclone/" + Version
 	c.StreamingUploadCutoff = SizeSuffix(100 * 1024)
 	c.MaxStatsGroups = 1000

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -126,6 +126,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.StringVarP(flagSet, &ci.ClientKey, "client-key", "", ci.ClientKey, "Client SSL private key (PEM) for mutual TLS auth")
 	flags.FVarP(flagSet, &ci.MultiThreadCutoff, "multi-thread-cutoff", "", "Use multi-thread downloads for files above this size")
 	flags.IntVarP(flagSet, &ci.MultiThreadStreams, "multi-thread-streams", "", ci.MultiThreadStreams, "Max number of streams to use for multi-thread downloads")
+	flags.FVarP(flagSet, &ci.MultiThreadWriteBufferSize, "multi-thread-write-buffer-size", "", "In memory buffer size for writing when in multi-thread mode")
 	flags.BoolVarP(flagSet, &ci.UseJSONLog, "use-json-log", "", ci.UseJSONLog, "Use json log format")
 	flags.StringVarP(flagSet, &ci.OrderBy, "order-by", "", ci.OrderBy, "Instructions on how to order the transfers, e.g. 'size,descending'")
 	flags.StringArrayVarP(flagSet, &uploadHeaders, "header-upload", "", nil, "Set HTTP header for upload transactions")


### PR DESCRIPTION
#### What is the purpose of this change?

This change adds an option to buffer multithread download parts before writing to disk.

In our testing, we saw that multithreaded downloads from S3 to CIFS (as a mounted filesystem) were much slower with rclone than with the official aws cli. Interestingly, single-threaded downloads were faster than multi-threaded, albeit still far away from what our bandwidth should offer. Downloads to local disk were fine.

The end result looked like this for us:

rclone standard: ~50 MiB/s
rclone with --multi-thread-buffer-size=1M: 400MiB/s+ 

this is close to our max theoretical speed based on bandwidth (5Gib/s)

I did consider just using the already existing buffer-size option, as it does seem to to exactly the same, only for multiple transfers. However I wasn't 100% sure, and with the extra option there should be *no changes* in behaviour unless the user uses the flag, which would not be the case with the buffer-size as it does have a non-zero default AFAIK. Let me know if I should change.

#### Was the change discussed in an issue or in the forum before?

no

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
