### PR TITLE
Fix to show the size occupied by a directory in onedrive.

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -1213,6 +1213,7 @@ func (f *Fs) itemToDirEntry(ctx context.Context, dir string, info *api.Item) (en
 		id := info.GetID()
 		f.dirCache.Put(remote, id)
 		d := fs.NewDir(remote, time.Time(info.GetLastModifiedDateTime())).SetID(id)
+		d.SetSize(info.GetSize())
 		d.SetItems(folder.ChildCount)
 		entry = d
 	} else {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

When running the rclone lsd command with the onedrive target, the size occupied by the directory was showing as -1.

So, I went through the code and changed it to set the value of size when item is converted to entry, so that the size is displayed.

In my opinion, it's better to display the size of the directory as displayed by the storage provider rather than having to recursively traverse the directory to get the size.

After patching and running, the size of the directory is displayed as below, which was originally displayed as -1.

```bash
$ rclone lsd onedrive:test
           0 2023-10-25 11:41:44         0 secret
  2646204760 2023-11-29 12:15:34         1 test
828450359073 2023-11-28 19:25:31       134 video
```

```bash
$ rclone rcd --rc-no-auth &
$ curl -X POST 'http://localhost:5572/operations/list?fs=onedrive:&remote=test' 
{
        "list": [
                {
                        "Path": "secret",
                        "Name": "secret",
                        "Size": 0,
                        "MimeType": "inode/directory",
                        "ModTime": "2023-10-25T02:41:44Z",
                        "IsDir": true,
                        "ID": "b!M...DDYKT"
                },
                {
                        "Path": "test",
                        "Name": "test",
                        "Size": 2646204760,
                        "MimeType": "inode/directory",
                        "ModTime": "2023-11-29T03:15:34Z",
                        "IsDir": true,
                        "ID": "b!M0...R3IML"
                },
                {
                        "Path": "video",
                        "Name": "video",
                        "Size": 828450359073,
                        "MimeType": "inode/directory",
                        "ModTime": "2023-11-28T10:25:31Z",
                        "IsDir": true,
                        "ID": "b!M...D7IJQ"
                }
        ]
}
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
