### PR TITLE
Doc change: Add the CreateBucket permission requirement for AWS S3

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -590,6 +590,7 @@ permissions are required to be available on the bucket being written to:
 * `GetObject`
 * `PutObject`
 * `PutObjectACL`
+* `CreateBucket` (unless using [s3-no-check-bucket](#s3-no-check-bucket))
 
 When using the `lsd` subcommand, the `ListAllMyBuckets` permission is required.
 
@@ -631,6 +632,7 @@ Notes on above:
    that `USER_NAME` has been created.
 2. The Resource entry must include both resource ARNs, as one implies
    the bucket and the other implies the bucket's objects.
+3. When using [s3-no-check-bucket](#s3-no-check-bucket) and the bucket already exsits, the `"arn:aws:s3:::BUCKET_NAME"` doesn't have to be included.
 
 For reference, [here's an Ansible script](https://gist.github.com/ebridges/ebfc9042dd7c756cd101cfa807b7ae2b)
 that will generate one or more buckets that will work with `rclone sync`.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### There is another permission required for AWS S3 access. I update the doc with the relevant changes.

<!--
Describe the changes here
-->

It was discussed here:
https://forum.rclone.org/t/s3-rclone-v-1-52-0-or-after-permission-denied/21961
But this was not written in the docs. It took me quite few hours to overcome this issue. I didn't know the "permission denied" reason. In the end, I had to use CloudTrail to find out what exactly rclone was trying to do. Then I googled it and only then found the above forum link.
(personally, I added the flag. But this is up to the user to decide what to do)

In my opinion, it should be part of the docs (maybe even with a link to the forum).

Thanks!
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
