### PR TITLE
azure-files: fix storage base url

### DIFF
--- a/backend/azurefiles/azurefiles.go
+++ b/backend/azurefiles/azurefiles.go
@@ -65,7 +65,7 @@ import (
 const (
 	maxFileSize           = 4 * fs.Tebi
 	defaultChunkSize      = 4 * fs.Mebi
-	storageDefaultBaseURL = "core.windows.net" // FIXME not sure this is correct
+	storageDefaultBaseURL = "file.core.windows.net" // FIXME not sure this is correct
 )
 
 func init() {

--- a/backend/azurefiles/azurefiles.go
+++ b/backend/azurefiles/azurefiles.go
@@ -65,7 +65,7 @@ import (
 const (
 	maxFileSize           = 4 * fs.Tebi
 	defaultChunkSize      = 4 * fs.Mebi
-	storageDefaultBaseURL = "file.core.windows.net" // FIXME not sure this is correct
+	storageDefaultBaseURL = "file.core.windows.net"
 )
 
 func init() {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Azure files are not working because of the invalid base URL. Now it's "core.windows.net", but according to documentation (proved with testing), it should be "file.core.windows.net" - see https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview (Azure Files  - `https://<storage-account>.file.core.windows.net`)
#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
