### PR TITLE
`combine`: fix `operations.DirMove` across upstreams - fixes #7661

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -2269,7 +2269,10 @@ func DirMove(ctx context.Context, f fs.Fs, srcRemote, dstRemote string) (err err
 		if err == nil {
 			accounting.Stats(ctx).Renames(1)
 		}
-		return err
+		if err != fs.ErrorCantDirMove && err != fs.ErrorDirExists {
+			return err
+		}
+		fs.Infof(f, "Can't DirMove - falling back to file moves: %v", err)
 	}
 
 	// Load the directory tree into memory


### PR DESCRIPTION
#### What is the purpose of this change?

Before this change, `operations.DirMove` would fail when moving a directory, if the src and dest were on different upstreams of a `combine` remote.

The issue only affected `operations.DirMove`, and not `sync.MoveDir`, because they checked for server-side-move support in different ways.

`MoveDir` checks by just trying it and seeing what error comes back. This works fine for `combine` because `combine` returns `fs.ErrorCantDirMove` which `MoveDir` understands what to do with.

`DirMove`, however, only checked whether the function pointer is `nil`. This is an unreliable way to check for `combine`, because `combine` does advertise support for `DirMove`, despite not always being able to do it.

This change fixes the issue by checking the returned error in a manner similar to `sync.MoveDir` and falling back to individual file moves (copy + delete) depending on which error was returned.

#### Was the change discussed in an issue or in the forum before?

- #7661 
- https://forum.rclone.org/t/combined-remotes-moving-directory-within-different-remotes-fails/44918/17?u=nielash
- https://forum.rclone.org/t/dropbox-io-error-movedir-failed-from-lookup-not-found-when-try-to-move-copy-works/34088

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
