### PR TITLE
serve restic: Fix error handling

### DIFF
--- a/cmd/serve/restic/restic.go
+++ b/cmd/serve/restic/restic.go
@@ -408,7 +408,7 @@ func (s *server) deleteObject(w http.ResponseWriter, r *http.Request) {
 
 	if err := o.Remove(r.Context()); err != nil {
 		fs.Errorf(remote, "Delete request remove error: %v", err)
-		if err == fs.ErrorObjectNotFound {
+		if errors.Is(err, fs.ErrorObjectNotFound) {
 			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
 		} else {
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)

--- a/cmd/serve/restic/restic.go
+++ b/cmd/serve/restic/restic.go
@@ -341,7 +341,11 @@ func (s *server) serveObject(w http.ResponseWriter, r *http.Request) {
 	o, err := s.newObject(r.Context(), remote)
 	if err != nil {
 		fs.Debugf(remote, "%s request error: %v", r.Method, err)
-		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		if errors.Is(err, fs.ErrorObjectNotFound) {
+			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		} else {
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		}
 		return
 	}
 	serve.Object(w, r, o)

--- a/cmd/serve/restic/restic.go
+++ b/cmd/serve/restic/restic.go
@@ -466,7 +466,7 @@ func (s *server) listObjects(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		if !errors.Is(err, fs.ErrorDirNotFound) {
 			fs.Errorf(remote, "list failed: %#v %T", err, err)
-			http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 	}


### PR DESCRIPTION
#### What is the purpose of this change?
We've discovered in https://github.com/restic/restic/issues/4612 that rclone returns a "not found" error instead of an "internal server error" if listing a directory fails. This is very problematic as since restic 0.16.0 a "not found" error while listing a directory is treated like an empty directory. Consequently, the `prune` command can end up believing that there are no snapshots if an error occurs while listing the snapshots and wipe the entire repository.

The second commit modifies the error handling while retrieving a file, such that it only returns "not found" if there's a corresponding error. A future restic version will stop retrying "not found" errors (see https://github.com/restic/restic/pull/4520) and therefore needs to be able to distinguish permanent errors like "not found" from other probably temporary ones.

I haven't added any tests as I'm not sure how to best test the error handling here.

#### Was the change discussed in an issue or in the forum before?
No.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- ~~[ ] I have added documentation for the changes if appropriate.~~
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
