### PR TITLE
docs: listremotes also includes remotes from env vars

### DIFF
--- a/cmd/listremotes/listremotes.go
+++ b/cmd/listremotes/listremotes.go
@@ -24,7 +24,7 @@ func init() {
 
 var commandDefinition = &cobra.Command{
 	Use:   "listremotes",
-	Short: `List all the remotes in the config file.`,
+	Short: `List all the remotes in the config file and defined in environment variables.`,
 	Long: `
 rclone listremotes lists all the available remotes from the config file.
 

--- a/docs/content/commands/rclone_listremotes.md
+++ b/docs/content/commands/rclone_listremotes.md
@@ -1,6 +1,6 @@
 ---
 title: "rclone listremotes"
-description: "List all the remotes in the config file."
+description: "List all the remotes in the config file and defined in environment variables."
 slug: rclone_listremotes
 url: /commands/rclone_listremotes/
 versionIntroduced: v1.34


### PR DESCRIPTION
"rclone listremotes" lists all the remotes in the config file and defined in environment variables. This is was clear from documentation.