### PR TITLE
protondrive: fix missing file sha1 and appstring issues

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"log"
 	"path"
-	"runtime"
 	"strings"
 	"time"
 
@@ -48,28 +47,11 @@ const (
 var (
 	ErrCanNotUploadFileWithUnknownSize = errors.New("proton Drive can't upload files with unknown size")
 	ErrCanNotPurgeRootDirectory        = errors.New("can't purge root directory")
-	ErrFileSHA1Missing                 = errors.New("file sha1 digest not found")
 
 	// for the auth/deauth handler
 	_mapper        configmap.Mapper
 	_saltedKeyPass string
 )
-
-func getAPIOS() string {
-	switch runtime.GOOS {
-	case "darwin":
-		return "macos"
-
-	case "linux":
-		return "linux"
-
-	case "windows":
-		return "windows"
-
-	default:
-		return "linux"
-	}
-}
 
 // Register with Fs
 func init() {
@@ -117,12 +99,9 @@ size, will fail to operate properly`,
 
 The app version string indicates the client that is currently performing 
 the API request. This information is required and will be sent with every 
-API request.
-
-Looks like using [OS]-drive (e.g. windows-drive) prefix will spare us from 
-getting aggressive human verification blocking.`,
+API request.`,
 			Advanced: true,
-			Default:  getAPIOS() + "-drive@1.0.0-alpha.1+rclone",
+			Default:  "macos-drive@1.0.0-alpha.1+rclone",
 		}, {
 			Name: "replace_existing_draft",
 			Help: `Create a new revision when filename conflict is detected
@@ -810,7 +789,8 @@ func (o *Object) Hash(ctx context.Context, t hash.Type) (string, error) {
 	}
 
 	if fileSystemAttrs == nil || fileSystemAttrs.Digests == "" {
-		return "", ErrFileSHA1Missing
+		fs.Debugf(o, "file sha1 digest missing")
+		return "", nil
 	}
 	return fileSystemAttrs.Digests, nil
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

- Fixed the sha1 issue discussed [here](https://github.com/rclone/rclone/pull/7093#discussion_r1271242878)
- Address the bug with `linux` client in the app string [here](https://github.com/rclone/rclone/issues/6072#issuecomment-1646651273) 

#6072

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

- [Issue 1](https://github.com/rclone/rclone/pull/7093#discussion_r1271242878)
- [Issue 2](https://github.com/rclone/rclone/issues/6072#issuecomment-1646651273) 

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
