### PR TITLE
cmd/gitannex: Add layout modes for compatibility

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
           sudo modprobe fuse
           sudo chmod 666 /dev/fuse
           sudo chown root:$USER /etc/fuse.conf
-          sudo apt-get install fuse3 libfuse-dev rpm pkg-config git-annex
+          sudo apt-get install fuse3 libfuse-dev rpm pkg-config git-annex git-annex-remote-rclone
         if: matrix.os == 'ubuntu-latest'
 
       - name: Install Libraries on macOS
@@ -137,7 +137,7 @@ jobs:
           brew untap --force homebrew/cask
           brew update
           brew install --cask macfuse
-          brew install git-annex
+          brew install git-annex git-annex-remote-rclone
         if: matrix.os == 'macos-latest'
 
       - name: Install Libraries on Windows

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ ifdef GOTAGS
 BUILDTAGS=-tags "$(GOTAGS)"
 LINTTAGS=--build-tags "$(GOTAGS)"
 endif
+LDFLAGS=--ldflags "-s -X github.com/rclone/rclone/fs.Version=$(TAG)"
 
 .PHONY: rclone test_all vars version
 
@@ -50,7 +51,7 @@ rclone:
 ifeq ($(GO_OS),windows)
 	go run bin/resource_windows.go -version $(TAG) -syso resource_windows_`go env GOARCH`.syso
 endif
-	go build -v --ldflags "-s -X github.com/rclone/rclone/fs.Version=$(TAG)" $(BUILDTAGS) $(BUILD_ARGS)
+	go build -v $(LDFLAGS) $(BUILDTAGS) $(BUILD_ARGS)
 ifeq ($(GO_OS),windows)
 	rm resource_windows_`go env GOARCH`.syso
 endif
@@ -59,7 +60,7 @@ endif
 	mv -v `go env GOPATH`/bin/rclone`go env GOEXE`.new `go env GOPATH`/bin/rclone`go env GOEXE`
 
 test_all:
-	go install --ldflags "-s -X github.com/rclone/rclone/fs.Version=$(TAG)" $(BUILDTAGS) $(BUILD_ARGS) github.com/rclone/rclone/fstest/test_all
+	go install $(LDFLAGS) $(BUILDTAGS) $(BUILD_ARGS) github.com/rclone/rclone/fstest/test_all
 
 vars:
 	@echo SHELL="'$(SHELL)'"
@@ -87,13 +88,13 @@ test:	rclone test_all
 
 # Quick test
 quicktest:
-	RCLONE_CONFIG="/notfound" go test $(BUILDTAGS) ./...
+	RCLONE_CONFIG="/notfound" go test $(LDFLAGS) $(BUILDTAGS) ./...
 
 racequicktest:
-	RCLONE_CONFIG="/notfound" go test $(BUILDTAGS) -cpu=2 -race ./...
+	RCLONE_CONFIG="/notfound" go test $(LDFLAGS) $(BUILDTAGS) -cpu=2 -race ./...
 
 compiletest:
-	RCLONE_CONFIG="/notfound" go test $(BUILDTAGS) -run XXX ./...
+	RCLONE_CONFIG="/notfound" go test $(LDFLAGS) $(BUILDTAGS) -run XXX ./...
 
 # Do source code quality checks
 check:	rclone

