### PR TITLE
Seafile: Fix download/upload error when FILE_SERVER_ROOT is relative

### DIFF
--- a/backend/seafile/webapi.go
+++ b/backend/seafile/webapi.go
@@ -608,14 +608,16 @@ func (f *Fs) download(ctx context.Context, downloadLink string, size int64, opti
 		Method:  "GET",
 		Options: options,
 	}
-	parsedURL, _ := url.Parse(downloadLink)
+	parsedURL, err := url.Parse(downloadLink)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse download url: %w", err)
+	}
 	if parsedURL.IsAbs() {
 		opts.RootURL = downloadLink
 	} else {
 		opts.Path = downloadLink
 	}
 	var resp *http.Response
-	var err error
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.Call(ctx, &opts)
 		return f.shouldRetry(ctx, resp, err)
@@ -697,7 +699,10 @@ func (f *Fs) upload(ctx context.Context, in io.Reader, uploadLink, filePath stri
 		ContentType: contentType,
 		Parameters:  url.Values{"ret-json": {"1"}}, // It needs to be on the url, not in the body parameters
 	}
-	parsedURL, _ := url.Parse(uploadLink)
+	parsedURL, err := url.Parse(uploadLink)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse upload url: %w", err)
+	}
 	if parsedURL.IsAbs() {
 		opts.RootURL = uploadLink
 	} else {


### PR DESCRIPTION
#### What is the purpose of this change?

This PR fixes an error in the Seafile backend implementation.
A Seafile server can be configured to use a relative url as `FILE_SERVER_ROOT` (e.g.: `/seafhttp` instead `https://seafile.example.com/seafhttp`) in order to support more than one hostname/ip (see https://github.com/haiwen/seahub/issues/3398#issuecomment-506920360).
The current backend implementation always expected an absolute download/upload url, resulting in an `unsupported protocol scheme` error. With this PR it supports both absolute and relative.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
