### PR TITLE
Support WebDAV headers with CORS

### DIFF
--- a/cmd/serve/webdav/webdav.go
+++ b/cmd/serve/webdav/webdav.go
@@ -240,6 +240,7 @@ func newWebDAV(ctx context.Context, f fs.Fs, opt *Options) (w *WebDAV, err error
 	return w, nil
 }
 
+// Add WebDAV-specific methods and headers for CORS.
 func MiddlewareCORS(allowOrigin string) libhttp.Middleware {
 
 	return func(next http.Handler) http.Handler {

--- a/cmd/serve/webdav/webdav.go
+++ b/cmd/serve/webdav/webdav.go
@@ -240,7 +240,7 @@ func newWebDAV(ctx context.Context, f fs.Fs, opt *Options) (w *WebDAV, err error
 	return w, nil
 }
 
-// Add WebDAV-specific methods and headers for CORS.
+// MiddlewareCORS adds WebDAV-specific methods and headers for CORS.
 func MiddlewareCORS(allowOrigin string) libhttp.Middleware {
 
 	return func(next http.Handler) http.Handler {

--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -183,8 +183,8 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
-				w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, TimeOut, Translate")
-				w.Header().Add("Access-Control-Allow-Methods", "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK")
+				w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
+				w.Header().Add("Access-Control-Request-Method", "POST, OPTIONS, GET, HEAD")
 			}
 
 			next.ServeHTTP(w, r)

--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -184,7 +184,7 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
 				w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
-				w.Header().Add("Access-Control-Request-Method", "POST, OPTIONS, GET, HEAD")
+				w.Header().Add("Access-Control-Allow-Methods", "POST, OPTIONS, GET, HEAD")
 			}
 
 			next.ServeHTTP(w, r)

--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -183,7 +183,7 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
-				w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
+				w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, TimeOut")
 				w.Header().Add("Access-Control-Allow-Methods", "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK")
 			}
 

--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -183,7 +183,7 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
-				w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, TimeOut")
+				w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, TimeOut, Translate")
 				w.Header().Add("Access-Control-Allow-Methods", "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK")
 			}
 


### PR DESCRIPTION
Fixes #7492

#### What is the purpose of this change?

Allow WebDAV headers when using CORS. 
WebDAV request parameters are sent through headers.

#### Was the change discussed in an issue or in the forum before?

It's a follow-up on previous fixes of WebDAV with CORS #7444, #7448. The direct issue is #7492.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
