### PR TITLE
`memory`: fix dst mutating src after server-side copy

### DIFF
--- a/backend/memory/memory.go
+++ b/backend/memory/memory.go
@@ -482,7 +482,8 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 	if od == nil {
 		return nil, fs.ErrorObjectNotFound
 	}
-	buckets.updateObjectData(dstBucket, dstPath, od)
+	odCopy := *od
+	buckets.updateObjectData(dstBucket, dstPath, &odCopy)
 	return f.NewObject(ctx, remote)
 }
 

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -1237,6 +1237,13 @@ func Run(t *testing.T, opt *Opt) {
 				// Check dst lightly - list above has checked ModTime/Hashes
 				assert.Equal(t, file2Copy.Path, dst.Remote())
 
+				// check that mutating dst does not mutate src
+				err = dst.SetModTime(ctx, fstest.Time("2004-03-03T04:05:06.499999999Z"))
+				if err != fs.ErrorCantSetModTimeWithoutDelete && err != fs.ErrorCantSetModTime {
+					assert.NoError(t, err)
+					assert.False(t, src.ModTime(ctx).Equal(dst.ModTime(ctx)), "mutating dst should not mutate src -- is it Copying by pointer?")
+				}
+
 				// Delete copy
 				err = dst.Remove(ctx)
 				require.NoError(t, err)


### PR DESCRIPTION
#### What is the purpose of this change?

Before this change, the `Memory` backend's `Copy` method created a `dst` object that referenced the `src`'s `objectData` by pointer instead of making a copy. While this minimized memory usage, an unintended consequence was that subsequently mutating the `src` (such as changing the `modtime`) would inadvertently also mutate the `dst`, and vice versa.

This change fixes the issue and adds a test.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
