### PR TITLE
bisync: normalize session name to non-canonical (and docs edits) - fixes #7423

### DIFF
--- a/cmd/bisync/bilib/canonical.go
+++ b/cmd/bisync/bilib/canonical.go
@@ -2,12 +2,15 @@
 package bilib
 
 import (
+	"context"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/operations"
 )
 
 // FsPath converts Fs to a suitable rclone argument
@@ -38,5 +41,57 @@ var nonCanonicalChars = regexp.MustCompile(`[\s\\/:?*]`)
 
 // SessionName makes a unique base name for the sync operation
 func SessionName(fs1, fs2 fs.Fs) string {
-	return CanonicalPath(FsPath(fs1)) + ".." + CanonicalPath(FsPath(fs2))
+	return StripHexString(CanonicalPath(FsPath(fs1))) + ".." + StripHexString(CanonicalPath(FsPath(fs2)))
+}
+
+// StripHexString strips the (first) canonical {hexstring} suffix
+func StripHexString(path string) string {
+	open := strings.IndexRune(path, '{')
+	close := strings.IndexRune(path, '}')
+	if open >= 0 && close > open {
+		return path[:open] + path[close+1:] // (trailing underscore)
+	}
+	return path
+}
+
+// HasHexString returns true if path contains at least one canonical {hexstring} suffix
+func HasHexString(path string) bool {
+	open := strings.IndexRune(path, '{')
+	if open >= 0 && strings.IndexRune(path, '}') > open {
+		return true
+	}
+	return false
+}
+
+// BasePath joins the workDir with the SessionName, stripping {hexstring} suffix if necessary
+func BasePath(ctx context.Context, workDir string, fs1, fs2 fs.Fs) string {
+	suffixedSession := CanonicalPath(FsPath(fs1)) + ".." + CanonicalPath(FsPath(fs2))
+	suffixedBasePath := filepath.Join(workDir, suffixedSession)
+	listing1 := suffixedBasePath + ".path1.lst"
+	listing2 := suffixedBasePath + ".path2.lst"
+
+	sessionName := SessionName(fs1, fs2)
+	basePath := filepath.Join(workDir, sessionName)
+
+	// Normalize to non-canonical version for overridden configs
+	// to ensure that backend-specific flags don't change the listing filename.
+	// For backward-compatibility, we first check if we found a listing file with the suffixed version.
+	// If so, we rename it (and overwrite non-suffixed version, if any.)
+	// If not, we carry on with the non-suffixed version.
+	// We should only find a suffixed version if bisync v1.66 or older created it.
+	if HasHexString(suffixedSession) && FileExists(listing1) {
+		fs.Infof(listing1, "renaming to: %s", basePath+".path1.lst")
+		if !operations.SkipDestructive(ctx, listing1, "rename to "+basePath+".path1.lst") {
+			_ = os.Rename(listing1, basePath+".path1.lst")
+		}
+	}
+	if HasHexString(suffixedSession) && FileExists(listing2) {
+		fs.Infof(listing2, "renaming to: %s", basePath+".path2.lst")
+		if !operations.SkipDestructive(ctx, listing1, "rename to "+basePath+".path2.lst") {
+			_ = os.Rename(listing2, basePath+".path2.lst")
+		} else {
+			return suffixedBasePath
+		}
+	}
+	return basePath
 }

--- a/cmd/bisync/cmd.go
+++ b/cmd/bisync/cmd.go
@@ -138,6 +138,7 @@ var commandDefinition = &cobra.Command{
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.58",
 		"groups":            "Filter,Copy,Important",
+		"status":            "Beta",
 	},
 	RunE: func(command *cobra.Command, args []string) error {
 		cmd.CheckArgs(2, 2, command, args)
@@ -163,7 +164,7 @@ var commandDefinition = &cobra.Command{
 			}
 		}
 
