### PR TITLE
Add go mod and sum to gitattributes for consistent line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,7 @@
+# Go writes go.mod and go.sum with lf even on windows
+go.mod text eol=lf
+go.sum text eol=lf
+
 # Ignore generated files in GitHub language statistics and diffs
 /MANUAL.* linguist-generated=true
 /rclone.1 linguist-generated=true


### PR DESCRIPTION
#### What is the purpose of this change?

Not at all important, but it avoids some git noise.

Go consistently uses `LF` when writing `go.mod` and `go.sum` files. Git on Windows by default transforms text files to `CRLF`. This means git clone writes `go.mod` and `go.sum` as `CRLF`, if updating them with e.g. `go mod tidy` go will rewrite them with `LF`, and then git will show them as different and warn if adding them to staging:

```
warning: in the working copy of 'go.mod', LF will be replaced by CRLF the next time Git touches it
warning: in the working copy of 'go.sum', LF will be replaced by CRLF the next time Git touches it
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
