### PR TITLE
s3 object storage: fix for silent bucket creation fail

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -4321,12 +4321,17 @@ func (f *Fs) makeBucket(ctx context.Context, bucket string) error {
 		}
 		err := f.pacer.Call(func() (bool, error) {
 			_, err := f.c.CreateBucketWithContext(ctx, &req)
-			return f.shouldRetry(ctx, err)
+			if err != nil {
+				fmt.Printf("CreateBucket error: %v\n", err)
+				return f.shouldRetry(ctx, err)
+			}
+			return false, nil
 		})
 		if err == nil {
 			fs.Infof(f, "Bucket %q created with ACL %q", bucket, f.opt.BucketACL)
 		}
 		if awsErr, ok := err.(awserr.Error); ok {
+			fmt.Printf("AWS Error: %v\n", awsErr)
 			switch awsErr.Code() {
 			case "BucketAlreadyOwnedByYou":
 				err = nil


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

When creating a bucket that already exists rclone silently fails. This throws an error so that the user knows

#### Was the change discussed in an issue or in the forum before?
Didn't see it discussed anywhere

#### Additional Note
I'm not sure if the return statements are correct like this. Everything works, but someone should check just in case.
Didn't find an issue for it, but since this is a small fix I didn't want to add one unnecessary. I don't think a unit test is necessary or easily possible, but if it is I would add one...

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
