### PR TITLE
docs: dynamic architecture selection for rclone pre signed binaries

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -42,8 +42,8 @@ won't re-download if not needed.
 Fetch and unpack
 
     curl -O https://downloads.rclone.org/rclone-current-linux-$(uname -m).zip
-    unzip rclone-current-linux-amd64.zip
-    cd rclone-*-linux-amd64
+    unzip rclone-current-linux-$(uname -m).zip
+    cd rclone-*-linux-$(uname -m)
 
 Copy binary file
 
@@ -88,7 +88,7 @@ Download the latest version of rclone.
 
 Unzip the download and cd to the extracted folder.
 
-    unzip -a rclone-current-osx-amd64.zip && cd rclone-*-osx-amd64
+    unzip -a rclone-current-osx-$(uname -m).zip && cd rclone-*-osx-$(uname -m)
 
 Move rclone to your $PATH. You will be prompted for your password.
 
@@ -99,7 +99,7 @@ Move rclone to your $PATH. You will be prompted for your password.
 
 Remove the leftover files.
 
-    cd .. && rm -rf rclone-*-osx-amd64 rclone-current-osx-amd64.zip
+    cd .. && rm -rf rclone-*-osx-$(uname -m) rclone-current-osx-$(uname -m).zip
 
 Run `rclone config` to setup. See [rclone config docs](/docs/) for more details.
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -41,7 +41,7 @@ won't re-download if not needed.
 
 Fetch and unpack
 
-    curl -O https://downloads.rclone.org/rclone-current-linux-amd64.zip
+    curl -O https://downloads.rclone.org/rclone-current-linux-$(uname -m).zip
     unzip rclone-current-linux-amd64.zip
     cd rclone-*-linux-amd64
 
@@ -84,7 +84,7 @@ notarized it is enough to download with `curl`.
 
 Download the latest version of rclone.
 
-    cd && curl -O https://downloads.rclone.org/rclone-current-osx-amd64.zip
+    cd && curl -O https://downloads.rclone.org/rclone-current-osx-$(uname -m).zip
 
 Unzip the download and cd to the extracted folder.
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Enhance the rclone setup process by introducing dynamic architecture selection. This ensures that users can easily obtain and install the correct package for their specific system architecture without the need for manual intervention and limits architecture incompatibility. 

```bash

# validation test for linux arm64 architecture
pd@mba ~ % curl -O https://downloads.rclone.org/rclone-current-linux-$(uname -m).zip; unzip rclone-current-linux-$(uname -m).zip; cd rclone-*-linux-$(uname -m); file rclone
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 15.7M  100 15.7M    0     0  5439k      0  0:00:02  0:00:02 --:--:-- 5448k
Archive:  rclone-current-linux-arm64.zip
   creating: rclone-v1.63.0-linux-arm64/
  inflating: rclone-v1.63.0-linux-arm64/rclone  
  inflating: rclone-v1.63.0-linux-arm64/README.txt  
  inflating: rclone-v1.63.0-linux-arm64/git-log.txt  
  inflating: rclone-v1.63.0-linux-arm64/rclone.1  
  inflating: rclone-v1.63.0-linux-arm64/README.html  
rclone: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, Go BuildID=KM7H-McBUrrT-ruR8Ij5/IsAy5pZeQyGLSp4yh2T4/_Bouq4UwpvCq5_Xb_bVU/OP0tAnH2VPMJyRV0630G, stripped

# validation test for osx arm64 architecture
pd@mba ~ % cd && curl -O https://downloads.rclone.org/rclone-current-osx-$(uname -m).zip; unzip -a rclone-current-osx-$(uname -m).zip && cd rclone-*-osx-$(uname -m); file rclone
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 19.3M  100 19.3M    0     0  3018k      0  0:00:06  0:00:06 --:--:-- 4075k
Archive:  rclone-current-osx-arm64.zip
   creating: rclone-v1.63.0-osx-arm64/
  inflating: rclone-v1.63.0-osx-arm64/git-log.txt  [text]  
  inflating: rclone-v1.63.0-osx-arm64/rclone  [binary]
  inflating: rclone-v1.63.0-osx-arm64/rclone.1  [text]  
  inflating: rclone-v1.63.0-osx-arm64/README.html  [text]  
  inflating: rclone-v1.63.0-osx-arm64/README.txt  [text]  
rclone: Mach-O 64-bit executable arm64

```


#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
