### PR TITLE
webdav: added a "rclone" WebDAV vendor

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -92,6 +92,9 @@ func init() {
 				Value: "sharepoint-ntlm",
 				Help:  "Sharepoint with NTLM authentication, usually self-hosted or on-premises",
 			}, {
+				Value: "rclone",
+				Help:  "rclone WebDAV server to serve a remote over HTTP via the WebDAV protocol",
+			}, {
 				Value: "other",
 				Help:  "Other site/service or software",
 			}},
@@ -644,6 +647,10 @@ func (f *Fs) setQuirks(ctx context.Context, vendor string) error {
 		// so we must perform an extra check to detect this
 		// condition and return a proper error code.
 		f.checkBeforePurge = true
+	case "rclone":
+		f.canStream = true
+		f.precision = time.Second
+		f.useOCMtime = true
 	case "other":
 	default:
 		fs.Debugf(f, "Unknown vendor %q", vendor)

--- a/cmd/serve/webdav/webdav_test.go
+++ b/cmd/serve/webdav/webdav_test.go
@@ -65,7 +65,7 @@ func TestWebDav(t *testing.T) {
 		// Config for the backend we'll use to connect to the server
 		config := configmap.Simple{
 			"type":   "webdav",
-			"vendor": "owncloud",
+			"vendor": "rclone",
 			"url":    w.Server.URLs()[0],
 			"user":   testUser,
 			"pass":   obscure.MustObscure(testPass),

--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -53,7 +53,9 @@ Choose a number from below, or type in your own value
    \ (sharepoint)
  5 / Sharepoint with NTLM authentication, usually self-hosted or on-premises
    \ (sharepoint-ntlm)
- 6 / Other site/service or software
+ 6 / rclone WebDAV server to serve a remote over HTTP via the WebDAV protocol
+   \ (rclone)
+ 7 / Other site/service or software
    \ (other)
 vendor> 2
 User name
@@ -149,6 +151,8 @@ Properties:
         - Sharepoint Online, authenticated by Microsoft account
     - "sharepoint-ntlm"
         - Sharepoint with NTLM authentication, usually self-hosted or on-premises
+    - "rclone",
+        - rclone WebDAV server to serve a remote over HTTP via the WebDAV protocol,
     - "other"
         - Other site/service or software
 
@@ -378,6 +382,14 @@ For Rclone calls copying files (especially Office files such as .docx, .xlsx, et
 ```
 --ignore-size --ignore-checksum --update
 ```
+
+## Rclone
+
+Use this option if you are hosting remotes over WebDAV provided by rclone.
+Read [rclone serve webdav](commands/rclone_serve_webdav/) for more details.
+
+rclone serve supports modified times using the `X-OC-Mtime` header.
+
 
 ### dCache
 

--- a/fstest/testserver/init.d/TestWebdavRclone
+++ b/fstest/testserver/init.d/TestWebdavRclone
@@ -12,6 +12,7 @@ start() {
     run rclone serve webdav --user $USER --pass $PASS --addr ${IP}:${PORT} ${DATADIR}
     
     echo type=webdav
+    echo vendor=rclone
     echo url=http://${IP}:${PORT}/
     echo user=$USER
     echo pass=$(rclone obscure $PASS)


### PR DESCRIPTION
Fixes #7160

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This change adds `rclone-serve` as one of the vendors for WebDAV backend. Only the following attributes are set:
- canStream = `true`
- useOCMtime = `true`


#### Was the change discussed in an issue or in the forum before?

Briefly discussed in github issue [#7160 ](https://github.com/rclone/rclone/issues/7160)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
