### PR TITLE
b2: Add tests for new `cleanup` and `cleanup-hidden` backend commands.

### DIFF
--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -5,6 +5,7 @@ package fstest
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"flag"
 	"fmt"
@@ -608,4 +609,15 @@ func CheckDirModTime(ctx context.Context, t *testing.T, f fs.Fs, dir fs.Director
 	}
 	gotT := dir.ModTime(ctx)
 	AssertTimeEqualWithPrecision(t, dir.Remote(), wantT, gotT, f.Precision())
+}
+
+// Gz returns a compressed version of its input string
+func Gz(t *testing.T, s string) string {
+	var buf bytes.Buffer
+	zw := gzip.NewWriter(&buf)
+	_, err := zw.Write([]byte(s))
+	require.NoError(t, err)
+	err = zw.Close()
+	require.NoError(t, err)
+	return buf.String()
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This PR expands test coverage of the `b2` backend, particularly for the new `cleanup` and `cleanup-hidden` commands introduced in https://github.com/rclone/rclone/pull/7656.

#### Was the change discussed in an issue or in the forum before?

Yes - see https://github.com/rclone/rclone/pull/7656#issuecomment-1994967987.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
