### PR TITLE
sync: use `operations.DirMove` instead of `sync.MoveDir` for `--fix-case`, fix `TestApplyTransforms`

### DIFF
--- a/fs/operations/check_test.go
+++ b/fs/operations/check_test.go
@@ -568,6 +568,13 @@ func TestApplyTransforms(t *testing.T) {
 		opt := operations.CheckOpt{}
 
 		remotefile := r.WriteObject(ctx, remotefileName, content, t2)
+		// test whether remote is capable of running test
+		entries, err := r.Fremote.List(ctx, "")
+		assert.NoError(t, err)
+		if entries.Len() == 1 && entries[0].Remote() != remotefileName {
+			t.Skipf("Fs is incapable of running test, skipping: %s (expected: %s (%s) actual: %s (%s))", scenario, remotefileName, detectEncoding(remotefileName), entries[0].Remote(), detectEncoding(entries[0].Remote()))
+		}
+
 		checkfile := r.WriteFile("test.sum", hash+"  "+checkfileName, t2)
 		r.CheckLocalItems(t, checkfile)
 		assert.False(t, checkfileName == remotefile.Path, "Values match but should not: %s %s", checkfileName, remotefile.Path)
@@ -577,7 +584,7 @@ func TestApplyTransforms(t *testing.T) {
 		ci.NoUnicodeNormalization = true
 		ci.IgnoreCaseSync = false
 		accounting.GlobalStats().ResetCounters()
-		err := operations.CheckSum(ctx, r.Fremote, r.Flocal, "test.sum", hashType, &opt, true)
+		err = operations.CheckSum(ctx, r.Fremote, r.Flocal, "test.sum", hashType, &opt, true)
 		assert.Error(t, err, "no expected error for %s %v %v", testname, checkfileName, remotefileName)
 
 		testname = scenario + " (with normalization)"
@@ -599,4 +606,17 @@ func TestApplyTransforms(t *testing.T) {
 	testScenario(nfcx2, both, "NFCx2 checkfile vs. both remote")
 	testScenario(both, nfdx2, "both checkfile vs. NFDx2 remote")
 	testScenario(both, nfcx2, "both checkfile vs. NFCx2 remote")
+}
+
+func detectEncoding(s string) string {
+	if norm.NFC.IsNormalString(s) && norm.NFD.IsNormalString(s) {
+		return "BOTH"
+	}
+	if !norm.NFC.IsNormalString(s) && norm.NFD.IsNormalString(s) {
+		return "NFD"
+	}
+	if norm.NFC.IsNormalString(s) && !norm.NFD.IsNormalString(s) {
+		return "NFC"
+	}
+	return "OTHER"
 }

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -2288,6 +2288,17 @@ func DirMove(ctx context.Context, f fs.Fs, srcRemote, dstRemote string) (err err
 	return nil
 }
 
+// DirMoveCaseInsensitive does DirMove in two steps (to temp name, then real name)
+// which is necessary for some case-insensitive backends
+func DirMoveCaseInsensitive(ctx context.Context, f fs.Fs, srcRemote, dstRemote string) (err error) {
+	tmpDstRemote := dstRemote + "-rclone-move-" + random.String(8)
+	err = DirMove(ctx, f, srcRemote, tmpDstRemote)
+	if err != nil {
+		return err
+	}
+	return DirMove(ctx, f, tmpDstRemote, dstRemote)
+}
+
 // FsInfo provides information about a remote
 type FsInfo struct {
 	// Name of the remote (as passed into NewFs)


### PR DESCRIPTION
#### What is the purpose of this change?

Two fixes for integration tests, discussed on #7591.

After this, I think we should just be down to `mailru`, `jottacloud`, and `linkbox`.

#### Was the change discussed in an issue or in the forum before?

- #7591 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
