### PR TITLE
bisync: fix io.PipeWriter not getting closed on tests

### DIFF
--- a/cmd/bisync/bilib/output.go
+++ b/cmd/bisync/bilib/output.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"log"
 
+	"github.com/rclone/rclone/fs"
 	"github.com/sirupsen/logrus"
 )
 
@@ -12,6 +13,12 @@ import (
 func CaptureOutput(fun func()) []byte {
 	logSave := log.Writer()
 	logrusSave := logrus.StandardLogger().Writer()
+	defer func() {
+		err := logrusSave.Close()
+		if err != nil {
+			fs.Errorf(nil, "error closing logrusSave: %v", err)
+		}
+	}()
 	buf := &bytes.Buffer{}
 	log.SetOutput(buf)
 	logrus.SetOutput(buf)


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes `logrus.StandardLogger().Writer()` not getting closed in `CaptureOutput` (used on tests). Might be part of the story with the goroutine leaks, but probably not all of it.

#### Was the change discussed in an issue or in the forum before?

- https://github.com/rclone/rclone/pull/7718#issuecomment-2040185347

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
