### PR TITLE
box: Fixed refresh of tokens with OAuth2.0 and JWT

### DIFF
--- a/backend/box/box.go
+++ b/backend/box/box.go
@@ -185,7 +185,9 @@ func refreshJWTToken(ctx context.Context, jsonFile string, boxSubType string, na
 	signingHeaders := getSigningHeaders(boxConfig)
 	queryParams := getQueryParams(boxConfig)
 	client := fshttp.NewClient(ctx)
-	err = jwtutil.Config("box", name, tokenURL, *claims, signingHeaders, queryParams, privateKey, m, client)
+	//When using OAuth2.0 with JWT Box appears to expire their tokens earlier than expected.
+	//To counter this, we manually set the token to expire 2 minutes earlier than expected
+	err = jwtutil.Config("box", name, tokenURL, *claims, signingHeaders, queryParams, privateKey, m, client, time.Duration(2*time.Minute))
 	return err
 }
 

--- a/lib/jwtutil/jwtutil.go
+++ b/lib/jwtutil/jwtutil.go
@@ -32,7 +32,7 @@ func RandomHex(n int) (string, error) {
 }
 
 // Config configures rclone using JWT
-func Config(id, name, url string, claims jwt.Claims, headerParams map[string]interface{}, queryParams map[string]string, privateKey *rsa.PrivateKey, m configmap.Mapper, client *http.Client) (err error) {
+func Config(id, name, url string, claims jwt.Claims, headerParams map[string]interface{}, queryParams map[string]string, privateKey *rsa.PrivateKey, m configmap.Mapper, client *http.Client, earlyExpire time.Duration) (err error) {
 	jwtToken := jwt.NewWithClaims(jwt.SigningMethodRS256, claims)
 	for key, value := range headerParams {
 		jwtToken.Header[key] = value
@@ -93,7 +93,7 @@ func Config(id, name, url string, claims jwt.Claims, headerParams map[string]int
 	}
 	e := result.ExpiresIn
 	if e != 0 {
-		token.Expiry = time.Now().Add(time.Duration(e) * time.Second)
+		token.Expiry = time.Now().Add(time.Duration(e) * time.Second - earlyExpire)
 	}
 	return oauthutil.PutToken(name, m, token, true)
 }

--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -18,7 +18,6 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/configmap"
-	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/fshttp"
 	"github.com/rclone/rclone/lib/random"
 	"github.com/skratchdot/open-golang/open"
@@ -267,9 +266,10 @@ func (ts *TokenSource) Token() (*oauth2.Token, error) {
 			if ts.reReadToken() {
 				changed = true
 			} else if ts.token.RefreshToken == "" {
-				return nil, fserrors.FatalError(
-					fmt.Errorf("token expired and there's no refresh token - manually refresh with \"rclone config reconnect %s:\"", ts.name),
-				)
+				//Box authentication OAuth2.0 with JWT does not provide refresh tokens
+				//return nil, fserrors.FatalError(
+				//	fmt.Errorf("token expired and there's no refresh token - manually refresh with \"rclone config reconnect %s:\"", ts.name),
+				//)
 			}
 		}
 


### PR DESCRIPTION
#### What is the purpose of this change?

If you use the authentication method OAuth2.0 with JWT on the Box backend rclone fails to refresh the token before Box expires it. If this happens mid-transfer the transfer is aborted. This fix expires the tokens from Box earlier (2 minutes) than expected.

Fixes #7214

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/7214
https://forum.rclone.org/t/box-remote-wont-auto-refresh-access-token/40310/6

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
