### PR TITLE
docs: Proton Drive, correct typo

### DIFF
--- a/docs/content/protondrive.md
+++ b/docs/content/protondrive.md
@@ -46,7 +46,7 @@ Type of storage to configure.
 Choose a number from below, or type in your own value
 [snip]
 XX / Proton Drive
-   \ "Proton Drive"
+   \ "protondrive"
 [snip]
 Storage> protondrive
 User name


### PR DESCRIPTION
Proton Drive correct typo

