### PR TITLE
swift: not HEADing 0-length objects when flag set

### DIFF
--- a/backend/swift/swift.go
+++ b/backend/swift/swift.go
@@ -561,7 +561,7 @@ func (f *Fs) newObjectWithInfo(ctx context.Context, remote string, info *swift.O
 	// returned as 0 bytes in the listing.  Correct this here by
 	// making sure we read the full metadata for all 0 byte files.
 	// We don't read the metadata for directory marker objects.
-	if info != nil && info.Bytes == 0 && info.ContentType != "application/directory" {
+	if info != nil && info.Bytes == 0 && info.ContentType != "application/directory" && !o.fs.opt.NoLargeObjects {
 		err := o.readMetaData(ctx) // reads info and headers, returning an error
 		if err == fs.ErrorObjectNotFound {
 			// We have a dangling large object here so just return the original metadata


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Swift returns zero length for dynamic large object files when they're included in a files lookup, which means that determining their size requires `HEAD`ing each file that returns a size of zero. rclone's `--swift-no-large-objects` instructs rclone that no large objects are present and accordingly rclone should not `HEAD` files that return zero length.

When rclone is performing an `ls` / `lsf` / `lsl` type lookup, however, it continues to `HEAD` any zero length objects it encounters, even with this flag set. Accordingly, this change causes rclone to respect the flag in these situations.

NB: It is worth noting that this will cause rclone to incorrectly report zero length for any dynamic large objects encountered with the `--swift-no-large-objects` flag set.

#### Was the change discussed in an issue or in the forum before?

Yep — [right here](https://forum.rclone.org/t/current-state-of-metadata-support-metadata-filtering/40304/11?u=timewornvenue):

> From looking at the code for the Swift backend, I'm wondering whether it's in [`newObjectWithInfo`](https://github.com/rclone/rclone/blob/88c72d1f4de94a5db75e6b685efdbe525adf70b8/backend/swift/swift.go#L564-L574) — it looks like it HEADs all zero-length (non-directory) objects regardless of whether `--swift-no-large-objects` is set.
> 
> I've given this patch a quick test locally and it seems to remove those extraneous HEADs for zero-length objects with that flag set (and they remain if it's unset)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
  - I didn't see any large object tests, so I haven't changed any of the test case code
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