--- a/cmd/gitannex/e2e_test.go
+++ b/cmd/gitannex/e2e_test.go
@@ -225,13 +225,6 @@ func TestEndToEnd(t *testing.T) {
 		t.Run(string(mode), func(t *testing.T) {
 			t.Parallel()
 
-			// Create a temp directory and chdir there, just in case.
-			originalWd, err := os.Getwd()
-			require.NoError(t, err)
-			tempDir := t.TempDir()
-			require.NoError(t, os.Chdir(tempDir))
-			t.Cleanup(func() { require.NoError(t, os.Chdir(originalWd)) })
-
 			testingContext := makeE2eTestingContext(t)
 			testingContext.installRcloneGitannexSymlink(t)
 			testingContext.installRcloneConfig(t)
@@ -260,13 +253,6 @@ func TestEndToEndRepoLayoutCompat(t *testing.T) {
 		mode := mode
 		t.Run(string(mode), func(t *testing.T) {
 			t.Parallel()
-
-			// Create a temp directory and chdir there, just in case.
-			originalWd, err := os.Getwd()
-			require.NoError(t, err)
-			tempDir := t.TempDir()
-			require.NoError(t, os.Chdir(tempDir))
-			defer func() { require.NoError(t, os.Chdir(originalWd)) }()
 
 			tc := makeE2eTestingContext(t)
 			tc.installRcloneGitannexSymlink(t)

--- a/cmd/gitannex/e2e_test.go
+++ b/cmd/gitannex/e2e_test.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -41,7 +42,7 @@ func checkRcloneBinaryVersion() error {
 	if parsed.Version != fs.Version {
 		return fmt.Errorf("expected version %q, but got %q", fs.Version, parsed.Version)
 	}
-	if !parsed.IsGit {
+	if parsed.IsGit != strings.HasSuffix(fs.Version, "-DEV") {
 		return errors.New("expected rclone to be a dev build")
 	}
 	_, tagString := buildinfo.GetLinkingAndTags()

--- a/cmd/gitannex/e2e_test.go
+++ b/cmd/gitannex/e2e_test.go
@@ -1,6 +1,7 @@
 package gitannex
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -50,25 +51,137 @@ func checkRcloneBinaryVersion() error {
 	return nil
 }
 
-// This end-to-end test runs `git annex testremote` in a temporary git repo.
-// This test will be skipped unless the `rclone` binary on PATH reports the
-// expected version.
+// countFilesRecursively returns the number of files nested underneath `dir`. It
+// counts files only and excludes directories.
+func countFilesRecursively(t *testing.T, dir string) int {
+	remoteFiles, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var count int
+	for _, f := range remoteFiles {
+		if f.IsDir() {
+			subdir := filepath.Join(dir, f.Name())
+			count += countFilesRecursively(t, subdir)
+		} else {
+			count++
+		}
+	}
+	return count
+}
+
+func findFileWithContents(t *testing.T, dir string, wantContents []byte) bool {
+	remoteFiles, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	for _, f := range remoteFiles {
+		fPath := filepath.Join(dir, f.Name())
+		if f.IsDir() {
+			if findFileWithContents(t, fPath, wantContents) {
+				return true
+			}
+		} else {
+			contents, err := os.ReadFile(fPath)
+			require.NoError(t, err)
+			if bytes.Equal(contents, wantContents) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+type e2eTestingContext struct {
+	tempDir          string
+	binDir           string
+	homeDir          string
+	configDir        string
+	rcloneConfigDir  string
+	ephemeralRepoDir string
+}
+
+// makeE2eTestingContext sets up a new e2eTestingContext rooted under
+// `t.TempDir()`. It creates the skeleton directory structure shown below in the
+// temp directory without creating any files.
 //
-// When run on CI, an rclone binary built from HEAD will be on the PATH. When
-// running locally, you will likely need to ensure the current binary is on the
-// PATH like so:
-//
-//	go build && PATH="$(realpath .):$PATH" go test -v ./cmd/gitannex/...
-//
-// In the future, this test will probably be extended to test a number of
-// parameters like repo layouts, and runtime may suffer from a combinatorial
-// explosion.
-func TestEndToEnd(t *testing.T) {
+//	.
+//	|-- bin
+//	|   `-- git-annex-remote-rclone-builtin -> ${PATH_TO_RCLONE_BINARY}
+//	|-- ephemeralRepo
+//	`-- user
+//		`-- .config
+//			`-- rclone
+//				`-- rclone.conf
+func makeE2eTestingContext(t *testing.T) e2eTestingContext {
+	tempDir := t.TempDir()
+
+	binDir := filepath.Join(tempDir, "bin")
+	homeDir := filepath.Join(tempDir, "user")
+	configDir := filepath.Join(homeDir, ".config")
+	rcloneConfigDir := filepath.Join(configDir, "rclone")
+	ephemeralRepoDir := filepath.Join(tempDir, "ephemeralRepo")
+
+	for _, dir := range []string{binDir, homeDir, configDir, rcloneConfigDir, ephemeralRepoDir} {
+		require.NoError(t, os.Mkdir(dir, 0700))
+	}
+
+	return e2eTestingContext{tempDir, binDir, homeDir, configDir, rcloneConfigDir, ephemeralRepoDir}
+}
+
+// Install the symlink that enables git-annex to invoke "rclone gitannex"
+// without explicitly specifying the subcommand.
+func (e *e2eTestingContext) installRcloneGitannexSymlink(t *testing.T) {
+	rcloneBinaryPath, err := exec.LookPath("rclone")
+	require.NoError(t, err)
+	require.NoError(t, os.Symlink(
+		rcloneBinaryPath,
+		filepath.Join(e.binDir, "git-annex-remote-rclone-builtin")))
+}
+
+// Install a rclone.conf file in an appropriate location in the fake home
+// directory. The config defines an rclone remote named "MyRcloneRemote" using
+// the local backend.
+func (e *e2eTestingContext) installRcloneConfig(t *testing.T) {
+	// Install the rclone.conf file that defines the remote.
+	rcloneConfigPath := filepath.Join(e.rcloneConfigDir, "rclone.conf")
+	rcloneConfigContents := "[MyRcloneRemote]\ntype = local"
+	require.NoError(t, os.WriteFile(rcloneConfigPath, []byte(rcloneConfigContents), 0600))
+}
+
+// runInRepo runs the given command from within the ephemeral repo directory. To
+// prevent accidental changes in the real home directory, it sets the HOME
+// variable to a subdirectory of the temp directory. It also ensures that the
+// git-annex-remote-rclone-builtin symlink will be found by extending the PATH.
+func (e *e2eTestingContext) runInRepo(t *testing.T, command string, args ...string) {
+	fmt.Printf("+ %s %v\n", command, args)
+	cmd := exec.Command(command, args...)
+	cmd.Dir = e.ephemeralRepoDir
+	cmd.Env = []string{
+		"HOME=" + e.homeDir,
+		"PATH=" + os.Getenv("PATH") + ":" + e.binDir,
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	require.NoError(t, cmd.Run())
+}
+
+// createGitRepo creates an empty git repository in the ephemeral repo
+// directory. It makes "global" config changes that are ultimately scoped to the
+// calling test thanks to runInRepo() overriding the HOME environment variable.
+func (e *e2eTestingContext) createGitRepo(t *testing.T) {
+	e.runInRepo(t, "git", "annex", "version")
+	e.runInRepo(t, "git", "config", "--global", "user.name", "User Name")
+	e.runInRepo(t, "git", "config", "--global", "user.email", "user@example.com")
+	e.runInRepo(t, "git", "config", "--global", "init.defaultBranch", "main")
+	e.runInRepo(t, "git", "init")
+	e.runInRepo(t, "git", "annex", "init")
+}
+
+func skipE2eTestIfNecessary(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping due to short mode.")
 	}
 
-	// TODO: Support this test on Windows. Need to evaluate the semantics of the
+	// TODO: Support e2e tests on Windows. Need to evaluate the semantics of the
 	// HOME and PATH environment variables.
 	switch runtime.GOOS {
 	case "darwin",
@@ -89,6 +202,23 @@ func TestEndToEnd(t *testing.T) {
 	if _, err := exec.LookPath("git-annex"); err != nil {
 		t.Skipf("Skipping because git-annex was not found: %s", err)
 	}
+}
+
+// This end-to-end test runs `git annex testremote` in a temporary git repo.
+// This test will be skipped unless the `rclone` binary on PATH reports the
+// expected version.
+//
+// When run on CI, an rclone binary built from HEAD will be on the PATH. When
+// running locally, you will likely need to ensure the current binary is on the
+// PATH like so:
+//
+//	go build && PATH="$(realpath .):$PATH" go test -v ./cmd/gitannex/...
+//
+// In the future, this test will probably be extended to test a number of
+// parameters like repo layouts, and runtime may suffer from a combinatorial
+// explosion.
+func TestEndToEnd(t *testing.T) {
+	skipE2eTestIfNecessary(t)
 
 	// Create a temp directory and chdir there, just in case.
 	originalWd, err := os.Getwd()
@@ -97,63 +227,114 @@ func TestEndToEnd(t *testing.T) {
 	require.NoError(t, os.Chdir(tempDir))
 	defer func() { require.NoError(t, os.Chdir(originalWd)) }()
 
-	// Flesh out subdirectories of the temp directory:
-	//
-	//  .
-	//  |-- bin
-	//  |   `-- git-annex-remote-rclone-builtin -> ${PATH_TO_RCLONE_BINARY}
-	//  |-- ephemeralRepo
-	//  `-- user
-	//  	`-- .config
-	//  		`-- rclone
-	//  			`-- rclone.conf
+	testingContext := makeE2eTestingContext(t)
+	testingContext.installRcloneGitannexSymlink(t)
+	testingContext.installRcloneConfig(t)
+	testingContext.createGitRepo(t)
 
-	binDir := filepath.Join(tempDir, "bin")
-	homeDir := filepath.Join(tempDir, "user")
-	configDir := filepath.Join(homeDir, ".config")
-	rcloneConfigDir := filepath.Join(configDir, "rclone")
-	ephemeralRepoDir := filepath.Join(tempDir, "ephemeralRepo")
-	for _, dir := range []string{binDir, homeDir, configDir, rcloneConfigDir, ephemeralRepoDir} {
-		require.NoError(t, os.Mkdir(dir, 0700))
+	testingContext.runInRepo(t, "git", "annex", "initremote", "MyTestRemote",
+		"type=external", "externaltype=rclone-builtin", "encryption=none",
+		"rcloneremotename=MyRcloneRemote", "rcloneprefix="+testingContext.ephemeralRepoDir)
+
+	testingContext.runInRepo(t, "git", "annex", "testremote", "MyTestRemote")
+}
+
+// For each layout mode, ensure that we're compatible with data written by
+// git-annex-remote-rclone.
+func TestEndToEndRepoLayoutCompat(t *testing.T) {
+	skipE2eTestIfNecessary(t)
+
+	if _, err := exec.LookPath("git-annex-remote-rclone"); err != nil {
+		t.Skipf("Skipping because git-annex-remote-rclone was not found: %s", err)
 	}
 
-	// Install the symlink that enables git-annex to invoke "rclone gitannex"
-	// without explicitly specifying the subcommand.
-	rcloneBinaryPath, err := exec.LookPath("rclone")
-	require.NoError(t, err)
-	require.NoError(t, os.Symlink(
-		rcloneBinaryPath,
-		filepath.Join(binDir, "git-annex-remote-rclone-builtin")))
+	for _, mode := range allLayoutModes() {
+		mode := mode
+		t.Run(string(mode), func(t *testing.T) {
+			t.Parallel()
 
-	// Install the rclone.conf file that defines the remote.
-	rcloneConfigPath := filepath.Join(rcloneConfigDir, "rclone.conf")
-	rcloneConfigContents := "[MyRcloneRemote]\ntype = local"
-	require.NoError(t, os.WriteFile(rcloneConfigPath, []byte(rcloneConfigContents), 0600))
+			// Create a temp directory and chdir there, just in case.
+			originalWd, err := os.Getwd()
+			require.NoError(t, err)
+			tempDir := t.TempDir()
+			require.NoError(t, os.Chdir(tempDir))
+			defer func() { require.NoError(t, os.Chdir(originalWd)) }()
 
-	// NOTE: These commands must be run with HOME pointing at an ephemeral
-	// directory, rather than the real home directory.
-	cmds := [][]string{
-		{"git", "annex", "version"},
-		{"git", "config", "--global", "user.name", "User Name"},
-		{"git", "config", "--global", "user.email", "user@example.com"},
-		{"git", "init"},
-		{"git", "annex", "init"},
-		{"git", "annex", "initremote", "MyTestRemote",
-			"type=external", "externaltype=rclone-builtin", "encryption=none",
-			"rcloneremotename=MyRcloneRemote", "rcloneprefix=" + ephemeralRepoDir},
-		{"git", "annex", "testremote", "MyTestRemote"},
-	}
+			tc := makeE2eTestingContext(t)
+			tc.installRcloneGitannexSymlink(t)
+			tc.installRcloneConfig(t)
+			tc.createGitRepo(t)
 
-	for _, args := range cmds {
-		fmt.Printf("+ %v\n", args)
-		cmd := exec.Command(args[0], args[1:]...)
-		cmd.Dir = ephemeralRepoDir
-		cmd.Env = []string{
-			"HOME=" + homeDir,
-			"PATH=" + os.Getenv("PATH") + ":" + binDir,
-		}
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		require.NoError(t, cmd.Run())
+			remoteStorage := filepath.Join(tc.tempDir, "remotePrefix")
+			require.NoError(t, os.Mkdir(remoteStorage, 0777))
+
+			tc.runInRepo(t,
+				"git", "annex", "initremote", "Control",
+				"type=external", "externaltype=rclone", "encryption=none",
+				"target=MyRcloneRemote",
+				"rclone_layout="+string(mode),
+				"prefix="+remoteStorage)
+
+			tc.runInRepo(t,
+				"git", "annex", "initremote", "Experiment",
+				"type=external", "externaltype=rclone-builtin", "encryption=none",
+				"rcloneremotename=MyRcloneRemote",
+				"rclonelayout="+string(mode),
+				"rcloneprefix="+remoteStorage)
+
+			fooFileContents := []byte{1, 2, 3, 4}
+			fooFilePath := filepath.Join(tc.ephemeralRepoDir, "foo")
+			require.NoError(t, os.WriteFile(fooFilePath, fooFileContents, 0700))
+			tc.runInRepo(t, "git", "annex", "add", "foo")
+			tc.runInRepo(t, "git", "commit", "-m", "Add foo file")
+			// Git-annex objects are not writable, which prevents `testing` from
+			// cleaning up the temp directory. We can work around this by
+			// explicitly dropping any files we add to the annex.
+			t.Cleanup(func() { tc.runInRepo(t, "git", "annex", "drop", "--force", "foo") })
+
+			require.Equal(t, 0, countFilesRecursively(t, remoteStorage))
+			require.False(t, findFileWithContents(t, remoteStorage, fooFileContents))
+
+			// Copy the file to Control and verify it's present on Experiment.
+
+			tc.runInRepo(t, "git", "annex", "copy", "--to=Control", "foo")
+			require.Equal(t, 1, countFilesRecursively(t, remoteStorage))
+			require.True(t, findFileWithContents(t, remoteStorage, fooFileContents))
+
+			tc.runInRepo(t, "git", "annex", "fsck", "--from=Experiment", "foo")
+			require.Equal(t, 1, countFilesRecursively(t, remoteStorage))
+			require.True(t, findFileWithContents(t, remoteStorage, fooFileContents))
+
+			// Drop the file locally and verify we can copy it back from Experiment.
+
+			tc.runInRepo(t, "git", "annex", "drop", "--force", "foo")
+			require.Equal(t, 1, countFilesRecursively(t, remoteStorage))
+			require.True(t, findFileWithContents(t, remoteStorage, fooFileContents))
+
+			tc.runInRepo(t, "git", "annex", "copy", "--from=Experiment", "foo")
+			require.Equal(t, 1, countFilesRecursively(t, remoteStorage))
+			require.True(t, findFileWithContents(t, remoteStorage, fooFileContents))
+
+			// Drop the file from Experiment, copy it back to Experiment, and
+			// verify it's still present on Control.
+
+			tc.runInRepo(t, "git", "annex", "drop", "--from=Experiment", "--force", "foo")
+			require.Equal(t, 0, countFilesRecursively(t, remoteStorage))
+			require.False(t, findFileWithContents(t, remoteStorage, fooFileContents))
+
+			tc.runInRepo(t, "git", "annex", "copy", "--to=Experiment", "foo")
+			require.Equal(t, 1, countFilesRecursively(t, remoteStorage))
+			require.True(t, findFileWithContents(t, remoteStorage, fooFileContents))
+
+			tc.runInRepo(t, "git", "annex", "fsck", "--from=Control", "foo")
+			require.Equal(t, 1, countFilesRecursively(t, remoteStorage))
+			require.True(t, findFileWithContents(t, remoteStorage, fooFileContents))
+
+			// Drop the file from Control.
+
+			tc.runInRepo(t, "git", "annex", "drop", "--from=Control", "--force", "foo")
+			require.Equal(t, 0, countFilesRecursively(t, remoteStorage))
+			require.False(t, findFileWithContents(t, remoteStorage, fooFileContents))
+		})
 	}
 }

--- a/cmd/gitannex/e2e_test.go
+++ b/cmd/gitannex/e2e_test.go
@@ -21,7 +21,7 @@ import (
 // checkRcloneBinaryVersion runs whichever rclone is on the PATH and checks
 // whether it reports a version that matches the test's expectations. Returns
 // nil when the version is the expected version, otherwise returns an error.
-func checkRcloneBinaryVersion() error {
+func checkRcloneBinaryVersion(t *testing.T) error {
 	// versionInfo is a subset of information produced by "core/version".
 	type versionInfo struct {
 		Version string
@@ -47,7 +47,8 @@ func checkRcloneBinaryVersion() error {
 	}
 	_, tagString := buildinfo.GetLinkingAndTags()
 	if parsed.GoTags != tagString {
-		return fmt.Errorf("expected tag string %q, but got %q", tagString, parsed.GoTags)
+		// TODO: Skip the test when tags do not match.
+		t.Logf("expected tag string %q, but got %q. Not skipping!", tagString, parsed.GoTags)
 	}
 	return nil
 }
@@ -196,7 +197,7 @@ func skipE2eTestIfNecessary(t *testing.T) {
 		t.Skipf("GOOS %q is not supported.", runtime.GOOS)
 	}
 
-	if err := checkRcloneBinaryVersion(); err != nil {
+	if err := checkRcloneBinaryVersion(t); err != nil {
 		t.Skipf("Skipping due to rclone version: %s", err)
 	}
 

--- a/cmd/gitannex/gitannex.md
+++ b/cmd/gitannex/gitannex.md
@@ -16,6 +16,16 @@ Installation on Linux
    "git-annex-remote-rclone-builtin", so the symlink from the previous step
    should be on your PATH.
 
+   * NOTE: If you are porting a remote from git-annex-remote-rclone, first
+     change the externaltype from "rclone" to "rclone-builtin". Watch out, our
+     configs have slightly different names:
+
+      | config for "rclone" | config for "rclone-builtin" |
+      |:--------------------|:----------------------------|
+      | `prefix`            | `rcloneprefix`              |
+      | `target`            | `rcloneremotename`          |
+      | `rclone_layout`     | `rclonelayout`              |
+
    The following example creates a new git-annex remote named "MyRemote" that
    will use the rclone remote named "SomeRcloneRemote". This rclone remote must
    be configured in your rclone.conf file, wherever that is located on your
@@ -27,7 +37,8 @@ Installation on Linux
             externaltype=rclone-builtin       \
             encryption=none                   \
             rcloneremotename=SomeRcloneRemote \
-            rcloneprefix=git-annex-content
+            rcloneprefix=git-annex-content    \
+            rclonelayout=nodir
 
 3. Before you trust this command with your precious data, be sure to **test the
    remote**. This command is very new and has not been tested on many rclone

--- a/cmd/gitannex/gitannex_test.go
+++ b/cmd/gitannex/gitannex_test.go
@@ -64,12 +64,10 @@ var messageParserTestCases = []messageParserTestCase{
 			assert.Error(t, err)
 			assert.Equal(t, param, "")
 
-			param, err = m.finalParameter()
-			assert.Error(t, err)
+			param = m.finalParameter()
 			assert.Equal(t, param, "")
 
-			param, err = m.finalParameter()
-			assert.Error(t, err)
+			param = m.finalParameter()
 			assert.Equal(t, param, "")
 
 			param, err = m.nextSpaceDelimitedParameter()
@@ -95,8 +93,7 @@ var messageParserTestCases = []messageParserTestCase{
 			assert.Error(t, err)
 			assert.Equal(t, param, "")
 
-			param, err = m.finalParameter()
-			assert.Error(t, err)
+			param = m.finalParameter()
 			assert.Equal(t, param, "")
 		},
 	},
@@ -118,8 +115,7 @@ var messageParserTestCases = []messageParserTestCase{
 			assert.Error(t, err)
 			assert.Equal(t, param, "")
 
-			param, err = m.finalParameter()
-			assert.Error(t, err)
+			param = m.finalParameter()
 			assert.Equal(t, param, "")
 		},
 	},
@@ -136,8 +132,7 @@ var messageParserTestCases = []messageParserTestCase{
 			assert.NoError(t, err)
 			assert.Equal(t, param, "secondparam")
 
-			param, err = m.finalParameter()
-			assert.NoError(t, err)
+			param = m.finalParameter()
 			assert.Equal(t, param, "final param with spaces")
 		},
 	},
@@ -151,12 +146,10 @@ var messageParserTestCases = []messageParserTestCase{
 				t.Run(testName, func(t *testing.T) {
 					m := messageParser{"one long final parameter" + lineEnding}
 
-					param, err := m.finalParameter()
-					assert.NoError(t, err)
+					param := m.finalParameter()
 					assert.Equal(t, param, "one long final parameter")
 
-					param, err = m.finalParameter()
-					assert.Error(t, err)
+					param = m.finalParameter()
 					assert.Equal(t, param, "")
 				})
 

--- a/cmd/gitannex/layout.go
+++ b/cmd/gitannex/layout.go
@@ -1,0 +1,72 @@
+package gitannex
+
+import (
+	"fmt"
+	"strings"
+)
+
+type layoutMode string
+
+// All layout modes from git-annex-remote-rclone are supported.
+const (
+	layoutModeLower       layoutMode = "lower"
+	layoutModeDirectory   layoutMode = "directory"
+	layoutModeNodir       layoutMode = "nodir"
+	layoutModeMixed       layoutMode = "mixed"
+	layoutModeFrankencase layoutMode = "frankencase"
+	layoutModeUnknown     layoutMode = ""
+)
+
+func allLayoutModes() []layoutMode {
+	return []layoutMode{
+		layoutModeLower,
+		layoutModeDirectory,
+		layoutModeNodir,
+		layoutModeMixed,
+		layoutModeFrankencase,
+	}
+}
+
+func parseLayoutMode(mode string) layoutMode {
+	for _, knownMode := range allLayoutModes() {
+		if mode == string(knownMode) {
+			return knownMode
+		}
+	}
+	return layoutModeUnknown
+}
+
+type queryDirhashFunc func(msg string) (string, error)
+
+func buildFsString(queryDirhash queryDirhashFunc, mode layoutMode, key, remoteName, prefix string) (string, error) {
+	if mode == layoutModeNodir {
+		return fmt.Sprintf("%s:%s", remoteName, prefix), nil
+	}
+
+	var dirhash string
+	var err error
+	switch mode {
+	case layoutModeLower, layoutModeDirectory:
+		dirhash, err = queryDirhash("DIRHASH-LOWER " + key)
+	case layoutModeMixed, layoutModeFrankencase:
+		dirhash, err = queryDirhash("DIRHASH " + key)
+	default:
+		panic("unreachable")
+	}
+	if err != nil {
+		return "", fmt.Errorf("buildFsString failed to query dirhash: %w", err)
+	}
+
+	switch mode {
+	case layoutModeLower:
+		return fmt.Sprintf("%s:%s/%s", remoteName, prefix, dirhash), nil
+	case layoutModeDirectory:
+		return fmt.Sprintf("%s:%s/%s%s", remoteName, prefix, dirhash, key), nil
+	case layoutModeMixed:
+		return fmt.Sprintf("%s:%s/%s", remoteName, prefix, dirhash), nil
+	case layoutModeFrankencase:
+		return fmt.Sprintf("%s:%s/%s", remoteName, prefix, strings.ToLower(dirhash)), nil
+	default:
+		panic("unreachable")
+	}
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

This change adds support for the repo layouts defined by  [git-annex-remote-rclone](https://github.com/git-annex-remote-rclone/git-annex-remote-rclone). This should enable git-annex users with external remotes of type "rclone" to switch to "rclone-builtin" without needing to retransfer content. It also adds e2e compatibility tests in an attempt to verify this claim!

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

Issue #7625 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
