### PR TITLE
bisync: Graceful Shutdown, --recover from interruptions without --resync

### DIFF
--- a/cmd/bisync/cmd.go
+++ b/cmd/bisync/cmd.go
@@ -48,10 +48,12 @@ type Options struct {
 	SaveQueues            bool // save extra debugging files (test only flag)
 	IgnoreListingChecksum bool
 	Resilient             bool
+	Recover               bool
 	TestFn                TestFunc // test-only option, for mocking errors
 	Retries               int
 	Compare               CompareOpt
 	CompareFlag           string
+	DebugName             string
 }
 
 // Default values
@@ -125,10 +127,12 @@ func init() {
 	flags.StringVarP(cmdFlags, &Opt.Workdir, "workdir", "", Opt.Workdir, makeHelp("Use custom working dir - useful for testing. (default: {WORKDIR})"), "")
 	flags.StringVarP(cmdFlags, &Opt.BackupDir1, "backup-dir1", "", Opt.BackupDir1, "--backup-dir for Path1. Must be a non-overlapping path on the same remote.", "")
 	flags.StringVarP(cmdFlags, &Opt.BackupDir2, "backup-dir2", "", Opt.BackupDir2, "--backup-dir for Path2. Must be a non-overlapping path on the same remote.", "")
+	flags.StringVarP(cmdFlags, &Opt.DebugName, "debugname", "", Opt.DebugName, "Debug by tracking one file at various points throughout a bisync run (when -v or -vv)", "")
 	flags.BoolVarP(cmdFlags, &tzLocal, "localtime", "", tzLocal, "Use local time in listings (default: UTC)", "")
 	flags.BoolVarP(cmdFlags, &Opt.NoCleanup, "no-cleanup", "", Opt.NoCleanup, "Retain working files (useful for troubleshooting and testing).", "")
 	flags.BoolVarP(cmdFlags, &Opt.IgnoreListingChecksum, "ignore-listing-checksum", "", Opt.IgnoreListingChecksum, "Do not use checksums for listings (add --ignore-checksum to additionally skip post-copy checksum checks)", "")
 	flags.BoolVarP(cmdFlags, &Opt.Resilient, "resilient", "", Opt.Resilient, "Allow future runs to retry after certain less-serious errors, instead of requiring --resync. Use at your own risk!", "")
+	flags.BoolVarP(cmdFlags, &Opt.Recover, "recover", "", Opt.Recover, "Automatically recover from interruptions without requiring --resync.", "")
 	flags.IntVarP(cmdFlags, &Opt.Retries, "retries", "", Opt.Retries, "Retry operations this many times if they fail", "")
 	flags.StringVarP(cmdFlags, &Opt.CompareFlag, "compare", "", Opt.CompareFlag, "Comma-separated list of bisync-specific compare options ex. 'size,modtime,checksum' (default: 'size,modtime')", "")
 	flags.BoolVarP(cmdFlags, &Opt.Compare.NoSlowHash, "no-slow-hash", "", Opt.Compare.NoSlowHash, "Ignore listing checksums only on backends where they are slow", "")

--- a/cmd/bisync/cmd.go
+++ b/cmd/bisync/cmd.go
@@ -54,6 +54,7 @@ type Options struct {
 	Compare               CompareOpt
 	CompareFlag           string
 	DebugName             string
+	MaxLock               time.Duration
 }
 
 // Default values
@@ -112,6 +113,7 @@ var Opt Options
 
 func init() {
 	Opt.Retries = 3
+	Opt.MaxLock = 0
 	cmd.Root.AddCommand(commandDefinition)
 	cmdFlags := commandDefinition.Flags()
 	// when adding new flags, remember to also update the rc params:
@@ -138,6 +140,7 @@ func init() {
 	flags.BoolVarP(cmdFlags, &Opt.Compare.NoSlowHash, "no-slow-hash", "", Opt.Compare.NoSlowHash, "Ignore listing checksums only on backends where they are slow", "")
 	flags.BoolVarP(cmdFlags, &Opt.Compare.SlowHashSyncOnly, "slow-hash-sync-only", "", Opt.Compare.SlowHashSyncOnly, "Ignore slow checksums for listings and deltas, but still consider them during sync calls.", "")
 	flags.BoolVarP(cmdFlags, &Opt.Compare.DownloadHash, "download-hash", "", Opt.Compare.DownloadHash, "Compute hash by downloading when otherwise unavailable. (warning: may be slow and use lots of data!)", "")
+	flags.DurationVarP(cmdFlags, &Opt.MaxLock, "max-lock", "", Opt.MaxLock, "Consider lock files older than this to be expired (default: 0 (never expire)) (minimum: 2m)", "")
 }
 
 // bisync command definition

--- a/cmd/bisync/listing.go
+++ b/cmd/bisync/listing.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/rclone/rclone/cmd/bisync/bilib"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/accounting"
 	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
@@ -368,6 +369,12 @@ func (b *bisyncRun) replaceCurrentListings() {
 	b.handleErr(b.newListing2, "error replacing Path2 listing", bilib.CopyFileIfExists(b.newListing2, b.listing2), true, true)
 }
 
+// revertToOldListings reverts to the most recent successful listing
+func (b *bisyncRun) revertToOldListings() {
+	b.handleErr(b.listing1, "error reverting to old Path1 listing", bilib.CopyFileIfExists(b.listing1+"-old", b.listing1), true, true)
+	b.handleErr(b.listing2, "error reverting to old Path2 listing", bilib.CopyFileIfExists(b.listing2+"-old", b.listing2), true, true)
+}
+
 func parseHash(str string) (string, string, error) {
 	if str == "-" {
 		return "", "", nil
@@ -497,6 +504,12 @@ func (b *bisyncRun) modifyListing(ctx context.Context, src fs.Fs, dst fs.Fs, res
 			dstList.hash = hash.MD5
 		}
 	}
+
+	b.debugFn(b.DebugName, func() {
+		var rs ResultsSlice = results
+		b.debug(b.DebugName, fmt.Sprintf("modifyListing direction: %s, results has name?: %v", direction, rs.has(b.DebugName)))
+		b.debug(b.DebugName, fmt.Sprintf("modifyListing direction: %s, srcList has name?: %v, dstList has name?: %v", direction, srcList.has(b.DebugName), dstList.has(b.DebugName)))
+	})
 
 	srcWinners := newFileList()
 	dstWinners := newFileList()
@@ -657,6 +670,55 @@ func (b *bisyncRun) modifyListing(ctx context.Context, src fs.Fs, dst fs.Fs, res
 		b.recheck(ctxRecheck, src, dst, srcList, dstList, is1to2)
 	}
 
+	if b.InGracefulShutdown {
+		var toKeep []string
+		var toRollback []string
+		fs.Debugf(direction, "stats for %s", direction)
+		trs := accounting.Stats(ctx).Transferred()
+		for _, tr := range trs {
+			b.debugFn(tr.Name, func() {
+				prettyprint(tr, tr.Name, fs.LogLevelInfo)
+			})
+			if tr.Error == nil && tr.Bytes > 0 || tr.Size <= 0 {
+				prettyprint(tr, "keeping: "+tr.Name, fs.LogLevelDebug)
+				toKeep = append(toKeep, tr.Name)
+			}
+		}
+		// Dirs (for the unlikely event that the shutdown was triggered post-sync during syncEmptyDirs)
+		for _, r := range results {
+			if r.Origin == "syncEmptyDirs" {
+				if srcWinners.has(r.Name) || dstWinners.has(r.Name) {
+					toKeep = append(toKeep, r.Name)
+					fs.Infof(r.Name, "keeping empty dir")
+				}
+			}
+		}
+		oldSrc, oldDst := b.getOldLists(is1to2)
+		prettyprint(oldSrc.list, "oldSrc", fs.LogLevelDebug)
+		prettyprint(oldDst.list, "oldDst", fs.LogLevelDebug)
+		prettyprint(srcList.list, "srcList", fs.LogLevelDebug)
+		prettyprint(dstList.list, "dstList", fs.LogLevelDebug)
+		combinedList := Concat(oldSrc.list, oldDst.list, srcList.list, dstList.list)
+		for _, f := range combinedList {
+			if !slices.Contains(toKeep, f) && !slices.Contains(toKeep, b.aliases.Alias(f)) && !b.opt.DryRun {
+				toRollback = append(toRollback, f)
+			}
+		}
+		b.prepareRollback(toRollback, srcList, dstList, is1to2)
+		prettyprint(oldSrc.list, "oldSrc", fs.LogLevelDebug)
+		prettyprint(oldDst.list, "oldDst", fs.LogLevelDebug)
+		prettyprint(srcList.list, "srcList", fs.LogLevelDebug)
+		prettyprint(dstList.list, "dstList", fs.LogLevelDebug)
+
+		// clear stats so we only do this once
+		accounting.MaxCompletedTransfers = 0
+		accounting.Stats(ctx).PruneTransfers()
+	}
+
+	if b.DebugName != "" {
+		b.debug(b.DebugName, fmt.Sprintf("%s pre-save srcList has it?: %v", direction, srcList.has(b.DebugName)))
+		b.debug(b.DebugName, fmt.Sprintf("%s pre-save dstList has it?: %v", direction, dstList.has(b.DebugName)))
+	}
 	// update files
 	err = srcList.save(ctx, srcListing)
 	b.handleErr(srcList, "error saving srcList from modifyListing", err, true, true)
@@ -737,8 +799,8 @@ func (b *bisyncRun) recheck(ctxRecheck context.Context, src, dst fs.Fs, srcList,
 		}
 
 		for _, item := range toRollback {
-			rollback(item, oldSrc, srcList)
-			rollback(item, oldDst, dstList)
+			b.rollback(item, oldSrc, srcList)
+			b.rollback(item, oldDst, dstList)
 		}
 	}
 }
@@ -750,10 +812,72 @@ func (b *bisyncRun) getListingNames(is1to2 bool) (srcListing string, dstListing 
 	return b.listing2, b.listing1
 }
 
-func rollback(item string, oldList, newList *fileList) {
+func (b *bisyncRun) rollback(item string, oldList, newList *fileList) {
+	alias := b.aliases.Alias(item)
 	if oldList.has(item) {
 		oldList.getPut(item, newList)
+		fs.Debugf(nil, "adding to newlist: %s", item)
+	} else if oldList.has(alias) {
+		oldList.getPut(alias, newList)
+		fs.Debugf(nil, "adding to newlist: %s", alias)
 	} else {
+		fs.Debugf(nil, "removing from newlist: %s (has it?: %v)", item, newList.has(item))
+		prettyprint(newList.list, "newList", fs.LogLevelDebug)
 		newList.remove(item)
+		newList.remove(alias)
 	}
+}
+
+func (b *bisyncRun) prepareRollback(toRollback []string, srcList, dstList *fileList, is1to2 bool) {
+	if len(toRollback) > 0 {
+		oldSrc, oldDst := b.getOldLists(is1to2)
+		if b.critical {
+			return
+		}
+
+		fs.Debugf("new lists", "src: (%v), dest: (%v)", len(srcList.list), len(dstList.list))
+
+		for _, item := range toRollback {
+			b.debugFn(item, func() {
+				b.debug(item, fmt.Sprintf("pre-rollback oldSrc has it?: %v", oldSrc.has(item)))
+				b.debug(item, fmt.Sprintf("pre-rollback oldDst has it?: %v", oldDst.has(item)))
+				b.debug(item, fmt.Sprintf("pre-rollback srcList has it?: %v", srcList.has(item)))
+				b.debug(item, fmt.Sprintf("pre-rollback dstList has it?: %v", dstList.has(item)))
+			})
+			b.rollback(item, oldSrc, srcList)
+			b.rollback(item, oldDst, dstList)
+			b.debugFn(item, func() {
+				b.debug(item, fmt.Sprintf("post-rollback oldSrc has it?: %v", oldSrc.has(item)))
+				b.debug(item, fmt.Sprintf("post-rollback oldDst has it?: %v", oldDst.has(item)))
+				b.debug(item, fmt.Sprintf("post-rollback srcList has it?: %v", srcList.has(item)))
+				b.debug(item, fmt.Sprintf("post-rollback dstList has it?: %v", dstList.has(item)))
+			})
+		}
+	}
+}
+
+func (b *bisyncRun) getOldLists(is1to2 bool) (*fileList, *fileList) {
+	srcListing, dstListing := b.getListingNames(is1to2)
+	oldSrc, err := b.loadListing(srcListing + "-old")
+	b.handleErr(oldSrc, "error loading old src listing", err, true, true)
+	oldDst, err := b.loadListing(dstListing + "-old")
+	b.handleErr(oldDst, "error loading old dst listing", err, true, true)
+	fs.Debugf("get old lists", "is1to2: %v, oldsrc: %s (%v), olddest: %s (%v)", is1to2, srcListing+"-old", len(oldSrc.list), dstListing+"-old", len(oldDst.list))
+	return oldSrc, oldDst
+}
+
+// Concat returns a new slice concatenating the passed in slices.
+func Concat[S ~[]E, E any](ss ...S) S {
+	size := 0
+	for _, s := range ss {
+		size += len(s)
+		if size < 0 {
+			panic("len out of range")
+		}
+	}
+	newslice := slices.Grow[S](nil, size)
+	for _, s := range ss {
+		newslice = append(newslice, s...)
+	}
+	return newslice
 }

--- a/cmd/bisync/lockfile.go
+++ b/cmd/bisync/lockfile.go
@@ -1,0 +1,154 @@
+package bisync
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/rclone/rclone/cmd/bisync/bilib"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/lib/terminal"
+)
+
+const basicallyforever = 200 * 365 * 24 * time.Hour
+
+var stopRenewal func()
+
+var data = struct {
+	Session     string
+	PID         string
+	TimeRenewed time.Time
+	TimeExpires time.Time
+}{}
+
+func (b *bisyncRun) setLockFile() error {
+	b.lockFile = ""
+	b.setLockFileExpiration()
+	if !b.opt.DryRun {
+		b.lockFile = b.basePath + ".lck"
+		if bilib.FileExists(b.lockFile) {
+			if !b.lockFileIsExpired() {
+				errTip := Color(terminal.MagentaFg, "Tip: this indicates that another bisync run (of these same paths) either is still running or was interrupted before completion. \n")
+				errTip += Color(terminal.MagentaFg, "If you're SURE you want to override this safety feature, you can delete the lock file with the following command, then run bisync again: \n")
+				errTip += fmt.Sprintf(Color(terminal.HiRedFg, "rclone deletefile \"%s\""), b.lockFile)
+				return fmt.Errorf(Color(terminal.RedFg, "prior lock file found: %s \n")+errTip, Color(terminal.HiYellowFg, b.lockFile))
+			}
+		}
+
+		pidStr := []byte(strconv.Itoa(os.Getpid()))
+		if err = os.WriteFile(b.lockFile, pidStr, bilib.PermSecure); err != nil {
+			return fmt.Errorf(Color(terminal.RedFg, "cannot create lock file: %s: %w"), b.lockFile, err)
+		}
+		fs.Debugf(nil, "Lock file created: %s", b.lockFile)
+		b.renewLockFile()
+		stopRenewal = b.startLockRenewal()
+	}
+	return nil
+}
+
+func (b *bisyncRun) removeLockFile() {
+	if b.lockFile != "" {
+		stopRenewal()
+		errUnlock := os.Remove(b.lockFile)
+		if errUnlock == nil {
+			fs.Debugf(nil, "Lock file removed: %s", b.lockFile)
+		} else if err == nil {
+			err = errUnlock
+		} else {
+			fs.Errorf(nil, "cannot remove lockfile %s: %v", b.lockFile, errUnlock)
+		}
+		b.lockFile = "" // block removing it again
+	}
+}
+
+func (b *bisyncRun) setLockFileExpiration() {
+	if b.opt.MaxLock > 0 && b.opt.MaxLock < 2*time.Minute {
+		fs.Logf(nil, Color(terminal.YellowFg, "--max-lock cannot be shorter than 2 minutes (unless 0.) Changing --max-lock from %v to %v"), b.opt.MaxLock, 2*time.Minute)
+		b.opt.MaxLock = 2 * time.Minute
+	} else if b.opt.MaxLock <= 0 {
+		b.opt.MaxLock = basicallyforever
+	}
+}
+
+func (b *bisyncRun) renewLockFile() {
+	if b.lockFile != "" && bilib.FileExists(b.lockFile) {
+
+		data.Session = b.basePath
+		data.PID = strconv.Itoa(os.Getpid())
+		data.TimeRenewed = time.Now()
+		data.TimeExpires = time.Now().Add(b.opt.MaxLock)
+
+		// save data file
+		df, err := os.Create(b.lockFile)
+		b.handleErr(b.lockFile, "error renewing lock file", err, true, true)
+		b.handleErr(b.lockFile, "error encoding JSON to lock file", json.NewEncoder(df).Encode(data), true, true)
+		b.handleErr(b.lockFile, "error closing lock file", df.Close(), true, true)
+		if b.opt.MaxLock < basicallyforever {
+			fs.Infof(nil, Color(terminal.HiBlueFg, "lock file renewed for %v. New expiration: %v"), b.opt.MaxLock, data.TimeExpires)
+		}
+	}
+}
+
+func (b *bisyncRun) lockFileIsExpired() bool {
+	if b.lockFile != "" && bilib.FileExists(b.lockFile) {
+		rdf, err := os.Open(b.lockFile)
+		b.handleErr(b.lockFile, "error reading lock file", err, true, true)
+		dec := json.NewDecoder(rdf)
+		for {
+			if err := dec.Decode(&data); err == io.EOF {
+				break
+			}
+		}
+		b.handleErr(b.lockFile, "error closing file", rdf.Close(), true, true)
+		if !data.TimeExpires.IsZero() && data.TimeExpires.Before(time.Now()) {
+			fs.Infof(b.lockFile, Color(terminal.GreenFg, "Lock file found, but it expired at %v. Will delete it and proceed."), data.TimeExpires)
+			markFailed(b.listing1) // listing is untrusted so force revert to prior (if --recover) or create new ones (if --resync)
+			markFailed(b.listing2)
+			return true
+		}
+		fs.Infof(b.lockFile, Color(terminal.RedFg, "Valid lock file found. Expires at %v. (%v from now)"), data.TimeExpires, time.Since(data.TimeExpires).Abs().Round(time.Second))
+		prettyprint(data, "Lockfile info", fs.LogLevelInfo)
+	}
+	return false
+}
+
+// StartLockRenewal renews the lockfile every --max-lock minus one minute.
+//
+// It returns a func which should be called to stop the renewal.
+func (b *bisyncRun) startLockRenewal() func() {
+	if b.opt.MaxLock <= 0 || b.opt.MaxLock >= basicallyforever || b.lockFile == "" {
+		return func() {}
+	}
+	stopLockRenewal := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ticker := time.NewTicker(b.opt.MaxLock - time.Minute)
+		for {
+			select {
+			case <-ticker.C:
+				b.renewLockFile()
+			case <-stopLockRenewal:
+				ticker.Stop()
+				return
+			}
+		}
+	}()
+	return func() {
+		close(stopLockRenewal)
+		wg.Wait()
+	}
+}
+
+func markFailed(file string) {
+	failFile := file + "-err"
+	if bilib.FileExists(file) {
+		_ = os.Remove(failFile)
+		_ = os.Rename(file, failFile)
+	}
+}

