### PR TITLE
`rclone backend restore s3:bucket --no-traverse` storageClass should not be checked

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -4761,9 +4761,19 @@ func (f *Fs) Command(ctx context.Context, name string, arg []string, opt map[str
 				st.Status = "Not an S3 object"
 				return
 			}
-			if o.storageClass == nil || (*o.storageClass != "GLACIER" && *o.storageClass != "DEEP_ARCHIVE") {
-				st.Status = "Not GLACIER or DEEP_ARCHIVE storage class"
-				return
+			if !o.fs.ci.NoTraverse {
+				if o.storageClass == nil {
+					st.Status = "storageClass == nil, skipped"
+					return
+				}
+				if *o.storageClass == "STANDARD" {
+					st.Status = "storageClass == STANDARD, skipped"
+					return
+				}
+				if *o.storageClass != "GLACIER" && *o.storageClass != "DEEP_ARCHIVE" && *o.storageClass != "INTELLIGENT_TIERING" {
+					st.Status = "Not GLACIER or DEEP_ARCHIVE or INTELLIGENT_TIERING storage class, skipped"
+					return
+				}
 			}
 			bucket, bucketPath := o.split()
 			reqCopy := req


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
`rclone backend restore s3:bucket --no-traverse --files-from` object keys are being skipped, with Status: "Not GLACIER or DEEP_ARCHIVE storage class".

This changes the storageClass nil check to not cause the object key to be skipped.

It also adds INTELLIGENT_TIERING as a storage class to check, because RestoreObject can be used with this storage class.

#### Was the change discussed in an issue or in the forum before?
No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
