### PR TITLE
docs: b2 versions names caveat

### DIFF
--- a/docs/content/b2.md
+++ b/docs/content/b2.md
@@ -231,6 +231,19 @@ $ rclone -q --b2-versions ls b2:cleanup-test
         9 one.txt
 ```
 
+#### Versions naming caveat
+
+When using `--b2-versions` flag rclone is relying on the file name
+to work out whether the objects are versions or not. Versions' names
+are created by inserting timestamp between file name and its extension.
+```
+        9 file.txt
+        8 file-v2023-07-17-161032-000.txt
+       16 file-v2023-06-15-141003-000.txt
+```
+If there are real files present with the same names as versions, then
+behaviour of `--b2-versions` can be unpredictable.
+
 ### Data usage
 
 It is useful to know how many requests are sent to the server in different scenarios.


### PR DESCRIPTION
When using --b2-versions flag rclone is relying on the file name
to work out whether the objects are versions or not. Versions' names
are created by inserting timestamp between file name and its extension.

        9 file.txt
        8 file-v2023-07-17-161032-000.txt
       16 file-v2023-06-15-141003-000.txt

If there are real files present with the same names as versions, then
behaviour of --b2-versions can be unpredictable.
