### PR TITLE
docs: Add R2 note about no_check_bucket

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -2377,6 +2377,8 @@ acl = private
 Now run `rclone lsf r2:` to see your buckets and `rclone lsf
 r2:bucket` to look within a bucket.
 
+For R2 tokens with the "Object Read & Write" permission, you may also need to add `no_check_bucket = true` for object uploads to work correctly.
+
 ### Dreamhost
 
 Dreamhost [DreamObjects](https://www.dreamhost.com/cloud/storage/) is


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Context: I work for Cloudflare.

Some time ago I added a note about `no_check_bucket` being required for R2 object-level tokens onto https://developers.cloudflare.com/r2/examples/rclone/ in https://github.com/cloudflare/cloudflare-docs/pull/11438

This is required for non-admin tokens due to rclone sending a PUT to buckets as part of the object upload flow.

This change adds the same note to the rclone docs as well, to reduce friction and confusion across the board.

P.S. Bonus: is this something that can be baked into rclone as a quirk or not? For now documentation will suffice.

#### Was the change discussed in an issue or in the forum before?

It was not, sorry! Let me know if that is needed.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
