### PR TITLE
webdav: WebDAV-specific methods and headers

### DIFF
--- a/cmd/serve/webdav/webdav.go
+++ b/cmd/serve/webdav/webdav.go
@@ -194,6 +194,10 @@ func newWebDAV(ctx context.Context, f fs.Fs, opt *Options) (w *WebDAV, err error
 		w._vfs = vfs.New(f, &vfsflags.Opt)
 	}
 
+	// WebDAV requires specific methods and headers.
+	w.opt.HTTP.CORSMethods = "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK"
+	w.opt.HTTP.CORSHeaders = "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, TimeOut, Translate"
+
 	w.Server, err = libhttp.NewServer(ctx,
 		libhttp.WithConfig(w.opt.HTTP),
 		libhttp.WithAuth(w.opt.Auth),

--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -166,9 +166,9 @@ func MiddlewareAuthCustom(fn CustomAuthFn, realm string, userFromContext bool) M
 var onlyOnceWarningAllowOrigin sync.Once
 
 // MiddlewareCORS instantiates middleware that handles basic CORS protections for rcd
-func MiddlewareCORS(allowOrigin string) Middleware {
+func MiddlewareCORS(cfg *Config) Middleware {
 	onlyOnceWarningAllowOrigin.Do(func() {
-		if allowOrigin == "*" {
+		if cfg.AllowOrigin == "*" {
 			fs.Logf(nil, "Warning: Allow origin set to *. This can cause serious security problems.")
 		}
 	})
@@ -181,10 +181,10 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 				return
 			}
 
-			if allowOrigin != "" {
-				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
-				w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
-				w.Header().Add("Access-Control-Allow-Methods", "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK")
+			if cfg.AllowOrigin != "" {
+				w.Header().Add("Access-Control-Allow-Origin", cfg.AllowOrigin)
+				w.Header().Add("Access-Control-Allow-Headers", cfg.CORSHeaders)
+				w.Header().Add("Access-Control-Allow-Methods", cfg.CORSMethods)
 			}
 
 			next.ServeHTTP(w, r)

--- a/lib/http/server.go
+++ b/lib/http/server.go
@@ -110,6 +110,8 @@ type Config struct {
 	ClientCA           string        // Client certificate authority to verify clients with
 	MinTLSVersion      string        // MinTLSVersion contains the minimum TLS version that is acceptable.
 	AllowOrigin        string        // AllowOrigin sets the Access-Control-Allow-Origin header
+	CORSMethods        string        // Methods to allow with CORS
+	CORSHeaders        string        // Headers to allow with CORS
 }
 
 // AddFlagsPrefix adds flags for the httplib
@@ -139,6 +141,8 @@ func DefaultCfg() Config {
 		ServerWriteTimeout: 1 * time.Hour,
 		MaxHeaderBytes:     4096,
 		MinTLSVersion:      "tls1.0",
+		CORSMethods:        "GET, HEAD, OPTIONS, POST",
+		CORSHeaders:        "Authorization, Content-Type",
 	}
 }
 
@@ -238,7 +242,7 @@ func NewServer(ctx context.Context, options ...Option) (*Server, error) {
 		return nil, err
 	}
 
-	s.mux.Use(MiddlewareCORS(s.cfg.AllowOrigin))
+	s.mux.Use(MiddlewareCORS(&s.cfg))
 
 	s.initAuth()
 


### PR DESCRIPTION
Fixes #7492

#### What is the purpose of this change?

Allow WebDAV headers when using CORS. 
WebDAV request parameters are sent through headers.

#### Was the change discussed in an issue or in the forum before?

This is new pull request instead of #7493 & #7494. The commits have been squashed and separated thematically.
It's a follow-up on previous fixes of WebDAV with CORS #7444, #7448. 
The direct issue (a problem encountered) is #7492.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
