### PR TITLE
docs: clarify hasher operation

### DIFF
--- a/docs/content/hasher.md
+++ b/docs/content/hasher.md
@@ -323,6 +323,7 @@ The `rclone hashsum` (or `md5sum` or `sha1sum`) command will:
 
 ### Other operations
 
+- any time a hash is requested, follow the logic from 1-4 from `hashsum` above
 - whenever a file is uploaded or downloaded **in full**, capture the stream
   to calculate all supported hashes on the fly and update database
 - server-side `move`  will update keys of existing cache entries


### PR DESCRIPTION
Add a line to the "other operations" block to indicate that the hasher overlay will apply auto-size and other checks for all commands.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Clarify behaviour of hasher overlay for non-hashsum commands

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
https://forum.rclone.org/t/copy-sync-checksum-download/44088/8

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
