### PR TITLE
docs: fix MANUAL formatting problems

### DIFF
--- a/docs/content/commands/rclone_mount.md
+++ b/docs/content/commands/rclone_mount.md
@@ -475,6 +475,7 @@ Mount option syntax includes a few extra options treated specially:
 - `vv...` will be transformed into appropriate `--verbose=N`
 - standard mount options like `x-systemd.automount`, `_netdev`, `nosuid` and alike
   are intended only for Automountd and ignored by rclone.
+
 ## VFS - Virtual File System
 
 This command uses the VFS layer. This adapts the cloud storage objects

--- a/docs/content/commands/rclone_nfsmount.md
+++ b/docs/content/commands/rclone_nfsmount.md
@@ -476,6 +476,7 @@ Mount option syntax includes a few extra options treated specially:
 - `vv...` will be transformed into appropriate `--verbose=N`
 - standard mount options like `x-systemd.automount`, `_netdev`, `nosuid` and alike
   are intended only for Automountd and ignored by rclone.
+
 ## VFS - Virtual File System
 
 This command uses the VFS layer. This adapts the cloud storage objects

--- a/docs/content/commands/rclone_serve_dlna.md
+++ b/docs/content/commands/rclone_serve_dlna.md
@@ -36,6 +36,7 @@ default "rclone (hostname)".
 
 Use `--log-trace` in conjunction with `-vv` to enable additional debug
 logging of all UPNP traffic.
+
 ## VFS - Virtual File System
 
 This command uses the VFS layer. This adapts the cloud storage objects

--- a/docs/content/commands/rclone_serve_docker.md
+++ b/docs/content/commands/rclone_serve_docker.md
@@ -51,6 +51,7 @@ directory with book-keeping records of created and mounted volumes.
 All mount and VFS options are submitted by the docker daemon via API, but
 you can also provide defaults on the command line as well as set path to the
 config file and cache directory or adjust logging verbosity.
+
 ## VFS - Virtual File System
 
 This command uses the VFS layer. This adapts the cloud storage objects

--- a/docs/content/commands/rclone_serve_ftp.md
+++ b/docs/content/commands/rclone_serve_ftp.md
@@ -33,6 +33,7 @@ then using Authentication is advised - see the next section for info.
 By default this will serve files without needing a login.
 
 You can set a single username and password with the --user and --pass flags.
+
 ## VFS - Virtual File System
 
 This command uses the VFS layer. This adapts the cloud storage objects

--- a/docs/content/commands/rclone_serve_http.md
+++ b/docs/content/commands/rclone_serve_http.md
@@ -134,6 +134,7 @@ The password file can be updated while rclone is running.
 Use `--realm` to set the authentication realm.
 
 Use `--salt` to change the password hashing salt from the default.
+
 ## VFS - Virtual File System
 
 This command uses the VFS layer. This adapts the cloud storage objects

--- a/docs/content/commands/rclone_serve_s3.md
+++ b/docs/content/commands/rclone_serve_s3.md
@@ -176,6 +176,7 @@ certificate authority certificate.
 --min-tls-version is minimum TLS version that is acceptable. Valid
   values are "tls1.0", "tls1.1", "tls1.2" and "tls1.3" (default
   "tls1.0").
+
 ## VFS - Virtual File System
 
 This command uses the VFS layer. This adapts the cloud storage objects

--- a/docs/content/commands/rclone_serve_webdav.md
+++ b/docs/content/commands/rclone_serve_webdav.md
@@ -163,6 +163,7 @@ The password file can be updated while rclone is running.
 Use `--realm` to set the authentication realm.
 
 Use `--salt` to change the password hashing salt from the default.
+
 ## VFS - Virtual File System
 
 This command uses the VFS layer. This adapts the cloud storage objects

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -306,6 +306,7 @@ docker run --rm \
 ls ~/data/mount
 kill %1
 ```
+
 ## Snap installation {#snap}
 
 [![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/rclone)

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -2469,6 +2469,7 @@ Once configured, you can create a new Space and begin copying files. For example
 rclone mkdir spaces:my-new-space
 rclone copy /path/to/files spaces:my-new-space
 ```
+
 ### Huawei OBS {#huawei-obs}
 
 Object Storage Service (OBS) provides stable, secure, efficient, and easy-to-use cloud storage that lets you store virtually any volume of unstructured data in any format and access it from anywhere.
@@ -4036,6 +4037,7 @@ e) Edit this remote
 d) Delete this remote
 y/e/d> y
 ```
+
 ### Leviia Cloud Object Storage {#leviia}
 
 [Leviia Object Storage](https://www.leviia.com/object-storage/), backup and secure your data in a 100% French cloud, independent of GAFAM..
@@ -5031,3 +5033,4 @@ e) Edit this remote
 d) Delete this remote
 
 y/e/d> y
+```


### PR DESCRIPTION
1) Missing closing code backticks (```) in s3.md causes formatting problems 

2) Pandoc requires blank lines before ATX headings

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

I noticed big formatting problems in the manual. In the second half of the manual some text appeared as Markdown code, rather than formatted text. On the other hand some code (terminal in/output was not formatted as such but as inline text, almost unreadable. It appeared that a closing code mark (```) was missing.

Moreover, pandoc requires a blank line before the headings, although the markdown spec doesn't reuire it. So some headings were formatted as inline markdown code rather than as heading.

#### Was the change discussed in an issue or in the forum before?

No.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
