### PR TITLE
protondrive: handle the empty credential case when reading from the config cache

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -271,16 +271,32 @@ func getConfigMap(m configmap.Mapper) (uid, accessToken, refreshToken, saltedKey
 	if accessToken, ok = m.Get(clientAccessTokenKey); !ok {
 		return
 	}
+	if len(accessToken) == 0 {
+		ok = false
+		return
+	}
 
 	if uid, ok = m.Get(clientUIDKey); !ok {
+		return
+	}
+	if len(uid) == 0 {
+		ok = false
 		return
 	}
 
 	if refreshToken, ok = m.Get(clientRefreshTokenKey); !ok {
 		return
 	}
+	if len(refreshToken) == 0 {
+		ok = false
+		return
+	}
 
 	if saltedKeyPass, ok = m.Get(clientSaltedKeyPassKey); !ok {
+		return
+	}
+	if len(saltedKeyPass) == 0 {
+		ok = false
 		return
 	}
 	_saltedKeyPass = saltedKeyPass


### PR DESCRIPTION
#### What is the purpose of this change?

<!--
Describe the changes here
-->

With this commit (https://github.com/rclone/rclone/commit/a5a61f48749a2b82711ac45989eb0cae142eeb27), on a newly created account in the config file, we will have empty values for access token, etc.

In this PR, we address this case by checking if the returned value has the string length of 0.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
