### PR TITLE
Improve JSON Unmarshalling for Duration Type in fs Package

### DIFF
--- a/fs/parseduration.go
+++ b/fs/parseduration.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"encoding/json"
 	"fmt"
 	"math"
 	"strconv"
@@ -231,10 +232,30 @@ func (d Duration) Type() string {
 
 // UnmarshalJSON makes sure the value can be parsed as a string or integer in JSON
 func (d *Duration) UnmarshalJSON(in []byte) error {
-	return UnmarshalJSONFlag(in, d, func(i int64) error {
-		*d = Duration(i)
+	// Check if the input is a string value.
+	if in[0] == '"' {
+		strVal := string(in[1 : len(in)-1]) // Remove the quotes
+		// Handle the special "off" case.
+		if strVal == "off" {
+			*d = DurationOff
+			return nil
+		}
+		// Attempt to parse the string as a duration.
+		parsedDuration, err := ParseDuration(strVal)
+		if err != nil {
+			return err
+		}
+		*d = Duration(parsedDuration)
 		return nil
-	})
+	}
+	// Handle numeric values.
+	var i int64
+	err := json.Unmarshal(in, &i)
+	if err != nil {
+		return err
+	}
+	*d = Duration(i)
+	return nil
 }
 
 // Scan implements the fmt.Scanner interface

--- a/fs/parseduration.go
+++ b/fs/parseduration.go
@@ -233,13 +233,9 @@ func (d Duration) Type() string {
 // UnmarshalJSON makes sure the value can be parsed as a string or integer in JSON
 func (d *Duration) UnmarshalJSON(in []byte) error {
 	// Check if the input is a string value.
-	if in[0] == '"' {
+	if len(in) >= 2 && in[0] == '"' && in[len(in)-1] == '"' {
 		strVal := string(in[1 : len(in)-1]) // Remove the quotes
-		// Handle the special "off" case.
-		if strVal == "off" {
-			*d = DurationOff
-			return nil
-		}
+
 		// Attempt to parse the string as a duration.
 		parsedDuration, err := ParseDuration(strVal)
 		if err != nil {

--- a/fs/parseduration_test.go
+++ b/fs/parseduration_test.go
@@ -214,3 +214,32 @@ func TestParseUnmarshalJSON(t *testing.T) {
 		assert.Equal(t, Duration(test.want), duration, test.in)
 	}
 }
+
+func TestUnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    Duration
+		wantErr bool
+	}{
+		{"off string", `"off"`, DurationOff, false},
+		{"max int64", `9223372036854775807`, DurationOff, false},
+		{"duration string", `"1h"`, Duration(time.Hour), false},
+		{"invalid string", `"invalid"`, 0, true},
+		{"negative int", `-1`, Duration(-1), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var d Duration
+			err := json.Unmarshal([]byte(tt.input), &d)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("UnmarshalJSON() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if d != tt.want {
+				t.Errorf("UnmarshalJSON() got = %v, want %v", d, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enhanced the UnmarshalJSON method for the Duration type to correctly handle the special string 'off' and ensure large integers are parsed accurately without floating-point rounding errors. This resolves issues with setting and removing the MinAge filter through the rclone rc command.

Fixes #3783


Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.


#### What is the purpose of this change?


This Pull Request introduces enhancements to the `Duration` type's `UnmarshalJSON` method within the `fs` package to correctly handle the special string "off" and ensure large integers are parsed accurately without floating-point rounding errors. This change is crucial for allowing users to set and remove the MinAge filter through the `rclone rc` command without encountering errors.

### Problem
When attempting to remove the MinAge filter by setting its value to the maximum integer, users encountered JSON unmarshalling errors due to the way large integers were handled.

### Solution
By checking for the special "off" string and parsing large integers directly as `int64`, we avoid the rounding errors associated with floating-point conversions and ensure compatibility with the expected `Duration` values.

### Impact
This fix allows for more flexible and error-free configuration of filters through the `rclone rc` command, enhancing the user experience.

Fixes #3783


#### Was the change discussed in an issue or in the forum before?


issue #3783 


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
