### PR TITLE
operations: ensure concurrency is no greater than the number of chunks - fixes #7299

### DIFF
--- a/fs/operations/multithread.go
+++ b/fs/operations/multithread.go
@@ -172,17 +172,18 @@ func multiThreadCopy(ctx context.Context, f fs.Fs, remote string, src fs.Object,
 		info.ChunkSize = src.Size()
 	}
 
+	// Use the backend concurrency if it is higher than --multi-thread-streams or if --multi-thread-streams wasn't set explicitly
+	if !ci.MultiThreadSet || info.Concurrency > concurrency {
+		fs.Debugf(src, "multi-thread copy: using backend concurrency of %d instead of --multi-thread-streams %d", info.Concurrency, concurrency)
+		concurrency = info.Concurrency
+	}
+
 	numChunks := calculateNumChunks(src.Size(), info.ChunkSize)
 	if concurrency > numChunks {
 		fs.Debugf(src, "multi-thread copy: number of streams %d was bigger than number of chunks %d", concurrency, numChunks)
 		concurrency = numChunks
 	}
 
-	// Use the backend concurrency if it is higher than --multi-thread-streams or if --multi-thread-streams wasn't set explicitly
-	if !ci.MultiThreadSet || info.Concurrency > concurrency {
-		fs.Debugf(src, "multi-thread copy: using backend concurrency of %d instead of --multi-thread-streams %d", info.Concurrency, concurrency)
-		concurrency = info.Concurrency
-	}
 	if concurrency < 1 {
 		concurrency = 1
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

This change fixes a minor bug in multithreaded copy that allowed more parallel streams to be used than there were chunks to transfer.

#### Was the change discussed in an issue or in the forum before?

See issue https://github.com/rclone/rclone/issues/7299

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
