### PR TITLE
Add S3 IPv6 "dualstack" endpoint support . Option = "use_dual_stack" [bool] 

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2220,6 +2220,13 @@ Use this only if v4 signatures don't work, e.g. pre Jewel/v10 CEPH.`,
 			Default:  false,
 			Advanced: true,
 		}, {
+			Name: "use_dual_stack",
+			Help: `If true use AWS S3 dual-stack endpoint (IPv6 support).
+
+See [AWS Docs on Dualstack Endpoints](https://docs.aws.amazon.com/AmazonS3/latest/userguide/dual-stack-endpoints.html)`,
+			Default:  false,
+			Advanced: true,
+		}, {
 			Name:     "use_accelerate_endpoint",
 			Provider: "AWS",
 			Help: `If true use the AWS S3 accelerated endpoint.
@@ -2628,6 +2635,7 @@ type Options struct {
 	Region                string               `config:"region"`
 	Endpoint              string               `config:"endpoint"`
 	STSEndpoint           string               `config:"sts_endpoint"`
+	UseDualStack          bool                 `config:"use_dual_stack"`
 	LocationConstraint    string               `config:"location_constraint"`
 	ACL                   string               `config:"acl"`
 	BucketACL             string               `config:"bucket_acl"`
@@ -2955,6 +2963,9 @@ func s3Connection(ctx context.Context, opt *Options, client *http.Client) (*s3.S
 		r.addService("s3", opt.Endpoint)
 		r.addService("sts", opt.STSEndpoint)
 		awsConfig.WithEndpointResolver(r)
+	}
+	if opt.UseDualStack {
+		awsConfig.UseDualStackEndpoint = endpoints.DualStackEndpointStateEnabled
 	}
 
 	// awsConfig.WithLogLevel(aws.LogDebugWithSigning)


### PR DESCRIPTION
#### What is the purpose of this change?
Currently rclone hangs when IPv4 route to S3 is unavailable (e.g. no IPV4 interface or no IPV4 route to internet ).  This change adds S3 IPv6 "dualstack" endpoint support . Option = `use_dual_stack` [bool] .   Default S3 endpoints are IPv4 NOT IPv6

See AWS docs on IPv6:
"To make a request to an S3 bucket over IPv6, you need to use a dual-stack endpoint."
* https://docs.aws.amazon.com/AmazonS3/latest/userguide/ipv6-access.html
* https://docs.aws.amazon.com/AmazonS3/latest/userguide/dual-stack-endpoints.html

#### Why Now?
Starting Feb, EC2 will charge for public IPv4 addresses & NAT traffic.  More AWS users will be using rclone & S3 on IPV6

#### Steps to Reproduce
1. Run test from a host with IPv6 address. 
1. If the host has IPv4 address,  use security-group, routing table or firewall to block IPv4 traffic (e.g. outbound destination 0.0.0.0 = block) 
2. configure new rclone endpoint "test-s3"
3. run `rclone ls test-s3:`

*ACTUAL RESULTS* 
rclone hangs

*EXPECTED RESULTS* 
Files listed are visible

``` 
go run . ls s3-test:|head -1
502256548864 tonym-backup/2021-12-29/archive2.tar
```
#### Testing This Change
1. Checkout this commit
2. set `use_dual_stack=true` in rclone.conf (see below)
2. Set up your rclone machine to block IPv4 (see STEPS TO REPRODUCE)
4. `go run . ls test-s3:` 


```
grep dual_stack~/.config/rclone/rclone.conf 
use_dual_stack= true
```

#### Testing S3 Default & DualStack endpoints

Example S3 queries to default & dual-stack endpoints for example
```
$ dig +short AAA s3.us-west-2.amazonaws.com|head -1
52.92.234.56
$ dig +short AAAA s3.us-west-2.amazonaws.com|head -1
# no answer

``` 
Dualstack (both IPv4 & IPv6 lookup work) 
```
# 
 dig +short AAAA s3.dualstack.us-west-2.amazonaws.com |head -1
2600:1fa0:403f:aa89:345c:c3b8::
$ dig +short A s3.dualstack.us-west-2.amazonaws.com |head -1
52.92.243.184
```
#### Was the change discussed in an issue or in the forum before?
https://forum.rclone.org/t/ipv6-guide-review-with-google-drive-ec2-s3/43218

IPv6 Support Could Use Attention...
1. ✅--bind to IPv6
2. ❌oauth using IPv6 (::1) 
3. (this PR) ❌Connect to S3 endpoint on IPv6 
4. ✅ Connect to Google Drive API endpoint on IPv6 (once authorized )
5. ❓Connect to other backend endpoints on IPv6 

I recommend dumping all rclone endpoints and testing `dig AAAA` to see which ones currently support IPv6.

<!--
Link issues and relevant forum posts here.
-->
#### Unit Testing
I've added test coverage s3.go covering enable/disable dualstack config
```
 cd backend/s3 ; go test .
ok      github.com/rclone/rclone/backend/s3     (cached)
```

no broken tests
```
 go test ./...

ok      github.com/rclone/rclone/backend/alias  0.023s
ok      github.com/rclone/rclone/backend/azureblob      0.024s
ok      github.com/rclone/rclone/backend/azurefiles     0.032s
# truncated
```

 
#### Checklist

- [✅ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [✅ ] I have added tests for all changes in this PR if appropriate.
- [✅ ] I have added documentation for the changes if appropriate.
- [✅ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [✅ ] I'm done, this Pull Request is ready for review :-)

