### PR TITLE
`memory`: fix incorrect list entries when rooted at subdirectory

### DIFF
--- a/backend/memory/memory.go
+++ b/backend/memory/memory.go
@@ -297,7 +297,7 @@ func (f *Fs) list(ctx context.Context, bucket, directory, prefix string, addBuck
 				slash := strings.IndexRune(localPath, '/')
 				if slash >= 0 {
 					// send a directory if have a slash
-					dir := directory + localPath[:slash]
+					dir := strings.TrimPrefix(directory, f.rootDirectory+"/") + localPath[:slash]
 					if addBucket {
 						dir = path.Join(bucket, dir)
 					}

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/cache"
 	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/fspath"
@@ -1204,6 +1205,28 @@ func Run(t *testing.T, opt *Opt) {
 					"hello? sausage/êé/Hello, 世界/ \" ' @ < > & ? + ≠",
 				}, fs.GetModifyWindow(ctx, f))
 			})
+
+			// TestFsListRootedSubdir tests putting and listing with an Fs that is rooted at a subdirectory 2 levels down
+			TestFsListRootedSubdir := func(t *testing.T) {
+				skipIfNotOk(t)
+				newF, err := cache.Get(ctx, subRemoteName+"/hello? sausage/êé")
+				assert.NoError(t, err)
+				nestedFile := fstest.Item{
+					ModTime: fstest.Time("2001-02-03T04:05:06.499999999Z"),
+					Path:    "a/b/c/d/e.txt",
+				}
+				_, _ = testPut(ctx, t, newF, &nestedFile)
+
+				objs, dirs, err := walk.GetAll(ctx, newF, "", true, 10)
+				require.NoError(t, err)
+				assert.Equal(t, []string{`Hello, 世界/ " ' @ < > & ? + ≠/z.txt`, nestedFile.Path}, objsToNames(objs))
+				assert.Equal(t, []string{`Hello, 世界`, `Hello, 世界/ " ' @ < > & ? + ≠`, "a", "a/b", "a/b/c", "a/b/c/d"}, dirsToNames(dirs))
+
+				// cleanup
+				err = operations.Purge(ctx, newF, "a")
+				require.NoError(t, err)
+			}
+			t.Run("FsListRootedSubdir", TestFsListRootedSubdir)
 
 			// TestFsCopy tests Copy
 			t.Run("FsCopy", func(t *testing.T) {


### PR DESCRIPTION
#### What is the purpose of this change?

Before this change, `List` would return incorrect directory paths (relative to the wrong root) if the Fs root pointed to a subdirectory. For example, listing dir `a/b/c/d` of remote `:memory:` would work correctly, but listing dir `c/d` of remote `:memory:a/b` would not, and would result in `Entry doesn't belong in directory %q (contains subdir)` errors.

This change fixes the issue and adds a test to detect any other backends that might have the same issue.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
