### PR TITLE
http: fix webdav OPTIONS response (#6433)

### DIFF
--- a/lib/http/middleware_test.go
+++ b/lib/http/middleware_test.go
@@ -459,8 +459,7 @@ func TestMiddlewareCORSWithAuth(t *testing.T) {
 				require.NoError(t, s.Shutdown())
 			}()
 
-			expected := []byte("data")
-			s.Router().Mount("/", testEchoHandler(expected))
+			s.Router().Mount("/", testEmptyHandler())
 			s.Serve()
 
 			url := testGetServerURL(t, s)

--- a/lib/http/server_test.go
+++ b/lib/http/server_test.go
@@ -14,6 +14,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func testEmptyHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+}
+
 func testEchoHandler(data []byte) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write(data)


### PR DESCRIPTION
#### What is the purpose of this change?

fix behavior changes of webdav server OPTIONS reponse on commit 6c8148ef39ea51b1d4092128c598ac12c6fc1523

#### Was the change discussed in an issue or in the forum before?

#6433

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
