### PR TITLE
linkbox: fix work with names longer than 8-25 Unicode chars.

### DIFF
--- a/backend/linkbox/linkbox.go
+++ b/backend/linkbox/linkbox.go
@@ -36,7 +36,7 @@ import (
 )
 
 const (
-	maxEntitiesPerPage = 1024
+	maxEntitiesPerPage = 1000
 	minSleep           = 200 * time.Millisecond
 	maxSleep           = 2 * time.Second
 	pacerBurst         = 1
@@ -220,7 +220,7 @@ type listAllFn func(*entity) bool
 //
 // If the name doesn't match this then do an dir list instead
 // N.B.: Linkbox doesn't support search by name that is longer than 50 chars
-var searchOK = regexp.MustCompile(`^[a-zA-Z0-9_ .]{1,50}$`)
+var searchOK = regexp.MustCompile(`^[a-zA-Z0-9_ -.]{1,50}$`)
 
 // Lists the directory required calling the user function on each item found
 //

--- a/backend/linkbox/linkbox.go
+++ b/backend/linkbox/linkbox.go
@@ -219,7 +219,8 @@ type listAllFn func(*entity) bool
 // Search is a bit fussy about which characters match
 //
 // If the name doesn't match this then do an dir list instead
-var searchOK = regexp.MustCompile(`^[a-zA-Z0-9_ .]+$`)
+// N.B.: Linkbox doesn't support search by name that is longer than 50 chars
+var searchOK = regexp.MustCompile(`^[a-zA-Z0-9_ .]{1,50}$`)
 
 // Lists the directory required calling the user function on each item found
 //
@@ -238,6 +239,7 @@ func (f *Fs) listAll(ctx context.Context, dirID string, name string, fn listAllF
 		// If name isn't good then do an unbounded search
 		name = ""
 	}
+
 OUTER:
 	for numberOfEntities == maxEntitiesPerPage {
 		pageNumber++
@@ -258,7 +260,6 @@ OUTER:
 		err = getUnmarshaledResponse(ctx, f, opts, &responseResult)
 		if err != nil {
 			return false, fmt.Errorf("getting files failed: %w", err)
-
 		}
 
 		numberOfEntities = len(responseResult.SearchData.Entities)

--- a/backend/linkbox/linkbox_test.go
+++ b/backend/linkbox/linkbox_test.go
@@ -13,5 +13,7 @@ func TestIntegration(t *testing.T) {
 	fstests.Run(t, &fstests.Opt{
 		RemoteName: "TestLinkbox:",
 		NilObject:  (*linkbox.Object)(nil),
+		// Linkbox doesn't support leading dots for files
+		SkipLeadingDot: true,
 	})
 }

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -303,6 +303,7 @@ type Opt struct {
 	SkipObjectCheckWrap             bool     // if set skip ObjectCheckWrap
 	SkipDirectoryCheckWrap          bool     // if set skip DirectoryCheckWrap
 	SkipInvalidUTF8                 bool     // if set skip invalid UTF-8 checks
+	SkipLeadingDot                  bool     // if set skip leading dot checks
 	QuickTestOK                     bool     // if set, run this test with make quicktest
 }
 
@@ -688,6 +689,9 @@ func Run(t *testing.T, opt *Opt) {
 			} {
 				t.Run(test.name, func(t *testing.T) {
 					if opt.SkipInvalidUTF8 && test.name == "invalid UTF-8" {
+						t.Skip("Skipping " + test.name)
+					}
+					if opt.SkipLeadingDot && test.name == "leading dot" {
 						t.Skip("Skipping " + test.name)
 					}
 					// turn raw strings into Standard encoding


### PR DESCRIPTION
#### What is the purpose of this change?

LinkBox API does not allow searching by more than 25 Unicode characters in the name, for this reason it is currently impossible to work with files and folders named longer than 8 Unicode chars (if encoded in base32). This fix queries all files in a long named directory and checks names there one by one, thus solving the issue.

#### Was the change discussed in an issue or in the forum before?

#7542

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
