### PR TITLE
Add left and right padding to prevent icon truncation

### DIFF
--- a/docs/static/css/custom.css
+++ b/docs/static/css/custom.css
@@ -142,6 +142,11 @@ h5 {
     font-size: 95%;
 }
 
+.container-fluid {
+    padding-left: 2.2rem !important;
+    padding-right: 2.2rem !important;
+}
+
 /* Make primary buttons rclone colours. Should learn sass and do this the proper way! */
 .btn-primary {
     background-color: #3f79ad;


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Before:
![before](https://github.com/rclone/rclone/assets/2276355/38f5716d-a06a-4a56-9ec8-4dd9c59a8646)

After:
![after](https://github.com/rclone/rclone/assets/2276355/cf16bf71-5012-41f4-a2b9-c6699bbcf3bd)

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