-		fs.Logf(nil, "bisync is EXPERIMENTAL. Don't use in production!")
+		fs.Logf(nil, "bisync is IN BETA. Don't use in production!")
 		cmd.Run(false, true, command, func() error {
 			err := Bisync(ctx, fs1, fs2, &opt)
 			if err == ErrBisyncAborted {

--- a/cmd/bisync/help.go
+++ b/cmd/bisync/help.go
@@ -56,5 +56,10 @@ On each successive run it will:
   Changes include |New|, |Newer|, |Older|, and |Deleted| files.
 - Propagate changes on Path1 to Path2, and vice-versa.
 
+Bisync is **in beta** and is considered an **advanced command**, so use with care.
+Make sure you have read and understood the entire [manual](https://rclone.org/bisync)
+(especially the [Limitations](https://rclone.org/bisync/#limitations) section) before using,
+or data loss can result. Questions can be asked in the [Rclone Forum](https://forum.rclone.org/).
+
 See [full bisync description](https://rclone.org/bisync/) for details.
 `)

--- a/cmd/bisync/operations.go
+++ b/cmd/bisync/operations.go
@@ -88,7 +88,7 @@ func Bisync(ctx context.Context, fs1, fs2 fs.Fs, optArg *Options) (err error) {
 	}
 
 	// Produce a unique name for the sync operation
-	b.basePath = filepath.Join(b.workDir, bilib.SessionName(b.fs1, b.fs2))
+	b.basePath = bilib.BasePath(ctx, b.workDir, b.fs1, b.fs2)
 	b.listing1 = b.basePath + ".path1.lst"
 	b.listing2 = b.basePath + ".path2.lst"
 	b.newListing1 = b.listing1 + "-new"

--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -614,19 +614,6 @@ and there is also a [known issue concerning Google Drive users with many empty d
 For now, the recommended way to avoid using `--fast-list` is to add `--disable ListR` 
 to all bisync commands. The default behavior may change in a future version.
 
-### Overridden Configs
-
-When rclone detects an overridden config, it adds a suffix like `{ABCDE}` on the fly 
-to the internal name of the remote. Bisync follows suit by including this suffix in its listing filenames. 
-However, this suffix does not necessarily persist from run to run, especially if different flags are provided. 
-So if next time the suffix assigned is `{FGHIJ}`, bisync will get confused, 
-because it's looking for a listing file with `{FGHIJ}`, when the file it wants has `{ABCDE}`. 
-As a result, it throws 
-`Bisync critical error: cannot find prior Path1 or Path2 listings, likely due to critical error on prior run` 
-and refuses to run again until the user runs a `--resync` (unless using `--resilient`). 
-The best workaround at the moment is to set any backend-specific flags in the [config file](/commands/rclone_config/) 
-instead of specifying them with command flags. (You can still override them as needed for other rclone commands.)
-
 ### Case (and unicode) sensitivity {#case-sensitivity}
 
 As of `v1.66`, case and unicode form differences no longer cause critical errors,
@@ -973,10 +960,6 @@ skip them.) To work around this, use the default (modtime and size) instead of
 
 To ignore Google Docs entirely, use
 [`--drive-skip-gdocs`](/drive/#drive-skip-gdocs).
-
-(Note that all flags starting with `--drive` are backend-specific, and
-therefore will cause the behavior explained in [Overridden
-Configs](/#overridden-configs).)
 
 ## Usage examples
 
@@ -1369,6 +1352,7 @@ for performance improvements and less [risk of error](https://forum.rclone.org/t
 * Google Docs (and other files of unknown size) are now supported (with the same options as in `sync`)
 * Equality checks before a sync conflict rename now fall back to `cryptcheck` (when possible) or `--download`,
 instead of of `--size-only`, when `check` is not available.
+* Bisync no longer fails to find the correct listing file when configs are overridden with backend-specific flags.
 
 ### `v1.64`
 * Fixed an [issue](https://forum.rclone.org/t/bisync-bugs-and-feature-requests/37636#:~:text=1.%20Dry%20runs%20are%20not%20completely%20dry) 

--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -361,7 +361,7 @@ Behavior of `--resilient` may change in a future version.
 
 #### --backup-dir1 and --backup-dir2
 
-As of `v1.65`, [`--backup-dir`](/docs/#backup-dir-dir) is supported in bisync.
+As of `v1.66`, [`--backup-dir`](/docs/#backup-dir-dir) is supported in bisync.
 Because `--backup-dir` must be a non-overlapping path on the same remote,
 Bisync has introduced new `--backup-dir1` and `--backup-dir2` flags to support
 separate backup-dirs for `Path1` and `Path2` (bisyncing between different
@@ -559,9 +559,9 @@ original path on the next sync, resulting in data loss.
 It is therefore recommended to _omit_ `--inplace`.
 
 Files that **change during** a bisync run may result in data loss.
-Prior to `rclone v1.65`, this was commonly seen in highly dynamic environments, where the filesystem
+Prior to `rclone v1.66`, this was commonly seen in highly dynamic environments, where the filesystem
 was getting hammered by running processes during the sync.
-As of `rclone v1.65`, bisync was redesigned to use a "snapshot" model,
+As of `rclone v1.66`, bisync was redesigned to use a "snapshot" model,
 greatly reducing the risks from changes during a sync.
 Changes that are not detected during the current sync will now be detected during the following sync,
 and will no longer cause the entire run to throw a critical error.
@@ -596,7 +596,7 @@ Bisync sees this as all files in the old directory name as deleted and all
 files in the new directory name as new. 
 
 A recommended solution is to use [`--track-renames`](/docs/#track-renames),
-which is now supported in bisync as of `rclone v1.65`.
+which is now supported in bisync as of `rclone v1.66`.
 Note that `--track-renames` is not available during `--resync`,
 as `--resync` does not delete anything (`--track-renames` only supports `sync`, not `copy`.)
 
@@ -629,7 +629,7 @@ instead of specifying them with command flags. (You can still override them as n
 
 ### Case (and unicode) sensitivity {#case-sensitivity}
 
-As of `v1.65`, case and unicode form differences no longer cause critical errors,
+As of `v1.66`, case and unicode form differences no longer cause critical errors,
 and normalization (when comparing between filesystems) is handled according to the same flags and defaults as `rclone sync`.
 See the following options (all of which are supported by bisync) to control this behavior more granularly:
 - [`--fix-case`](/docs/#fix-case)
@@ -923,7 +923,7 @@ consider using the flag
 
 ### Google Docs (and other files of unknown size) {#gdocs}
 
-As of `v1.65`, [Google Docs](/drive/#import-export-of-google-documents)
+As of `v1.66`, [Google Docs](/drive/#import-export-of-google-documents)
 (including Google Sheets, Slides, etc.) are now supported in bisync, subject to
 the same options, defaults, and limitations as in `rclone sync`. When bisyncing
 drive with non-drive backends, the drive -> non-drive direction is controlled
@@ -1354,7 +1354,7 @@ about _Unison_ and synchronization in general.
 
 ## Changelog
 
-### `v1.65`
+### `v1.66`
 * Copies and deletes are now handled in one operation instead of two
 * `--track-renames` and `--backup-dir` are now supported
 * Partial uploads known issue on `local`/`ftp`/`sftp` has been resolved (unless using `--inplace`)

--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -2,7 +2,12 @@
 title: "Bisync"
 description: "Bidirectional cloud sync solution in rclone"
 versionIntroduced: "v1.58"
+status: Beta
 ---
+
+## Bisync
+`bisync` is **in beta** and is considered an **advanced command**, so use with care.
+Make sure you have read and understood the entire [manual](https://rclone.org/bisync) (especially the [Limitations](#limitations) section) before using, or data loss can result. Questions can be asked in the [Rclone Forum](https://forum.rclone.org/).
 
 ## Getting started {#getting-started}
 


### PR DESCRIPTION
(This PR is dependent on #7410 -- only 3 of the commits are new 🙂 )

#### What is the purpose of this change?

Before this change, bisync used the "canonical" Fs name in the filename for its listing files, including any {hexstring} suffix. An unintended consequence of this was that if a user added a backend-specific flag from the command line (thus "overriding" the config), bisync would fail to find the listing files it created during the prior run without this flag, due to the path now having a {hexstring} suffix that wasn't there before (or vice versa, if the flag was present when the session was established, and later removed.) This would sometimes cause bisync to fail with a critical error (if no listing existed with the alternate name), or worse -- it would sometimes cause bisync to use an old, incorrect listing (if old listings with the alternate name DID still exist, from before the user changed their flags.) 

After this change, the issue is fixed by always normalizing the SessionName to the non-canonical version (no {hexstring} suffix), regardless of the flags. To avoid a breaking change, we first check if a suffixed listing exists. If so, we rename it (and overwrite the non-suffixed version, if any.) If not, we carry on with the non-suffixed version. (We should only find a suffixed version if created prior to this commit.) 

The result for the user is that the same pair of paths will always use the same .lst filenames, with or without backend-specific flags.

#### Was the change discussed in an issue or in the forum before?

- #7423
- [Forum post](https://forum.rclone.org/t/bisync-bugs-and-feature-requests/37636#:~:text=7.%20Overridden%20config%20can%20cause%20bisync%20critical%20error%20requiring%20%2D%2Dresync)
- [User Report](https://forum.rclone.org/t/bisync-missed-syncing-changed-file-no-error-no-warning/41174/6?u=nielash)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
