### PR TITLE
`combine`: fix `CopyDirMetadata` error on upstream root

### DIFF
--- a/backend/combine/combine.go
+++ b/backend/combine/combine.go
@@ -813,7 +813,7 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 	if f.root == "" && dir == "" {
 		entries = make(fs.DirEntries, 0, len(f.upstreams))
 		for combineDir := range f.upstreams {
-			d := fs.NewDir(combineDir, f.when)
+			d := fs.NewLimitedDirWrapper(combineDir, fs.NewDir(combineDir, f.when))
 			entries = append(entries, d)
 		}
 		return entries, nil
@@ -1002,7 +1002,7 @@ func (f *Fs) DirSetModTime(ctx context.Context, dir string, modTime time.Time) e
 		return err
 	}
 	if uDir == "" {
-		fs.Debugf(dir, "can't set modtime on upstream root. skipping.")
+		fs.Debugf(dir, "Can't set modtime on upstream root. skipping.")
 		return nil
 	}
 	if do := u.f.Features().DirSetModTime; do != nil {

--- a/docs/content/bugs.md
+++ b/docs/content/bugs.md
@@ -7,10 +7,13 @@ description: "Rclone Bugs and Limitations"
 
 ## Limitations
 
-### Directory timestamps aren't preserved
+### Directory timestamps aren't preserved on some backends
 
-Rclone doesn't currently preserve the timestamps of directories.  This
-is because rclone only really considers objects when syncing.
+As of `v1.66`, rclone supports syncing directory modtimes, if the backend
+supports it. Some backends do not support it -- see
+[overview](https://rclone.org/overview/) for a complete list. Additionally, note
+that empty directories are not synced by default (this can be enabled with
+`--create-empty-src-dirs`.)
 
 ### Rclone struggles with millions of files in a directory/bucket
 

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -2546,7 +2546,7 @@ func CopyDirMetadata(ctx context.Context, f fs.Fs, dst fs.Directory, dir string,
 	} else {
 		do, ok := dst.(fs.SetMetadataer)
 		if !ok {
-			return nil, fmt.Errorf("internal error: expecting directory %T from %v to have SetMetadata method: %w", dir, f, fs.ErrorNotImplemented)
+			return nil, fmt.Errorf("internal error: expecting directory %s (%T) from %v to have SetMetadata method: %w", logName, dst, f, fs.ErrorNotImplemented)
 		}
 		err = do.SetMetadata(ctx, metadata)
 		newDst = dst
@@ -2598,5 +2598,5 @@ func SetDirModTime(ctx context.Context, f fs.Fs, dst fs.Directory, dir string, m
 	}
 
 	// Something should have worked so return an error
-	return nil, fmt.Errorf("no method to set directory modtime found for %v (%T): %w", f, dir, fs.ErrorNotImplemented)
+	return nil, fmt.Errorf("no method to set directory modtime found for %v (%T): %w", f, dst, fs.ErrorNotImplemented)
 }


### PR DESCRIPTION
#### What is the purpose of this change?

`operations.CopyDirMetadata` was failing with:

```
internal error: expecting directory string from combine root '' to have SetMetadata method: optional feature not implemented
```

if the `dst` was the root directory of a `combine` upstream. This is because combine was returning a `*fs.Dir`, which does not satisfy the `fs.SetMetadataer` interface.

Here's one proposed solution, but feel free to toss it if you have a different one in mind 🙂 

Also, I didn't check, but it seems possible that Union and other similar backends might need a similar fix.

#### Was the change discussed in an issue or in the forum before?

No, I just noticed it tonight.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
