### PR TITLE
`onedrive`: fix `--metadata-mapper` called twice if writing permissions

### DIFF
--- a/backend/onedrive/metadata.go
+++ b/backend/onedrive/metadata.go
@@ -613,7 +613,7 @@ func (o *Object) tryGetBtime(modTime time.Time) time.Time {
 }
 
 // adds metadata (except permissions) if --metadata is in use
-func (o *Object) fetchMetadataForCreate(ctx context.Context, src fs.ObjectInfo, options []fs.OpenOption, modTime time.Time) (createRequest api.CreateUploadRequest, err error) {
+func (o *Object) fetchMetadataForCreate(ctx context.Context, src fs.ObjectInfo, options []fs.OpenOption, modTime time.Time) (createRequest api.CreateUploadRequest, metadata fs.Metadata, err error) {
 	createRequest = api.CreateUploadRequest{ // we set mtime no matter what
 		Item: api.Metadata{
 			FileSystemInfo: &api.FileSystemInfoFacet{
@@ -625,10 +625,10 @@ func (o *Object) fetchMetadataForCreate(ctx context.Context, src fs.ObjectInfo, 
 
 	meta, err := fs.GetMetadataOptions(ctx, o.fs, src, options)
 	if err != nil {
-		return createRequest, fmt.Errorf("failed to read metadata from source object: %w", err)
+		return createRequest, nil, fmt.Errorf("failed to read metadata from source object: %w", err)
 	}
 	if meta == nil {
-		return createRequest, nil // no metadata or --metadata not in use, so just return mtime
+		return createRequest, nil, nil // no metadata or --metadata not in use, so just return mtime
 	}
 	if o.meta == nil {
 		o.meta = o.fs.newMetadata(o.Remote())
@@ -636,13 +636,13 @@ func (o *Object) fetchMetadataForCreate(ctx context.Context, src fs.ObjectInfo, 
 	o.meta.mtime = modTime
 	numSet, err := o.meta.Set(ctx, meta)
 	if err != nil {
-		return createRequest, err
+		return createRequest, meta, err
 	}
 	if numSet == 0 {
-		return createRequest, nil
+		return createRequest, meta, nil
 	}
 	createRequest.Item = o.meta.toAPIMetadata()
-	return createRequest, nil
+	return createRequest, meta, nil
 }
 
 // Fetch metadata and update updateInfo if --metadata is in use
@@ -654,27 +654,6 @@ func (f *Fs) fetchAndUpdateMetadata(ctx context.Context, src fs.ObjectInfo, opti
 	}
 	if meta == nil {
 		return updateInfo.setModTime(ctx, src.ModTime(ctx)) // no metadata or --metadata not in use, so just set modtime
-	}
-	if updateInfo.meta == nil {
-		updateInfo.meta = f.newMetadata(updateInfo.Remote())
-	}
-	newInfo, err := updateInfo.updateMetadata(ctx, meta)
-	if newInfo == nil {
-		return info, err
-	}
-	return newInfo, err
-}
-
-// Fetch and update permissions if --metadata is in use
-// This is similar to fetchAndUpdateMetadata, except it does NOT set modtime or other metadata if there are no permissions to set.
-// This is intended for cases where metadata may already have been set during upload and an extra step is needed only for permissions.
-func (f *Fs) fetchAndUpdatePermissions(ctx context.Context, src fs.ObjectInfo, options []fs.OpenOption, updateInfo *Object) (info *api.Item, err error) {
-	meta, err := fs.GetMetadataOptions(ctx, f, src, options)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read metadata from source object: %w", err)
-	}
-	if meta == nil || !f.needsUpdatePermissions(meta) {
-		return nil, nil // no metadata, --metadata not in use, or wrong flags
 	}
 	if updateInfo.meta == nil {
 		updateInfo.meta = f.newMetadata(updateInfo.Remote())

--- a/backend/onedrive/metadata.md
+++ b/backend/onedrive/metadata.md
@@ -4,11 +4,11 @@ differences between OneDrive Personal and Business (see table below for
 details).
 
 Permissions are also supported, if `--onedrive-metadata-permissions` is set. The
-accepted values for `--onedrive-metadata-permissions` are `read`, `write`,
-`read,write`, and `off` (the default). `write` supports adding new permissions,
+accepted values for `--onedrive-metadata-permissions` are "`read`", "`write`",
+"`read,write`", and "`off`" (the default). "`write`" supports adding new permissions,
 updating the "role" of existing permissions, and removing permissions. Updating
 and removing require the Permission ID to be known, so it is recommended to use
-`read,write` instead of `write` if you wish to update/remove permissions.
+"`read,write`" instead of "`write`" if you wish to update/remove permissions.
 
 Permissions are read/written in JSON format using the same schema as the
 [OneDrive API](https://learn.microsoft.com/en-us/onedrive/developer/rest-api/resources/permission?view=odsp-graph-online),
@@ -92,31 +92,14 @@ an ObjectID can be provided in `User.ID`. At least one valid recipient must be
 provided in order to add a permission for a user. Creating a Public Link is also
 supported, if `Link.Scope` is set to `"anonymous"`.
 
-Example request to add a "read" permission:
+Example request to add a "read" permission with `--metadata-mapper`:
 
 ```json
-[
-	{
-			"id": "",
-			"grantedTo": {
-					"user": {},
-					"application": {},
-					"device": {}
-			},
-			"grantedToIdentities": [
-					{
-							"user": {
-									"id": "ryan@contoso.com"
-							},
-							"application": {},
-							"device": {}
-					}
-			],
-			"roles": [
-					"read"
-			]
-	}
-]
+{
+    "Metadata": {
+        "permissions": "[{\"grantedToIdentities\":[{\"user\":{\"id\":\"ryan@contoso.com\"}}],\"roles\":[\"read\"]}]"
+    }
+}
 ```
 
 Note that adding a permission can fail if a conflicting permission already

--- a/fs/log.go
+++ b/fs/log.go
@@ -203,7 +203,7 @@ func PrettyPrint(in any, label string, level LogLevel) {
 		return
 	}
 	inBytes, err := json.MarshalIndent(in, "", "\t")
-	if err != nil {
+	if err != nil || string(inBytes) == "{}" || string(inBytes) == "[]" {
 		LogPrintf(level, label, "\n%+v\n", in)
 		return
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

Before this change, the `--metadata-mapper` was called twice if an object was uploaded via multipart upload with `--metadata` and `--onedrive-metadata-permissions write` or `read,write`. This change fixes the issue.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
