### PR TITLE
Listremotes filtering

### DIFF
--- a/backend/alias/alias_internal_test.go
+++ b/backend/alias/alias_internal_test.go
@@ -23,8 +23,8 @@ func prepare(t *testing.T, root string) {
 	configfile.Install()
 
 	// Configure the remote
-	config.FileSet(remoteName, "type", "alias")
-	config.FileSet(remoteName, "remote", root)
+	config.FileSetValue(remoteName, "type", "alias")
+	config.FileSetValue(remoteName, "remote", root)
 }
 
 func TestNewFS(t *testing.T) {

--- a/backend/cache/cache_internal_test.go
+++ b/backend/cache/cache_internal_test.go
@@ -875,12 +875,12 @@ func (r *run) newCacheFs(t *testing.T, remote, id string, needRemote, purge bool
 	cacheRemote := remote
 	if !remoteExists {
 		localRemote := remote + "-local"
-		config.FileSet(localRemote, "type", "local")
-		config.FileSet(localRemote, "nounc", "true")
+		config.FileSetValue(localRemote, "type", "local")
+		config.FileSetValue(localRemote, "nounc", "true")
 		m.Set("type", "cache")
 		m.Set("remote", localRemote+":"+filepath.Join(os.TempDir(), localRemote))
 	} else {
-		remoteType := config.FileGet(remote, "type")
+		remoteType := config.GetValue(remote, "type")
 		if remoteType == "" {
 			t.Skipf("skipped due to invalid remote type for %v", remote)
 			return nil, nil
@@ -891,14 +891,14 @@ func (r *run) newCacheFs(t *testing.T, remote, id string, needRemote, purge bool
 				m.Set("password", cryptPassword1)
 				m.Set("password2", cryptPassword2)
 			}
-			remoteRemote := config.FileGet(remote, "remote")
+			remoteRemote := config.GetValue(remote, "remote")
 			if remoteRemote == "" {
 				t.Skipf("skipped due to invalid remote wrapper for %v", remote)
 				return nil, nil
 			}
 			remoteRemoteParts := strings.Split(remoteRemote, ":")
 			remoteWrapping := remoteRemoteParts[0]
-			remoteType := config.FileGet(remoteWrapping, "type")
+			remoteType := config.GetValue(remoteWrapping, "type")
 			if remoteType != "cache" {
 				t.Skipf("skipped due to invalid remote type for %v: '%v'", remoteWrapping, remoteType)
 				return nil, nil

--- a/backend/cache/cache_internal_test.go
+++ b/backend/cache/cache_internal_test.go
@@ -850,8 +850,8 @@ func (r *run) encryptRemoteIfNeeded(t *testing.T, remote string) string {
 func (r *run) newCacheFs(t *testing.T, remote, id string, needRemote, purge bool, flags map[string]string) (fs.Fs, *cache.Persistent) {
 	fstest.Initialise()
 	remoteExists := false
-	for _, s := range config.FileSections() {
-		if s == remote {
+	for _, s := range config.GetRemotes() {
+		if s.Name == remote {
 			remoteExists = true
 		}
 	}

--- a/cmd/bisync/bisync_test.go
+++ b/cmd/bisync/bisync_test.go
@@ -1304,7 +1304,7 @@ func touchFiles(ctx context.Context, dateStr string, f fs.Fs, dir, glob string) 
 		return files, fmt.Errorf("invalid date %q: %w", dateStr, err)
 	}
 
-	matcher, firstErr := filter.GlobToRegexp(glob, false)
+	matcher, firstErr := filter.GlobPathToRegexp(glob, false)
 	if firstErr != nil {
 		return files, fmt.Errorf("invalid glob %q", glob)
 	}

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/configflags"
 	"github.com/rclone/rclone/fs/config/flags"
+	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/filter/filterflags"
 	"github.com/rclone/rclone/fs/log/logflags"
 	"github.com/rclone/rclone/fs/rc/rcflags"
@@ -62,14 +63,15 @@ var flagsRe *regexp.Regexp
 
 // Show the flags
 var helpFlags = &cobra.Command{
-	Use:   "flags [<regexp to match>]",
+	Use:   "flags [<filter>]",
 	Short: "Show the global flags for rclone",
 	Run: func(command *cobra.Command, args []string) {
 		if len(args) > 0 {
-			re, err := regexp.Compile(`(?i)` + args[0])
+			re, err := filter.GlobStringToRegexp(args[0], false)
 			if err != nil {
 				log.Fatalf("Failed to compile flags regexp: %v", err)
 			}
+			fs.Debugf(nil, "Flags filter: %s", re.String())
 			flagsRe = re
 		}
 		if GeneratingDocs {

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -59,20 +59,25 @@ var helpCommand = &cobra.Command{
 }
 
 // to filter the flags with
-var flagsRe *regexp.Regexp
+var (
+	filterFlagsGroup     string
+	filterFlagsRe        *regexp.Regexp
+	filterFlagsNamesOnly bool
+)
 
 // Show the flags
 var helpFlags = &cobra.Command{
 	Use:   "flags [<filter>]",
 	Short: "Show the global flags for rclone",
 	Run: func(command *cobra.Command, args []string) {
+		command.Flags()
 		if len(args) > 0 {
 			re, err := filter.GlobStringToRegexp(args[0], false)
 			if err != nil {
-				log.Fatalf("Failed to compile flags regexp: %v", err)
+				log.Fatalf("Invalid flag filter: %v", err)
 			}
-			fs.Debugf(nil, "Flags filter: %s", re.String())
-			flagsRe = re
+			fs.Debugf(nil, "Flag filter: %s", re.String())
+			filterFlagsRe = re
 		}
 		if GeneratingDocs {
 			Root.SetUsageTemplate(docFlagsTemplate)
@@ -159,7 +164,7 @@ func setupRootCommand(rootCmd *cobra.Command) {
 				fs.Errorf(nil, "Flag --%s is unknown", flag.Name)
 			}
 		})
-		groups := flags.All.Filter(flagsRe).Include(cmd.Annotations["groups"])
+		groups := flags.All.Filter(filterFlagsGroup, filterFlagsRe, filterFlagsNamesOnly).Include(cmd.Annotations["groups"])
 		return groups.Groups
 	})
 	rootCmd.SetUsageTemplate(usageTemplate)
@@ -171,6 +176,9 @@ func setupRootCommand(rootCmd *cobra.Command) {
 
 	rootCmd.AddCommand(helpCommand)
 	helpCommand.AddCommand(helpFlags)
+	helpFlagsFlags := helpFlags.Flags()
+	flags.StringVarP(helpFlagsFlags, &filterFlagsGroup, "group", "", "", "Only include flags from specific group", "")
+	flags.BoolVarP(helpFlagsFlags, &filterFlagsNamesOnly, "name", "", false, "Apply filter only on flag names", "")
 	helpCommand.AddCommand(helpBackends)
 	helpCommand.AddCommand(helpBackend)
 

--- a/cmd/listremotes/listremotes.go
+++ b/cmd/listremotes/listremotes.go
@@ -2,60 +2,236 @@
 package ls
 
 import (
+	"encoding/json"
 	"fmt"
+	"os"
+	"regexp"
 	"sort"
+	"strings"
 
 	"github.com/rclone/rclone/cmd"
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/flags"
+	"github.com/rclone/rclone/fs/filter"
 	"github.com/spf13/cobra"
 )
 
-// Globals
 var (
-	listLong bool
+	listLong          bool
+	jsonOutput        bool
+	filterName        string
+	filterType        string
+	filterSource      string
+	filterDescription string
+	orderBy           string
 )
 
 func init() {
 	cmd.Root.AddCommand(commandDefinition)
 	cmdFlags := commandDefinition.Flags()
-	flags.BoolVarP(cmdFlags, &listLong, "long", "", listLong, "Show the type and the description as well as names", "")
+	flags.BoolVarP(cmdFlags, &listLong, "long", "", false, "Show type, source and description in addition to name", "")
+	flags.StringVarP(cmdFlags, &filterName, "name", "", "", "Filter remotes by name", "")
+	flags.StringVarP(cmdFlags, &filterType, "type", "", "", "Filter remotes by type", "")
+	flags.StringVarP(cmdFlags, &filterSource, "source", "", "", "filter remotes by source", "")
+	flags.StringVarP(cmdFlags, &filterDescription, "description", "", "", "filter remotes by description", "")
+	flags.StringVarP(cmdFlags, &orderBy, "order-by", "", "", "Instructions on how to order the result, e.g. 'type,name=descending'", "")
+	flags.BoolVarP(cmdFlags, &jsonOutput, "json", "", false, "Format output as JSON", "")
+}
+
+// lessFn compares to remotes for order by
+type lessFn func(a, b config.Remote) bool
+
+// newLess returns a function for comparing remotes based on an order by string
+func newLess(orderBy string) (less lessFn, err error) {
+	if orderBy == "" {
+		return nil, nil
+	}
+	parts := strings.Split(strings.ToLower(orderBy), ",")
+	n := len(parts)
+	for i := n - 1; i >= 0; i-- {
+		fieldAndDirection := strings.SplitN(parts[i], "=", 2)
+
+		descending := false
+		if len(fieldAndDirection) > 1 {
+			switch fieldAndDirection[1] {
+			case "ascending", "asc":
+			case "descending", "desc":
+				descending = true
+			default:
+				return nil, fmt.Errorf("unknown --order-by direction %q", fieldAndDirection[1])
+			}
+		}
+
+		var field func(o config.Remote) string
+		switch fieldAndDirection[0] {
+		case "name":
+			field = func(o config.Remote) string {
+				return o.Name
+			}
+		case "type":
+			field = func(o config.Remote) string {
+				return o.Type
+			}
+		case "source":
+			field = func(o config.Remote) string {
+				return o.Source
+			}
+		case "description":
+			field = func(o config.Remote) string {
+				return o.Description
+			}
+		default:
+			return nil, fmt.Errorf("unknown --order-by field %q", fieldAndDirection[0])
+		}
+
+		var thisLess lessFn
+		if descending {
+			thisLess = func(a, b config.Remote) bool {
+				return field(a) > field(b)
+			}
+		} else {
+			thisLess = func(a, b config.Remote) bool {
+				return field(a) < field(b)
+			}
+		}
+
+		if i == n-1 {
+			less = thisLess
+		} else {
+			nextLess := less
+			less = func(a, b config.Remote) bool {
+				if field(a) == field(b) {
+					return nextLess(a, b)
+				}
+				return thisLess(a, b)
+			}
+		}
+	}
+	return less, nil
 }
 
 var commandDefinition = &cobra.Command{
-	Use:   "listremotes",
+	Use:   "listremotes [<filter>]",
 	Short: `List all the remotes in the config file and defined in environment variables.`,
 	Long: `
-rclone listremotes lists all the available remotes from the config file.
+rclone listremotes lists all the available remotes from the config file,
+or the remotes matching an optional filter.
 
-When used with the ` + "`--long`" + ` flag it lists the types and the descriptions too.
+Prints the result in human-readable format by default, and as a simple list of
+remote names, or if used with flag ` + "`--long`" + ` a tabular format including
+all attributes of the remotes: name, type, source and description. Using flag
+` + "`--json`" + ` produces machine-readable output instead, which always includes
+all attributes.
+
+Result can be filtered by a filter argument which applies to all attributes,
+and/or filter flags specific for each attribute. The values must be specified
+according to regular rclone filtering pattern syntax.
 `,
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.34",
 	},
-	Run: func(command *cobra.Command, args []string) {
-		cmd.CheckArgs(0, 0, command, args)
-		remotes := config.FileSections()
-		sort.Strings(remotes)
-		maxlen := 1
-		maxlentype := 1
-		for _, remote := range remotes {
-			if len(remote) > maxlen {
-				maxlen = len(remote)
-			}
-			t := config.FileGet(remote, "type")
-			if len(t) > maxlentype {
-				maxlentype = len(t)
+	RunE: func(command *cobra.Command, args []string) error {
+		cmd.CheckArgs(0, 1, command, args)
+		var filterDefault string
+		if len(args) > 0 {
+			filterDefault = args[0]
+		}
+		filters := make(map[string]*regexp.Regexp)
+		for k, v := range map[string]string{
+			"all":         filterDefault,
+			"name":        filterName,
+			"type":        filterType,
+			"source":      filterSource,
+			"description": filterDescription,
+		} {
+			if v != "" {
+				filterRe, err := filter.GlobStringToRegexp(v, false)
+				if err != nil {
+					return fmt.Errorf("invalid %s filter argument: %w", k, err)
+				}
+				fs.Debugf(nil, "Filter for %s: %s", k, filterRe.String())
+				filters[k] = filterRe
 			}
 		}
+		remotes := config.GetRemotes()
+		maxName := 0
+		maxType := 0
+		maxSource := 0
+		i := 0
 		for _, remote := range remotes {
-			if listLong {
-				remoteType := config.FileGet(remote, "type")
-				description := config.FileGet(remote, "description")
-				fmt.Printf("%-*s %-*s %s\n", maxlen+1, remote+":", maxlentype+1, remoteType, description)
-			} else {
-				fmt.Printf("%s:\n", remote)
+			include := true
+			for k, v := range filters {
+				if k == "all" && !(v.MatchString(remote.Name) || v.MatchString(remote.Type) || v.MatchString(remote.Source) || v.MatchString(remote.Description)) {
+					include = false
+				} else if k == "name" && !v.MatchString(remote.Name) {
+					include = false
+				} else if k == "type" && !v.MatchString(remote.Type) {
+					include = false
+				} else if k == "source" && !v.MatchString(remote.Source) {
+					include = false
+				} else if k == "description" && !v.MatchString(remote.Description) {
+					include = false
+				}
+			}
+			if include {
+				if len(remote.Name) > maxName {
+					maxName = len(remote.Name)
+				}
+				if len(remote.Type) > maxType {
+					maxType = len(remote.Type)
+				}
+				if len(remote.Source) > maxSource {
+					maxSource = len(remote.Source)
+				}
+				remotes[i] = remote
+				i++
 			}
 		}
+		remotes = remotes[:i]
+
+		less, err := newLess(orderBy)
+		if err != nil {
+			return err
+		}
+		if less != nil {
+			sliceLessFn := func(i, j int) bool {
+				return less(remotes[i], remotes[j])
+			}
+			sort.SliceStable(remotes, sliceLessFn)
+		}
+
+		if jsonOutput {
+			fmt.Println("[")
+			first := true
+			for _, remote := range remotes {
+				out, err := json.Marshal(remote)
+				if err != nil {
+					return fmt.Errorf("failed to marshal remote object: %w", err)
+				}
+				if first {
+					first = false
+				} else {
+					fmt.Print(",\n")
+				}
+				_, err = os.Stdout.Write(out)
+				if err != nil {
+					return fmt.Errorf("failed to write to output: %w", err)
+				}
+			}
+			if !first {
+				fmt.Println()
+			}
+			fmt.Println("]")
+		} else if listLong {
+			for _, remote := range remotes {
+				fmt.Printf("%-*s %-*s %-*s %s\n", maxName+1, remote.Name+":", maxType, remote.Type, maxSource, remote.Source, remote.Description)
+			}
+		} else {
+			for _, remote := range remotes {
+				fmt.Printf("%s:\n", remote.Name)
+			}
+		}
+		return nil
 	},
 }

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -444,11 +444,12 @@ func SetValueAndSave(remote, key, value string) error {
 	return nil
 }
 
-// Remote defines a remote with a name, type and source
+// Remote defines a remote with a name, type, source and description
 type Remote struct {
-	Name   string `json:"name"`
-	Type   string `json:"type"`
-	Source string `json:"source"`
+	Name        string `json:"name"`
+	Type        string `json:"type"`
+	Source      string `json:"source"`
+	Description string `json:"description"`
 }
 
 var remoteEnvRe = regexp.MustCompile(`^RCLONE_CONFIG_(.+?)_TYPE=(.+)$`)
@@ -482,10 +483,12 @@ func GetRemotes() []Remote {
 		if !remoteExists(section) {
 			typeValue, found := LoadedData().GetValue(section, "type")
 			if found {
+				description, _ := LoadedData().GetValue(section, "description")
 				remotes = append(remotes, Remote{
-					Name:   section,
-					Type:   typeValue,
-					Source: "file",
+					Name:        section,
+					Type:        typeValue,
+					Source:      "file",
+					Description: description,
 				})
 			}
 		}

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -637,7 +637,7 @@ func FileDeleteKey(section, key string) bool {
 	return LoadedData().DeleteKey(section, key)
 }
 
-var matchEnv = regexp.MustCompile(`^RCLONE_CONFIG_(.*?)_TYPE=.*$`)
+var matchEnv = regexp.MustCompile(`^RCLONE_CONFIG_(.+?)_TYPE=.*$`)
 
 // FileSections returns the sections in the config file
 // including any defined by environment variables.

--- a/fs/config/flags/flags.go
+++ b/fs/config/flags/flags.go
@@ -50,16 +50,17 @@ func (gs *Groups) NewGroup(name, help string) *Group {
 }
 
 // Filter makes a copy of groups filtered by flagsRe
-func (gs *Groups) Filter(flagsRe *regexp.Regexp) *Groups {
+func (gs *Groups) Filter(group string, filterRe *regexp.Regexp, filterNamesOnly bool) *Groups {
 	newGs := NewGroups()
 	for _, g := range gs.Groups {
-		newG := newGs.NewGroup(g.Name, g.Help)
-		g.Flags.VisitAll(func(f *pflag.Flag) {
-			matched := flagsRe == nil || flagsRe.MatchString(f.Name) || flagsRe.MatchString(f.Usage)
-			if matched {
-				newG.Flags.AddFlag(f)
-			}
-		})
+		if group == "" || strings.EqualFold(g.Name, group) {
+			newG := newGs.NewGroup(g.Name, g.Help)
+			g.Flags.VisitAll(func(f *pflag.Flag) {
+				if filterRe == nil || filterRe.MatchString(f.Name) || (!filterNamesOnly && filterRe.MatchString(f.Usage)) {
+					newG.Flags.AddFlag(f)
+				}
+			})
+		}
 	}
 	return newGs
 }

--- a/fs/config/rc.go
+++ b/fs/config/rc.go
@@ -74,9 +74,9 @@ See the [listremotes](/commands/rclone_listremotes/) command for more informatio
 // Return the a list of remotes in the config file
 // including any defined by environment variables.
 func rcListRemotes(ctx context.Context, in rc.Params) (out rc.Params, err error) {
-	remotes := FileSections()
+	remoteNames := GetRemoteNames()
 	out = rc.Params{
-		"remotes": remotes,
+		"remotes": remoteNames,
 	}
 	return out, nil
 }

--- a/fs/config/rc_test.go
+++ b/fs/config/rc_test.go
@@ -33,8 +33,8 @@ func TestRc(t *testing.T) {
 	out, err := call.Fn(ctx, in)
 	require.NoError(t, err)
 	require.Nil(t, out)
-	assert.Equal(t, "local", config.FileGet(testName, "type"))
-	assert.Equal(t, "sausage", config.FileGet(testName, "test_key"))
+	assert.Equal(t, "local", config.GetValue(testName, "type"))
+	assert.Equal(t, "sausage", config.GetValue(testName, "test_key"))
 
 	// The sub tests rely on the remote created above but they can
 	// all be run independently
@@ -102,9 +102,9 @@ func TestRc(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, out)
 
-		assert.Equal(t, "local", config.FileGet(testName, "type"))
-		assert.Equal(t, "rutabaga", config.FileGet(testName, "test_key"))
-		assert.Equal(t, "cabbage", config.FileGet(testName, "test_key2"))
+		assert.Equal(t, "local", config.GetValue(testName, "type"))
+		assert.Equal(t, "rutabaga", config.GetValue(testName, "test_key"))
+		assert.Equal(t, "cabbage", config.GetValue(testName, "test_key2"))
 	})
 
 	t.Run("Password", func(t *testing.T) {
@@ -122,9 +122,9 @@ func TestRc(t *testing.T) {
 		require.NoError(t, err)
 		assert.Nil(t, out)
 
-		assert.Equal(t, "local", config.FileGet(testName, "type"))
-		assert.Equal(t, "rutabaga", obscure.MustReveal(config.FileGet(testName, "test_key")))
-		assert.Equal(t, pw2, obscure.MustReveal(config.FileGet(testName, "test_key2")))
+		assert.Equal(t, "local", config.GetValue(testName, "type"))
+		assert.Equal(t, "rutabaga", obscure.MustReveal(config.GetValue(testName, "test_key")))
+		assert.Equal(t, pw2, obscure.MustReveal(config.GetValue(testName, "test_key2")))
 	})
 
 	// Delete the test remote
@@ -136,8 +136,8 @@ func TestRc(t *testing.T) {
 	out, err = call.Fn(context.Background(), in)
 	require.NoError(t, err)
 	assert.Nil(t, out)
-	assert.Equal(t, "", config.FileGet(testName, "type"))
-	assert.Equal(t, "", config.FileGet(testName, "test_key"))
+	assert.Equal(t, "", config.GetValue(testName, "type"))
+	assert.Equal(t, "", config.GetValue(testName, "test_key"))
 }
 
 func TestRcProviders(t *testing.T) {

--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -280,7 +280,7 @@ func ShowRemotes() {
 	fmt.Printf("%-20s %s\n", "Name", "Type")
 	fmt.Printf("%-20s %s\n", "====", "====")
 	for _, remote := range remotes {
-		fmt.Printf("%-20s %s\n", remote, FileGet(remote, "type"))
+		fmt.Printf("%-20s %s\n", remote, GetValue(remote, "type"))
 	}
 }
 
@@ -295,7 +295,7 @@ func ChooseRemote() string {
 // mustFindByName finds the RegInfo for the remote name passed in or
 // exits with a fatal error.
 func mustFindByName(name string) *fs.RegInfo {
-	fsType := FileGet(name, "type")
+	fsType := GetValue(name, "type")
 	if fsType == "" {
 		log.Fatalf("Couldn't find type of fs for %q", name)
 	}
@@ -305,7 +305,7 @@ func mustFindByName(name string) *fs.RegInfo {
 // findByName finds the RegInfo for the remote name passed in or
 // returns an error
 func findByName(name string) (*fs.RegInfo, error) {
-	fsType := FileGet(name, "type")
+	fsType := GetValue(name, "type")
 	if fsType == "" {
 		return nil, fmt.Errorf("couldn't find type of fs for %q", name)
 	}
@@ -333,7 +333,7 @@ func printRemoteOptions(name string, prefix string, sep string, redacted bool) {
 				}
 			}
 		}
-		value := FileGet(name, key)
+		value := GetValue(name, key)
 		if redacted && (isSensitive || isPassword) && value != "" {
 			fmt.Printf("%s%s%sXXX\n", prefix, key, sep)
 		} else if isPassword && value != "" {
@@ -613,7 +613,7 @@ func copyRemote(name string) string {
 	newName := NewRemoteName()
 	// Copy the keys
 	for _, key := range LoadedData().GetKeyList(name) {
-		value := getWithDefault(name, key, "")
+		value, _ := FileGetValue(name, key)
 		LoadedData().SetValue(newName, key, value)
 	}
 	return newName

--- a/fs/config/ui_test.go
+++ b/fs/config/ui_test.go
@@ -110,9 +110,9 @@ func TestCRUD(t *testing.T) {
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
 	assert.Equal(t, []string{"test"}, config.Data().GetSectionList())
-	assert.Equal(t, "config_test_remote", config.FileGet("test", "type"))
-	assert.Equal(t, "true", config.FileGet("test", "bool"))
-	assert.Equal(t, "secret", obscure.MustReveal(config.FileGet("test", "pass")))
+	assert.Equal(t, "config_test_remote", config.GetValue("test", "type"))
+	assert.Equal(t, "true", config.GetValue("test", "bool"))
+	assert.Equal(t, "secret", obscure.MustReveal(config.GetValue("test", "pass")))
 
 	// normal rename, test → asdf
 	config.ReadLine = makeReadLine([]string{
@@ -123,9 +123,9 @@ func TestCRUD(t *testing.T) {
 	config.RenameRemote("test")
 
 	assert.Equal(t, []string{"asdf"}, config.Data().GetSectionList())
-	assert.Equal(t, "config_test_remote", config.FileGet("asdf", "type"))
-	assert.Equal(t, "true", config.FileGet("asdf", "bool"))
-	assert.Equal(t, "secret", obscure.MustReveal(config.FileGet("asdf", "pass")))
+	assert.Equal(t, "config_test_remote", config.GetValue("asdf", "type"))
+	assert.Equal(t, "true", config.GetValue("asdf", "bool"))
+	assert.Equal(t, "secret", obscure.MustReveal(config.GetValue("asdf", "pass")))
 
 	// delete remote
 	config.DeleteRemote("asdf")
@@ -152,8 +152,8 @@ func TestChooseOption(t *testing.T) {
 	}
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
-	assert.Equal(t, "", config.FileGet("test", "bool")) // this is the default now
-	assert.Equal(t, "not very random password", obscure.MustReveal(config.FileGet("test", "pass")))
+	assert.Equal(t, "", config.GetValue("test", "bool")) // this is the default now
+	assert.Equal(t, "not very random password", obscure.MustReveal(config.GetValue("test", "pass")))
 
 	// script for creating remote
 	config.ReadLine = makeReadLine([]string{
@@ -164,8 +164,8 @@ func TestChooseOption(t *testing.T) {
 	})
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
-	assert.Equal(t, "true", config.FileGet("test", "bool"))
-	assert.Equal(t, "", config.FileGet("test", "pass"))
+	assert.Equal(t, "true", config.GetValue("test", "bool"))
+	assert.Equal(t, "", config.GetValue("test", "pass"))
 }
 
 func TestNewRemoteName(t *testing.T) {
@@ -212,9 +212,9 @@ func TestCreateUpdatePasswordRemote(t *testing.T) {
 				require.NoError(t, err)
 
 				assert.Equal(t, []string{"test2"}, config.Data().GetSectionList())
-				assert.Equal(t, "config_test_remote", config.FileGet("test2", "type"))
-				assert.Equal(t, "true", config.FileGet("test2", "bool"))
-				gotPw := config.FileGet("test2", "pass")
+				assert.Equal(t, "config_test_remote", config.GetValue("test2", "type"))
+				assert.Equal(t, "true", config.GetValue("test2", "bool"))
+				gotPw := config.GetValue("test2", "pass")
 				if !noObscure {
 					gotPw = obscure.MustReveal(gotPw)
 				}
@@ -229,9 +229,9 @@ func TestCreateUpdatePasswordRemote(t *testing.T) {
 				require.NoError(t, err)
 
 				assert.Equal(t, []string{"test2"}, config.Data().GetSectionList())
-				assert.Equal(t, "config_test_remote", config.FileGet("test2", "type"))
-				assert.Equal(t, "false", config.FileGet("test2", "bool"))
-				gotPw = config.FileGet("test2", "pass")
+				assert.Equal(t, "config_test_remote", config.GetValue("test2", "type"))
+				assert.Equal(t, "false", config.GetValue("test2", "bool"))
+				gotPw = config.GetValue("test2", "pass")
 				if doObscure {
 					gotPw = obscure.MustReveal(gotPw)
 				}
@@ -242,9 +242,9 @@ func TestCreateUpdatePasswordRemote(t *testing.T) {
 				}))
 
 				assert.Equal(t, []string{"test2"}, config.Data().GetSectionList())
-				assert.Equal(t, "config_test_remote", config.FileGet("test2", "type"))
-				assert.Equal(t, "false", config.FileGet("test2", "bool"))
-				assert.Equal(t, "potato3", obscure.MustReveal(config.FileGet("test2", "pass")))
+				assert.Equal(t, "config_test_remote", config.GetValue("test2", "type"))
+				assert.Equal(t, "false", config.GetValue("test2", "bool"))
+				assert.Equal(t, "potato3", obscure.MustReveal(config.GetValue("test2", "pass")))
 			})
 		}
 	}
@@ -280,10 +280,10 @@ func TestDefaultRequired(t *testing.T) {
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
 	assert.Equal(t, []string{"test"}, config.Data().GetSectionList())
-	assert.Equal(t, "config_test_remote", config.FileGet("test", "type"))
-	assert.Equal(t, "111", config.FileGet("test", "string_required"))
-	assert.Equal(t, "222", config.FileGet("test", "string_default"))
-	assert.Equal(t, "333", config.FileGet("test", "string_required_default"))
+	assert.Equal(t, "config_test_remote", config.GetValue("test", "type"))
+	assert.Equal(t, "111", config.GetValue("test", "string_required"))
+	assert.Equal(t, "222", config.GetValue("test", "string_default"))
+	assert.Equal(t, "333", config.GetValue("test", "string_required_default"))
 
 	// delete remote
 	config.DeleteRemote("test")
@@ -301,10 +301,10 @@ func TestDefaultRequired(t *testing.T) {
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
 	assert.Equal(t, []string{"test"}, config.Data().GetSectionList())
-	assert.Equal(t, "config_test_remote", config.FileGet("test", "type"))
-	assert.Equal(t, "111", config.FileGet("test", "string_required"))
-	assert.Equal(t, "", config.FileGet("test", "string_default"))
-	assert.Equal(t, "", config.FileGet("test", "string_required_default"))
+	assert.Equal(t, "config_test_remote", config.GetValue("test", "type"))
+	assert.Equal(t, "111", config.GetValue("test", "string_required"))
+	assert.Equal(t, "", config.GetValue("test", "string_default"))
+	assert.Equal(t, "", config.GetValue("test", "string_required_default"))
 }
 
 func TestMultipleChoice(t *testing.T) {
@@ -383,11 +383,11 @@ func TestMultipleChoice(t *testing.T) {
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
 	assert.Equal(t, []string{"test"}, config.Data().GetSectionList())
-	assert.Equal(t, "config_test_remote", config.FileGet("test", "type"))
-	assert.Equal(t, "CCC", config.FileGet("test", "multiple_choice"))
-	assert.Equal(t, "CCC", config.FileGet("test", "multiple_choice_required"))
-	assert.Equal(t, "CCC", config.FileGet("test", "multiple_choice_default"))
-	assert.Equal(t, "CCC", config.FileGet("test", "multiple_choice_required_default"))
+	assert.Equal(t, "config_test_remote", config.GetValue("test", "type"))
+	assert.Equal(t, "CCC", config.GetValue("test", "multiple_choice"))
+	assert.Equal(t, "CCC", config.GetValue("test", "multiple_choice_required"))
+	assert.Equal(t, "CCC", config.GetValue("test", "multiple_choice_default"))
+	assert.Equal(t, "CCC", config.GetValue("test", "multiple_choice_required_default"))
 
 	// delete remote
 	config.DeleteRemote("test")
@@ -405,11 +405,11 @@ func TestMultipleChoice(t *testing.T) {
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
 	assert.Equal(t, []string{"test"}, config.Data().GetSectionList())
-	assert.Equal(t, "config_test_remote", config.FileGet("test", "type"))
-	assert.Equal(t, "XXX", config.FileGet("test", "multiple_choice"))
-	assert.Equal(t, "XXX", config.FileGet("test", "multiple_choice_required"))
-	assert.Equal(t, "XXX", config.FileGet("test", "multiple_choice_default"))
-	assert.Equal(t, "XXX", config.FileGet("test", "multiple_choice_required_default"))
+	assert.Equal(t, "config_test_remote", config.GetValue("test", "type"))
+	assert.Equal(t, "XXX", config.GetValue("test", "multiple_choice"))
+	assert.Equal(t, "XXX", config.GetValue("test", "multiple_choice_required"))
+	assert.Equal(t, "XXX", config.GetValue("test", "multiple_choice_default"))
+	assert.Equal(t, "XXX", config.GetValue("test", "multiple_choice_required_default"))
 
 	// delete remote
 	config.DeleteRemote("test")
@@ -428,11 +428,11 @@ func TestMultipleChoice(t *testing.T) {
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
 	assert.Equal(t, []string{"test"}, config.Data().GetSectionList())
-	assert.Equal(t, "config_test_remote", config.FileGet("test", "type"))
-	assert.Equal(t, "", config.FileGet("test", "multiple_choice"))
-	assert.Equal(t, "XXX", config.FileGet("test", "multiple_choice_required"))
-	assert.Equal(t, "", config.FileGet("test", "multiple_choice_default"))
-	assert.Equal(t, "", config.FileGet("test", "multiple_choice_required_default"))
+	assert.Equal(t, "config_test_remote", config.GetValue("test", "type"))
+	assert.Equal(t, "", config.GetValue("test", "multiple_choice"))
+	assert.Equal(t, "XXX", config.GetValue("test", "multiple_choice_required"))
+	assert.Equal(t, "", config.GetValue("test", "multiple_choice_default"))
+	assert.Equal(t, "", config.GetValue("test", "multiple_choice_required_default"))
 }
 
 func TestMultipleChoiceExclusive(t *testing.T) {
@@ -483,9 +483,9 @@ func TestMultipleChoiceExclusive(t *testing.T) {
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
 	assert.Equal(t, []string{"test"}, config.Data().GetSectionList())
-	assert.Equal(t, "config_test_remote", config.FileGet("test", "type"))
-	assert.Equal(t, "", config.FileGet("test", "multiple_choice_exclusive"))
-	assert.Equal(t, "", config.FileGet("test", "multiple_choice_exclusive_default"))
+	assert.Equal(t, "config_test_remote", config.GetValue("test", "type"))
+	assert.Equal(t, "", config.GetValue("test", "multiple_choice_exclusive"))
+	assert.Equal(t, "", config.GetValue("test", "multiple_choice_exclusive_default"))
 }
 
 func TestMultipleChoiceExclusiveRequired(t *testing.T) {
@@ -539,7 +539,7 @@ func TestMultipleChoiceExclusiveRequired(t *testing.T) {
 	require.NoError(t, config.NewRemote(ctx, "test"))
 
 	assert.Equal(t, []string{"test"}, config.Data().GetSectionList())
-	assert.Equal(t, "config_test_remote", config.FileGet("test", "type"))
-	assert.Equal(t, "CCC", config.FileGet("test", "multiple_choice_exclusive_required"))
-	assert.Equal(t, "", config.FileGet("test", "multiple_choice_exclusive_required_default"))
+	assert.Equal(t, "config_test_remote", config.GetValue("test", "type"))
+	assert.Equal(t, "CCC", config.GetValue("test", "multiple_choice_exclusive_required"))
+	assert.Equal(t, "", config.GetValue("test", "multiple_choice_exclusive_required_default"))
 }

--- a/fs/filter/filter.go
+++ b/fs/filter/filter.go
@@ -258,7 +258,7 @@ func (f *Filter) addDirGlobs(Include bool, glob string) error {
 		if dirGlob == "/" {
 			continue
 		}
-		dirRe, err := GlobToRegexp(dirGlob, f.Opt.IgnoreCase)
+		dirRe, err := GlobPathToRegexp(dirGlob, f.Opt.IgnoreCase)
 		if err != nil {
 			return err
 		}
@@ -278,7 +278,7 @@ func (f *Filter) Add(Include bool, glob string) error {
 	if strings.Contains(glob, "**") {
 		isDirRule, isFileRule = true, true
 	}
-	re, err := GlobToRegexp(glob, f.Opt.IgnoreCase)
+	re, err := GlobPathToRegexp(glob, f.Opt.IgnoreCase)
 	if err != nil {
 		return err
 	}

--- a/fs/filter/glob.go
+++ b/fs/filter/glob.go
@@ -11,30 +11,59 @@ import (
 	"github.com/rclone/rclone/fs"
 )
 
-// GlobToRegexp converts an rsync style glob to a regexp
+// GlobPathToRegexp converts an rsync style glob path to a regexp
+func GlobPathToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
+	return globToRegexp(glob, true, true, ignoreCase)
+}
+
+// GlobStringToRegexp converts an rsync style glob string to a regexp
+func GlobStringToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
+	return globToRegexp(glob, false, true, ignoreCase)
+}
+
+// globToRegexp converts an rsync style glob to a regexp
 //
-// documented in filtering.md
-func GlobToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
+// Set pathMode true for matching of path/file names, e.g.
+// special treatment of path separator `/` and double asterisk `**`,
+// see filtering.md for details.
+//
+// Set addAnchors true to add start of string `^` and end of string `$` anchors.
+func globToRegexp(glob string, pathMode bool, addAnchors bool, ignoreCase bool) (*regexp.Regexp, error) {
 	var re bytes.Buffer
 	if ignoreCase {
 		_, _ = re.WriteString("(?i)")
 	}
-	if strings.HasPrefix(glob, "/") {
-		glob = glob[1:]
-		_ = re.WriteByte('^')
-	} else {
-		_, _ = re.WriteString("(^|/)")
+	if addAnchors {
+		if pathMode {
+			if strings.HasPrefix(glob, "/") {
+				glob = glob[1:]
+				_ = re.WriteByte('^')
+			} else {
+				_, _ = re.WriteString("(^|/)")
+			}
+		} else {
+			_, _ = re.WriteString("^")
+		}
 	}
 	consecutiveStars := 0
 	insertStars := func() error {
 		if consecutiveStars > 0 {
-			switch consecutiveStars {
-			case 1:
-				_, _ = re.WriteString(`[^/]*`)
-			case 2:
-				_, _ = re.WriteString(`.*`)
-			default:
-				return fmt.Errorf("too many stars in %q", glob)
+			if pathMode {
+				switch consecutiveStars {
+				case 1:
+					_, _ = re.WriteString(`[^/]*`)
+				case 2:
+					_, _ = re.WriteString(`.*`)
+				default:
+					return fmt.Errorf("too many stars in %q", glob)
+				}
+			} else {
+				switch consecutiveStars {
+				case 1:
+					_, _ = re.WriteString(`.*`)
+				default:
+					return fmt.Errorf("too many stars in %q", glob)
+				}
 			}
 		}
 		consecutiveStars = 0
@@ -102,7 +131,11 @@ func GlobToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
 		case '*':
 			consecutiveStars++
 		case '?':
-			_, _ = re.WriteString(`[^/]`)
+			if pathMode {
+				_, _ = re.WriteString(`[^/]`)
+			} else {
+				_, _ = re.WriteString(`.`)
+			}
 		case '[':
 			_, _ = re.WriteRune(c)
 			inBrackets++
@@ -152,7 +185,9 @@ func GlobToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
 	if inRegexp {
 		return nil, fmt.Errorf("mismatched '{{' and '}}' in glob %q", glob)
 	}
-	_ = re.WriteByte('$')
+	if addAnchors {
+		_ = re.WriteByte('$')
+	}
 	result, err := regexp.Compile(re.String())
 	if err != nil {
 		return nil, fmt.Errorf("bad glob pattern %q (regexp %q): %w", glob, re.String(), err)

--- a/fs/filter/glob_test.go
+++ b/fs/filter/glob_test.go
@@ -7,7 +7,129 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGlobToRegexp(t *testing.T) {
+func TestGlobStringToRegexp(t *testing.T) {
+	for _, test := range []struct {
+		in    string
+		want  string
+		error string
+	}{
+		{``, `^$`, ``},
+		{`potato`, `^potato$`, ``},
+		{`potato,sausage`, `^potato,sausage$`, ``},
+		{`/potato`, `^/potato$`, ``},
+		{`potato?sausage`, `^potato.sausage$`, ``},
+		{`potat[oa]`, `^potat[oa]$`, ``},
+		{`potat[a-z]or`, `^potat[a-z]or$`, ``},
+		{`potat[[:alpha:]]or`, `^potat[[:alpha:]]or$`, ``},
+		{`'.' '+' '(' ')' '|' '^' '$'`, `^'\.' '\+' '\(' '\)' '\|' '\^' '\$'$`, ``},
+		{`*.jpg`, `^.*\.jpg$`, ``},
+		{`a{b,c,d}e`, `^a(b|c|d)e$`, ``},
+		{`potato**`, ``, `too many stars`},
+		{`potato**sausage`, ``, `too many stars`},
+		{`*.p[lm]`, `^.*\.p[lm]$`, ``},
+		{`[\[\]]`, `^[\[\]]$`, ``},
+		{`***potato`, ``, `too many stars`},
+		{`***`, ``, `too many stars`},
+		{`ab]c`, ``, `mismatched ']'`},
+		{`ab[c`, ``, `mismatched '[' and ']'`},
+		{`ab{x{cd`, ``, `can't nest`},
+		{`ab{}}cd`, ``, `mismatched '{' and '}'`},
+		{`ab}c`, ``, `mismatched '{' and '}'`},
+		{`ab{c`, ``, `mismatched '{' and '}'`},
+		{`*.{jpg,png,gif}`, `^.*\.(jpg|png|gif)$`, ``},
+		{`[a--b]`, ``, `bad glob pattern`},
+		{`a\*b`, `^a\*b$`, ``},
+		{`a\\b`, `^a\\b$`, ``},
+		{`a{{.*}}b`, `^a(.*)b$`, ``},
+		{`a{{.*}`, ``, `mismatched '{{' and '}}'`},
+		{`{{regexp}}`, `^(regexp)$`, ``},
+		{`\{{{regexp}}`, `^\{(regexp)$`, ``},
+		{`/{{regexp}}`, `^/(regexp)$`, ``},
+		{`/{{\d{8}}}`, `^/(\d{8})$`, ``},
+		{`/{{\}}}`, `^/(\})$`, ``},
+		{`{{(?i)regexp}}`, `^((?i)regexp)$`, ``},
+	} {
+		for _, ignoreCase := range []bool{false, true} {
+			gotRe, err := GlobStringToRegexp(test.in, ignoreCase)
+			if test.error == "" {
+				require.NoError(t, err, test.in)
+				prefix := ""
+				if ignoreCase {
+					prefix = "(?i)"
+				}
+				got := gotRe.String()
+				assert.Equal(t, prefix+test.want, got, test.in)
+			} else {
+				require.Error(t, err, test.in)
+				assert.Contains(t, err.Error(), test.error, test.in)
+				assert.Nil(t, gotRe)
+			}
+		}
+	}
+}
+
+func TestGlobStringToRegexpWithoutAnchors(t *testing.T) {
+	for _, test := range []struct {
+		in    string
+		want  string
+		error string
+	}{
+		{``, ``, ``},
+		{`potato`, `potato`, ``},
+		{`potato,sausage`, `potato,sausage`, ``},
+		{`/potato`, `/potato`, ``},
+		{`potato?sausage`, `potato.sausage`, ``},
+		{`potat[oa]`, `potat[oa]`, ``},
+		{`potat[a-z]or`, `potat[a-z]or`, ``},
+		{`potat[[:alpha:]]or`, `potat[[:alpha:]]or`, ``},
+		{`'.' '+' '(' ')' '|' '^' '$'`, `'\.' '\+' '\(' '\)' '\|' '\^' '\$'`, ``},
+		{`*.jpg`, `.*\.jpg`, ``},
+		{`a{b,c,d}e`, `a(b|c|d)e`, ``},
+		{`potato**`, ``, `too many stars`},
+		{`potato**sausage`, ``, `too many stars`},
+		{`*.p[lm]`, `.*\.p[lm]`, ``},
+		{`[\[\]]`, `[\[\]]`, ``},
+		{`***potato`, ``, `too many stars`},
+		{`***`, ``, `too many stars`},
+		{`ab]c`, ``, `mismatched ']'`},
+		{`ab[c`, ``, `mismatched '[' and ']'`},
+		{`ab{x{cd`, ``, `can't nest`},
+		{`ab{}}cd`, ``, `mismatched '{' and '}'`},
+		{`ab}c`, ``, `mismatched '{' and '}'`},
+		{`ab{c`, ``, `mismatched '{' and '}'`},
+		{`*.{jpg,png,gif}`, `.*\.(jpg|png|gif)`, ``},
+		{`[a--b]`, ``, `bad glob pattern`},
+		{`a\*b`, `a\*b`, ``},
+		{`a\\b`, `a\\b`, ``},
+		{`a{{.*}}b`, `a(.*)b`, ``},
+		{`a{{.*}`, ``, `mismatched '{{' and '}}'`},
+		{`{{regexp}}`, `(regexp)`, ``},
+		{`\{{{regexp}}`, `\{(regexp)`, ``},
+		{`/{{regexp}}`, `/(regexp)`, ``},
+		{`/{{\d{8}}}`, `/(\d{8})`, ``},
+		{`/{{\}}}`, `/(\})`, ``},
+		{`{{(?i)regexp}}`, `((?i)regexp)`, ``},
+	} {
+		for _, ignoreCase := range []bool{false, true} {
+			gotRe, err := globToRegexp(test.in, false, false, ignoreCase)
+			if test.error == "" {
+				require.NoError(t, err, test.in)
+				prefix := ""
+				if ignoreCase {
+					prefix = "(?i)"
+				}
+				got := gotRe.String()
+				assert.Equal(t, prefix+test.want, got, test.in)
+			} else {
+				require.Error(t, err, test.in)
+				assert.Contains(t, err.Error(), test.error, test.in)
+				assert.Nil(t, gotRe)
+			}
+		}
+	}
+}
+
+func TestGlobPathToRegexp(t *testing.T) {
 	for _, test := range []struct {
 		in    string
 		want  string
@@ -28,20 +150,20 @@ func TestGlobToRegexp(t *testing.T) {
 		{`potato**sausage`, `(^|/)potato.*sausage$`, ``},
 		{`*.p[lm]`, `(^|/)[^/]*\.p[lm]$`, ``},
 		{`[\[\]]`, `(^|/)[\[\]]$`, ``},
-		{`***potato`, `(^|/)`, `too many stars`},
-		{`***`, `(^|/)`, `too many stars`},
-		{`ab]c`, `(^|/)`, `mismatched ']'`},
-		{`ab[c`, `(^|/)`, `mismatched '[' and ']'`},
-		{`ab{x{cd`, `(^|/)`, `can't nest`},
-		{`ab{}}cd`, `(^|/)`, `mismatched '{' and '}'`},
-		{`ab}c`, `(^|/)`, `mismatched '{' and '}'`},
-		{`ab{c`, `(^|/)`, `mismatched '{' and '}'`},
+		{`***potato`, ``, `too many stars`},
+		{`***`, ``, `too many stars`},
+		{`ab]c`, ``, `mismatched ']'`},
+		{`ab[c`, ``, `mismatched '[' and ']'`},
+		{`ab{x{cd`, ``, `can't nest`},
+		{`ab{}}cd`, ``, `mismatched '{' and '}'`},
+		{`ab}c`, ``, `mismatched '{' and '}'`},
+		{`ab{c`, ``, `mismatched '{' and '}'`},
 		{`*.{jpg,png,gif}`, `(^|/)[^/]*\.(jpg|png|gif)$`, ``},
-		{`[a--b]`, `(^|/)`, `bad glob pattern`},
+		{`[a--b]`, ``, `bad glob pattern`},
 		{`a\*b`, `(^|/)a\*b$`, ``},
 		{`a\\b`, `(^|/)a\\b$`, ``},
 		{`a{{.*}}b`, `(^|/)a(.*)b$`, ``},
-		{`a{{.*}`, `(^|/)a(.*)b$`, `mismatched '{{' and '}}'`},
+		{`a{{.*}`, ``, `mismatched '{{' and '}}'`},
 		{`{{regexp}}`, `(^|/)(regexp)$`, ``},
 		{`\{{{regexp}}`, `(^|/)\{(regexp)$`, ``},
 		{`/{{regexp}}`, `^(regexp)$`, ``},
@@ -50,7 +172,7 @@ func TestGlobToRegexp(t *testing.T) {
 		{`{{(?i)regexp}}`, `(^|/)((?i)regexp)$`, ``},
 	} {
 		for _, ignoreCase := range []bool{false, true} {
-			gotRe, err := GlobToRegexp(test.in, ignoreCase)
+			gotRe, err := GlobPathToRegexp(test.in, ignoreCase)
 			if test.error == "" {
 				require.NoError(t, err, test.in)
 				prefix := ""
@@ -111,7 +233,7 @@ func TestGlobToDirGlobs(t *testing.T) {
 		{"/sausage3**", []string{`/sausage3**/`, "/"}},
 		{"/a/*.jpg", []string{`/a/`, "/"}},
 	} {
-		_, err := GlobToRegexp(test.in, false)
+		_, err := GlobPathToRegexp(test.in, false)
 		assert.NoError(t, err)
 		got := globToDirGlobs(test.in)
 		assert.Equal(t, test.want, got, test.in)

--- a/fs/filter/rules.go
+++ b/fs/filter/rules.go
@@ -67,7 +67,7 @@ func (rs *rules) add(Include bool, re *regexp.Regexp) {
 
 // Add adds a filter rule with include or exclude status indicated
 func (rs *rules) Add(Include bool, glob string) error {
-	re, err := GlobToRegexp(glob, false /* f.Opt.IgnoreCase */)
+	re, err := GlobPathToRegexp(glob, false /* f.Opt.IgnoreCase */)
 	if err != nil {
 		return err
 	}

--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -308,14 +308,14 @@ func (s *Server) handleOptions(w http.ResponseWriter, r *http.Request, path stri
 }
 
 func (s *Server) serveRoot(w http.ResponseWriter, r *http.Request) {
-	remotes := config.FileSections()
-	sort.Strings(remotes)
+	remoteNames := config.GetRemoteNames()
+	sort.Strings(remoteNames)
 	directory := serve.NewDirectory("", s.server.HTMLTemplate())
 	directory.Name = "List of all rclone remotes."
 	q := url.Values{}
-	for _, remote := range remotes {
-		q.Set("fs", remote)
-		directory.AddHTMLEntry("["+remote+":]", true, -1, time.Time{})
+	for _, remoteName := range remoteNames {
+		q.Set("fs", remoteName)
+		directory.AddHTMLEntry("["+remoteName+":]", true, -1, time.Time{})
 	}
 	sortParm := r.URL.Query().Get("sort")
 	orderParm := r.URL.Query().Get("order")

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -428,7 +428,7 @@ func Run(t *testing.T, opt *Opt) {
 
 	// Set extra config if supplied
 	for _, item := range opt.ExtraConfig {
-		config.FileSet(item.Name, item.Key, item.Value)
+		config.FileSetValue(item.Name, item.Key, item.Value)
 	}
 	if *fstest.RemoteName != "" {
 		remoteName = *fstest.RemoteName


### PR DESCRIPTION
#### What is the purpose of this change?

The main purpose is to add support for filtering the output from `listremotes` command, as discussed in the forum. Some additional, somewhat related, features were also added, namely ordering and json output. During extended testing of this command, some issues and inconsistencies within the fs/filter and fs/config libs, which the listremotes command depends on, were discovered and improved.

Now to the details: First the improvements to listremotes, as these are the most user-facing part, then later some details regarding the changes in fs libs - although these commits comes first in the PR as some of they create a foundation for some of the listremote improvements.

Improvements to listremotes:
- Including source of the remote definition in the `--long` output format, i.e. if it was defined in environment variable or in config file. The complete remote configuration may contain options from both environment and config, but this shows where it is "defined" - where the name and type comes from. This follows the documented [preference](https://rclone.org/docs/#precedence), so if it is defined in both places its the one from environment that will be shown.
  ```
  $ rclone listremotes --long
  temp_box: dropbox    environment
  temp_jfs: jottacloud environment
  box:      dropbox    file
  box_1:    dropbox    file
  box_2:    dropbox    file
  jfs:      jottacloud file
  gd:       drive      file
  box_1b:   dropbox    file
  ```
- Optional flag `--type` to list only remotes of a specific type:
  ```
  $ rclone listremotes --long --type dropbox
  temp_box: dropbox environment
  box:      dropbox file
  box_1:    dropbox file
  box_2:    dropbox file
  box_1b:   dropbox file
  ```
- Optional flag `--source` to list only remotes from a specific source:
  ```
  $ rclone listremotes --type dropbox --source environment
  temp_box: dropbox environment
  ```
- Search/filter on name. A query string can be specified as an optional (unnamed) argument. I did considered implementing it as a simple string "binary" matching, or full blown regular expression, but I find the glob syntax quite convenient, flexible while easy to use - easier to understand than regex for less technical users at least. I ended up re-using rclone's [filtering syntax](https://rclone.org/filtering/): This is convenient in that it uses a quite easy-to-use glob pattern by default, while allowing for some more advanced features and even regular expressions for those who want it:
  ```
  $ rclone listremotes box
  
  $ rclone listremotes box*
  box:
  box_1:
  box_2:
  box_1b:
  $ rclone listremotes *box
  temp_box:
  $ rclone listremotes box{{(_\d+)?}} --type dropbox
  box:
  box_1:
  box_2:
  ```
- Sorting. Option flag `--order-by` can be used to sort on any of the fields (`name`, `type` and `source`) in any direction (`ascending` or `asc`, and `descending` or `desc`), and they can be combined with the syntax: `field[=order],field[=order],...` (order is optional).
  ```
  $ rclone listremotes --long --order-by type,source=desc,name
  gd:       drive      file
  box:      dropbox    file
  box_1:    dropbox    file
  box_1b:   dropbox    file
  box_2:    dropbox    file
  temp_box: dropbox    environment
  jfs:      jottacloud file
  temp_jfs: jottacloud environment
  ```
- Machine-readable output with option `--json`, also for completeness with other commands such as `size` and `about`. It produces a valid array json output in format similar to `lsjson`, and can be combined with filtering and other options (except `--long`):
  ```
  $ rclone listremotes --json --type jottacloud
  [
  {"name":"temp_jfs","type":"jottacloud","source":"environment"},
  {"name":"jfs","type":"jottacloud","source":"file"}
  ]
  ```

Improvements in fs/filter:
- To implement the glob-filtering I had to tweak the `fs.GlobToRegexp` function a little, so that we can tell it to not treat `/` as path separator, and to not make `*` stop consuming them, and not support `**` as additional symbol that will consume them, etc.. As can be seen from the examples above, the `rclone listremotes box` does not give any result as it would with the simplest binary matching alternative, so this is sort of a tradeoff between the absolute simplest syntax and flexibility.
- For consistency I updated the `help flags` command to use the same logic. It used plain regex before, and my reasoning was that we should try to avoid using different filtering syntax for different command, as that will not be easy to remember for users. The main difference is that a glob pattern is implicitly anchored. E.g. previously you could write `rclone help flags dropbox` and it would return any flags with this word in its name or description. But now you will have to write `rclone help flags *dropbox*` to get the same result. That is a less convenient, so a bit unfortunate actually. Maybe in an attempt at compensating - I added some more flexibility to the flags filtering:
  - You can now add flag `--name` to make the filter match the *name* of the flag only. E.g. `rclone help flags *password* --name` will only match flags with "password" in their name, it will not include `--sftp-pass` even if it mentions "password" in its description.
  - You can now specify name of a flag group with `--group`, e.g. `rclone help flags --group sync` or  `rclone help flags --group backend`. This uses (case insensitive) string matching by the way, requires complete match on the group name. Contradicting myself a bit here, I guess. Could have used the same pattern matching also here, but that complicated flags and parameter passing code, and there are only a few short group names so I figured there is not much to loose from having to spell out the entire name. The same is true for the new `--type` and `--source` flags in `listremote` by the way.
- **Note:** This part I'm least certain about. Is the existing filter syntax for help flags so well established, and easy to use, that it is bad to change it? If uncertain, I could split this out to a separate PR. In any case, do you agree with me that the glob syntax is clever, and useful enough that we want to keep it for the listremotes command (and possibly use it elsewhere as well)?

Improvements in fs/config:
- Issues:
  - It is possible to create nameless remotes with environment variable, like this:
    ```
    $ set RCLONE_CONFIG__TYPE=sftp
    $ rclone listremotes --long
    : sftp
    ```
  - If you define a remote with same name in environment as in file, it is listed twice:
    ```
    $ type rclone.conf
    [box]
    type = dropbox
    
    [box_1]
    type = dropbox
    
    [box_1b]
    type = dropbox
    
    $ set RCLONE_CONFIG_BOX_1B_TYPE=sftp
    $ rclone listremotes --long
    box:    dropbox
    box_1:  dropbox
    box_1b: dropbox
    box_1b: dropbox
    ```
    And even worse; notice that the duplicate remote is listed with same type - the type from config file. So it does not actually reflect the truth very well. And another point to this is that it chooses the remote type from config file over the environment, which is opposite of what the documentation says - and what rclone uses in "real" operations:
    ```
    $ rclone lsd box_1b: -vvv
    DEBUG : Setting type="sftp" for "box_1b" from environment variable RCLONE_CONFIG_WORK_BOX_1B_TYPE
    ```
- Explanations:
  - While looking into the issues described above, I found the some parts of the fs/config a bit confusing, misleading and wrong (in my opinion): Function `config.FileSections` did not only return the sections, i.e. remotes, from the config file - but also included any configured as environment variables. Same with `config.FileGet`, which retrieves value of options. Misleading function names, at least. But also; while collecting remote names from environment it appends them to the list even if there is one with same name in configuration file, which could be considered a feature to inform users - except as we see above `listremotes` does not present it with its correct type so its a bug there regardless what we want it to show. Which brings me to next point; when collecting remotes from environment, remember these are defined by the `_TYPE` environment variable specifying the type of remote, the type information is ignored and when using `listremotes` command it uses `config.FileGet` to get the value of the type property. But this function reads the configuration file first, and only if not found there considers environment variable - which is the wrong way around. Together this leads to the issue above.
- Improvements:
  - Make fs/config functions with prefix `File` consider the configuration file only, consistent with its name. Then make new "convenience" functions `GetRemotes` and `GetValues` which also considers environment (there were already a couple of similar functions).
  - The new `GetRemotes` returns not only the remote names, but also the type and the "source" (if it was found from file or environment). This ensures we make use of the type information from the `_TYPE` environment variable when that is used to define a remote (name) as well, avoiding the extra call but more importantly avoiding inconsistency (although the next point should also fix this).
  - When considering options set in environment variables, make sure these take precedence over configuration file.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/suggestion-separate-crypt-and-non-crypt-remotes/42581

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
