### PR TITLE
quatrix: fix pointing to the wrong root

### DIFF
--- a/backend/quatrix/quatrix.go
+++ b/backend/quatrix/quatrix.go
@@ -226,9 +226,10 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		}
 
 		if fileID.IsFile() {
-			root, _ = dircache.SplitPath(root)
-			f.dirCache = dircache.New(root, rootID.FileID, f)
+			f.root, _ = dircache.SplitPath(root)
+			f.dirCache = dircache.New(f.root, rootID.FileID, f)
 
+			// return an error with an fs which points to the parent
 			return f, fs.ErrorIsFile
 		}
 	}


### PR DESCRIPTION
This fixes the Root() returned by Quatrix when it has returned fs.ErrorIsFile.

Before this change, it returned a root which included the file path.

Discovered after integration tests was added to check https://forum.rclone.org/t/rclone-move-chunker-dir-file-chunker-dir-deletes-all-file-chunks/43333/

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix Quatrix behavior after a bug was discovered

#### Was the change discussed in an issue or in the forum before?

It wasn't

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
