### PR TITLE
Add Fuzz Driver for serve.Object API (Issue  #6310)

### DIFF
--- a/lib/http/serve/serve_test_FuzzTestObjectBadRange.go
+++ b/lib/http/serve/serve_test_FuzzTestObjectBadRange.go
@@ -1,0 +1,33 @@
+package serve
+
+import (
+	"net/http/httptest"
+	"os"
+	"secsys/gout-transformation/pkg/transstruct"
+	"testing"
+
+	"github.com/rclone/rclone/fstest/mockobject"
+)
+
+func FuzzTestObjectBadRange(XVl []byte) int {
+	t := &testing.T{}
+	_ = t
+	var skippingTableDriven bool
+	_, skippingTableDriven = os.LookupEnv("SKIPPING_TABLE_DRIVEN")
+	_ = skippingTableDriven
+	transstruct.SetFuzzData(XVl)
+	FDG_FuzzGlobal()
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "http://example.com/aFile", nil)
+	r.Header.Add("Range", "xxxbytes=3-5")
+	o := mockobject.New(transstruct.GetString("aFile")).WithContent([]byte(transstruct.GetString("0123456789")), mockobject.SeekModeNone)
+	Object(w, r, o)
+	_ = w.Result()
+
+	return 1
+}
+
+func FDG_FuzzGlobal() {
+
+}


### PR DESCRIPTION
## Overview

This pull request introduces a fuzz driver that addresses issue #6310. The purpose of this fuzz driver is to rigorously test the serve.Object API by injecting mutated data into its arguments. By doing so, we aim to enhance our continuous testing efforts and ensure the robustness of this API.

## Details

The fuzz driver has been designed to thoroughly exercise the serve.Object API.
It accomplishes this by systematically injecting various forms of mutated data into the API's arguments.
Through this approach, we can identify potential vulnerabilities and edge cases that might otherwise go unnoticed.
## Additional Information

We want to highlight that we have already developed numerous fuzz drivers, each serving as a valuable addition to our testing suite. If this PR is well-received, we are eager to contribute more fuzz drivers to further bolster our testing capabilities.

Thus, we are eager for your feedback and guidance on the process of adding fuzz drivers. Specifically, we would appreciate insights on the following:

- Deployment: How should we handle the deployment of these fuzz drivers within the project's testing infrastructure?
- Testing Metrics: Are there specific testing metrics or criteria that you consider essential for evaluating the effectiveness of these fuzz drivers?
- Any Other Concerns: Please let us know if you have any other concerns or preferences related to the inclusion of fuzz drivers in the project.

Thank you for considering this contribution, and we look forward to your feedback.