### PR TITLE
docs: add binary installation using script in Linux and macOS section

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -37,6 +37,10 @@ won't re-download if not needed.
 
 ## Linux installation {#linux}
 
+### Precompiled binary, using script {#linux-precompiled-script}
+
+    sudo -v ; curl https://rclone.org/install.sh | sudo bash
+
 ### Precompiled binary {#linux-precompiled}
 
 Fetch and unpack
@@ -62,6 +66,10 @@ Run `rclone config` to setup. See [rclone config docs](/docs/) for more details.
     rclone config
 
 ## macOS installation {#macos}
+
+### Precompiled binary, using script {#macos-precompiled-script}
+
+    sudo -v ; curl https://rclone.org/install.sh | sudo bash
 
 ### Installation with brew {#macos-brew}
 


### PR DESCRIPTION
#### What is the purpose of this change?

The change adds the script installation section in the Linux and macOS section, this change would be useful for cases where folks jump to their relevant OS and may miss on the script installation option. This change also highlights that the installation script is working with a precompiled binary.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/pull/7139

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
