### PR TITLE
docs/librclone: the newer and recommended ucrt64 subsystem of msys2 can now be used for building on windows

### DIFF
--- a/librclone/README.md
+++ b/librclone/README.md
@@ -12,16 +12,17 @@ notice will be removed.
 The shims are a thin wrapper over the rclone RPC.
 
 The implementation is based on cgo; to build it you need Go and a GCC compatible
-C compiler (GCC or Clang). On Windows you can use the MinGW port of GCC,
-e.g. by installing it in a [MSYS2](https://www.msys2.org) distribution
-(make sure you install GCC in the classic mingw64 subsystem, the ucrt64 version
-is not compatible with cgo).
+C compiler (GCC or Clang). On Windows you can use the MinGW ports, e.g. by installing
+in a [MSYS2](https://www.msys2.org) distribution (you may now install GCC in the newer
+and recommended UCRT64 subsystem, however there were compatibility issues with previous
+versions of cgo where, if not force rebuild with go build option `-a` helped, you had
+to resort to the classic MINGW64 subsystem).
 
-Build a shared library like this:
+Build a shared library like this (change from .so to .dll on Windows):
 
     go build --buildmode=c-shared -o librclone.so github.com/rclone/rclone/librclone
 
-Build a static library like this:
+Build a static library like this (change from .a to .lib on Windows):
 
     go build --buildmode=c-archive -o librclone.a github.com/rclone/rclone/librclone
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
