### PR TITLE
`memory`: fix deadlock in `operations.Purge`

### DIFF
--- a/backend/memory/memory_internal_test.go
+++ b/backend/memory/memory_internal_test.go
@@ -1,0 +1,40 @@
+package memory
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	_ "github.com/rclone/rclone/backend/local"
+	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fstest"
+	"github.com/rclone/rclone/fstest/fstests"
+	"github.com/stretchr/testify/require"
+)
+
+var t1 = fstest.Time("2001-02-03T04:05:06.499999999Z")
+
+// InternalTest dispatches all internal tests
+func (f *Fs) InternalTest(t *testing.T) {
+	t.Run("PurgeListDeadlock", func(t *testing.T) {
+		testPurgeListDeadlock(t)
+	})
+}
+
+// test that Purge fallback does not result in deadlock from concurrently listing and removing
+func testPurgeListDeadlock(t *testing.T) {
+	ctx := context.Background()
+	r := fstest.NewRunIndividual(t)
+	r.Mkdir(ctx, r.Fremote)
+	r.Fremote.Features().Disable("Purge") // force fallback-purge
+
+	// make a lot of files to prevent it from finishing too quickly
+	for i := 0; i < 100; i++ {
+		dst := "file" + fmt.Sprint(i) + ".txt"
+		r.WriteObject(ctx, dst, "hello", t1)
+	}
+
+	require.NoError(t, operations.Purge(ctx, r.Fremote, ""))
+}
+
+var _ fstests.InternalTester = (*Fs)(nil)


### PR DESCRIPTION
#### What is the purpose of this change?

Before this change, the `Memory` backend had the potential to deadlock under certain conditions, if the `ListR` callback required locking the `b.mu` mutex. This was the case with `operations.Purge`, because `Memory` has no `Purge` method, and the fallback option does:

https://github.com/rclone/rclone/blob/ca903b9872790921ae85dee316ca1800657281c4/fs/operations/operations.go#L1126

which potentially starts removing objects before the listing has completed.

This change fixes the issue by ensuring the mu is unlocked for the duration of `fn`.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
