### PR TITLE
Fix a heading level in webdav.md documentation

### DIFF
--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -278,7 +278,7 @@ Properties:
 
 See below for notes on specific providers.
 
-## Fastmail Files
+### Fastmail Files
 
 Use `https://webdav.fastmail.com/` or a subdirectory as the URL,
 and your Fastmail email `username@domain.tld` as the username.


### PR DESCRIPTION
This is a drive-by commit to fix a heading problem under the "Provider Notes" section. Thanks!

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The heading levels in the WebDAV documentation were slightly messed up.

#### Was the change discussed in an issue or in the forum before?

No, it is a single character change in documentation.


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
