### PR TITLE
Support custom HTTP response headers

### DIFF
--- a/docs/content/rc.md
+++ b/docs/content/rc.md
@@ -103,14 +103,6 @@ Set this flag to serve the default web gui on the same port as rclone.
 
 Default Off.
 
-### --rc-allow-origin
-
-Set the allowed Access-Control-Allow-Origin for rc requests.
-
-Can be used with --rc-web-gui if the rclone is running on different IP than the web-gui.
-
-Default is IP address on which rc is running.
-
 ### --rc-web-fetch-url
 
 Set the URL to fetch the rclone-web-gui files from.

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -150,23 +150,6 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &ci.Inplace, "inplace", "", ci.Inplace, "Download directly to destination file instead of atomic download to temp/rename", "Copy")
 }
 
-// ParseHeaders converts the strings passed in via the header flags into HTTPOptions
-func ParseHeaders(headers []string) []*fs.HTTPOption {
-	opts := []*fs.HTTPOption{}
-	for _, header := range headers {
-		parts := strings.SplitN(header, ":", 2)
-		if len(parts) == 1 {
-			log.Fatalf("Failed to parse '%s' as an HTTP header. Expecting a string like: 'Content-Encoding: gzip'", header)
-		}
-		option := &fs.HTTPOption{
-			Key:   strings.TrimSpace(parts[0]),
-			Value: strings.TrimSpace(parts[1]),
-		}
-		opts = append(opts, option)
-	}
-	return opts
-}
-
 // SetFlags converts any flags into config which weren't straight forward
 func SetFlags(ci *fs.ConfigInfo) {
 	if dumpHeaders {
@@ -273,16 +256,13 @@ func SetFlags(ci *fs.ConfigInfo) {
 	}
 
 	if len(uploadHeaders) != 0 {
-		ci.UploadHeaders = ParseHeaders(uploadHeaders)
+		ci.UploadHeaders = fs.ParseHeaders(uploadHeaders)
 	}
 	if len(downloadHeaders) != 0 {
-		ci.DownloadHeaders = ParseHeaders(downloadHeaders)
+		ci.DownloadHeaders = fs.ParseHeaders(downloadHeaders)
 	}
 	if len(headers) != 0 {
-		ci.Headers = ParseHeaders(headers)
-	}
-	if len(headers) != 0 {
-		ci.Headers = ParseHeaders(headers)
+		ci.Headers = fs.ParseHeaders(headers)
 	}
 	if len(metadataSet) != 0 {
 		ci.MetadataSet = make(fs.Metadata, len(metadataSet))

--- a/fs/open_options.go
+++ b/fs/open_options.go
@@ -5,6 +5,7 @@ package fs
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net/http"
 	"strconv"
 	"strings"
@@ -201,6 +202,23 @@ func (o *SeekOption) Mandatory() bool {
 type HTTPOption struct {
 	Key   string
 	Value string
+}
+
+// ParseHeaders converts the strings passed in via the header flags into HTTPOptions
+func ParseHeaders(headers []string) []*HTTPOption {
+	opts := []*HTTPOption{}
+	for _, header := range headers {
+		parts := strings.SplitN(header, ":", 2)
+		if len(parts) == 1 {
+			log.Fatalf("Failed to parse '%s' as an HTTP header. Expecting a string like: 'Content-Encoding: gzip'", header)
+		}
+		option := &HTTPOption{
+			Key:   strings.TrimSpace(parts[0]),
+			Value: strings.TrimSpace(parts[1]),
+		}
+		opts = append(opts, option)
+	}
+	return opts
 }
 
 // Header formats the option as an http header

--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -198,3 +198,14 @@ func MiddlewareStripPrefix(prefix string) Middleware {
 		return http.StripPrefix(prefix, next)
 	}
 }
+
+func MiddlewareCustomResponseHeaders(headers []*fs.HTTPOption) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for _, header := range headers {
+				w.Header().Add(header.Key, header.Value)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/lib/http/server.go
+++ b/lib/http/server.go
@@ -59,6 +59,8 @@ inserts leading and trailing "/" on ` + "`--{{ .Prefix }}baseurl`" + `, so ` + "
 ` + "`--{{ .Prefix }}baseurl \"/rclone\"` and `--{{ .Prefix }}baseurl \"/rclone/\"`" + ` are all treated
 identically.
 
+` + "`--{{ .Prefix }}allow-origin`" + ` sets the origin which cross-domain request (CORS) can be executed from.
+
 #### TLS (SSL)
 
 By default this will serve over http.  If you want you can serve over


### PR DESCRIPTION
#### What is the purpose of this change?

Allow passing custom HTTP response headers for `rclone serve http` and co. For example:

 ```
rclone serve webdav . --response-header "Cache-Control: no-store, must-revalidate"
```

#### Was the change discussed in an issue or in the forum before?

Yes, see #7222

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

#### Notes

I believe #7089 forgot to update the docs properly. I hope c8171ecdc6f59e04b9bf6a787d7e80a025e959d5 corrects this but please double check my work because I'm unfamiliar with the docs pipeline.

I moved `ParseHeaders` from `fs/config/configflags/configflags.go` to `fs/open_options.go` to avoid an import cycle. I chose this file because `HTTPOption`, the return type of `ParseHeaders`, is defined there. I don't know the codebase good enough to say whether this is a good place or not. Tell me in case I should move it.