### PR TITLE
Update s3.md (documentation) - restoring single objects from glacier requires --include argument

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -3029,7 +3029,7 @@ to normal storage.
 
 Usage Examples:
 
-    rclone backend restore s3:bucket/path/to/object [-o priority=PRIORITY] [-o lifetime=DAYS]
+    rclone backend restore s3:bucket/path/to/ --include /object [-o priority=PRIORITY] [-o lifetime=DAYS]
     rclone backend restore s3:bucket/path/to/directory [-o priority=PRIORITY] [-o lifetime=DAYS]
     rclone backend restore s3:bucket [-o priority=PRIORITY] [-o lifetime=DAYS]
 


### PR DESCRIPTION
#### What is the purpose of this change?

example in the [documentation](https://rclone.org/s3/#restore) doesn't seem to work:
`rclone backend restore s3:bucket/path/to/object [-o priority=PRIORITY] [-o lifetime=DAYS]`
should be:
`rclone backend restore s3:bucket/path/to --include object [-o priority=PRIORITY] [-o lifetime=DAYS]
`
#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/cant-restore-files-from-aws-glacier-deep-only-directories/39258/3

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
