### PR TITLE
install.sh: Clean up temp files in install script

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -193,6 +193,8 @@ case "$OS" in
     exit 2
 esac
 
+#cleanup
+rm -rf "$tmp_dir"
 
 #update version variable post install
 version=$(rclone --version 2>>errors | head -n 1)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

The install script at [rclone.org/install.sh](https://rclone.org/install.sh) leaves temp files behind, which [increases docker image size](https://forum.rclone.org/t/install-sh-leaves-temp-files-around-inflating-docker-image-size/42940)

#### Was the change discussed in an issue or in the forum before?
https://forum.rclone.org/t/install-sh-leaves-temp-files-around-inflating-docker-image-size/42940
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ n/a] I have added tests for all changes in this PR if appropriate.
- [ n/a] I have added documentation for the changes if appropriate.
- [x ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)

#### Testing
Ran repro steps described in the forum thread:

Dockerfile:
```
FROM ubuntu:22.04
RUN apt-get update && apt-get install -y \
    curl zip \
    && rm -rf /var/lib/apt/lists/*
# This url contains the fix
RUN curl https://sh.uuid.rocks/install/rclone.sh | bash
```
```sh
docker build . -t rclone-example
dive rclone-example
```
With this change, we can see the temp files no longer inflate the docker image:
![image](https://github.com/rclone/rclone/assets/10719325/b9a7106a-6d5c-4ffd-a156-7aaeaac40054)
