### PR TITLE
chunker: Update documentation to mention issue with small files

### DIFF
--- a/docs/content/chunker.md
+++ b/docs/content/chunker.md
@@ -135,7 +135,7 @@ This will result in unnecessary API calls and can severely restrict throughput
 when handling transfers primarily composed of small files on some backends (e.g. Box).
 A workaround to this issue is to use chunker only for files above the chunk threshold
 via `--min-size` and then perform a separate call without chunker on the remaining
-files.
+files. 
 
 
 #### Chunk names

--- a/docs/content/chunker.md
+++ b/docs/content/chunker.md
@@ -97,7 +97,7 @@ will put files in a directory called `name` in the current directory.
 
 When rclone starts a file upload, chunker checks the file size. If it
 doesn't exceed the configured chunk size, chunker will just pass the file
-to the wrapped remote. If a file is large, chunker will transparently cut
+to the wrapped remote (however, see caveat below). If a file is large, chunker will transparently cut
 data in pieces with temporary names and stream them one by one, on the fly.
 Each data chunk will contain the specified number of bytes, except for the
 last one which may have less data. If file size is unknown in advance
@@ -128,6 +128,14 @@ by default print warning, skip the whole incomplete group of chunks but
 proceed with current command.
 You can set the `--chunker-fail-hard` flag to have commands abort with
 error message in such cases.
+
+**Caveat**: As it is now, chunker will always create a temporary file in the 
+backend and then rename it, even if the file is below the chunk threshold.
+This will result in unnecessary API calls and can severely restrict throughput
+when handling transfers primarily composed of small files on some backends (e.g. Box).
+A workaround to this issue is to use chunker only for files above the chunk threshold
+via `--min-size` and then perform a separate call without chunker on the remaining
+files.
 
 
 #### Chunk names


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Update chunker documentation to warn users that chunker will still rename and move small files below the chunk threshold. This will lead to wasted API calls, and in the case of more restricted backends like Box, can lead to a massive decrease in throughput.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/chunker-not-deactivating-for-small-files-and-wasting-api-calls/40122

#5108 (?)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
