### PR TITLE
bisync: more fixes for integration tests

### DIFF
--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -386,7 +386,7 @@ func (s *syncCopyMove) pairChecker(in *pipe, out *pipe, fraction int, wg *sync.W
 			}
 			// Fix case for case insensitive filesystems
 			if s.ci.FixCase && !s.ci.Immutable && src.Remote() != pair.Dst.Remote() {
-				if newDst, err := operations.Move(s.ctx, s.fdst, pair.Dst, src.Remote(), pair.Dst); err != nil {
+				if newDst, err := operations.Move(s.ctx, s.fdst, nil, src.Remote(), pair.Dst); err != nil {
 					fs.Errorf(pair.Dst, "Error while attempting to rename to %s: %v", src.Remote(), err)
 					s.processError(err)
 				} else {


### PR DESCRIPTION
#### What is the purpose of this change?

More fixes for bisync integration tests:

- `operations`: fix `Move` ignoring `remote` when falling back to `Copy`
- fix endless loop if lockfile decoder returns a non-nil error that is not `io.EOF`
- make `tempDir` path shorter to avoid exceeding linux filename length limits
- use `fs.ConfigStringFull` instead of `bilib.StripHexString` to properly reverse connection string remotes
- `chunker`: fix `NewFs` when root points to composite multi-chunk file without metadata
- `chunker`: fix case-insensitive comparison on `local` without metadata

#### Was the change discussed in an issue or in the forum before?

- #7665 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
