### PR TITLE
sync: don't set dir modtimes if already set

### DIFF
--- a/cmd/bisync/bisync_test.go
+++ b/cmd/bisync/bisync_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/rclone/rclone/fs/object"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fs/sync"
+	"github.com/rclone/rclone/fs/walk"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/lib/atexit"
 	"github.com/rclone/rclone/lib/encoder"
@@ -57,6 +58,8 @@ const (
 	slash           = string(os.PathSeparator)
 	fixSlash        = (runtime.GOOS == "windows")
 )
+
+var initDate = time.Date(2000, time.January, 1, 0, 0, 0, 0, bisync.TZ)
 
 // logReplacements make modern test logs comparable with golden dir.
 // It is a string slice of even length with this structure:
@@ -87,9 +90,9 @@ var logReplacements = []string{
 	`^.*? for same-side diffs on .*?$`, dropMe,
 	`^.*?Downloading hashes.*?$`, dropMe,
 	// ignore timestamps in directory time updates
-	`^(INFO  : .*?: Made directory with (metadata|modification time)).*$`, `$1`,
+	`^(INFO  : .*?: (Made directory with|Set directory) (metadata|modification time)).*$`, dropMe,
 	// ignore sizes in directory time updates
-	`^(NOTICE: .*?: Skipped set directory modification time as --dry-run is set).*$`, `$1`,
+	`^(NOTICE: .*?: Skipped set directory modification time as --dry-run is set).*$`, dropMe,
 }
 
 // Some dry-run messages differ depending on the particular remote.
