### PR TITLE
Ensure empty line between text and a following heading

### DIFF
--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -31,6 +31,11 @@ import (
 //go:embed mount.md
 var mountHelp string
 
+// help returns the help string cleaned up to simplify appending
+func help(commandName string) string {
+	return strings.TrimSpace(strings.ReplaceAll(mountHelp, "@", commandName)) + "\n\n"
+}
+
 // Options for creating the mount
 type Options struct {
 	DebugFUSE          bool
@@ -196,7 +201,7 @@ func NewMountCommand(commandName string, hidden bool, mount MountFn) *cobra.Comm
 		Use:    commandName + " remote:path /path/to/mountpoint",
 		Hidden: hidden,
 		Short:  `Mount the remote as file system on a mountpoint.`,
-		Long:   strings.ReplaceAll(mountHelp, "@", commandName) + vfs.Help,
+		Long:   help(commandName) + vfs.Help(),
 		Annotations: map[string]string{
 			"versionIntroduced": "v1.33",
 			"groups":            "Filter",

--- a/cmd/mountlib/mount.md
+++ b/cmd/mountlib/mount.md
@@ -1,6 +1,5 @@
-rclone @ allows Linux, FreeBSD, macOS and Windows to
-mount any of Rclone's cloud storage systems as a file system with
-FUSE.
+Rclone @ allows Linux, FreeBSD, macOS and Windows to
+mount any of Rclone's cloud storage systems as a file system with FUSE.
 
 First set up your remote using `rclone config`.  Check it works with `rclone ls` etc.
 

--- a/cmd/rcd/rcd.go
+++ b/cmd/rcd/rcd.go
@@ -20,8 +20,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "rcd <path to files to serve>*",
 	Short: `Run rclone listening to remote control commands only.`,
-	Long: `
-This runs rclone so that it only listens to remote control commands.
+	Long: `This runs rclone so that it only listens to remote control commands.
 
 This is useful if you are controlling rclone via the rc API.
 
@@ -30,6 +29,7 @@ for GET requests on the URL passed in.  It will also open the URL in
 the browser when rclone is run.
 
 See the [rc documentation](/rc/) for more info on the rc flags.
+
 ` + libhttp.Help(rcflags.FlagPrefix) + libhttp.TemplateHelp(rcflags.FlagPrefix) + libhttp.AuthHelp(rcflags.FlagPrefix),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.45",

--- a/cmd/serve/dlna/dlna.go
+++ b/cmd/serve/dlna/dlna.go
@@ -50,7 +50,7 @@ based on media formats or file extensions. Additionally, there is no
 media transcoding support. This means that some players might show
 files that they are not able to play back correctly.
 
-` + dlnaflags.Help + vfs.Help,
+` + dlnaflags.Help + vfs.Help(),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.46",
 		"groups":            "Filter",

--- a/cmd/serve/dlna/dlnaflags/dlnaflags.go
+++ b/cmd/serve/dlna/dlnaflags/dlnaflags.go
@@ -10,8 +10,7 @@ import (
 )
 
 // Help contains the text for the command line help and manual.
-var Help = `
-### Server options
+var Help = `### Server options
 
 Use ` + "`--addr`" + ` to specify which IP address and port the server should
 listen on, e.g. ` + "`--addr 1.2.3.4:8000` or `--addr :8080`" + ` to listen to all
@@ -22,6 +21,7 @@ default "rclone (hostname)".
 
 Use ` + "`--log-trace` in conjunction with `-vv`" + ` to enable additional debug
 logging of all UPNP traffic.
+
 `
 
 // Options is the type for DLNA serving options.

--- a/cmd/serve/docker/docker.go
+++ b/cmd/serve/docker/docker.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	_ "embed"
 	"path/filepath"
+	"strings"
 	"syscall"
 
 	"github.com/spf13/cobra"
@@ -33,6 +34,11 @@ var (
 //go:embed docker.md
 var longHelp string
 
+// help returns the help string cleaned up to simplify appending
+func help() string {
+	return strings.TrimSpace(longHelp) + "\n\n"
+}
+
 func init() {
 	cmdFlags := Command.Flags()
 	// Add command specific flags
@@ -50,7 +56,7 @@ func init() {
 var Command = &cobra.Command{
 	Use:   "docker",
 	Short: `Serve any remote on docker's volume plugin API.`,
-	Long:  longHelp + vfs.Help,
+	Long:  help() + vfs.Help(),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.56",
 		"groups":            "Filter",

--- a/cmd/serve/ftp/ftp.go
+++ b/cmd/serve/ftp/ftp.go
@@ -80,8 +80,7 @@ func init() {
 var Command = &cobra.Command{
 	Use:   "ftp remote:path",
 	Short: `Serve remote:path over FTP.`,
-	Long: `
-Run a basic FTP server to serve a remote over FTP protocol.
+	Long: `Run a basic FTP server to serve a remote over FTP protocol.
 This can be viewed with a FTP client or you can make a remote of
 type FTP to read and write it.
 
@@ -100,7 +99,8 @@ then using Authentication is advised - see the next section for info.
 By default this will serve files without needing a login.
 
 You can set a single username and password with the --user and --pass flags.
-` + vfs.Help + proxy.Help,
+
+` + vfs.Help() + proxy.Help,
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.44",
 		"groups":            "Filter",

--- a/cmd/serve/http/http.go
+++ b/cmd/serve/http/http.go
@@ -73,7 +73,8 @@ The server will log errors.  Use ` + "`-v`" + ` to see access logs.
 
 ` + "`--bwlimit`" + ` will be respected for file transfers.  Use ` + "`--stats`" + ` to
 control the stats printing.
-` + libhttp.Help(flagPrefix) + libhttp.TemplateHelp(flagPrefix) + libhttp.AuthHelp(flagPrefix) + vfs.Help + proxy.Help,
+
+` + libhttp.Help(flagPrefix) + libhttp.TemplateHelp(flagPrefix) + libhttp.AuthHelp(flagPrefix) + vfs.Help() + proxy.Help,
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.39",
 		"groups":            "Filter",

--- a/cmd/serve/nfs/nfs.go
+++ b/cmd/serve/nfs/nfs.go
@@ -92,7 +92,7 @@ Where ` + "`$PORT`" + ` is the same port number we used in the serve nfs command
 
 This feature is only available on Unix platforms.
 
-` + vfs.Help,
+` + vfs.Help(),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.65",
 		"groups":            "Filter",

--- a/cmd/serve/proxy/proxy.go
+++ b/cmd/serve/proxy/proxy.go
@@ -23,8 +23,7 @@ import (
 )
 
 // Help contains text describing how to use the proxy
-var Help = strings.Replace(`
-### Auth Proxy
+var Help = strings.Replace(`### Auth Proxy
 
 If you supply the parameter |--auth-proxy /path/to/program| then
 rclone will use that program to generate backends on the fly which
@@ -104,6 +103,7 @@ before it takes effect.
 
 This can be used to build general purpose proxies to any kind of
 backend that rclone supports.  
+
 `, "|", "`", -1)
 
 // Options is options for creating the proxy

--- a/cmd/serve/restic/restic.go
+++ b/cmd/serve/restic/restic.go
@@ -147,6 +147,7 @@ these **must** end with /.  Eg
 
 The` + "`--private-repos`" + ` flag can be used to limit users to repositories starting
 with a path of ` + "`/<username>/`" + `.
+
 ` + libhttp.Help(flagPrefix) + libhttp.AuthHelp(flagPrefix),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.40",

--- a/cmd/serve/s3/s3.go
+++ b/cmd/serve/s3/s3.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	_ "embed"
+	"strings"
 
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/config/flags"
@@ -40,6 +41,11 @@ func init() {
 //go:embed serve_s3.md
 var serveS3Help string
 
+// help returns the help string cleaned up to simplify appending
+func help() string {
+	return strings.TrimSpace(serveS3Help) + "\n\n"
+}
+
 // Command definition for cobra
 var Command = &cobra.Command{
 	Annotations: map[string]string{
@@ -49,7 +55,7 @@ var Command = &cobra.Command{
 	},
 	Use:   "s3 remote:path",
 	Short: `Serve remote:path over s3.`,
-	Long:  serveS3Help + httplib.Help(flagPrefix) + vfs.Help,
+	Long:  help() + httplib.Help(flagPrefix) + vfs.Help(),
 	RunE: func(command *cobra.Command, args []string) error {
 		cmd.CheckArgs(1, 1, command, args)
 		f := cmd.NewFsSrc(args)

--- a/cmd/serve/sftp/sftp.go
+++ b/cmd/serve/sftp/sftp.go
@@ -114,7 +114,7 @@ used. Omitting "restrict" and using  ` + "`--sftp-path-override`" + ` to enable
 checksumming is possible but less secure and you could use the SFTP server
 provided by OpenSSH in this case.
 
-` + vfs.Help + proxy.Help,
+` + vfs.Help() + proxy.Help,
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.48",
 		"groups":            "Filter",

--- a/cmd/serve/webdav/webdav.go
+++ b/cmd/serve/webdav/webdav.go
@@ -89,6 +89,7 @@ supported hash on the backend or you can use a named hash such as
 to see the full list.
 
 ### Access WebDAV on Windows
+
 WebDAV shared folder can be mapped as a drive on Windows, however the default settings prevent it.
 Windows will fail to connect to the server using insecure Basic authentication.
 It will not even display any login dialog. Windows requires SSL / HTTPS connection to be used with Basic.
@@ -104,6 +105,7 @@ If required, increase the FileSizeLimitInBytes to a higher value.
 Navigate to the Services interface, then restart the WebClient service.
 
 ### Access Office applications on WebDAV
+
 Navigate to following registry HKEY_CURRENT_USER\Software\Microsoft\Office\[14.0/15.0/16.0]\Common\Internet
 Create a new DWORD BasicAuthLevel with value 2.
     0 - Basic authentication disabled
@@ -112,7 +114,7 @@ Create a new DWORD BasicAuthLevel with value 2.
 
 https://learn.microsoft.com/en-us/office/troubleshoot/powerpoint/office-opens-blank-from-sharepoint
 
-` + libhttp.Help(flagPrefix) + libhttp.TemplateHelp(flagPrefix) + libhttp.AuthHelp(flagPrefix) + vfs.Help + proxy.Help,
+` + libhttp.Help(flagPrefix) + libhttp.TemplateHelp(flagPrefix) + libhttp.AuthHelp(flagPrefix) + vfs.Help() + proxy.Help,
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.39",
 		"groups":            "Filter",

--- a/lib/http/auth.go
+++ b/lib/http/auth.go
@@ -11,8 +11,7 @@ import (
 
 // AuthHelp returns text describing the http authentication to add to the command help.
 func AuthHelp(prefix string) string {
-	help := `
-#### Authentication
+	help := `#### Authentication
 
 By default this will serve files without needing a login.
 
@@ -38,6 +37,7 @@ The password file can be updated while rclone is running.
 Use ` + "`--{{ .Prefix }}realm`" + ` to set the authentication realm.
 
 Use ` + "`--{{ .Prefix }}salt`" + ` to change the password hashing salt from the default.
+
 `
 	tmpl, err := template.New("auth help").Parse(help)
 	if err != nil {

--- a/lib/http/server.go
+++ b/lib/http/server.go
@@ -27,8 +27,7 @@ import (
 // Help returns text describing the http server to add to the command
 // help.
 func Help(prefix string) string {
-	help := `
-### Server options
+	help := `### Server options
 
 Use ` + "`--{{ .Prefix }}addr`" + ` to specify which IP address and port the server should
 listen on, eg ` + "`--{{ .Prefix }}addr 1.2.3.4:8000` or `--{{ .Prefix }}addr :8080`" + ` to listen to all
@@ -74,6 +73,7 @@ certificate authority certificate.
 --{{ .Prefix }}min-tls-version is minimum TLS version that is acceptable. Valid
   values are "tls1.0", "tls1.1", "tls1.2" and "tls1.3" (default
   "tls1.0").
+
 `
 	tmpl, err := template.New("server help").Parse(help)
 	if err != nil {

--- a/lib/http/template.go
+++ b/lib/http/template.go
@@ -16,8 +16,7 @@ import (
 
 // TemplateHelp returns a string that describes how to use a custom template
 func TemplateHelp(prefix string) string {
-	help := `
-#### Template
+	help := `#### Template
 
 ` + "`--{{ .Prefix }}template`" + ` allows a user to specify a custom markup template for HTTP
 and WebDAV serve functions.  The server exports the following markup
@@ -52,6 +51,7 @@ be used to render HTML based on specific conditions.
 | contains    | Checks whether a given substring is present or not in a given string. |
 | hasPrefix   | Checks whether the given string begins with the specified prefix. |
 | hasSuffix   | Checks whether the given string end with the specified suffix. |
+
 `
 
 	tmpl, err := template.New("template help").Parse(help)

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -43,10 +43,13 @@ import (
 	"github.com/rclone/rclone/vfs/vfscommon"
 )
 
-// Help for the VFS.
-//
 //go:embed vfs.md
-var Help string
+var help string
+
+// Help returns the help string cleaned up to simplify appending
+func Help() string {
+	return strings.TrimSpace(help) + "\n\n"
+}
 
 // Node represents either a directory (*Dir) or a file (*File)
 type Node interface {


### PR DESCRIPTION
#### What is the purpose of this change?

To ensure there is an empty line between text and a following heading. Because some consumers (like pandoc) may otherwise not parse the Markdown correctly.

The challenge here is when combining different help string snippets, e.g. common http and vfs help into a specific serve command's help. I think we have tried to make sure string constants containing help snippets contain an empty line at the end, so that simple concatenation `help1 + help2` will always give correct result, but there was some not conforming to this. However an additional challenge is that some help snippets are read from markdown file using `go:embed`. To make the use of these consistent with others, without having to remember to add `\n` constants when concatenating these or something like that, I wrapped a function around the embedded markdown, like this:

```go
//go:embed help.md
var help string

// Help returns the formatted help string
func help() string {
	return strings.TrimSpace(help) + "\n\n"
}
```

Additional:
- Consistent no newline at beginning of help for commands etc.
  - Most already conformed to this, but there were some outliers that I cleaned up.
- Empty line after headings (between heading and body).
  - Most already conformed to this, but there were some outliers that I cleaned up.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/pull/7722

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
