### PR TITLE
`fs/cache`: fix parent not getting pinned when remote is a file & `hasher`: look for cached hash if passed hash unexpectedly blank 

### DIFF
--- a/fs/cache/cache.go
+++ b/fs/cache/cache.go
@@ -4,6 +4,7 @@ package cache
 import (
 	"context"
 	"runtime"
+	"strings"
 	"sync"
 
 	"github.com/rclone/rclone/fs"
@@ -12,10 +13,11 @@ import (
 )
 
 var (
-	once  sync.Once // creation
-	c     *cache.Cache
-	mu    sync.Mutex            // mutex to protect remap
-	remap = map[string]string{} // map user supplied names to canonical names
+	once           sync.Once // creation
+	c              *cache.Cache
+	mu             sync.Mutex            // mutex to protect remap
+	remap          = map[string]string{} // map user supplied names to canonical names - [fsString]canonicalName
+	childParentMap = map[string]string{} // tracks a one-to-many relationship between parent dirs and their direct children files - [child]parent
 )
 
 // Create the cache just once
@@ -57,6 +59,39 @@ func addMapping(fsString, canonicalName string) {
 	mu.Unlock()
 }
 
+// addChild tracks known file (child) to directory (parent) relationships.
+// Note that the canonicalName of a child will always equal that of its parent,
+// but not everything with an equal canonicalName is a child.
+// It could be an alias or overridden version of a directory.
+func addChild(child, parent string) {
+	if child == parent {
+		return
+	}
+	mu.Lock()
+	childParentMap[child] = parent
+	mu.Unlock()
+}
+
+// returns true if name is definitely known to be a child (i.e. a file, not a dir).
+// returns false if name is a dir or if we don't know.
+func isChild(child string) bool {
+	mu.Lock()
+	_, found := childParentMap[child]
+	mu.Unlock()
+	return found
+}
+
+// ensures that we return fs.ErrorIsFile when necessary
+func getError(fsString string, err error) error {
+	if err != nil && err != fs.ErrorIsFile {
+		return err
+	}
+	if isChild(fsString) {
+		return fs.ErrorIsFile
+	}
+	return nil
+}
+
 // GetFn gets an fs.Fs named fsString either from the cache or creates
 // it afresh with the create function
 func GetFn(ctx context.Context, fsString string, create func(ctx context.Context, fsString string) (fs.Fs, error)) (f fs.Fs, err error) {
@@ -69,31 +104,39 @@ func GetFn(ctx context.Context, fsString string, create func(ctx context.Context
 		created = ok
 		return f, ok, err
 	})
+	f, ok := value.(fs.Fs)
 	if err != nil && err != fs.ErrorIsFile {
+		if ok {
+			return f, err // for possible future uses of PutErr
+		}
 		return nil, err
 	}
-	f = value.(fs.Fs)
 	// Check we stored the Fs at the canonical name
 	if created {
 		canonicalName := fs.ConfigString(f)
 		if canonicalName != canonicalFsString {
-			// Note that if err == fs.ErrorIsFile at this moment
-			// then we can't rename the remote as it will have the
-			// wrong error status, we need to add a new one.
-			if err == nil {
+			if err == nil { // it's a dir
 				fs.Debugf(nil, "fs cache: renaming cache item %q to be canonical %q", canonicalFsString, canonicalName)
 				value, found := c.Rename(canonicalFsString, canonicalName)
 				if found {
 					f = value.(fs.Fs)
 				}
 				addMapping(canonicalFsString, canonicalName)
-			} else {
-				fs.Debugf(nil, "fs cache: adding new entry for parent of %q, %q", canonicalFsString, canonicalName)
-				Put(canonicalName, f)
+			} else { // it's a file
+				// the fs we cache is always the file's parent, never the file,
+				// but we use the childParentMap to return the correct error status based on the fsString passed in.
+				fs.Debugf(nil, "fs cache: renaming child cache item %q to be canonical for parent %q", canonicalFsString, canonicalName)
+				value, found := c.Rename(canonicalFsString, canonicalName) // rename the file entry to parent
+				if found {
+					f = value.(fs.Fs) // if parent already exists, use it
+				}
+				Put(canonicalName, f)                        // force err == nil for the cache
+				addMapping(canonicalFsString, canonicalName) // note the fsString-canonicalName connection for future lookups
+				addChild(fsString, canonicalName)            // note the file-directory connection for future lookups
 			}
 		}
 	}
-	return f, err
+	return f, getError(fsString, err) // ensure fs.ErrorIsFile is returned when necessary
 }
 
 // Pin f into the cache until Unpin is called
@@ -111,7 +154,6 @@ func PinUntilFinalized(f fs.Fs, x interface{}) {
 	runtime.SetFinalizer(x, func(_ interface{}) {
 		Unpin(f)
 	})
-
 }
 
 // Unpin f from the cache
@@ -174,6 +216,9 @@ func PutErr(fsString string, f fs.Fs, err error) {
 	canonicalName := fs.ConfigString(f)
 	c.PutErr(canonicalName, f, err)
 	addMapping(fsString, canonicalName)
+	if err == fs.ErrorIsFile {
+		addChild(fsString, canonicalName)
+	}
 }
 
 // Put puts an fs.Fs named fsString into the cache
@@ -186,6 +231,7 @@ func Put(fsString string, f fs.Fs) {
 // Returns number of entries deleted
 func ClearConfig(name string) (deleted int) {
 	createOnFirstUse()
+	ClearMappingsPrefix(name)
 	return c.DeletePrefix(name + ":")
 }
 
@@ -193,10 +239,47 @@ func ClearConfig(name string) (deleted int) {
 func Clear() {
 	createOnFirstUse()
 	c.Clear()
+	ClearMappings()
 }
 
 // Entries returns the number of entries in the cache
 func Entries() int {
 	createOnFirstUse()
 	return c.Entries()
+}
+
+// ClearMappings removes everything from remap and childParentMap
+func ClearMappings() {
+	mu.Lock()
+	defer mu.Unlock()
+	remap = map[string]string{}
+	childParentMap = map[string]string{}
+}
+
+// ClearMappingsPrefix deletes all mappings to parents with given prefix
+//
+// Returns number of entries deleted
+func ClearMappingsPrefix(prefix string) (deleted int) {
+	mu.Lock()
+	do := func(mapping map[string]string) {
+		for key, val := range mapping {
+			if !strings.HasPrefix(val, prefix) {
+				continue
+			}
+			delete(mapping, key)
+			deleted++
+		}
+	}
+	do(remap)
+	do(childParentMap)
+	mu.Unlock()
+	return deleted
+}
+
+// EntriesWithPinCount returns the number of pinned and unpinned entries in the cache
+//
+// Each entry is counted only once, regardless of entry.pinCount
+func EntriesWithPinCount() (pinned, unpinned int) {
+	createOnFirstUse()
+	return c.EntriesWithPinCount()
 }

--- a/fs/rc/cache_test.go
+++ b/fs/rc/cache_test.go
@@ -22,7 +22,7 @@ func mockNewFs(t *testing.T) func() {
 	require.NoError(t, err)
 	cache.Put("mock:/", f)
 	cache.Put(":mock:/", f)
-	f, err = mockfs.NewFs(ctx, "mock", "dir/file.txt", nil)
+	f, err = mockfs.NewFs(ctx, "mock", "dir/", nil)
 	require.NoError(t, err)
 	cache.PutErr("mock:dir/file.txt", f, fs.ErrorIsFile)
 	return func() {

--- a/lib/cache/cache.go
+++ b/lib/cache/cache.go
@@ -260,3 +260,19 @@ func (c *Cache) SetFinalizer(finalize func(interface{})) {
 	c.finalize = finalize
 	c.mu.Unlock()
 }
+
+// EntriesWithPinCount returns the number of pinned and unpinned entries in the cache
+//
+// Each entry is counted only once, regardless of entry.pinCount
+func (c *Cache) EntriesWithPinCount() (pinned, unpinned int) {
+	c.mu.Lock()
+	for _, entry := range c.cache {
+		if entry.pinCount <= 0 {
+			unpinned++
+		} else {
+			pinned++
+		}
+	}
+	c.mu.Unlock()
+	return pinned, unpinned
+}


### PR DESCRIPTION
#### What is the purpose of this change?

Three related bug fixes identified on https://forum.rclone.org/t/hasher-with-gdrive-backend-does-not-return-sha1-sha256-for-old-files/44680/9?u=nielash

1. `fs/cache`: fix parent not getting pinned when remote is a file
2. `hasher`: fix error from trying to stop an already-stopped db
3. `hasher`: look for cached hash if passed hash unexpectedly blank

`2` and `3` are specific to `hasher`, but `1` might possibly explain some unexplained behavior in other backends.

Before this change, when `cache.GetFn` was called on a _file_ rather than a directory, two cache entries would be added (the file + its parent) but only one of them would get pinned if the caller then called `Pin(f)`. This left the other one exposed to expiration if the `ci.FsCacheExpireDuration` was reached. This was problematic because both entries point to the same Fs, and if one entry expires while the other is pinned, the `Shutdown` method gets erroneously called on an Fs that is still in use.

An example of the problem showed up in the `Hasher` backend, which uses the `Shutdown` method to stop the bolt db used to store hashes. If a command was run on a Hasher file (ex. `rclone md5sum --download hasher:somelargefile.zip`) and hashing the file took longer than the `--fs-cache-expire-duration` (5m by default), the bolt db was stopped before the hashing operation completed, resulting in an error.

This change fixes the issue by ensuring that the Pin/Unpin functions also Pin/Unpin any aliases in lockstep, so that pinning a file also pins the cache entry for its parent.

#### Was the change discussed in an issue or in the forum before?

- https://forum.rclone.org/t/hasher-with-gdrive-backend-does-not-return-sha1-sha256-for-old-files/44680/9?u=nielash

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
