### PR TITLE
drive: backend query command

### DIFF
--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -524,6 +524,44 @@ func (f *Fs) InternalTestCopyID(t *testing.T) {
 	})
 }
 
+// TestIntegration/FsMkdir/FsPutFiles/Internal/Query
+func (f *Fs) InternalTestQuery(t *testing.T) {
+	ctx := context.Background()
+	var err error
+	t.Run("BadQuery", func(t *testing.T) {
+		_, err = f.query(ctx, "this is a bad query")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to execute query")
+	})
+
+	t.Run("NoMatch", func(t *testing.T) {
+		results, err := f.query(ctx, fmt.Sprintf("name='%s' and name!='%s'", existingSubDir, existingSubDir))
+		require.NoError(t, err)
+		assert.Len(t, results, 0)
+	})
+
+	t.Run("GoodQuery", func(t *testing.T) {
+		pathSegments := strings.Split(existingFile, "/")
+		var parent string
+		for _, item := range pathSegments {
+			// the file name contains ' characters which must be escaped
+			escapedItem := f.opt.Enc.FromStandardName(item)
+			escapedItem = strings.ReplaceAll(escapedItem, `\`, `\\`)
+			escapedItem = strings.ReplaceAll(escapedItem, `'`, `\'`)
+
+			results, err := f.query(ctx, fmt.Sprintf("%strashed=false and name='%s'", parent, escapedItem))
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			elem := strings.Split(results[0], "\t")
+			id := elem[0]
+			name := elem[1]
+			assert.Len(t, id, 33)
+			assert.Equal(t, name, item)
+			parent = fmt.Sprintf("'%s' in parents and ", id)
+		}
+	})
+}
+
 // TestIntegration/FsMkdir/FsPutFiles/Internal/AgeQuery
 func (f *Fs) InternalTestAgeQuery(t *testing.T) {
 	// Check set up for filtering
@@ -611,6 +649,7 @@ func (f *Fs) InternalTest(t *testing.T) {
 	t.Run("Shortcuts", f.InternalTestShortcuts)
 	t.Run("UnTrash", f.InternalTestUnTrash)
 	t.Run("CopyID", f.InternalTestCopyID)
+	t.Run("Query", f.InternalTestQuery)
 	t.Run("AgeQuery", f.InternalTestAgeQuery)
 	t.Run("ShouldRetry", f.InternalTestShouldRetry)
 }

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -552,12 +552,9 @@ func (f *Fs) InternalTestQuery(t *testing.T) {
 			results, err := f.query(ctx, fmt.Sprintf("%strashed=false and name='%s'", parent, escapedItem))
 			require.NoError(t, err)
 			require.Len(t, results, 1)
-			elem := strings.Split(results[0], "\t")
-			id := elem[0]
-			name := elem[1]
-			assert.Len(t, id, 33)
-			assert.Equal(t, name, item)
-			parent = fmt.Sprintf("'%s' in parents and ", id)
+			assert.Len(t, results[0].Id, 33)
+			assert.Equal(t, results[0].Name, item)
+			parent = fmt.Sprintf("'%s' in parents and ", results[0].Id)
 		}
 	})
 }


### PR DESCRIPTION
#### What is the purpose of this change?

This command executes a list query in Google Drive’s native query language and returns id, name pairs for any matches. It’s useful for locating files quickly in folders with a large number of files, where rclone’s normal list command is slow due to client-side filtering.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
