### PR TITLE
rc: Add operations/settier to API

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -2091,6 +2091,20 @@ func SetTier(ctx context.Context, fsrc fs.Fs, tier string) error {
 	})
 }
 
+// SetTierFile changes tier of a single file in remote
+func SetTierFile(ctx context.Context, o fs.Object, tier string) error {
+	do, ok := o.(fs.SetTierer)
+	if !ok {
+		return errors.New("remote object does not implement SetTier")
+	}
+	err := do.SetTier(tier)
+	if err != nil {
+		fs.Errorf(o, "Failed to do SetTier, %v", err)
+		return err
+	}
+	return nil
+}
+
 // TouchDir touches every file in directory with time t
 func TouchDir(ctx context.Context, f fs.Fs, remote string, t time.Time, recursive bool) error {
 	return walk.ListR(ctx, f, remote, false, ConfigMaxDepth(ctx, recursive), walk.ListObjects, func(entries fs.DirEntries) error {

--- a/fs/operations/rc.go
+++ b/fs/operations/rc.go
@@ -209,6 +209,8 @@ func init() {
 		{name: "copyurl", title: "Copy the URL to the object", help: "- url - string, URL to read from\n - autoFilename - boolean, set to true to retrieve destination file name from url\n"},
 		{name: "uploadfile", title: "Upload file using multiform/form-data", help: "- each part in body represents a file to be uploaded\n", needsRequest: true},
 		{name: "cleanup", title: "Remove trashed files in the remote or path", noRemote: true},
+		{name: "settier", title: "Changes storage tier or class on all files in the path", noRemote: true},
+		{name: "settierfile", title: "Changes storage tier or class on the single file pointed to"},
 	} {
 		op := op
 		remote := "- remote - a path within that remote e.g. \"dir\"\n"
@@ -316,6 +318,28 @@ func rcSingleCommand(ctx context.Context, in rc.Params, name string, noRemote bo
 		return nil, nil
 	case "cleanup":
 		return nil, CleanUp(ctx, f)
+	case "settier":
+		if !f.Features().SetTier {
+			return nil, fmt.Errorf("remote %s does not support settier", f.Name())
+		}
+		tier, err := in.GetString("tier")
+		if err != nil {
+			return nil, err
+		}
+		return nil, SetTier(ctx, f, tier)
+	case "settierfile":
+		if !f.Features().SetTier {
+			return nil, fmt.Errorf("remote %s does not support settier", f.Name())
+		}
+		tier, err := in.GetString("tier")
+		if err != nil {
+			return nil, err
+		}
+		o, err := f.NewObject(ctx, remote)
+		if err != nil {
+			return nil, err
+		}
+		return nil, SetTierFile(ctx, o, tier)
 	}
 	panic("unknown rcSingleCommand type")
 }

--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -306,6 +306,61 @@ func TestRcStat(t *testing.T) {
 	})
 }
 
+// operations/settier: Set the storage tier of a fs
+func TestRcSetTier(t *testing.T) {
+	ctx := context.Background()
+	r, call := rcNewRun(t, "operations/settier")
+	if !r.Fremote.Features().SetTier {
+		t.Skip("settier not supported")
+	}
+	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
+	r.CheckRemoteItems(t, file1)
+
+	// Because we don't know what the current tier options here are, let's
+	// just get the current tier, and re-use that
+	o, err := r.Fremote.NewObject(ctx, file1.Path)
+	require.NoError(t, err)
+	trr, ok := o.(fs.GetTierer)
+	require.True(t, ok)
+	ctier := trr.GetTier()
+	in := rc.Params{
+		"fs":   r.FremoteName,
+		"tier": ctier,
+	}
+	out, err := call.Fn(context.Background(), in)
+	require.NoError(t, err)
+	assert.Equal(t, rc.Params(nil), out)
+
+}
+
+// operations/settier: Set the storage tier of a file
+func TestRcSetTierFile(t *testing.T) {
+	ctx := context.Background()
+	r, call := rcNewRun(t, "operations/settierfile")
+	if !r.Fremote.Features().SetTier {
+		t.Skip("settier not supported")
+	}
+	file1 := r.WriteObject(context.Background(), "file1", "file1 contents", t1)
+	r.CheckRemoteItems(t, file1)
+
+	// Because we don't know what the current tier options here are, let's
+	// just get the current tier, and re-use that
+	o, err := r.Fremote.NewObject(ctx, file1.Path)
+	require.NoError(t, err)
+	trr, ok := o.(fs.GetTierer)
+	require.True(t, ok)
+	ctier := trr.GetTier()
+	in := rc.Params{
+		"fs":     r.FremoteName,
+		"remote": "file1",
+		"tier":   ctier,
+	}
+	out, err := call.Fn(context.Background(), in)
+	require.NoError(t, err)
+	assert.Equal(t, rc.Params(nil), out)
+
+}
+
 // operations/mkdir: Make a destination directory or container
 func TestRcMkdir(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
#### What is the purpose of this change?

This change adds `operations/settier` to the API. It behaves in a way similar to the `rclone settier` CLI option.

A couple things I'm not sure how to best handle, would love any pointers/examples on how to make this better:

* Test case currently looks for the SetTier feature, which doesn't appear to be in the test framework, so while there is a test case, I don't think it's being properly evaluated
* In my local testing, even when the remote is set to a file, the settier is being done on the entire remote directory. I'm unsure why this is, or what the best fix is

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/using-settier-with-librclone/41461/2

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
