### PR TITLE
backend: rename variables to fix CI lint test failures

### DIFF
--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -428,15 +428,15 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		members := []*team.UserSelectorArg{&user}
 		args := team.NewMembersGetInfoArgs(members)
 
-		memberIds, err := f.team.MembersGetInfo(args)
+		memberIDs, err := f.team.MembersGetInfo(args)
 		if err != nil {
 			return nil, fmt.Errorf("invalid dropbox team member: %q: %w", opt.Impersonate, err)
 		}
-		if len(memberIds) == 0 || memberIds[0].MemberInfo == nil || memberIds[0].MemberInfo.Profile == nil {
+		if len(memberIDs) == 0 || memberIDs[0].MemberInfo == nil || memberIDs[0].MemberInfo.Profile == nil {
 			return nil, fmt.Errorf("dropbox team member not found: %q", opt.Impersonate)
 		}
 
-		cfg.AsMemberID = memberIds[0].MemberInfo.Profile.MemberProfile.TeamMemberId
+		cfg.AsMemberID = memberIDs[0].MemberInfo.Profile.MemberProfile.TeamMemberId
 	}
 
 	f.srv = files.New(cfg)
@@ -1231,7 +1231,7 @@ func (f *Fs) About(ctx context.Context) (usage *fs.Usage, err error) {
 		return nil, err
 	}
 	var total uint64
