### PR TITLE
Multi-threaded / parallel writes to SMB

### DIFF
--- a/backend/smb/smb.go
+++ b/backend/smb/smb.go
@@ -500,10 +500,6 @@ func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.Wr
 	if err != nil {
 		return nil, err
 	}
-	defer func() {
-		o.statResult, _ = cn.smbShare.Stat(filename)
-		o.fs.putConnection(&cn)
-	}()
 
 	fl, err := cn.smbShare.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {

--- a/backend/smb/smb.go
+++ b/backend/smb/smb.go
@@ -475,6 +475,11 @@ func (f *Fs) About(ctx context.Context) (_ *fs.Usage, err error) {
 	return usage, nil
 }
 
+// OpenWriterAt opens with a handle for random access writes
+//
+// Pass in the remote desired and the size if known.
+//
+// It truncates any existing object
 func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.WriterAtCloser, error) {
 	var err error
 	o := &Object{


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This PR makes it possible to do multi-threaded / parallel writes to the SMB backend

<!--
Describe the changes here
-->

Implement the OpenWriterAt feature by adding a OpenWriterAt function on the smb backend. It returns the smb2.File Object, which implements the WriterAtCloser interface defined in `fs/types.go`.

#### Was the change discussed in an issue or in the forum before?

No

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate. ->  there's already a generic test for OpenWriterAt.
- [x] I have added documentation for the changes if appropriate. -> not needed, I think?
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
