### PR TITLE
vfs: Fix multiple oversized downloaders when mounting with --vfs-read…

### DIFF
--- a/vfs/vfscache/downloaders/downloaders.go
+++ b/vfs/vfscache/downloaders/downloaders.go
@@ -363,6 +363,32 @@ func (dls *Downloaders) _ensureDownloader(r ranges.Range) (err error) {
 	if r.Size == 0 {
 		return nil
 	}
+
+	// Shrink existing downloaders to prevent doubling up of ReadAhead in case of multiple file threads / accesses
+	if dls.opt.ReadAhead > 0 {
+		for _, dl = range dls.dls {
+			if dl._closed {
+				continue
+			}
+
+			if dl.maxOffset-dl.start <= window {
+				continue
+			}
+
+			// Adjust this range to shrink without ReadAhead value
+			dl.mu.Lock()
+			dl.maxOffset -= int64(dls.opt.ReadAhead)
+			if dl.maxOffset < dl.start {
+				dl.maxOffset = dl.start
+			}
+			dl.mu.Unlock()
+
+			select {
+			case dl.kick <- struct{}{}:
+			default:
+			}
+		}
+	}
 	// Downloader not found so start a new one
 	_, err = dls._newDownloader(r)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
I was trying to mount my remote server using rclone and wanted to use `--vfs-read-ahead` to smooth out files with variable bitrates. They typically average 60mb/s but can hit peaks of 120-150mb/s. However I observed having a large `--vfs-read-ahead` value (say `4G` or `8G`) would often kill performance, especially when starting the stream from middle. 

When mounting with `--vfs-read-ahead` option, if a file is accessed at multiple offsets (for example, by a video player like Plex to read audio and video tracks) then each corresponding downloader would have the `ReadAhead` added to its `offset`, killing performance.

This fix would shrink old downloaders and only keep the latest one with enhanced `offset`.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
I posted about the issue I was facing here: https://forum.rclone.org/t/plex-seeking-slow-until-it-reads-till-vfs-read-ahead/45346 but it gained no traction. 
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