-	var used = q.Used
+	used := q.Used
 	if q.Allocation != nil {
 		if q.Allocation.Individual != nil {
 			total += q.Allocation.Individual.Allocated

--- a/backend/googlephotos/api/types.go
+++ b/backend/googlephotos/api/types.go
@@ -56,8 +56,7 @@ type MediaItem struct {
 		CreationTime time.Time `json:"creationTime"`
 		Width        string    `json:"width"`
 		Height       string    `json:"height"`
-		Photo        struct {
-		} `json:"photo"`
+		Photo        struct{}  `json:"photo"`
 	} `json:"mediaMetadata"`
 	Filename string `json:"filename"`
 }
@@ -68,7 +67,7 @@ type MediaItems struct {
 	NextPageToken string      `json:"nextPageToken"`
 }
 
-//Content categories
+// Content categories
 // NONE	Default content category. This category is ignored when any other category is used in the filter.
 // LANDSCAPES	Media items containing landscapes.
 // RECEIPTS	Media items containing receipts.
@@ -187,5 +186,5 @@ type BatchCreateResponse struct {
 
 // BatchRemoveItems is for removing items from an album
 type BatchRemoveItems struct {
-	MediaItemIds []string `json:"mediaItemIds"`
+	MediaItemIDs []string `json:"mediaItemIds"`
 }

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -280,7 +280,7 @@ func errorHandler(resp *http.Response) error {
 	if strings.HasPrefix(resp.Header.Get("Content-Type"), "image/") {
 		body = []byte("Image not found or broken")
 	}
-	var e = api.Error{
+	e := api.Error{
 		Details: api.ErrorDetails{
 			Code:    resp.StatusCode,
 			Message: string(body),
@@ -702,7 +702,7 @@ func (f *Fs) createAlbum(ctx context.Context, albumTitle string) (album *api.Alb
 		Path:       "/albums",
 		Parameters: url.Values{},
 	}
-	var request = api.CreateAlbum{
+	request := api.CreateAlbum{
 		Album: &api.Album{
 			Title: albumTitle,
 		},
@@ -1002,7 +1002,7 @@ func (f *Fs) commitBatchAlbumID(ctx context.Context, items []uploadedItem, resul
 		Method: "POST",
 		Path:   "/mediaItems:batchCreate",
 	}
-	var request = api.BatchCreateRequest{
+	request := api.BatchCreateRequest{
 		AlbumID: albumID,
 	}
 	itemsInBatch := 0
@@ -1174,8 +1174,8 @@ func (o *Object) Remove(ctx context.Context) (err error) {
 		Path:       "/albums/" + album.ID + ":batchRemoveMediaItems",
 		NoResponse: true,
 	}
-	var request = api.BatchRemoveItems{
-		MediaItemIds: []string{o.id},
+	request := api.BatchRemoveItems{
+		MediaItemIDs: []string{o.id},
 	}
 	var resp *http.Response
 	err = o.fs.pacer.Call(func() (bool, error) {

--- a/backend/pikpak/api/types.go
+++ b/backend/pikpak/api/types.go
@@ -71,12 +71,11 @@ type Error struct {
 
 // ErrorDetails contains further details of api error
 type ErrorDetails struct {
-	Type     string `json:"@type,omitempty"`
-	Reason   string `json:"reason,omitempty"`
-	Domain   string `json:"domain,omitempty"`
-	Metadata struct {
-	} `json:"metadata,omitempty"` // TODO: undiscovered yet
-	Locale       string        `json:"locale,omitempty"` // e.g. "en"
+	Type         string        `json:"@type,omitempty"`
+	Reason       string        `json:"reason,omitempty"`
+	Domain       string        `json:"domain,omitempty"`
+	Metadata     struct{}      `json:"metadata,omitempty"` // TODO: undiscovered yet
+	Locale       string        `json:"locale,omitempty"`   // e.g. "en"
 	Message      string        `json:"message,omitempty"`
 	StackEntries []interface{} `json:"stack_entries,omitempty"` // TODO: undiscovered yet
 	Detail       string        `json:"detail,omitempty"`
@@ -266,13 +265,11 @@ type FileApp struct {
 	NeedMoreQuota bool          `json:"need_more_quota,omitempty"`
 	IconLink      string        `json:"icon_link,omitempty"`
 	IsDefault     bool          `json:"is_default,omitempty"`
-	Params        struct {
-	} `json:"params,omitempty"` // TODO
-	CategoryIds []interface{} `json:"category_ids,omitempty"`
-	AdSceneType int           `json:"ad_scene_type,omitempty"`
-	Space       string        `json:"space,omitempty"`
-	Links       struct {
-	} `json:"links,omitempty"` // TODO
+	Params        struct{}      `json:"params,omitempty"` // TODO
+	CategoryIDs   []interface{} `json:"category_ids,omitempty"`
+	AdSceneType   int           `json:"ad_scene_type,omitempty"`
+	Space         string        `json:"space,omitempty"`
+	Links         struct{}      `json:"links,omitempty"` // TODO
 }
 
 // ------------------------------------------------------------
@@ -384,11 +381,10 @@ type NewTask struct {
 
 // About informs drive status
 type About struct {
-	Kind      string `json:"kind,omitempty"` // "drive#about"
-	Quota     *Quota `json:"quota,omitempty"`
-	ExpiresAt string `json:"expires_at,omitempty"`
-	Quotas    struct {
-	} `json:"quotas,omitempty"` // maybe []*Quota?
+	Kind      string   `json:"kind,omitempty"` // "drive#about"
+	Quota     *Quota   `json:"quota,omitempty"`
+	ExpiresAt string   `json:"expires_at,omitempty"`
+	Quotas    struct{} `json:"quotas,omitempty"` // maybe []*Quota?
 }
 
 // Quota informs drive quota
@@ -462,7 +458,7 @@ type DecompressResult struct {
 
 // RequestShare is to request for file share
 type RequestShare struct {
-	FileIds        []string `json:"file_ids,omitempty"`
+	FileIDs        []string `json:"file_ids,omitempty"`
 	ShareTo        string   `json:"share_to,omitempty"`         // "publiclink",
 	ExpirationDays int      `json:"expiration_days,omitempty"`  // -1 = 'forever'
 	PassCodeOption string   `json:"pass_code_option,omitempty"` // "NOT_REQUIRED"
@@ -470,7 +466,7 @@ type RequestShare struct {
 
 // RequestBatch is to request for batch actions
 type RequestBatch struct {
-	Ids []string          `json:"ids,omitempty"`
+	IDs []string          `json:"ids,omitempty"`
 	To  map[string]string `json:"to,omitempty"`
 }
 

--- a/backend/pikpak/pikpak.go
+++ b/backend/pikpak/pikpak.go
@@ -775,7 +775,7 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 		expiry = int(math.Ceil(time.Duration(expire).Hours() / 24))
 	}
 	req := api.RequestShare{
-		FileIds:        []string{id},
+		FileIDs:        []string{id},
 		ShareTo:        "publiclink",
 		ExpirationDays: expiry,
 		PassCodeOption: "NOT_REQUIRED",
@@ -797,7 +797,7 @@ func (f *Fs) deleteObjects(ctx context.Context, IDs []string, useTrash bool) (er
 		action = "batchTrash"
 	}
 	req := api.RequestBatch{
-		Ids: IDs,
+		IDs: IDs,
 	}
 	if err := f.requestBatchAction(ctx, action, &req); err != nil {
 		return fmt.Errorf("delete object failed: %w", err)
@@ -817,7 +817,7 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 		return err
 	}
 
-	var trashedFiles = false
+	trashedFiles := false
 	if check {
 		found, err := f.listAll(ctx, rootID, "", "", func(item *api.File) bool {
 			if !item.Trashed {
@@ -893,7 +893,7 @@ func (f *Fs) moveObjects(ctx context.Context, IDs []string, dirID string) (err e
 		return nil
 	}
 	req := api.RequestBatch{
-		Ids: IDs,
+		IDs: IDs,
 		To:  map[string]string{"parent_id": parentIDForRequest(dirID)},
 	}
 	if err := f.requestBatchAction(ctx, "batchMove", &req); err != nil {
@@ -1039,7 +1039,7 @@ func (f *Fs) copyObjects(ctx context.Context, IDs []string, dirID string) (err e
 		return nil
 	}
 	req := api.RequestBatch{
-		Ids: IDs,
+		IDs: IDs,
 		To:  map[string]string{"parent_id": parentIDForRequest(dirID)},
 	}
 	if err := f.requestBatchAction(ctx, "batchCopy", &req); err != nil {


### PR DESCRIPTION
#### What is the purpose of this change?

The CI lint test has recently started complaining about struct fields named `Id` instead of `ID`, and failing because of this. This change should fix it.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
