### PR TITLE
rcserver: set `Last-Modified` header for files served by `--rc-serve`

### DIFF
--- a/fstest/mockobject/mockobject.go
+++ b/fstest/mockobject/mockobject.go
@@ -93,13 +93,14 @@ const (
 // SeekModes contains all valid SeekMode's
 var SeekModes = []SeekMode{SeekModeNone, SeekModeRegular, SeekModeRange}
 
-// ContentMockObject mocks an fs.Object and has content
+// ContentMockObject mocks an fs.Object and has content, mod time
 type ContentMockObject struct {
 	Object
 	content     []byte
 	seekMode    SeekMode
 	f           fs.Fs
 	unknownSize bool
+	modTime     time.Time
 }
 
 // WithContent returns an fs.Object with the given content.
@@ -190,6 +191,18 @@ func (o *ContentMockObject) Hash(ctx context.Context, t hash.Type) (string, erro
 		return "", err
 	}
 	return hasher.Sums()[t], nil
+}
+
+// ModTime returns the modification date of the file
+// It should return a best guess if one isn't available
+func (o *ContentMockObject) ModTime(ctx context.Context) time.Time {
+	return o.modTime
+}
+
+// SetModTime sets the metadata on the object to set the modification date
+func (o *ContentMockObject) SetModTime(ctx context.Context, t time.Time) error {
+	o.modTime = t
+	return nil
 }
 
 type readCloser struct{ io.Reader }

--- a/lib/http/serve/serve.go
+++ b/lib/http/serve/serve.go
@@ -35,6 +35,10 @@ func Object(w http.ResponseWriter, r *http.Request, o fs.Object) {
 		w.Header().Set("Content-Type", mimeType)
 	}
 
+	// Set last modified
+	modTime := o.ModTime(r.Context())
+	w.Header().Set("Last-Modified", modTime.UTC().Format(http.TimeFormat))
+
 	if r.Method == "HEAD" {
 		return
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Set `Last-Modified` header for files served by `--rc-serve`.

To test the changes methods `ModTime` and `SetModTime` were
implemented for `fstest/mockobject.ContentMockObject`.

#### Was the change discussed in an issue or in the forum before?

Fixes #7329

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
