### PR TITLE
fs: Fix transferTime not being set in JSON logs

### DIFF
--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -313,6 +313,8 @@ func (s *StatsInfo) calculateTransferStats() (ts transferStats) {
 	// we take it off here to avoid double counting
 	ts.totalBytes = s.transferQueueSize + s.bytes + transferringBytesTotal - transferringBytesDone
 	ts.speed = s.average.speed
+	dt := s.totalDuration()
+	ts.transferTime = dt.Seconds()
 
 	return ts
 }

--- a/fs/accounting/stats_test.go
+++ b/fs/accounting/stats_test.go
@@ -251,6 +251,28 @@ func TestStatsTotalDuration(t *testing.T) {
 	})
 }
 
+func TestRemoteStats(t *testing.T) {
+	ctx := context.Background()
+	startTime := time.Now()
+	time1 := startTime.Add(-40 * time.Second)
+	time2 := time1.Add(10 * time.Second)
+
+	t.Run("Single completed transfer", func(t *testing.T) {
+		s := NewStats(ctx)
+		tr1 := &Transfer{
+			startedAt:   time1,
+			completedAt: time2,
+		}
+		s.AddTransfer(tr1)
+		time.Sleep(time.Millisecond)
+		rs, err := s.RemoteStats()
+
+		require.NoError(t, err)
+		assert.Equal(t, float64(10), rs["transferTime"])
+		assert.Greater(t, rs["elapsedTime"], float64(0))
+	})
+}
+
 // make time ranges from string description for testing
 func makeTimeRanges(t *testing.T, in []string) timeRanges {
 	trs := make(timeRanges, len(in))


### PR DESCRIPTION
#### What is the purpose of this change?
transferTime is always 0 in JSON logs (and anything else that uses `RemoteStats()`.)

This was unintentionally broken in https://github.com/rclone/rclone/commit/04aa6969a47516643cdf9084f9cdeae320a3bb81#diff-6a0766bcecac2744ee5f6050fdd22077ff967a44fb9df9fc2711130fcde3230bL279

#### Was the change discussed in an issue or in the forum before?

No - found while looking at JSON logs when using rclone

#### Testing

- Added unit test
- Tested locally and confirmed that --use-json-log shows transferTime counting in seconds as a float

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate. // none needed
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
