### PR TITLE
Remove Ubuntu-ism from text: clarify non-root use

### DIFF
--- a/cmd/genautocomplete/genautocomplete_bash.go
+++ b/cmd/genautocomplete/genautocomplete_bash.go
@@ -18,20 +18,31 @@ var bashCommandDefinition = &cobra.Command{
 	Long: `
 Generates a bash shell autocompletion script for rclone.
 
-This writes to /etc/bash_completion.d/rclone by default so will
-probably need to be run with sudo or as root, e.g.
+By default, when run without any arguments, 
 
-    sudo rclone genautocomplete bash
+    rclone genautocomplete bash
 
-Logout and login again to use the autocompletion scripts, or source
-them directly
+the generated script will be written to
 
-    . /etc/bash_completion
+/etc/bash_completion.d/rclone
 
-If you supply a command line argument the script will be written
-there.
+and so will probably need to be run as root, or with sudo.
+
+If you supply a path to a file as the command line argument, theh 
+the generated script will be written to that file, in which case
+you should not need root privileges.
 
 If output_file is "-", then the output will be written to stdout.
+
+If you have installed the script into the default location, you
+can logout and login again to use the autocompletion script.
+
+Alternatively, you can source the script directly
+
+    . /path/to/my_bash_completion_scripts/rclone
+
+and the autocompletion functionality will be added to your
+current shell.
 `,
 	Run: func(command *cobra.Command, args []string) {
 		cmd.CheckArgs(0, 1, command, args)

--- a/cmd/genautocomplete/genautocomplete_bash.go
+++ b/cmd/genautocomplete/genautocomplete_bash.go
@@ -24,11 +24,11 @@ By default, when run without any arguments,
 
 the generated script will be written to
 
-/etc/bash_completion.d/rclone
+    /etc/bash_completion.d/rclone
 
-and so will probably need to be run as root, or with sudo.
+and so rclone will probably need to be run as root, or with sudo.
 
-If you supply a path to a file as the command line argument, theh 
+If you supply a path to a file as the command line argument, then 
 the generated script will be written to that file, in which case
 you should not need root privileges.
 


### PR DESCRIPTION
As requested, here is a PR containing some changes that present
a fuller functionality of the `genautocomplete_bash` via its docs.

It's a bit more of a re-write than the changes that the issue I had
raised originally suggested would be needed, but I think I have
"covered all the bases" now.

