### PR TITLE
Changes to exit codes

### DIFF
--- a/cmd/bisync/cmd.go
+++ b/cmd/bisync/cmd.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/filter"
+	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/hash"
 
 	"github.com/spf13/cobra"
@@ -193,7 +194,7 @@ var commandDefinition = &cobra.Command{
 		cmd.Run(false, true, command, func() error {
 			err := Bisync(ctx, fs1, fs2, &opt)
 			if err == ErrBisyncAborted {
-				os.Exit(2)
+				return fserrors.FatalError(err)
 			}
 			return err
 		})

--- a/cmd/bisync/operations.go
+++ b/cmd/bisync/operations.go
@@ -23,7 +23,7 @@ import (
 	"github.com/rclone/rclone/lib/terminal"
 )
 
-// ErrBisyncAborted signals that bisync is aborted and forces exit code 2
+// ErrBisyncAborted signals that bisync is aborted and forces non-zero exit code
 var ErrBisyncAborted = errors.New("bisync aborted")
 
 // bisyncRun keeps bisync runtime state

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -50,7 +50,6 @@ var (
 	version       bool
 	// Errors
 	errorCommandNotFound    = errors.New("command not found")
-	errorUncategorized      = errors.New("uncategorized error")
 	errorNotEnoughArguments = errors.New("not enough arguments")
 	errorTooManyArguments   = errors.New("too many arguments")
 )
@@ -495,8 +494,6 @@ func resolveExitCode(err error) {
 		os.Exit(exitcode.DirNotFound)
 	case errors.Is(err, fs.ErrorObjectNotFound):
 		os.Exit(exitcode.FileNotFound)
-	case errors.Is(err, errorUncategorized):
-		os.Exit(exitcode.UncategorizedError)
 	case errors.Is(err, accounting.ErrorMaxTransferLimitReached):
 		os.Exit(exitcode.TransferExceeded)
 	case errors.Is(err, fssync.ErrorMaxDurationReached):
@@ -507,8 +504,10 @@ func resolveExitCode(err error) {
 		os.Exit(exitcode.NoRetryError)
 	case fserrors.IsFatalError(err):
 		os.Exit(exitcode.FatalError)
-	default:
+	case errors.Is(err, errorCommandNotFound), errors.Is(err, errorNotEnoughArguments), errors.Is(err, errorTooManyArguments):
 		os.Exit(exitcode.UsageError)
+	default:
+		os.Exit(exitcode.UncategorizedError)
 	}
 }
 
@@ -536,6 +535,7 @@ func Main() {
 		if strings.HasPrefix(err.Error(), "unknown command") && selfupdateEnabled {
 			Root.PrintErrf("You could use '%s selfupdate' to get latest features.\n\n", Root.CommandPath())
 		}
-		fs.Fatalf(nil, "Fatal error: %v", err)
+		fs.Logf(nil, "Fatal error: %v", err)
+		os.Exit(exitcode.UsageError)
 	}
 }

--- a/cmdtest/cmdtest_test.go
+++ b/cmdtest/cmdtest_test.go
@@ -174,7 +174,7 @@ func TestCmdTest(t *testing.T) {
 	// Test error and error output
 	out, err = rclone("version", "--provoke-an-error")
 	if assert.Error(t, err) {
-		assert.Contains(t, err.Error(), "exit status 1")
+		assert.Contains(t, err.Error(), "exit status 2")
 		assert.Contains(t, out, "Error: unknown flag")
 	}
 

--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -968,12 +968,15 @@ that while concurrent bisync runs are allowed, _be very cautious_
 that there is no overlap in the trees being synched between concurrent runs,
 lest there be replicated files, deleted files and general mayhem.
 
-### Return codes
+### Exit codes
 
 `rclone bisync` returns the following codes to calling program:
 - `0` on a successful run,
 - `1` for a non-critical failing run (a rerun may be successful),
-- `2` for a critically aborted run (requires a `--resync` to recover).
+- `2` on syntax or usage error,
+- `7` for a critically aborted run (requires a `--resync` to recover).
+
+See also the section about [exit codes](/docs/#exit-code) in main docs.
 
 ### Graceful Shutdown
 

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -2868,9 +2868,9 @@ messages may not be valid after the retry. If rclone has done a retry
 it will log a high priority message if the retry was successful.
 
 ### List of exit codes ###
-  * `0` - success
-  * `1` - Syntax or usage error
-  * `2` - Error not otherwise categorised
+  * `0` - Success
+  * `1` - Error not otherwise categorised
+  * `2` - Syntax or usage error
   * `3` - Directory not found
   * `4` - File not found
   * `5` - Temporary error (one that more retries might fix) (Retry errors)

--- a/lib/exitcode/exitcode.go
+++ b/lib/exitcode/exitcode.go
@@ -4,10 +4,10 @@ package exitcode
 const (
 	// Success is returned when rclone finished without error.
 	Success = iota
-	// UsageError is returned when there was a syntax or usage error in the arguments.
-	UsageError
 	// UncategorizedError is returned for any error not categorised otherwise.
 	UncategorizedError
+	// UsageError is returned when there was a syntax or usage error in the arguments.
+	UsageError
 	// DirNotFound is returned when a source or destination directory is not found.
 	DirNotFound
 	// FileNotFound is returned when a source or destination file is not found.


### PR DESCRIPTION
#### What is the purpose of this change?

According to rclone [documentation](https://rclone.org/docs/#list-of-exit-codes), exit code 1 is for "syntax or usage" and 2 is for "not otherwise categorised" errors. However, in current implementation, exit code 2 will never be returned (*with one exception in bisync, see below), and in reality exit code 1 will be used for anything other than the "otherwise categorised" errors - exit code 1 is the *default* for unsuccessful returns.

There seem to be a more or less convention for exit codes in Linux/shell world,  maybe some specifically for bash:
- Values between 0 and 255
- 0 is for success
- 1 is for general errors
- 2 is usage errors, invalid options or missing arguments.
- Values above 125 are specifically used by the shell (bash), e.g. when program is terminated on response to a signal.

(https://www.gnu.org/software/bash/manual/html_node/Exit-Status.html)
(https://www.redhat.com/sysadmin/exit-codes-demystified)

This PR does the following changes to exit codes from rclone:
- Explicitely checks for "syntax or usage" type errors from rclone and return exit code 2 in those cases. E.g. `rclone copy a`, `rclone copy a b c` or `rclone copy --unknownflag a b`.
- Explicitely return exit code 2 when cobra command processor returns before rclone's command handling, where the resolving of exit codes occur. E.g. when running `rclone unknowncommand`, or simply `rclone`, this now returns exit code 2 instead of 1.
- Keep using exit code 1 as *default* for unsuccessful returns, which needs no change in existing code, but an update to the documentation so that it correctly reflects this - now after the previous point by switching the description of exit code 1 and 2.

\* **bisync exception:** There was actually one case of exit code 2, in bisync, where it explicitely called `os.Exit` without going through `resolveExitCode`. I added a commit to change that to exit code 7, more in-line with rest of rclone, and updated the description of exit codes in bisync documentation according to these changes affecting exit codes 1, 2 and 7.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/minor-bug-return-code-from-rclone-check/44236
- That thread started out by questioning why the check command returned exit code 1, documented as "syntax or usage error", when differences were found. With the changes in this PR it will still return exit code 1, but this is now documented as "error not otherwise categorised", and in case of "syntax or usage error" one will get a separate exit code 2. So this somewhat improves the situation, although the suggestion in that thread was to introduce a (or maybe several?) new exit codes for reporting result from a check, which could still be considered..

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
