### PR TITLE
#7444 enable WebDAV methods with CORS

### DIFF
--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -183,8 +183,8 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
-				w.Header().Add("Access-Control-Request-Method", "POST, OPTIONS, GET, HEAD")
 				w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
+				w.Header().Add("Access-Control-Allow-Methods", "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK")
 			}
 
 			next.ServeHTTP(w, r)

--- a/lib/http/middleware_test.go
+++ b/lib/http/middleware_test.go
@@ -323,8 +323,8 @@ func TestMiddlewareAuthCertificateUser(t *testing.T) {
 
 var _testCORSHeaderKeys = []string{
 	"Access-Control-Allow-Origin",
-	"Access-Control-Request-Method",
 	"Access-Control-Allow-Headers",
+	"Access-Control-Allow-Methods",
 }
 
 func TestMiddlewareCORS(t *testing.T) {


### PR DESCRIPTION
Fixes #7444

#### What is the purpose of this change?

Enables the HTTP methods used with WebDAV protocol. It allows requests to rclone WebDAV issued from web browsers, which are currently blocked by CORS policy.

#### Was the change discussed in an issue or in the forum before?

#7444

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
