### PR TITLE
Remove the temporary Uloz.to filesize limit

### DIFF
--- a/backend/ulozto/ulozto.go
+++ b/backend/ulozto/ulozto.go
@@ -38,8 +38,6 @@ const (
 	maxSleep      = 2 * time.Second
 	decayConstant = 2 // bigger for slower decay, exponential
 	rootURL       = "https://apis.uloz.to"
-	// TODO temporary limitation, remove with chunked upload impl
-	maxFileSizeBytes = 2500 * 1024 * 1024
 )
 
 // Options defines the configuration for this backend
@@ -194,9 +192,7 @@ func errorHandler(resp *http.Response) error {
 // retryErrorCodes is a slice of error codes that we will retry
 var retryErrorCodes = []int{
 	429, // Too Many Requests.
-	// TODO: random 500s should be retried but the error code corresponds to a known issue with uploading large files,
-	//   leading to numerous (slow & resource consuming) retries. Don't retry them until the root cause is addressed.
-	// 500, // Internal Server Error
+	500, // Internal Server Error
 	502, // Bad Gateway
 	503, // Service Unavailable
 	504, // Gateway Timeout
@@ -447,10 +443,6 @@ func (f *Fs) uploadUnchecked(ctx context.Context, name, parentSlug string, info 
 
 // Put implements the mandatory method fs.Fs.Put.
 func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
-	// TODO: workaround for uloz.to's bug. Remove when chunked upload support is implemented.
-	if src.Size() > maxFileSizeBytes {
-		return nil, errors.New("file size over the supported max threshold")
-	}
 	existingObj, err := f.NewObject(ctx, src.Remote())
 
 	switch {

--- a/backend/ulozto/ulozto.go
+++ b/backend/ulozto/ulozto.go
@@ -346,6 +346,11 @@ func (f *Fs) uploadUnchecked(ctx context.Context, name, parentSlug string, info 
 		MultipartFileName:    encodedName,
 		Parameters:           url.Values{},
 	}
+	if info.Size() > 0 {
+		size := info.Size()
+		opts.ContentLength = &size
+	}
+
 	var uploadResponse api.SendFilePayloadResponse
 
 	err = f.pacer.CallNoRetry(func() (bool, error) {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
Remove the workarounds for uloz.to's file size. 

The combination of large files, absence of `Content-Length` header, and chunked encoding triggers the issue. 

- files under 2.5G are uploaded fine as demonstrated. 
- setting the `Content-Length` either fixes the issue (non-negative value), or triggers a 400 if the file size is not known (-1). 
- removing chunked encoding does nothing (if `Content-Length` is set), or triggers a 415 (if `Content-Length` is not specified)

This currently means we still run into the issue with large files if rclone doesn't know their size beforehand. Such scenario is presumably very rare though, and explicitly setting the size to -1 isn't handled properly in rclone's multipart generation code. 

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/pull/7552

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
