### PR TITLE
operations: implement --partial-upload-extension option

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1278,8 +1278,9 @@ flag set) such as:
 - sftp
 
 Without `--inplace` (the default) rclone will first upload to a
-temporary file with an extension like this where `XXXXXX` represents a
-random string.
+temporary file with an extension like this, where `XXXXXX` represents a
+random string and `partial` is [--partial-upload-extension](#partial-upload-extension) value
+(`partial` by default).
 
     original-file-name.XXXXXX.partial
 
@@ -1725,6 +1726,13 @@ being more of a best efforts flag rather than a perfect ordering.
 If you want perfect ordering then you will need to specify
 [--check-first](#check-first) which will find all the files which need
 transferring first before transferring any.
+
+### --partial-upload-extension {#partial-upload-extension}
+
+When [--inplace](#inplace) is not used, it causes rclone to use
+the `--partial-upload-extension` as extension for temporary files.
+
+The default is `partial`.
 
 ### --password-command SpaceSepList ###
 

--- a/fs/config.go
+++ b/fs/config.go
@@ -148,6 +148,7 @@ type ConfigInfo struct {
 	TerminalColorMode          TerminalColorMode
 	DefaultTime                Time // time that directories with no time should display
 	Inplace                    bool // Download directly to destination file instead of atomic download to temp/rename
+	PartialUploadExtension     string
 }
 
 // NewConfig creates a new config with everything set to the default
@@ -192,6 +193,7 @@ func NewConfig() *ConfigInfo {
 	c.FsCacheExpireInterval = 60 * time.Second
 	c.KvLockTime = 1 * time.Second
 	c.DefaultTime = Time(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
+	c.PartialUploadExtension = "partial"
 
 	// Perform a simple check for debug flags to enable debug logging during the flag initialization
 	for argIndex, arg := range os.Args {

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -148,6 +148,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.FVarP(flagSet, &ci.TerminalColorMode, "color", "", "When to show colors (and other ANSI codes) AUTO|NEVER|ALWAYS", "Config")
 	flags.FVarP(flagSet, &ci.DefaultTime, "default-time", "", "Time to show if modtime is unknown for files and directories", "Config,Listing")
 	flags.BoolVarP(flagSet, &ci.Inplace, "inplace", "", ci.Inplace, "Download directly to destination file instead of atomic download to temp/rename", "Copy")
+	flags.StringVarP(flagSet, &ci.PartialUploadExtension, "partial-upload-extension", "", ci.PartialUploadExtension, "Add partial-upload-extension to temporary file name when --inplace is not used", "Copy")
 }
 
 // ParseHeaders converts the strings passed in via the header flags into HTTPOptions

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -361,7 +361,7 @@ func Copy(ctx context.Context, f fs.Fs, dst fs.Object, remote string, src fs.Obj
 	if !ci.Inplace && f.Features().Move != nil && f.Features().PartialUploads && !strings.HasSuffix(remote, ".rclonelink") {
 		// Avoid making the leaf name longer if it's already lengthy to avoid
 		// trouble with file name length limits.
-		suffix := "." + random.String(8) + ".partial"
+		suffix := "." + random.String(8) + "." + ci.PartialUploadExtension
 		base := path.Base(remotePartial)
 		if len(base) > 100 {
 			remotePartial = remotePartial[:len(remotePartial)-len(suffix)] + suffix


### PR DESCRIPTION
Added `--partial-upload-extension` to allow setting temporary file name extension 

Default is `partial`

#### What is the purpose of this change?

Some systems may already have defined filter for temporary files (e.g. `*.tmp`). So it would be great to have an option to configure how `rclone` names it.

#### Was the change discussed in an issue or in the forum before?

No, it wasn't. This is our need. And it can be useful for others.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
