### PR TITLE
fs: Don't stop calculating average transfer speed until the operation is complete

### DIFF
--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -777,7 +777,7 @@ func (s *StatsInfo) DoneTransferring(remote string, ok bool) {
 		s.transfers++
 		s.mu.Unlock()
 	}
-	if s.transferring.empty() {
+	if s.transferring.empty() && s.checking.empty() {
 		time.AfterFunc(averageStopAfter, s.stopAverageLoop)
 	}
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Currently, the average transfer speed will stop calculating 1 minute after the last queued transfer completes. This causes the average to stop calculating when checking is slow and the transfer queue becomes empty.

This change will require all checks to complete before stopping the average speed calculation.

#### Was the change discussed in an issue or in the forum before?

No - I was doing an rclone transfer with a slow backend that took a while to run checks and noticed that the average transfer speed stopped updating.

#### Testing
I have tested this change with my slow remote, and stats continue to update past the 1 minute mark, despite it depleting the transfer queue while it ran checks.

I tried running `go test ./...` - but this currently fails for me on the `master` branch as well, so I'm waiting on CI to check tests.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate. // Looked a bit, but didn't see a great way to test this given that repro takes 60 seconds
- [x] I have added documentation for the changes if appropriate. // none needed
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
