### PR TITLE
lib/http: export basic go strings functions

### DIFF
--- a/lib/http/template.go
+++ b/lib/http/template.go
@@ -41,6 +41,17 @@ to be used within the template to server pages:
 |-- .IsDir    | Boolean for if an entry is a directory or not. |
 |-- .Size     | Size in Bytes of the entry. |
 |-- .ModTime  | The UTC timestamp of an entry. |
+
+The server also makes the following functions available so that they can be used within the
+template. These functions help extend the options for dynamic rendering of HTML. They can
+be used to render HTML based on specific conditions.
+
+| Function   | Description |
+| :---------- | :---------- |
+| afterEpoch  | Returns the time since the epoch for the given time. |
+| contains    | Checks whether a given substring is present or not in a given string. |
+| hasPrefix   | Checks whether the given string begins with the specified prefix. |
+| hasSuffix   | Checks whether the given string end with the specified suffix. |
 `
 
 	tmpl, err := template.New("template help").Parse(help)

--- a/lib/http/template.go
+++ b/lib/http/template.go
@@ -6,6 +6,7 @@ import (
 	"html/template"
 	"log"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/spf13/pflag"
@@ -105,6 +106,9 @@ func GetTemplate(tmpl string) (*template.Template, error) {
 
 	funcMap := template.FuncMap{
 		"afterEpoch": AfterEpoch,
+		"contains":   strings.Contains,
+		"hasPrefix":  strings.HasPrefix,
+		"hasSuffix":  strings.HasSuffix,
 	}
 
 	tpl, err := template.New("index").Funcs(funcMap).Parse(string(data))


### PR DESCRIPTION
Makes the following go strings functions available to be used in custom markup templates for HTTP and WebDAV server functions:
- contains
 - hasPrefix
 - hasSuffix

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
This will allow users who specify their own custom markup template for HTTP and WebDAV server to use those strings functions to help them modify how their server pages look.  

#### Was the change discussed in an issue or in the forum before?
https://forum.rclone.org/t/cannot-use-strings-functions-in-user-defined-go-template-for-serve-http/36205

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
