### PR TITLE
log: Added support to include date-time in log filename

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1390,6 +1390,42 @@ The options mean
 
 During rmdirs it will not remove root directory, even if it's empty.
 
+### --log-file-time-format=FORMAT ###
+
+A format that is used to generate a datetime string. Any `:dt:` wildcard
+in the log filename specified via `--log-file=FILE` will be replaced with
+this datetime string.
+
+If `FORMAT` is `%Y-%m-%d`, and log-file `FILE` is `err_:dt:.log`, then
+all rclone output will be logged to the file `err_2024-03-26.log`
+assuming that the current date it `26 March 2024`.
+
+Following keywords in the `FORMAT` are recognised as below:
+
+`%A` - Weekday (E.g.: Monday)
+
+`%a` - Short Weekday (E.g.: Mon)
+
+`%Y` - Year (E.g.: 2006)
+
+`%y` - Short Year (E.g.: 06)
+
+`%B` - Month name (E.g.: January)
+
+`%b` - Short Month name (E.g.: Jan)
+
+`%m` - Month number (E.g.: 01)
+
+`%d` - Day of month (E.g.: 02)
+
+`%H` - Hour of day in 24-hour format (E.g.: 15)
+
+`%I` - Hour of day in 12-hour format (E.g.: 03)
+
+`%M` - Minute of hour (E.g.: 04)
+
+`%S` - Second of minute (E.g.: 05)
+
 ### --log-file=FILE ###
 
 Log all of rclone's output to FILE.  This is not active by default.

--- a/fs/log/logflags/logflags.go
+++ b/fs/log/logflags/logflags.go
@@ -12,6 +12,7 @@ import (
 func AddFlags(flagSet *pflag.FlagSet) {
 	rc.AddOption("log", &log.Opt)
 
+	flags.StringVarP(flagSet, &log.Opt.FilenameTimeFormat, "log-filename-time-format", "", log.Opt.FilenameTimeFormat, "Date time format that is used to replace the :dt: in logging filename", "Logging")
 	flags.StringVarP(flagSet, &log.Opt.File, "log-file", "", log.Opt.File, "Log everything to this file", "Logging")
 	flags.StringVarP(flagSet, &log.Opt.Format, "log-format", "", log.Opt.Format, "Comma separated list of log format options", "Logging")
 	flags.BoolVarP(flagSet, &log.Opt.UseSyslog, "syslog", "", log.Opt.UseSyslog, "Use Syslog for logging", "Logging")


### PR DESCRIPTION
Added a flag `log-file-time-format` that allows specifying a date-time format that is used to replace the `:dt:` wildcard in the filename of the log file.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This change allows users to specify a Date-time Format string for a new flag `log-file-time-format`. A datetime string is generated using this format that replaces the wildcard `:dt:` in the log filename. This change is required for a specific scenario: -

By default, rclone always appends (not overwrite) logs to a file. This is the same with cases when a Windows Service is created to allow rclone to run in the background while mounting. Based on the logging level, these logs can be huge and one might not prefer them getting appended to the same file every time the mount command is used (say after the device is restarted). Making dynamic filename (in the context of Windows Service) is a tricky challenge, as the `%....%` variable templates are not replaced with the actual values.

This change allows users to now use dynamic filenames based on the date and time of each session of the rclone.

#### Was the change discussed in an issue or in the forum before?

While the change has not been discussed in any issues, a couple of users have talked in the context of similar requirements in the forums.

https://forum.rclone.org/t/dynamically-create-log-file-with-date-in-the-name/27603
https://forum.rclone.org/t/rclone-win2019-scheduled-tasks-date-in-logfile/33232

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