@@ -320,7 +323,6 @@ func (b *bisyncTest) runTestCase(ctx context.Context, t *testing.T, testCase str
 
 	// For test stability, jam initial dates to a fixed past date.
 	// Test cases that change files will touch specific files to fixed new dates.
-	initDate := time.Date(2000, time.January, 1, 0, 0, 0, 0, bisync.TZ)
 	err = filepath.Walk(b.initDir, func(path string, info os.FileInfo, err error) error {
 		if err == nil && !info.IsDir() {
 			return os.Chtimes(path, initDate, initDate)
@@ -868,6 +870,20 @@ func (b *bisyncTest) runBisync(ctx context.Context, args []string) (err error) {
 		}
 	}
 
+	// set all dirs to a fixed date for test stability, as they are considered as of v1.66.
+	jamDirTimes := func(f fs.Fs) {
+		err := walk.ListR(ctx, f, "", true, -1, walk.ListDirs, func(entries fs.DirEntries) error {
+			var err error
+			entries.ForDir(func(dir fs.Directory) {
+				_, err = operations.SetDirModTime(ctx, f, dir, "", initDate)
+			})
+			return err
+		})
+		assert.NoError(b.t, err, "error jamming dirtimes")
+	}
+	jamDirTimes(fs1)
+	jamDirTimes(fs2)
+
 	output := bilib.CaptureOutput(func() {
 		err = bisync.Bisync(octx, fs1, fs2, opt)
 	})
@@ -1385,10 +1401,10 @@ func (b *bisyncTest) mangleListing(text string, golden bool, file string) string
 				lines[i] = match[1] + "-" + match[3] + match[4] // replace it with "-" for comparison purposes (see #5679)
 			}
 			// account for modtime precision
-			var lineRegex = regexp.MustCompile(`^(\S) +(-?\d+) (\S+) (\S+) (\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{9}[+-]\d{4}) (".+")$`)
+			lineRegex := regexp.MustCompile(`^(\S) +(-?\d+) (\S+) (\S+) (\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{9}[+-]\d{4}) (".+")$`)
 			const timeFormat = "2006-01-02T15:04:05.000000000-0700"
 			const lineFormat = "%s %8d %s %s %s %q\n"
-			var TZ = time.UTC
+			TZ := time.UTC
 			fields := lineRegex.FindStringSubmatch(strings.TrimSuffix(lines[i], "\n"))
 			if fields != nil {
 				sizeVal, sizeErr := strconv.ParseInt(fields[2], 10, 64)
@@ -1509,7 +1525,8 @@ func (b *bisyncTest) listDir(dir string) (names []string) {
 	ignoreIt := func(file string) bool {
 		ignoreList := []string{
 			// ".lst-control", ".lst-dry-control", ".lst-old", ".lst-dry-old",
-			".DS_Store"}
+			".DS_Store",
+		}
 		for _, s := range ignoreList {
 			if strings.Contains(file, s) {
 				return true

--- a/cmd/bisync/testdata/test_all_changed/golden/test.log
+++ b/cmd/bisync/testdata/test_all_changed/golden/test.log
@@ -16,11 +16,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -63,8 +59,6 @@ INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{
 INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{path2/}file1.txt[0m
 INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{path2/}subdir/file20.txt[0m
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -139,8 +133,6 @@ INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{
 INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{path2/}file1.txt[0m
 INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{path2/}subdir/file20.txt[0m
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_basic/golden/test.log
+++ b/cmd/bisync/testdata/test_basic/golden/test.log
@@ -16,11 +16,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -57,8 +53,6 @@ INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}file1.txt[0m
 INFO  : - [34mPath2[0m    [35mDo queued copies to[0m                - [36mPath1[0m
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_check_access/golden/test.log
+++ b/cmd/bisync/testdata/test_check_access/golden/test.log
@@ -16,11 +16,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -91,11 +87,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -188,11 +180,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_check_access_filters/golden/test.log
+++ b/cmd/bisync/testdata/test_check_access_filters/golden/test.log
@@ -21,15 +21,7 @@ INFO  : Using filters file {workdir/}exclude-other-filtersfile.txt
 INFO  : Storing filters file hash to {workdir/}exclude-other-filtersfile.txt.md5
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir/subdirB: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir/subdirB: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir/subdirB: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir/subdirB: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -144,23 +136,7 @@ INFO  : Using filters file {workdir/}include-other-filtersfile.txt
 INFO  : Storing filters file hash to {workdir/}include-other-filtersfile.txt.md5
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdirX: Set directory modification time (using SetModTime)
-INFO  : subdirX/subdirX1: Set directory modification time (using SetModTime)
-INFO  : subdir/subdirB: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdirX: Set directory modification time (using SetModTime)
-INFO  : subdirX/subdirX1: Set directory modification time (using SetModTime)
-INFO  : subdir/subdirB: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdirX: Set directory modification time (using SetModTime)
-INFO  : subdir/subdirB: Set directory modification time (using SetModTime)
-INFO  : subdirX/subdirX1: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdirX: Set directory modification time (using SetModTime)
-INFO  : subdir/subdirB: Set directory modification time (using SetModTime)
-INFO  : subdirX/subdirX1: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_check_filename/golden/test.log
+++ b/cmd/bisync/testdata/test_check_filename/golden/test.log
@@ -16,11 +16,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -94,11 +90,7 @@ INFO  : Copying Path2 files to Path1
 INFO  : Checking access health
 INFO  : Found 2 matching ".chk_file" files on both paths
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_createemptysrcdirs/golden/test.log
+++ b/cmd/bisync/testdata/test_createemptysrcdirs/golden/test.log
@@ -147,11 +147,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Made directory with metadata (mtime=2024-02-27T04:53:52.809861575-05:00)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_extended_char_paths/golden/test.log
+++ b/cmd/bisync/testdata/test_extended_char_paths/golden/test.log
@@ -84,11 +84,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -133,11 +129,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -182,11 +174,7 @@ INFO  : Using filters file {workdir/}測試_filtersfile.txt
 INFO  : Storing filters file hash to {workdir/}測試_filtersfile.txt.md5
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_extended_filenames/golden/test.log
+++ b/cmd/bisync/testdata/test_extended_filenames/golden/test.log
@@ -25,11 +25,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir_with_ࢺ_: Set directory modification time (using SetModTime)
-INFO  : subdir_with_ࢺ_: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir_with_ࢺ_: Set directory modification time (using SetModTime)
-INFO  : subdir_with_ࢺ_: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -116,15 +112,7 @@ INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m"
 INFO  : - [36mPath1[0m    [35m[31mQueue delete[0m[0m              - [36m{path1/}subdir_with_ࢺ_/filename_contains_ě_.txt[0m
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}subdir_with_ࢺ_/filename_contains_ࢺ_p2s.txt[0m
 INFO  : - [34mPath2[0m    [35mDo queued copies to[0m                - [36mPath1[0m
-INFO  : subdir with␊white space.txt: Made directory with metadata (mtime=2024-02-27T04:53:52.913860529-05:00)
-INFO  : subdir_rawchars_␙_�_�: Made directory with metadata (mtime=2024-02-27T04:53:52.913860529-05:00)
-INFO  : subdir_with_ࢺ_: Set directory modification time (using SetModTime)
-INFO  : subdir with␊white space.txt: Set directory modification time (using SetModTime)
-INFO  : subdir_rawchars_␙_�_�: Set directory modification time (using SetModTime)
-INFO  : subdir_with_ࢺ_: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : subdir_with_ࢺ_: Set directory modification time (using SetModTime)
-INFO  : subdir_with_ࢺ_: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_filters/golden/test.log
+++ b/cmd/bisync/testdata/test_filters/golden/test.log
@@ -20,11 +20,7 @@ INFO  : Using filters file {workdir/}filtersfile.flt
 INFO  : Storing filters file hash to {workdir/}filtersfile.flt.md5
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -58,8 +54,6 @@ INFO  : Path2 checking for diffs
 INFO  : Applying changes
 INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{path2/}subdir/fileZ.txt[0m
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_filtersfile_checks/golden/test.log
+++ b/cmd/bisync/testdata/test_filtersfile_checks/golden/test.log
@@ -16,11 +16,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -85,11 +81,7 @@ INFO  : Using filters file {workdir/}filtersfile.txt
 INFO  : Storing filters file hash to {workdir/}filtersfile.txt.md5
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -154,11 +146,7 @@ INFO  : Using filters file {workdir/}filtersfile.txt
 INFO  : Skipped storing filters file hash to {workdir/}filtersfile.txt.md5 as --dry-run is set
 INFO  : Copying Path2 files to Path1
 NOTICE: - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-NOTICE: subdir: Skipped set directory modification time as --dry-run is set
-NOTICE: {path1String}: Skipped set directory modification time as --dry-run is set
 NOTICE: - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-NOTICE: subdir: Skipped set directory modification time as --dry-run is set
-NOTICE: {path2String}: Skipped set directory modification time as --dry-run is set
 INFO  : Resync updating listings
 INFO  : [32mBisync successful[0m
 

--- a/cmd/bisync/testdata/test_ignorelistingchecksum/golden/test.log
+++ b/cmd/bisync/testdata/test_ignorelistingchecksum/golden/test.log
@@ -16,11 +16,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -37,11 +33,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -77,8 +69,6 @@ INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}file1.txt[0m
 INFO  : - [34mPath2[0m    [35mDo queued copies to[0m                - [36mPath1[0m
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_normalization/golden/test.log
+++ b/cmd/bisync/testdata/test_normalization/golden/test.log
@@ -17,11 +17,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
-INFO  : 測試_Русский_ _ _ě_áñ: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -74,12 +70,8 @@ INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m"
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}file1.txt[0m
 INFO  : - [34mPath2[0m    [35mDo queued copies to[0m                - [36mPath1[0m
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : 測試_Русский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Made directory with metadata (mtime=2024-02-27T04:53:52.993859723-05:00)
-INFO  : folder: Set directory modification time (using SetModTime)
 INFO  : folder/hello,WORLD!.txt: Fixed case by renaming to: folder/HeLlO,wOrLd!.txt
 INFO  : folder/éééö.txt: Fixed case by renaming to: folder/éééö.txt
-INFO  : 測試_Русский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Set directory modification time (using SetModTime)
-INFO  : folder: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -158,11 +150,7 @@ INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{
 INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m"{path2/}測試_Руский___ě_áñ👸🏼🧝🏾\u200d♀️💆🏿\u200d♂️🐨🤙🏼🤮🧑🏻\u200d🔧🧑\u200d🔬éö/測試_Руский___ě_áñ👸🏼🧝🏾\u200d♀️💆🏿\u200d♂️🐨🤙🏼🤮🧑🏻\u200d🔧🧑\u200d🔬éö.txt"[0m
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}file1.txt[0m
 INFO  : - [34mPath2[0m    [35mDo queued copies to[0m                - [36mPath1[0m
-INFO  : folder: Set directory modification time (using SetModTime)
-INFO  : folder: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : 測試_Руский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Made directory with metadata (mtime=2024-02-27T04:53:53.001859642-05:00)
-INFO  : 測試_Руский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -182,15 +170,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : folder: Set directory modification time (using SetModTime)
-INFO  : 測試_Руский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Set directory modification time (using SetModTime)
-INFO  : folder: Set directory modification time (using SetModTime)
-INFO  : 測試_Руский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : folder: Set directory modification time (using SetModTime)
-INFO  : 測試_Руский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Set directory modification time (using SetModTime)
-INFO  : folder: Set directory modification time (using SetModTime)
-INFO  : 測試_Руский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -230,10 +210,6 @@ INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m"
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}file1.txt[0m
 INFO  : - [34mPath2[0m    [35mDo queued copies to[0m                - [36mPath1[0m
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : folder: Set directory modification time (using SetModTime)
-INFO  : 測試_Руский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Set directory modification time (using SetModTime)
-INFO  : folder: Set directory modification time (using SetModTime)
-INFO  : 測試_Руский___ě_áñ👸🏼🧝🏾‍♀️💆🏿‍♂️🐨🤙🏼🤮🧑🏻‍🔧🧑‍🔬éö: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_rclone_args/golden/test.log
+++ b/cmd/bisync/testdata/test_rclone_args/golden/test.log
@@ -15,11 +15,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -111,11 +107,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -149,8 +141,6 @@ INFO  : Applying changes
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}file2.txt[0m
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}subdir/file21.txt[0m
 INFO  : - [34mPath2[0m    [35mDo queued copies to[0m                - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -168,11 +158,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -214,11 +200,7 @@ INFO  : - [36mPath1[0m    [35m[32mQueue copy to[0m Path2[0m       - [36m{
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}file2.txt[0m
 INFO  : - [34mPath2[0m    [35m[32mQueue copy to[0m Path1[0m       - [36m{path1/}subdir/file21.txt[0m
 INFO  : - [34mPath2[0m    [35mDo queued copies to[0m                - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/cmd/bisync/testdata/test_rmdirs/golden/test.log
+++ b/cmd/bisync/testdata/test_rmdirs/golden/test.log
@@ -16,11 +16,7 @@ INFO  : Bisyncing with Comparison Settings:
 INFO  : Synching Path1 "{path1/}" with Path2 "{path2/}"
 INFO  : Copying Path2 files to Path1
 INFO  : - [34mPath2[0m    [35mResync is copying files to[0m         - [36mPath1[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : - [36mPath1[0m    [35mResync is copying files to[0m         - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Resync updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m
@@ -49,8 +45,6 @@ INFO  : Path2 checking for diffs
 INFO  : Applying changes
 INFO  : - [34mPath2[0m    [35m[31mQueue delete[0m[0m              - [36m{path2/}subdir/file20.txt[0m
 INFO  : - [36mPath1[0m    [35mDo queued copies to[0m                - [36mPath2[0m
-INFO  : subdir: Set directory modification time (using SetModTime)
-INFO  : subdir: Set directory modification time (using SetModTime)
 INFO  : Updating listings
 INFO  : Validating listings for Path1 "{path1/}" vs Path2 "{path2/}"
 INFO  : [32mBisync successful[0m

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -55,7 +55,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.StringVarP(flagSet, &tempDir, "temp-dir", "", os.TempDir(), "Directory rclone will use for temporary files", "Config")
 	flags.BoolVarP(flagSet, &ci.CheckSum, "checksum", "c", ci.CheckSum, "Check for changes with size & checksum (if available, or fallback to size only).", "Copy")
 	flags.BoolVarP(flagSet, &ci.SizeOnly, "size-only", "", ci.SizeOnly, "Skip based on size only, not modtime or checksum", "Copy")
-	flags.BoolVarP(flagSet, &ci.IgnoreTimes, "ignore-times", "I", ci.IgnoreTimes, "Don't skip files that match size and time - transfer all files", "Copy")
+	flags.BoolVarP(flagSet, &ci.IgnoreTimes, "ignore-times", "I", ci.IgnoreTimes, "Don't skip items that match size and time - transfer all unconditionally", "Copy")
 	flags.BoolVarP(flagSet, &ci.IgnoreExisting, "ignore-existing", "", ci.IgnoreExisting, "Skip all files that exist on destination", "Copy")
 	flags.BoolVarP(flagSet, &ci.IgnoreErrors, "ignore-errors", "", ci.IgnoreErrors, "Delete even if there are I/O errors", "Sync")
 	flags.BoolVarP(flagSet, &ci.DryRun, "dry-run", "n", ci.DryRun, "Do a trial run with no permanent changes", "Config,Important")

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -19,6 +19,7 @@ import (
 	mutex "sync" // renamed as "sync" already in use
 
 	_ "github.com/rclone/rclone/backend/all" // import all backends
+	"github.com/rclone/rclone/cmd/bisync/bilib"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/accounting"
 	"github.com/rclone/rclone/fs/filter"
@@ -2497,6 +2498,74 @@ func TestSyncConcurrentDelete(t *testing.T) {
 
 func TestSyncConcurrentTruncate(t *testing.T) {
 	testSyncConcurrent(t, "truncate")
+}
+
+// Tests that nothing is transferred when src and dst already match
+// Run the same sync twice, ensure no action is taken the second time
+func TestNothingToTransfer(t *testing.T) {
+	accounting.GlobalStats().ResetCounters()
+	ctx, _ := fs.AddConfig(context.Background())
+	r := fstest.NewRun(t)
+	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
+	file2 := r.WriteFile("sub dir2/very/very/very/very/very/nested/subdir/hello world", "hello world", t1)
+	r.CheckLocalItems(t, file1, file2)
+	_, err := operations.SetDirModTime(ctx, r.Flocal, nil, "sub dir", t2)
+	if err != nil && !errors.Is(err, fs.ErrorNotImplemented) {
+		require.NoError(t, err)
+	}
+	r.Mkdir(ctx, r.Fremote)
+	_, err = operations.MkdirModTime(ctx, r.Fremote, "sub dir", t3)
+	require.NoError(t, err)
+
+	// set logging
+	// (this checks log output as DirModtime operations do not yet have stats, and r.CheckDirectoryModTimes also does not tell us what actions were taken)
+	oldLogLevel := fs.GetConfig(context.Background()).LogLevel
+	defer func() { fs.GetConfig(context.Background()).LogLevel = oldLogLevel }() // reset to old val after test
+	// need to do this as fs.Infof only respects the globalConfig
+	fs.GetConfig(context.Background()).LogLevel = fs.LogLevelInfo
+
+	accounting.GlobalStats().ResetCounters()
+	ctx = predictDstFromLogger(ctx)
+	output := bilib.CaptureOutput(func() {
+		err = CopyDir(ctx, r.Fremote, r.Flocal, true)
+		require.NoError(t, err)
+	})
+	require.NotNil(t, output)
+	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
+	// Check that the modtimes of the directories are as expected
+	r.CheckDirectoryModTimes(t, "sub dir")
+
+	// check that actions were taken
+	assert.True(t, strings.Contains(string(output), "Copied"), `expected to find at least one "Copied" log: `+string(output))
+	if r.Fremote.Features().DirSetModTime != nil || r.Fremote.Features().MkdirMetadata != nil {
+		assert.True(t, strings.Contains(string(output), "Set directory modification time"), `expected to find at least one "Set directory modification time" log: `+string(output))
+	}
+	assert.False(t, strings.Contains(string(output), "There was nothing to transfer"), `expected to find no "There was nothing to transfer" logs, but found one: `+string(output))
+	assert.Equal(t, int64(2), accounting.GlobalStats().GetTransfers())
+
+	// run it again and make sure no actions were taken
+	accounting.GlobalStats().ResetCounters()
+	ctx = predictDstFromLogger(ctx)
+	output = bilib.CaptureOutput(func() {
+		err = CopyDir(ctx, r.Fremote, r.Flocal, true)
+		require.NoError(t, err)
+	})
+	require.NotNil(t, output)
+	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	r.CheckLocalItems(t, file1, file2)
+	r.CheckRemoteItems(t, file1, file2)
+	// Check that the modtimes of the directories are as expected
+	r.CheckDirectoryModTimes(t, "sub dir")
+
+	// check that actions were NOT taken
+	assert.False(t, strings.Contains(string(output), "Copied"), `expected to find no "Copied" logs, but found one: `+string(output))
+	if r.Fremote.Features().DirSetModTime != nil || r.Fremote.Features().MkdirMetadata != nil {
+		assert.False(t, strings.Contains(string(output), "Set directory modification time"), `expected to find no "Set directory modification time" logs, but found one: `+string(output))
+	}
+	assert.True(t, strings.Contains(string(output), "There was nothing to transfer"), `expected to find a "There was nothing to transfer" log: `+string(output))
+	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
 }
 
 // for testing logger:


### PR DESCRIPTION
#### What is the purpose of this change?

Before this change, directory modtimes (and metadata) were always synced from src to dst, even if already in sync (i.e. their modtimes already matched.) This potentially required excessive API calls, made logs noisy, and was potentially problematic for backends that create "versions" or otherwise log activity updates when modtime/metadata is updated.

After this change, a new `DirsEqual` function is added to check whether dirs are equal based on a number of factors such as ModifyWindow and sync flags in use. If the dirs are equal, the modtime/metadata update is skipped.

For backends that require `setDirModTimeAfter`, the "after" sync is performed only for dirs that could have been changed by the sync (i.e. dirs containing files that were created/updated.)

Note that dir metadata (other than modtime) is not currently considered by DirsEqual, consistent with [how object metadata is synced](https://rclone.org/docs/#metadata) (only when objects are unequal for reasons other than metadata).

To sync dir modtimes and metadata unconditionally (the previous behavior), use `--ignore-times`.

#### Was the change discussed in an issue or in the forum before?

- https://github.com/rclone/rclone/issues/6685#issuecomment-1971552577

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
