### PR TITLE
lib/rest: remove unnecessary nil check

### DIFF
--- a/lib/rest/rest.go
+++ b/lib/rest/rest.go
@@ -275,10 +275,8 @@ func (api *Client) Call(ctx context.Context, opts *Opts) (resp *http.Response, e
 		req.Close = true
 	}
 	// Set any extra headers
-	if opts.ExtraHeaders != nil {
-		for k, v := range opts.ExtraHeaders {
-			headers[k] = v
-		}
+	for k, v := range opts.ExtraHeaders {
+		headers[k] = v
 	}
 	// add any options to the headers
 	fs.OpenOptionAddHeaders(opts.Options, headers)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Just a pedantic change.

From the Go docs:

> "A `nil` map is equivalent to an empty map. https://go.dev/ref/spec#Map_types

Therefore, an additional nil check for `opts.ExtraHeaders` before the loop is unnecessary because `opts.ExtraHeaders` is a `map`. Example: https://go.dev/play/p/EnnDEF7svOd

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
