### PR TITLE
b2: generate valid link when object path contains special characters

### DIFF
--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -1426,7 +1426,7 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 	if err != nil {
 		return "", err
 	}
-	absPath := "/" + bucketPath
+	absPath := "/" + urlEncode(bucketPath)
 	link = RootURL + "/file/" + urlEncode(bucket) + absPath
 	bucketType, err := f.getbucketType(ctx, bucket)
 	if err != nil {


### PR DESCRIPTION
#### What is the purpose of this change?

I came across an error when following a link generated by `rclone link`. For example, if an object is named `a & b`, the link currently looks like: `https://f000.backblazeb2.com/file/my-bucket/a & b`. Following this link returns a `400` error with:

```json
{
  "code": "bad_request",
  "message": "Bad character in percent-encoded string: 38 (0x26)",
  "status": 400
}
```

The B2 [encoding docs](https://www.backblaze.com/docs/cloud-storage-native-api-string-encoding#url-encoding) state the following:

> When you download a file by name, you must URL-encode the file name before you append it to the download URL

> Some characters, such as "&" are safe in some contexts and not others. For consistency, Backblaze B2 requires that you percent-encode them every time.

`&` is not in `noNeedToEncode`, so we just need to call `urlEncode` on the object path to encode it. After this change, `rclone link` returns the following for an object named `a & b`: `https://f000.backblazeb2.com/file/my-bucket/a%20%26%20b`. This link is valid and results in a file download.

The same error would happen for any characters not in the set of characters allowed without encoding, and this change fixes links for those cases too.

#### Was the change discussed in an issue or in the forum before?

I couldn't find any relevant issues or forum posts.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [-] I have added tests for all changes in this PR if appropriate.
- [-] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
