### PR TITLE
docs: mention Box as base32768 compatible

### DIFF
--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -379,7 +379,7 @@ address this problem to a certain degree.
 For cloud storage systems with case sensitive file names (e.g. Google Drive),
 `base64` can be used to reduce file name length. 
 For cloud storage systems using UTF-16 to store file names internally
-(e.g. OneDrive, Dropbox), `base32768` can be used to drastically reduce
+(e.g. OneDrive, Dropbox, Box), `base32768` can be used to drastically reduce
 file name length. 
 
 An alternative, future rclone file name encryption mode may tolerate
@@ -600,7 +600,7 @@ Properties:
         - Encode using base64. Suitable for case sensitive remote.
     - "base32768"
         - Encode using base32768. Suitable if your remote counts UTF-16 or
-        - Unicode codepoint instead of UTF-8 byte length. (Eg. Onedrive, Dropbox)
+        - Unicode codepoint instead of UTF-8 byte length. (Eg. Onedrive, Dropbox, Box)
 
 #### --crypt-suffix
 


### PR DESCRIPTION
As suddenly many people keep moving data to Box remote (another "unlimited" cloud story migration saga) there are frequent questions about crypt files encoding to be used. Box has 1024 max path limit but for people coming from Google it is often not enough:)

It has been tested with:

https://pub.rclone.org/base32768.zip files (`copy` all files to box and run `rclone check`)

and:

```
$ rclone test info --check-length box_remote:

maxFileLength = 255 // for 1 byte unicode characters
maxFileLength = 255 // for 2 byte unicode characters
maxFileLength = 255 // for 3 byte unicode characters
maxFileLength = -1 // for 4 byte unicode characters
```

In addition few users took risk and used it for their migration without any issues.

As a conclusion I suggest to update `crypt` docs to avoid forum questions:) And for completeness of documentation.