### PR TITLE
http: CORS should not be send if not set (#6433)

### DIFF
--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -212,11 +212,6 @@ func writeError(path string, in rc.Params, w http.ResponseWriter, err error, sta
 func (s *Server) handler(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimLeft(r.URL.Path, "/")
 
-	// echo back access control headers client needs
-	//reqAccessHeaders := r.Header.Get("Access-Control-Request-Headers")
-	w.Header().Add("Access-Control-Request-Method", "POST, OPTIONS, GET, HEAD")
-	w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
-
 	switch r.Method {
 	case "POST":
 		s.handlePost(w, r, path)

--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -173,13 +173,9 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
-			} else {
-				w.Header().Add("Access-Control-Allow-Origin", PublicURL(r))
+				w.Header().Add("Access-Control-Request-Method", "POST, OPTIONS, GET, HEAD")
+				w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
 			}
-
-			// echo back access control headers client needs
-			w.Header().Add("Access-Control-Request-Method", "POST, OPTIONS, GET, HEAD")
-			w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
 
 			if r.Method == "OPTIONS" {
 				w.WriteHeader(http.StatusOK)


### PR DESCRIPTION
#### What is the purpose of this change?

fix CORS option, if `--allow-origin` option is not set, CORS headers should not be sent

#### Was the change discussed in an issue or in the forum before?

#6433

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
