### PR TITLE
Hdfs namenode list fix

### DIFF
--- a/backend/hdfs/fs.go
+++ b/backend/hdfs/fs.go
@@ -93,7 +93,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	options := hdfs.ClientOptions{
-		Addresses:           strings.Split(opt.Namenode, ","),
+		Addresses:           opt.Namenode,
 		UseDatanodeHostname: false,
 	}
 

--- a/backend/hdfs/fs.go
+++ b/backend/hdfs/fs.go
@@ -93,7 +93,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	options := hdfs.ClientOptions{
-		Addresses:           []string{opt.Namenode},
+		Addresses:           strings.Split(opt.Namenode, ","),
 		UseDatanodeHostname: false,
 	}
 

--- a/backend/hdfs/hdfs.go
+++ b/backend/hdfs/hdfs.go
@@ -20,7 +20,7 @@ func init() {
 		NewFs:       NewFs,
 		Options: []fs.Option{{
 			Name:      "namenode",
-			Help:      "Hadoop name node and port.\n\nE.g. \"namenode:8020\" to connect to host namenode at port 8020.",
+			Help:      "Hadoop name nodes and ports.\n\nE.g. \"namenode-1:8020,namenode-2:8020,...\" to connect to host namenodes at port 8020.",
 			Required:  true,
 			Sensitive: true,
 		}, {

--- a/backend/hdfs/hdfs.go
+++ b/backend/hdfs/hdfs.go
@@ -23,6 +23,7 @@ func init() {
 			Help:      "Hadoop name nodes and ports.\n\nE.g. \"namenode-1:8020,namenode-2:8020,...\" to connect to host namenodes at port 8020.",
 			Required:  true,
 			Sensitive: true,
+			Default:   fs.CommaSepList{},
 		}, {
 			Name: "username",
 			Help: "Hadoop user name.",
@@ -65,7 +66,7 @@ and 'privacy'. Used only with KERBEROS enabled.`,
 
 // Options for this backend
 type Options struct {
-	Namenode               string               `config:"namenode"`
+	Namenode               fs.CommaSepList      `config:"namenode"`
 	Username               string               `config:"username"`
 	ServicePrincipalName   string               `config:"service_principal_name"`
 	DataTransferProtection string               `config:"data_transfer_protection"`


### PR DESCRIPTION
 Users can now input a list of namenodes when writing config for hdfs remotes.

 This is required when you have multiple namenodes in your hdfs cluster and cannot be certain which namenodes will be in 'standby' or 'active' states.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Users can now input a list of namenodes when writing config for hdfs remotes.
-->

#### Was the change discussed in an issue or in the forum before?

<!--
No.
-->

#### Checklist

- [✅] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [✅] I have added tests for all changes in this PR if appropriate.
- [✅] I have added documentation for the changes if appropriate.
- [✅] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [✅] I'm done, this Pull Request is ready for review :-)
