### PR TITLE
s3: fix OpenOptions being ignored in uploadMultipart with chunkWriter

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -6070,7 +6070,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	var err error
 	var ui uploadInfo
 	if multipart {
-		wantETag, gotETag, versionID, ui, err = o.uploadMultipart(ctx, src, in)
+		wantETag, gotETag, versionID, ui, err = o.uploadMultipart(ctx, src, in, options...)
 	} else {
 		ui, err = o.prepareUpload(ctx, src, options)
 		if err != nil {


### PR DESCRIPTION
#### What is the purpose of this change?

When doing S3 multipart uploads, the OpenOption array was not passed to uploadMultipart and openChunkWriter.  

#### Was the change discussed in an issue or in the forum before?
No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
