### PR TITLE
s3: fix missing etag on multipart objects in s3

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -5037,7 +5037,7 @@ func (o *Object) Remote() string {
 	return o.remote
 }
 
-var matchMd5 = regexp.MustCompile(`^[0-9a-f]{32}$`)
+var matchMd5 = regexp.MustCompile(`^[0-9a-f]{32}(-[0-9]+)?$`)
 
 // Set the MD5 from the etag
 func (o *Object) setMD5FromEtag(etag string) {

--- a/backend/s3/s3_internal_test.go
+++ b/backend/s3/s3_internal_test.go
@@ -408,6 +408,27 @@ func (f *Fs) InternalTestVersions(t *testing.T) {
 	// Purge gets tested later
 }
 
+func TestSetMD5FromETag(t *testing.T) {
+	makeMD5Test := func(eTag string) func(*testing.T) {
+		return func(t *testing.T) {
+			o := &Object{
+				fs: new(Fs),
+			}
+			o.setMD5FromEtag(eTag)
+			if o.md5 == "" {
+				t.Errorf("setMD5FromEtag failed for %s\n", eTag)
+			}
+		}
+	}
+	for _, testHash := range []string{
+		"\"2af8106f012e78e6bca8547cd06da912\"",
+		"\"2af8106f012e78e6bca8547cd06da912-1\"",
+		"\"2af8106f012e78e6bca8547cd06da912-15\"",
+	} {
+		t.Run(fmt.Sprintf("MD5 %s", testHash), makeMD5Test(testHash))
+	}
+}
+
 func (f *Fs) InternalTest(t *testing.T) {
 	t.Run("Metadata", f.InternalTestMetadata)
 	t.Run("NoHead", f.InternalTestNoHead)


### PR DESCRIPTION
In S3, multipart objects return an ETag value with the number of parts as a suffix, "somehash-10".  The regex to validate the ETag does not take this into account, causing the ETag value to be empty when listing objects from an S3 bucket.  This fix updates the regex to optionally validate the part count suffix.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

I was using the clone code embedded in a prototype application to list files from S3, and noticed that the ETag value was not being returned.  It appears that the regex used to validate the md5 hash does not take into account the part count suffix that S3 uses for objects uploaded using the multipart API.  This fix just updates the regex to validate standard and multipart md5 / ETag values returned by S3.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

I have not found this exact issue, but I believe it relates to issue #4687 

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
