### PR TITLE
A proof of concept PR to programmatically upload to Google Photos with an XMP Title

### DIFF
--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -36,6 +36,8 @@ import (
 	"github.com/rclone/rclone/lib/rest"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+
+	"github.com/barasher/go-exiftool"
 )
 
 var (
@@ -992,6 +994,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 // input to the batcher
 type uploadedItem struct {
 	AlbumID     string // desired album
+	ImageTitle  string // Title taken from the EXIF XMP Title
 	UploadToken string // upload ID
 }
 
@@ -1009,6 +1012,7 @@ func (f *Fs) commitBatchAlbumID(ctx context.Context, items []uploadedItem, resul
 	for i := range items {
 		if items[i].AlbumID == albumID {
 			request.NewMediaItems = append(request.NewMediaItems, api.NewMediaItem{
+	            Description: items[i].ImageTitle,
 				SimpleMediaItem: api.SimpleMediaItem{
 					UploadToken: items[i].UploadToken,
 				},
@@ -1125,8 +1129,13 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		return errors.New("empty upload token")
 	}
 
+	et, err := exiftool.NewExiftool()
+	fileInfos := et.ExtractMetadata(fileName)
+	exifTitle, err := fileInfos[0].GetString("Title")
+
 	uploaded := uploadedItem{
 		AlbumID:     albumID,
+		ImageTitle:  exifTitle,
 		UploadToken: uploadToken,
 	}
 


### PR DESCRIPTION




#### What is the purpose of this change?

Due to some recent changes at Google Photos, the Title of photos (as entered in external programs like lightRoom, Apple Photos etc and embedded in the XMP headers) are no longer shown in the google photos interface.  The 'caption' information is written into an "Other" field in the interface but the title (or description) embedded in the file headers are now ignored.  The only way to add that information once it has been uploaded is manually in the web interface for each photo.  So, people who have spent time adding this information will not be able to see use it.

There are several long threads and discussions about this you can find on the web.

Here is a discussion of the issue on the google pages:

https://support.google.com/photos/thread/143046752?hl=en&msgid=145433598

and here is a more technical discussion in the exiftools forum.  The last post points out this can in fact be done programmatically on upload via the API.

https://exiftool.org/forum/index.php?topic=10161.msg80066#msg80066

This stack overflow post shows some detail:

https://stackoverflow.com/questions/72639040/programmatically-set-a-google-photos-caption

I decided to see if I could implement this in rclone.  

This is a proof of principle PR to show that it can be done.  I managed to do this by only 7 lines of modification to googlephotos.go.  Technically, this change adds an ImageTitle entry to the uploadedItem struct.  It then fills it using an exiftools wrapper API and the info is uploaded to google photos via the API along with the AlbumID and UploadToken.  But, here are some caveats:

- I have never programmed in go (or even really read a go program) before.  So, I just did this by looking at the pattern of other code syntax in the file using my general coding knowledge.

- This is not a complete solution.  I completely ignored the batching functionality and assumed there would be only one file per upload.  I'm not familiar with the overall structure of the codebase and batcher.  I think there will need be changes made to make it work generally. When using it, I am using the `--transfers 1` option to require this. (I needed this anyway as I need to make sure the files are uploaded and completed in a fixed order).

- In order to extract the EXIF header information I used the package https://github.com/barasher/go-exiftool that I found through searching.  I am familiar with exiftool which is why I used it, but this is likely overkill for solving this problem.  The capability to extract the title from the header of an image may even be included in the standard libraries for all I know.

I've confirmed this code works for me when using a command like:

```
rclone copy -v --check-first --order-by name --transfers 1 .  photos:album/Album_Name
```

With these small changes, the Title shows up in the "description" at the top of the info panel and also shows as an overlay on the image view. 

So, as I said I am offering this a proof of concept PR, and I hope it is useful to the rclone experts and it would be great if the functionality could be merged into a more complete solution and included in the distribution.

Thanks for rclone! It's really impressive.

#### Was the change discussed in an issue or in the forum before?

I didn't see this discussed in the rclone forums when I looked.

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ X] I'm done, this Pull Request is ready for review :-)
