### PR TITLE
docs: s3 versions names caveat

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -464,6 +464,19 @@ $ rclone -q --s3-versions ls s3:cleanup-test
         9 one.txt
 ```
 
+#### Versions naming caveat
+
+When using `--s3-versions` flag rclone is relying on the file name
+to work out whether the objects are versions or not. Versions' names
+are created by inserting timestamp between file name and its extension.
+```
+        9 file.txt
+        8 file-v2023-07-17-161032-000.txt
+       16 file-v2023-06-15-141003-000.txt
+```
+If there are real files present with the same names as versions, then
+behaviour of `--s3-versions` can be unpredictable.
+
 ### Cleanup
 
 If you run `rclone cleanup s3:bucket` then it will remove all pending


### PR DESCRIPTION
When using `--s3-versions` flag rclone is relying on the file name
to work out whether the objects are versions or not. Versions' names
are created by inserting timestamp between file name and its extension.
```
        9 file.txt
        8 file-v2023-07-17-161032-000.txt
       16 file-v2023-06-15-141003-000.txt
```
If there are real files present with the same names as versions, then
behaviour of `--s3-versions` can be unpredictable.

discussed on the forum: https://forum.rclone.org/t/cannot-copy-the-versioned-files-again-after-rclone-copy-with-s3-versions/40280/15