### PR TITLE
bisync: delete flushCache() function from tests

### DIFF
--- a/cmd/bisync/bisync_test.go
+++ b/cmd/bisync/bisync_test.go
@@ -532,7 +532,6 @@ func (b *bisyncTest) runTestStep(ctx context.Context, line string) (err error) {
 		if err != nil {
 			return err
 		}
-		flushCache(fsrc)
 		return
 	case "delete-file":
 		b.checkArgs(args, 1, 1)
@@ -769,13 +768,6 @@ func (b *bisyncTest) checkArgs(args []string, min, max int) {
 	}
 }
 
-func flushCache(f fs.Fs) {
-	dirCacheFlush := f.Features().DirCacheFlush
-	if dirCacheFlush == nil {
-		fs.Errorf(nil, "%v: can't flush dir cache", f)
-	}
-}
-
 func (b *bisyncTest) runBisync(ctx context.Context, args []string) (err error) {
 	opt := &bisync.Options{
 		Workdir:       b.workDir,
@@ -788,10 +780,6 @@ func (b *bisyncTest) runBisync(ctx context.Context, args []string) (err error) {
 	}
 	octx, ci := fs.AddConfig(ctx)
 	fs1, fs2 := b.fs1, b.fs2
-
-	// flush cache
-	flushCache(fs1)
-	flushCache(fs2)
 
 	addSubdir := func(path, subdir string) fs.Fs {
 		remote := path + subdir
@@ -967,9 +955,6 @@ func (b *bisyncTest) listSubdirs(ctx context.Context, remote string, DirsOnly bo
 	if err != nil {
 		return err
 	}
-
-	// flush cache
-	flushCache(f)
 
 	opt := operations.ListJSONOpt{
 		NoModTime:  true,


### PR DESCRIPTION
The flushCache() function has a bug that causes it to never actually flush the cache. Specifically, it checks whether DirCacheFlush is nil, but never calls it.

The tests are already passing without flushing the dir cache, so this commit just deletes flushCache() and its call sites.

Fixes rclone/rclone#7623

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Clarify the bisync tests by removing an accidentally misleading function.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
