### PR TITLE
Check: Report differences and error counts separately

### DIFF
--- a/fs/operations/check.go
+++ b/fs/operations/check.go
@@ -249,7 +249,7 @@ func (c *checkMarch) reportResults(ctx context.Context, err error) error {
 		fs.Logf(c.opt.Fsrc, "%d %s missing", c.srcFilesMissing.Load(), entity)
 	}
 
-	fs.Logf(c.opt.Fdst, "%d differences found", accounting.Stats(ctx).GetErrors())
+	fs.Logf(c.opt.Fdst, "%d differences found", c.differences.Load())
 	if errs := accounting.Stats(ctx).GetErrors(); errs > 0 {
 		fs.Logf(c.opt.Fdst, "%d errors while checking", errs)
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

On code inspection I noticed that the reported number of differences and errors after a check operation would always the same. It reports `"%d differences found"` using `accounting.Stats(ctx).GetErrors()`, followed by `"%d errors while checking"` using the exact same parameter, only difference is that "differences" is always reported while "errors" is only reported if `>0`. I cannot see a reason why this should be of any importance.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
