### PR TITLE
docs: sftp, clarify `shell_type = none` and `ssh = ` behaviour

### DIFF
--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -279,6 +279,8 @@ option before first run, the auto-detection will be skipped, and if
 you set a different value later this will override any existing.
 Value `none` can be set to avoid any attempts at executing shell
 commands, e.g. if this is not allowed on the server.
+If you have `shell_type = none` in the configuration then
+the [ssh](#sftp-ssh) must not be set.
 
 When the server is [rclone serve sftp](/commands/rclone_serve_sftp/),
 the rclone SFTP remote will detect this as a Unix type shell - even


### PR DESCRIPTION
Discussed on the forum:

https://forum.rclone.org/t/can-rclone-be-made-to-work-with-an-sftp-server-confining-users-to-an-sftp-jail-and-no-login/44931

#### Checklist

- [ x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ x] I have added documentation for the changes if appropriate.
- [ x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)
