### PR TITLE
drive: add an  indication in case of recursive shortcuts in documentation

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -436,7 +436,7 @@ The [rclone backend](https://rclone.org/commands/rclone_backend/) command can be
 Shortcuts can be completely ignored with the `--drive-skip-shortcuts` flag
 or the corresponding `skip_shortcuts` configuration setting.
 
-If you have shortcuts that leads to an infinite recursion in your drive (eg a shorcut pointing to a parent folder), `skip_shortcuts` might be mandatory to be able to clone the drive.
+If you have shortcuts that lead to an infinite recursion in your drive (e.g. a shortcut pointing to a parent folder), `skip_shortcuts` might be mandatory to be able to copy the drive.
 
 ### Emptying trash
 

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -436,6 +436,8 @@ The [rclone backend](https://rclone.org/commands/rclone_backend/) command can be
 Shortcuts can be completely ignored with the `--drive-skip-shortcuts` flag
 or the corresponding `skip_shortcuts` configuration setting.
 
+If you have shortcuts that leads to an infinite recursion in your drive (eg a shorcut pointing to a parent folder), `skip_shortcuts` might be mandatory to be able to clone the drive.
+
 ### Emptying trash
 
 If you wish to empty your trash you can use the `rclone cleanup remote:`


### PR DESCRIPTION

#### What is the purpose of this change?

Help people handle an issue which might be difficult to understand otherwise.

If you have recursive shortcuts (pointing to a parent folder) in a google drive, rclone is doing infinite recursion, never ending and filling the disk. Even if you ask not to get shortcuts content. 

#### Was the change discussed in an issue or in the forum before?

See https://forum.rclone.org/t/trying-to-backup-a-google-drive-ends-up-filling-my-disk-with-recursive-stuff/44601/2

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
