### PR TITLE
quatrix: fix Content-Range header

### DIFF
--- a/backend/quatrix/quatrix.go
+++ b/backend/quatrix/quatrix.go
@@ -1198,11 +1198,12 @@ func (o *Object) uploadSession(ctx context.Context, parentID, name string) (uplo
 
 func (o *Object) upload(ctx context.Context, uploadKey string, chunk io.Reader, fullSize int64, offset int64, chunkSize int64, options ...fs.OpenOption) (err error) {
 	opts := rest.Opts{
-		Method:       "POST",
-		RootURL:      fmt.Sprintf(uploadURL, o.fs.opt.Host) + uploadKey,
-		Body:         chunk,
-		ContentRange: fmt.Sprintf("bytes %d-%d/%d", offset, offset+chunkSize, fullSize),
-		Options:      options,
+		Method:        "POST",
+		RootURL:       fmt.Sprintf(uploadURL, o.fs.opt.Host) + uploadKey,
+		Body:          chunk,
+		ContentLength: &chunkSize,
+		ContentRange:  fmt.Sprintf("bytes %d-%d/%d", offset, offset+chunkSize-1, fullSize),
+		Options:       options,
 	}
 
 	var fileID string


### PR DESCRIPTION
This change does not actually affect uploads. Just to be right according to definition of Content-Range in https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Range#range-end

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Content-Range is inclusive according to MDN

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
