### PR TITLE
Show more user friendly names of custom types in config ui

### DIFF
--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -495,7 +495,7 @@ func ChooseOption(o *fs.Option, name string) string {
 		case uint, byte, uint16, uint32, uint64:
 			what = "unsigned integer"
 		default:
-			what = fmt.Sprintf("%T value", o.Default)
+			what = fmt.Sprintf("value of type %s", o.Type())
 		}
 	}
 	var in string


### PR DESCRIPTION
#### What is the purpose of this change?

Instead of:

```
Choose a number from below, or type in your own fs.Enum[github.com/rclone/rclone/backend/local.timeTypeChoices] value.
Press Enter for the default (mtime).
 1 / The last modification time.
   \ (mtime)
 2 / The last access time.
   \ (atime)
 3 / The creation time.
   \ (btime)
 4 / The last status change time.
   \ (ctime)
time_type>
```

Then:

```
Choose a number from below, or type in your own value of type mtime|atime|btime|ctime.
Press Enter for the default (mtime).
...
```

Another less visible example is, instead of:

```
Enter a encoder.MultiEncoder value. Press Enter for the default (Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,RightSpace,RightPeriod,InvalidUtf8,Dot).
```

Then:
```
Enter a value of type Encoding. Press Enter for the default (Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,Ctl,RightSpace,RightPeriod,InvalidUtf8,Dot).
```

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
