### PR TITLE
protondrive: implement two-password mode

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -61,13 +61,23 @@ func init() {
 		NewFs:       NewFs,
 		Options: []fs.Option{{
 			Name:     "username",
-			Help:     `The username of your proton drive account`,
+			Help:     `The username of your proton account`,
 			Required: true,
 		}, {
 			Name:       "password",
-			Help:       "The password of your proton drive account.",
+			Help:       "The password of your proton account.",
 			Required:   true,
 			IsPassword: true,
+		}, {
+			Name: "mailboxPassword",
+			Help: `The mailbox password of your two-password proton account.
+
+For more information regarding the mailbox password, please check the 
+following official knowledge base article: 
+https://proton.me/support/the-difference-between-the-mailbox-password-and-login-password
+`,
+			IsPassword: true,
+			Advanced:   true,
 		}, {
 			Name: "2fa",
 			Help: `The 2FA code
@@ -149,9 +159,10 @@ then we might have a problem with caching the stale data.`,
 
 // Options defines the configuration for this backend
 type Options struct {
-	Username string `config:"username"`
-	Password string `config:"password"`
-	TwoFA    string `config:"2fa"`
+	Username        string `config:"username"`
+	Password        string `config:"password"`
+	MailboxPassword string `config:"mailboxPassword"`
+	TwoFA           string `config:"2fa"`
 
 	// advanced
 	Enc                  encoder.MultiEncoder `config:"encoding"`
@@ -313,6 +324,7 @@ func newProtonDrive(ctx context.Context, f *Fs, opt *Options, m configmap.Mapper
 	config.UseReusableLogin = false
 	config.FirstLoginCredential.Username = opt.Username
 	config.FirstLoginCredential.Password = opt.Password
+	config.FirstLoginCredential.MailboxPassword = opt.MailboxPassword
 	config.FirstLoginCredential.TwoFA = opt.TwoFA
 	protonDrive, auth, err := protonDriveAPI.NewProtonDrive(ctx, config, authHandler, deAuthHandler)
 	if err != nil {
@@ -341,6 +353,14 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		opt.Password, err = obscure.Reveal(opt.Password)
 		if err != nil {
 			return nil, fmt.Errorf("couldn't decrypt password: %w", err)
+		}
+	}
+
+	if opt.MailboxPassword != "" {
+		var err error
+		opt.MailboxPassword, err = obscure.Reveal(opt.MailboxPassword)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't decrypt mailbox password: %w", err)
 		}
 	}
 

--- a/docs/content/protondrive.md
+++ b/docs/content/protondrive.md
@@ -90,7 +90,7 @@ To copy a local directory to an Proton Drive directory called backup
 
 ### Modified time
 
-Proton Drive Bridge does not support modification times yet.
+Proton Drive Bridge does not support updating modification times yet.
 
 ### Restricted filename characters
 
@@ -102,6 +102,10 @@ right spaces will be removed ([code reference](https://github.com/ProtonMail/Web
 Proton Drive can not have two files with exactly the same name and path. If the 
 conflict occurs, depending on the advanced config, the file might or might not 
 be overwritten.
+
+### [Mailbox password](https://proton.me/support/the-difference-between-the-mailbox-password-and-login-password)
+
+Please set your mailbox password in the advanced config section.
 
 ### Caching
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Implements the [two-password mode](https://proton.me/support/switch-two-password-mode).



<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

Feature request (or it's kind of a bug :D) from https://github.com/rclone/rclone/issues/6072#issuecomment-1704380975 and https://github.com/rclone/rclone/issues/6072#issuecomment-1704378529.

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
