### PR TITLE
#7566 change the comments in the operations.DeleteFile as it does not use --backup-dir, despite comment

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -485,8 +485,8 @@ func SuffixName(ctx context.Context, remote string) string {
 // DeleteFileWithBackupDir deletes a single file respecting --dry-run
 // and accumulating stats and errors.
 //
-// If backupDir is set then it moves the file to there instead of
-// deleting
+// If backupDir is set then it moves the file to there instead of deleting
+// you use BackupDir to find the --backup-dir as it is relatively expensive so don't put it in a loop
 func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs) (err error) {
 	tr := accounting.Stats(ctx).NewCheckingTransfer(dst, "deleting")
 	defer func() {
@@ -519,8 +519,8 @@ func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs
 
 // DeleteFile deletes a single file respecting --dry-run and accumulating stats and errors.
 //
-// If useBackupDir is set and --backup-dir is in effect then it moves
-// the file to there instead of deleting
+// call DeleteFileWithBackupDir if --backup-dir support is required
+// as calling this function with --backup-dir will always returns nil
 func DeleteFile(ctx context.Context, dst fs.Object) (err error) {
 	return DeleteFileWithBackupDir(ctx, dst, nil)
 }

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -420,7 +420,7 @@ func (s *syncCopyMove) pairChecker(in *pipe, out *pipe, fraction int, wg *sync.W
 							return
 						}
 					} else {
-						deleteFileErr := operations.DeleteFile(s.ctx, src)
+						deleteFileErr := operations.DeleteFileWithBackupDir(s.ctx, src, s.backupDir)
 						s.processError(deleteFileErr)
 						s.logger(s.ctx, operations.TransferError, pair.Src, pair.Dst, deleteFileErr)
 					}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

1.  leave operations.DeleteFile alone but fix the comment to say call DeleteFileWithBackupDir if --backup-dir support is required
2.  add a note to DeleteFileWithBackupDir noting that you use BackupDir to find the --backup-dir and that it is relatively expensive so don't put it in a loop


#### Was the change discussed in an issue or in the forum before?
yes 
(https://github.com/rclone/rclone/issues/7566)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
