### PR TITLE
fs/fshttp: use fs ctx instead of request ctx

### DIFF
--- a/fs/fshttp/dialer.go
+++ b/fs/fshttp/dialer.go
@@ -14,10 +14,6 @@ import (
 	"golang.org/x/net/ipv6"
 )
 
-func dialContext(ctx context.Context, network, address string, ci *fs.ConfigInfo) (net.Conn, error) {
-	return NewDialer(ctx).DialContext(ctx, network, address)
-}
-
 // Dialer structure contains default dialer and timeout, tclass support
 type Dialer struct {
 	net.Dialer

--- a/fs/fshttp/http.go
+++ b/fs/fshttp/http.go
@@ -91,8 +91,8 @@ func NewTransportCustom(ctx context.Context, customize func(*http.Transport)) ht
 	}
 
 	t.DisableCompression = ci.NoGzip
-	t.DialContext = func(ctx context.Context, network, addr string) (net.Conn, error) {
-		return dialContext(ctx, network, addr, ci)
+	t.DialContext = func(reqCtx context.Context, network, addr string) (net.Conn, error) {
+		return NewDialer(ctx).DialContext(reqCtx, network, addr)
 	}
 	t.IdleConnTimeout = 60 * time.Second
 	t.ExpectContinueTimeout = ci.ExpectContinueTimeout


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
The original `ctx` parameter of func  `dialContext`  is the context of `http request`.
The func `NewDialer` requires the `context of fs` in order to create the `Dialer` using the user-specified `--timeout` and `--contimeout` flasgs.
So add a new parameter `fsCtx` .
#### Was the change discussed in an issue or in the forum before?
None.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