--- a/cmd/bisync/march.go
+++ b/cmd/bisync/march.go
@@ -48,6 +48,7 @@ func (b *bisyncRun) makeMarchListing(ctx context.Context) (*fileList, *fileList,
 	if err != nil {
 		b.handleErr("march", "error during march", err, true, true)
 		b.abort = true
+		return ls1, ls2, err
 	}
 
 	// save files
@@ -160,7 +161,7 @@ func (b *bisyncRun) ForObject(o fs.Object, isPath1 bool) {
 	if b.opt.Compare.Modtime {
 		modtime = o.ModTime(marchCtx).In(TZ)
 	}
-	id := ""     // TODO
+	id := ""     // TODO: ID(o)
 	flags := "-" // "-" for a file and "d" for a directory
 	marchLsLock.Lock()
 	ls.put(o.Remote(), o.Size(), modtime, hashVal, id, flags)
@@ -234,4 +235,13 @@ func (b *bisyncRun) findCheckFiles(ctx context.Context) (*fileList, *fileList, e
 	}
 
 	return ls1, ls2, err
+}
+
+// ID returns the ID of the Object if known, or "" if not
+func ID(o fs.Object) string {
+	do, ok := o.(fs.IDer)
+	if !ok {
+		return ""
+	}
+	return do.ID()
 }


### PR DESCRIPTION
(This PR is dependent on #7410, #7497, and #7498 -- only 2 commits are new 🙂 )

#### What is the purpose of this change?

Before this change, bisync had no mechanism to gracefully cancel a sync early and exit in a clean state. Additionally, there was no way to recover on the next run -- any interruption at all would cause bisync to require a --resync, which made bisync more difficult to use as a scheduled background process. 

This change introduces a "Graceful Shutdown" mode and --recover flag to robustly recover from even un-graceful shutdowns. Details are documented thoroughly in the commit messages, and [the docs](https://github.com/nielash/rclone/blob/bisync-recover/docs/content/bisync.md#--recover).

#### Was the change discussed in an issue or in the forum before?

- #7470
- #7332
- [How to reduce need for bisync::resync?](https://forum.rclone.org/t/how-to-reduce-need-for-bisync-resync/31067)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
