### PR TITLE
Don't show duplicate object count in size command when less than 1k

### DIFF
--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs"
@@ -69,7 +70,13 @@ of the size command.
 			if jsonOutput {
 				return json.NewEncoder(os.Stdout).Encode(results)
 			}
-			fmt.Printf("Total objects: %s (%d)\n", fs.CountSuffix(results.Count), results.Count)
+			count := strconv.FormatInt(results.Count, 10)
+			countSuffix := fs.CountSuffix(results.Count).String()
+			if count == countSuffix {
+				fmt.Printf("Total objects: %s\n", count)
+			} else {
+				fmt.Printf("Total objects: %s (%s)\n", countSuffix, count)
+			}
 			fmt.Printf("Total size: %s (%d Byte)\n", fs.SizeSuffix(results.Bytes).ByteUnit(), results.Bytes)
 			if results.Sizeless > 0 {
 				fmt.Printf("Total objects with unknown size: %s (%d)\n", fs.CountSuffix(results.Sizeless), results.Sizeless)


### PR DESCRIPTION
#### What is the purpose of this change?

Minor UX tweak. Noticed that someone in the forum seemed a bit confused about the duplicate number for object counts, which happens when the count is <1000, e.g.:

```
Total objects: 0 (0)
Total size: 0 B (0 Byte)
```

```
Total objects: 3 (3)
Total size: 896.593 KiB (918111 Byte)
```

Compared to when count is larger, then there is a difference:

```
Total objects: 11.379k (11379)
Total size: 1.462 GiB (1570257443 Byte)
```

Changed this so that it detects the "duplicates" and avoids them:

```
Total objects: 0
Total size: 0 B (0 Byte)
```

```
Total objects: 3
Total size: 896.593 KiB (918111 Byte)
```

```
Total objects: 11.379k (11379)
Total size: 1.462 GiB (1570257443 Byte)
```

#### Was the change discussed in an issue or in the forum before?

Briefly mentioned somewhere... I think...

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
