### PR TITLE
#7029 Data direction when using --dry-run 

### DIFF
--- a/cmd/bisync/bisync_test.go
+++ b/cmd/bisync/bisync_test.go
@@ -75,7 +75,7 @@ var logReplacements = []string{
 
 // Some dry-run messages differ depending on the particular remote.
 var dryrunReplacements = []string{
-	`^(NOTICE: file5.txt: Skipped) (copy|update modification time) (as --dry-run is set [(]size \d+[)])$`,
+	`^(INFO: file5.txt: Skipped) (copy|update modification time) (as --dry-run is set [(]size \d+[)])$`,
 	`$1 copy (or update modification time) $3`,
 }
 

--- a/cmd/bisync/bisync_test.go
+++ b/cmd/bisync/bisync_test.go
@@ -84,7 +84,7 @@ var dryrunReplacements = []string{
 var logHoppers = []string{
 	// Test case `dry-run` produced log mismatches due to non-deterministic
 	// order of captured dry-run info messages.
-	`NOTICE: \S+?: Skipped (?:copy|move|delete|copy \(or [^)]+\)|update modification time) as --dry-run is set \(size \d+\)`,
+	`NOTICE: \S+?: Skipped (?:copy|move|delete|copy \(or [^)]+\)|update modification time) to \S+? as --dry-run is set \(size \d+\)`,
 
 	// Test case `extended-filenames` detected difference in order of files
 	// with extended unicode names between Windows and Unix or GDrive,

--- a/cmd/bisync/operations.go
+++ b/cmd/bisync/operations.go
@@ -163,6 +163,7 @@ func (b *bisyncRun) runLocked(octx context.Context, listing1, listing2 string) (
 		return err
 	}
 
+	fs.Infof(nil, "Synching Path1 %s with Path2 %s", quotePath(path1), quotePath(path2))
 	fs.Logf(nil, "Synching Path1 %s with Path2 %s", quotePath(path1), quotePath(path2))
 
 	if opt.DryRun {

--- a/cmd/bisync/operations.go
+++ b/cmd/bisync/operations.go
@@ -163,7 +163,6 @@ func (b *bisyncRun) runLocked(octx context.Context, listing1, listing2 string) (
 		return err
 	}
 
-	fs.Infof(nil, "Synching Path1 %s with Path2 %s", quotePath(path1), quotePath(path2))
 	fs.Logf(nil, "Synching Path1 %s with Path2 %s", quotePath(path1), quotePath(path2))
 
 	if opt.DryRun {

--- a/cmd/bisync/operations.go
+++ b/cmd/bisync/operations.go
@@ -163,7 +163,7 @@ func (b *bisyncRun) runLocked(octx context.Context, listing1, listing2 string) (
 		return err
 	}
 
-	fs.Infof(nil, "Synching Path1 %s with Path2 %s", quotePath(path1), quotePath(path2))
+	fs.Logf(nil, "Synching Path1 %s with Path2 %s", quotePath(path1), quotePath(path2))
 
 	if opt.DryRun {
 		// In --dry-run mode, preserve original listings and save updates to the .lst-dry files

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -2507,7 +2507,7 @@ func SkipDestructive(ctx context.Context, subject interface{}, action string) (s
 			size = do.Size()
 		}
 		if size >= 0 {
-			fs.Logf(subject, "Skipped %s to %s as %s is set (size %v)", fs.LogValue("skipped", action), flag, subject.(fs.Object).Remote(), fs.LogValue("size", fs.SizeSuffix(size)))
+			fs.Logf(subject, "Skipped %s to %s as %s is set (size %v)", fs.LogValue("skipped", action), subject.(fs.Object).Remote(), flag, fs.LogValue("size", fs.SizeSuffix(size)))
 		} else {
 			fs.Logf(subject, "Skipped %s as %s is set", fs.LogValue("skipped", action), flag)
 		}

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -2507,7 +2507,7 @@ func SkipDestructive(ctx context.Context, subject interface{}, action string) (s
 			size = do.Size()
 		}
 		if size >= 0 {
-			fs.Logf(subject, "Skipped %s as %s is set (size %v)", fs.LogValue("skipped", action), flag, fs.LogValue("size", fs.SizeSuffix(size)))
+			fs.Logf(subject, "Skipped %s to %s as %s is set (size %v)", fs.LogValue("skipped", action), flag, subject.(fs.Object).Remote(), fs.LogValue("size", fs.SizeSuffix(size)))
 		} else {
 			fs.Logf(subject, "Skipped %s as %s is set", fs.LogValue("skipped", action), flag)
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
To clarify in logs from where the data is being copied/updated to where.
-->

#### Was the change discussed in an issue or in the forum before?

<!--
[Data direction when using --dry-run is unclear](https://github.com/rclone/rclone/issues/7029)
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
