### PR TITLE
Fix golangci-lint issues reported on different OS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -226,18 +226,50 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Code quality test
-        uses: golangci/golangci-lint-action@v4
-        with:
-          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: latest
-
-      # Run govulncheck on the latest go version, the one we build binaries with
       - name: Install Go
         uses: actions/setup-go@v5
         with:
           go-version: '>=1.22.0-rc.1'
           check-latest: true
+          cache: false
+
+      - name: Code quality test (Linux)
+        uses: golangci/golangci-lint-action@v4
+        with:
+          version: latest
+          skip-cache: false # Caching enabled (which is default) on this first lint step only, it handles complete cache of build, go modules and golangci-lint analysis which was necessary to get all lint steps to properly take advantage of it
+
+      - name: Code quality test (Windows)
+        uses: golangci/golangci-lint-action@v4
+        env:
+          GOOS: "windows"
+        with:
+          version: latest
+          skip-cache: true
+
+      - name: Code quality test (macOS)
+        uses: golangci/golangci-lint-action@v4
+        env:
+          GOOS: "darwin"
+        with:
+          version: latest
+          skip-cache: true
+
+      - name: Code quality test (FreeBSD)
+        uses: golangci/golangci-lint-action@v4
+        env:
+          GOOS: "freebsd"
+        with:
+          version: latest
+          skip-cache: true
+
+      - name: Code quality test (OpenBSD)
+        uses: golangci/golangci-lint-action@v4
+        env:
+          GOOS: "openbsd"
+        with:
+          version: latest
+          skip-cache: true
 
       - name: Install govulncheck
         run: go install golang.org/x/vuln/cmd/govulncheck@latest

--- a/backend/azureblob/azureblob_unsupported.go
+++ b/backend/azureblob/azureblob_unsupported.go
@@ -3,4 +3,5 @@
 
 //go:build plan9 || solaris || js
 
+// Package azureblob provides an interface to the Microsoft Azure blob object storage system
 package azureblob

--- a/backend/azurefiles/azurefiles_unsupported.go
+++ b/backend/azurefiles/azurefiles_unsupported.go
@@ -3,4 +3,5 @@
 
 //go:build plan9 || js
 
+// Package azurefiles provides an interface to Microsoft Azure Files
 package azurefiles

--- a/backend/cache/cache_unsupported.go
+++ b/backend/cache/cache_unsupported.go
@@ -3,4 +3,5 @@
 
 //go:build plan9 || js
 
+// Package cache implements a virtual provider to cache existing remotes.
 package cache

--- a/backend/cache/utils_test.go
+++ b/backend/cache/utils_test.go
@@ -1,3 +1,6 @@
+//go:build !plan9 && !js
+// +build !plan9,!js
+
 package cache
 
 import bolt "go.etcd.io/bbolt"

--- a/backend/hdfs/hdfs_unsupported.go
+++ b/backend/hdfs/hdfs_unsupported.go
@@ -3,4 +3,5 @@
 
 //go:build plan9
 
+// Package hdfs provides an interface to the HDFS storage system.
 package hdfs

--- a/backend/local/about_unix.go
+++ b/backend/local/about_unix.go
@@ -23,9 +23,9 @@ func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 	}
 	bs := int64(s.Bsize) // nolint: unconvert
 	usage := &fs.Usage{
-		Total: fs.NewUsageValue(bs * int64(s.Blocks)),         // quota of bytes that can be used
-		Used:  fs.NewUsageValue(bs * int64(s.Blocks-s.Bfree)), // bytes in use
-		Free:  fs.NewUsageValue(bs * int64(s.Bavail)),         // bytes which can be uploaded before reaching the quota
+		Total: fs.NewUsageValue(bs * int64(s.Blocks)),         //nolint: unconvert // quota of bytes that can be used
+		Used:  fs.NewUsageValue(bs * int64(s.Blocks-s.Bfree)), //nolint: unconvert // bytes in use
+		Free:  fs.NewUsageValue(bs * int64(s.Bavail)),         //nolint: unconvert // bytes which can be uploaded before reaching the quota
 	}
 	return usage, nil
 }

--- a/backend/local/metadata_other.go
+++ b/backend/local/metadata_other.go
@@ -1,4 +1,4 @@
-//go:build plan9 || js
+//go:build dragonfly || plan9 || js
 
 package local
 

--- a/backend/local/remove_windows.go
+++ b/backend/local/remove_windows.go
@@ -4,14 +4,10 @@ package local
 
 import (
 	"os"
-	"syscall"
 	"time"
 
 	"github.com/rclone/rclone/fs"
-)
-
-const (
-	ERROR_SHARING_VIOLATION syscall.Errno = 32
+	"golang.org/x/sys/windows"
 )
 
 // Removes name, retrying on a sharing violation
@@ -27,7 +23,7 @@ func remove(name string) (err error) {
 		if !ok {
 			break
 		}
-		if pathErr.Err != ERROR_SHARING_VIOLATION {
+		if pathErr.Err != windows.ERROR_SHARING_VIOLATION {
 			break
 		}
 		fs.Logf(name, "Remove detected sharing violation - retry %d/%d sleeping %v", i+1, maxTries, sleepTime)

--- a/backend/local/xattr_unsupported.go
+++ b/backend/local/xattr_unsupported.go
@@ -1,6 +1,7 @@
+// The pkg/xattr module doesn't compile for openbsd or plan9
+
 //go:build openbsd || plan9
 
-// The pkg/xattr module doesn't compile for openbsd or plan9
 package local
 
 import "github.com/rclone/rclone/fs"

--- a/backend/netstorage/netstorage.go
+++ b/backend/netstorage/netstorage.go
@@ -443,7 +443,7 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 	}
 
 	URL := f.url(dir)
-	files, err := f.netStorageDirRequest(ctx, dir, URL)
+	files, err := f.netStorageDirRequest(ctx, URL)
 	if err != nil {
 		return nil, err
 	}
@@ -932,7 +932,7 @@ func (f *Fs) netStorageStatRequest(ctx context.Context, URL string, directory bo
 }
 
 // netStorageDirRequest performs a NetStorage dir request
-func (f *Fs) netStorageDirRequest(ctx context.Context, dir string, URL string) ([]File, error) {
+func (f *Fs) netStorageDirRequest(ctx context.Context, URL string) ([]File, error) {
 	const actionHeader = "version=1&action=dir&format=xml&encoding=utf-8"
 	statResp := &Stat{}
 	if _, err := f.callBackend(ctx, URL, "GET", actionHeader, false, statResp, nil); err != nil {

--- a/backend/oracleobjectstorage/oracleobjectstorage_unsupported.go
+++ b/backend/oracleobjectstorage/oracleobjectstorage_unsupported.go
@@ -3,4 +3,5 @@
 
 //go:build plan9 || solaris || js
 
+// Package oracleobjectstorage provides an interface to the OCI object storage system.
 package oracleobjectstorage

--- a/backend/qingstor/qingstor_unsupported.go
+++ b/backend/qingstor/qingstor_unsupported.go
@@ -3,4 +3,6 @@
 
 //go:build plan9 || js
 
+// Package qingstor provides an interface to QingStor object storage
+// Home: https://www.qingcloud.com/
 package qingstor

--- a/backend/sftp/sftp_unsupported.go
+++ b/backend/sftp/sftp_unsupported.go
@@ -3,4 +3,5 @@
 
 //go:build plan9
 
+// Package sftp provides a filesystem interface using github.com/pkg/sftp
 package sftp

--- a/backend/storj/storj_unsupported.go
+++ b/backend/storj/storj_unsupported.go
@@ -1,3 +1,4 @@
 //go:build plan9
 
+// Package storj provides an interface to Storj decentralized object storage.
 package storj

--- a/cmd/cachestats/cachestats_unsupported.go
+++ b/cmd/cachestats/cachestats_unsupported.go
@@ -3,4 +3,5 @@
 
 //go:build plan9 || js
 
+// Package cachestats provides the cachestats command.
 package cachestats

--- a/cmd/ncdu/ncdu_unsupported.go
+++ b/cmd/ncdu/ncdu_unsupported.go
@@ -3,4 +3,5 @@
 
 //go:build plan9 || js
 
+// Package ncdu implements a text based user interface for exploring a remote
 package ncdu

--- a/cmd/serve/ftp/ftp_unsupported.go
+++ b/cmd/serve/ftp/ftp_unsupported.go
@@ -3,9 +3,10 @@
 
 //go:build plan9
 
+// Package ftp implements an FTP server for rclone
 package ftp
 
 import "github.com/spf13/cobra"
 
 // Command definition is nil to show not implemented
-var Command *cobra.Command = nil
+var Command *cobra.Command

--- a/cmd/serve/nfs/nfs_unsupported.go
+++ b/cmd/serve/nfs/nfs_unsupported.go
@@ -8,5 +8,5 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// For unsupported platforms we just put nil
-var Command *cobra.Command = nil
+// Command is just nil for unsupported platforms
+var Command *cobra.Command

--- a/cmd/serve/sftp/sftp_unsupported.go
+++ b/cmd/serve/sftp/sftp_unsupported.go
@@ -3,9 +3,10 @@
 
 //go:build plan9
 
+// Package sftp implements an SFTP server to serve an rclone VFS
 package sftp
 
 import "github.com/spf13/cobra"
 
 // Command definition is nil to show not implemented
-var Command *cobra.Command = nil
+var Command *cobra.Command

--- a/fs/accounting/token_bucket.go
+++ b/fs/accounting/token_bucket.go
@@ -40,7 +40,7 @@ type tokenBucket struct {
 // Return true if limit is disabled
 //
 // Call with lock held
-func (bs *buckets) _isOff() bool {
+func (bs *buckets) _isOff() bool { //nolint:unused // Don't include unused when running golangci-lint in case its on windows where this is not called
 	return bs[0] == nil
 }
 

--- a/fs/fserrors/enospc_error_notsupported.go
+++ b/fs/fserrors/enospc_error_notsupported.go
@@ -2,7 +2,7 @@
 
 package fserrors
 
-// IsErrNoSpace() on plan9 returns false because
+// IsErrNoSpace on plan9 returns false because
 // plan9 does not support syscall.ENOSPC error.
 func IsErrNoSpace(cause error) (isNoSpc bool) {
 	isNoSpc = false

--- a/fs/fserrors/error_syscall_test.go
+++ b/fs/fserrors/error_syscall_test.go
@@ -1,0 +1,74 @@
+//go:build !plan9
+// +build !plan9
+
+package fserrors
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// make a plausible network error with the underlying errno
+func makeNetErr(errno syscall.Errno) error {
+	return &net.OpError{
+		Op:     "write",
+		Net:    "tcp",
+		Source: &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 123},
+		Addr:   &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 8080},
+		Err: &os.SyscallError{
+			Syscall: "write",
+			Err:     errno,
+		},
+	}
+}
+
+func TestWithSyscallCause(t *testing.T) {
+	for i, test := range []struct {
+		err           error
+		wantRetriable bool
+		wantErr       error
+	}{
+		{makeNetErr(syscall.EAGAIN), true, syscall.EAGAIN},
+		{makeNetErr(syscall.Errno(123123123)), false, syscall.Errno(123123123)},
+	} {
+		gotRetriable, gotErr := Cause(test.err)
+		what := fmt.Sprintf("test #%d: %v", i, test.err)
+		assert.Equal(t, test.wantErr, gotErr, what)
+		assert.Equal(t, test.wantRetriable, gotRetriable, what)
+	}
+}
+
+func TestWithSyscallShouldRetry(t *testing.T) {
+	for i, test := range []struct {
+		err  error
+		want bool
+	}{
+		{makeNetErr(syscall.EAGAIN), true},
+		{makeNetErr(syscall.Errno(123123123)), false},
+		{
+			wrap(&url.Error{
+				Op:  "post",
+				URL: "http://localhost/",
+				Err: makeNetErr(syscall.EPIPE),
+			}, "potato error"),
+			true,
+		},
+		{
+			wrap(&url.Error{
+				Op:  "post",
+				URL: "http://localhost/",
+				Err: makeNetErr(syscall.Errno(123123123)),
+			}, "listing error"),
+			false,
+		},
+	} {
+		got := ShouldRetry(test.err)
+		assert.Equal(t, test.want, got, fmt.Sprintf("test #%d: %v", i, test.err))
+	}
+}

--- a/fs/fserrors/retriable_errors_windows.go
+++ b/fs/fserrors/retriable_errors_windows.go
@@ -23,8 +23,8 @@ const (
 	WSAEHOSTUNREACH   syscall.Errno = 10065
 	WSAEDISCON        syscall.Errno = 10101
 	WSAEREFUSED       syscall.Errno = 10112
-	WSAHOST_NOT_FOUND syscall.Errno = 11001
-	WSATRY_AGAIN      syscall.Errno = 11002
+	WSAHOST_NOT_FOUND syscall.Errno = 11001 //nolint:revive // Don't include revive when running golangci-lint to avoid var-naming: don't use ALL_CAPS in Go names; use CamelCase (revive)
+	WSATRY_AGAIN      syscall.Errno = 11002 //nolint:revive // Don't include revive when running golangci-lint to avoid var-naming: don't use ALL_CAPS in Go names; use CamelCase (revive)
 )
 
 func init() {

--- a/fs/log/redirect_stderr_windows.go
+++ b/fs/log/redirect_stderr_windows.go
@@ -20,7 +20,7 @@ var (
 )
 
 func setStdHandle(stdhandle int32, handle syscall.Handle) error {
-	r0, _, e1 := syscall.Syscall(procSetStdHandle.Addr(), 2, uintptr(stdhandle), uintptr(handle), 0)
+	r0, _, e1 := syscall.SyscallN(procSetStdHandle.Addr(), uintptr(stdhandle), uintptr(handle))
 	if r0 == 0 {
 		if e1 != 0 {
 			return error(e1)

--- a/fs/logger/logger_test.go
+++ b/fs/logger/logger_test.go
@@ -1,3 +1,6 @@
+//go:build !plan9
+// +build !plan9
+
 package logger_test
 
 import (

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/pmezard/go-difflib v1.0.0
 	github.com/prometheus/client_golang v1.18.0
 	github.com/putdotio/go-putio/putio v0.0.0-20200123120452-16d982cac2b8
+	github.com/rclone/gofakes3 v0.0.3-0.20240413171058-b7a9fdb78ddb
 	github.com/rfjakob/eme v1.1.2
 	github.com/rivo/uniseg v0.4.4
 	github.com/rogpeppe/go-internal v1.11.0
@@ -157,7 +158,6 @@ require (
 	github.com/prometheus/common v0.45.0 // indirect
 	github.com/prometheus/procfs v0.12.0 // indirect
 	github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93 // indirect
-	github.com/rclone/gofakes3 v0.0.3-0.20240413171058-b7a9fdb78ddb // indirect
 	github.com/relvacode/iso8601 v1.3.0 // indirect
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -456,8 +456,6 @@ github.com/quic-go/qtls-go1-20 v0.4.1 h1:D33340mCNDAIKBqXuAvexTNMUByrYmFYVfKfDN5
 github.com/quic-go/quic-go v0.40.1 h1:X3AGzUNFs0jVuO3esAGnTfvdgvL4fq655WaOi1snv1Q=
 github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93 h1:UVArwN/wkKjMVhh2EQGC0tEc1+FqiLlvYXY5mQ2f8Wg=
 github.com/rasky/go-xdr v0.0.0-20170124162913-1a41d1a06c93/go.mod h1:Nfe4efndBz4TibWycNE+lqyJZiMX4ycx+QKV8Ta0f/o=
-github.com/rclone/gofakes3 v0.0.3-0.20240413163749-372c3e746e45 h1:qrH/G7j3Ru2E6tuKaNvpA+KD9uQSujTTMyQoonCJ7kU=
-github.com/rclone/gofakes3 v0.0.3-0.20240413163749-372c3e746e45/go.mod h1:L0VIBE0mT6ArN/5dfHsJm3UjqCpi5B/cdN+qWDNh7ko=
 github.com/rclone/gofakes3 v0.0.3-0.20240413171058-b7a9fdb78ddb h1:HJJ7XgRBfXew3EosVk45aGPJRY5wSTSpmAJqz8Kiw0w=
 github.com/rclone/gofakes3 v0.0.3-0.20240413171058-b7a9fdb78ddb/go.mod h1:L0VIBE0mT6ArN/5dfHsJm3UjqCpi5B/cdN+qWDNh7ko=
 github.com/relvacode/iso8601 v1.3.0 h1:HguUjsGpIMh/zsTczGN3DVJFxTU/GX+MMmzcKoMO7ko=

--- a/lib/buildinfo/osversion_windows.go
+++ b/lib/buildinfo/osversion_windows.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/shirou/gopsutil/v3/host"
 	"golang.org/x/sys/windows"
-	"golang.org/x/sys/windows/registry"
 )
 
 // GetOSVersion returns OS version, kernel and bitness
@@ -95,38 +94,4 @@ func getRegistryVersionString(name string) string {
 	}
 
 	return windows.UTF16ToString(regBuf[:])
-}
-
-func getRegistryVersionInt(name string) int {
-	var (
-		err     error
-		handle  windows.Handle
-		bufLen  uint32
-		valType uint32
-	)
-
-	err = windows.RegOpenKeyEx(windows.HKEY_LOCAL_MACHINE, regVersionKeyUTF16, 0, windows.KEY_READ|windows.KEY_WOW64_64KEY, &handle)
-	if err != nil {
-		return 0
-	}
-	defer func() {
-		_ = windows.RegCloseKey(handle)
-	}()
-
-	nameUTF16 := windows.StringToUTF16Ptr(name)
-	err = windows.RegQueryValueEx(handle, nameUTF16, nil, &valType, nil, &bufLen)
-	if err != nil {
-		return 0
-	}
-
-	if valType != registry.DWORD || bufLen != 4 {
-		return 0
-	}
-	var val32 uint32
-	err = windows.RegQueryValueEx(handle, nameUTF16, nil, &valType, (*byte)(unsafe.Pointer(&val32)), &bufLen)
-	if err != nil {
-		return 0
-	}
-
-	return int(val32)
 }

--- a/lib/file/mkdir_windows_test.go
+++ b/lib/file/mkdir_windows_test.go
@@ -34,7 +34,11 @@ func TestMkdirAll(t *testing.T) {
 	if err != nil {
 		t.Fatalf("create %q: %s", fpath, err)
 	}
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			t.Fatalf("Close %q: %s", fpath, err)
+		}
+	}()
 
 	// Can't make directory named after file.
 	err = MkdirAll(fpath, 0777)

--- a/lib/file/preallocate_windows.go
+++ b/lib/file/preallocate_windows.go
@@ -55,10 +55,10 @@ func PreAllocate(size int64, out *os.File) error {
 
 	// Query info about the block sizes on the file system
 	_, _, e1 := ntQueryVolumeInformationFile.Call(
-		uintptr(out.Fd()),
+		out.Fd(),
 		uintptr(unsafe.Pointer(&iosb)),
 		uintptr(unsafe.Pointer(&fsSizeInfo)),
-		uintptr(unsafe.Sizeof(fsSizeInfo)),
+		unsafe.Sizeof(fsSizeInfo),
 		uintptr(3), // FileFsSizeInformation
 	)
 	if e1 != nil && e1 != syscall.Errno(0) {
@@ -74,14 +74,14 @@ func PreAllocate(size int64, out *os.File) error {
 
 	// Ask for the allocation
 	_, _, e1 = ntSetInformationFile.Call(
-		uintptr(out.Fd()),
+		out.Fd(),
 		uintptr(unsafe.Pointer(&iosb)),
 		uintptr(unsafe.Pointer(&allocInfo)),
-		uintptr(unsafe.Sizeof(allocInfo)),
+		unsafe.Sizeof(allocInfo),
 		uintptr(19), // FileAllocationInformation
 	)
 	if e1 != nil && e1 != syscall.Errno(0) {
-		if e1 == syscall.Errno(windows.ERROR_DISK_FULL) || e1 == syscall.Errno(windows.ERROR_HANDLE_DISK_FULL) {
+		if e1 == windows.ERROR_DISK_FULL || e1 == windows.ERROR_HANDLE_DISK_FULL {
 			return ErrDiskFull
 		}
 		return fmt.Errorf("preAllocate NtSetInformationFile failed: %w", e1)
@@ -90,10 +90,6 @@ func PreAllocate(size int64, out *os.File) error {
 	return nil
 }
 
-const (
-	FSCTL_SET_SPARSE = 0x000900c4 // Control code to set or clears the FILE_ATTRIBUTE_SPARSE_FILE attribute of a file.
-)
-
 // SetSparseImplemented is a constant indicating whether the
 // implementation of SetSparse actually does anything.
 const SetSparseImplemented = true
@@ -101,7 +97,7 @@ const SetSparseImplemented = true
 // SetSparse makes the file be a sparse file
 func SetSparse(out *os.File) error {
 	var bytesReturned uint32
-	err := syscall.DeviceIoControl(syscall.Handle(out.Fd()), FSCTL_SET_SPARSE, nil, 0, nil, 0, &bytesReturned, nil)
+	err := syscall.DeviceIoControl(syscall.Handle(out.Fd()), windows.FSCTL_SET_SPARSE, nil, 0, nil, 0, &bytesReturned, nil)
 	if err != nil {
 		return fmt.Errorf("DeviceIoControl FSCTL_SET_SPARSE: %w", err)
 	}

--- a/lib/kv/unsupported.go
+++ b/lib/kv/unsupported.go
@@ -1,5 +1,6 @@
 //go:build plan9 || js
 
+// Package kv provides key/value database.
 package kv
 
 import (

--- a/lib/terminal/hidden_windows.go
+++ b/lib/terminal/hidden_windows.go
@@ -13,7 +13,7 @@ func HideConsole() {
 	if getConsoleWindow.Find() == nil && showWindow.Find() == nil {
 		hwnd, _, _ := getConsoleWindow.Call()
 		if hwnd != 0 {
-			showWindow.Call(hwnd, 0)
+			_, _, _ = showWindow.Call(hwnd, 0)
 		}
 	}
 }

--- a/vfs/vfstest/write_other.go
+++ b/vfs/vfstest/write_other.go
@@ -1,0 +1,20 @@
+//go:build !linux && !darwin && !freebsd && !windows
+// +build !linux,!darwin,!freebsd,!windows
+
+package vfstest
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+)
+
+// TestWriteFileDoubleClose tests double close on write
+func TestWriteFileDoubleClose(t *testing.T) {
+	t.Skip("not supported on " + runtime.GOOS)
+}
+
+// writeTestDup performs the platform-specific implementation of the dup() unix
+func writeTestDup(oldfd uintptr) (uintptr, error) {
+	return 0, errors.New("not supported on " + runtime.GOOS)
+}

--- a/vfs/vfstest/write_windows.go
+++ b/vfs/vfstest/write_windows.go
@@ -1,4 +1,4 @@
-//go:build !linux && !darwin && !freebsd
+//go:build windows
 
 package vfstest
 


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes the following issues from running golangci-lint on Windows, as well as a couple of more:

```
cmd\serve\nfs\nfs_unsupported.go:13:30: var-declaration: should drop = nil from declaration of var Command; it is the zero value (revive)
var Command *cobra.Command = nil
                             ^
cmd\serve\nfs\nfs_unsupported.go:12:1: exported: comment on exported var Command should be of the form "Command ..." (revive)
// For unsupported platforms we just put nil
^
lib\buildinfo\osversion_windows.go:100:6: func `getRegistryVersionInt` is unused (unused)
func getRegistryVersionInt(name string) int {
     ^
lib\file\mkdir_windows_test.go:38:15: Error return value of `f.Close` is not checked (errcheck)
        defer f.Close()
                     ^
lib\file\preallocate_windows.go:95:32: exported: comment on exported const FSCTL_SET_SPARSE should be of the form "FSCTL_SET_SPARSE ..." (revive)
        FSCTL_SET_SPARSE = 0x000900c4 // Control code to set or clears the FILE_ATTRIBUTE_SPARSE_FILE attribute of a file.
                                      ^
lib\file\preallocate_windows.go:59:10: unnecessary conversion (unconvert)
                uintptr(out.Fd()),
                       ^
lib\file\preallocate_windows.go:62:10: unnecessary conversion (unconvert)
                uintptr(unsafe.Sizeof(fsSizeInfo)),
                       ^
lib\file\preallocate_windows.go:78:10: unnecessary conversion (unconvert)
                uintptr(out.Fd()),
                       ^
lib\file\preallocate_windows.go:81:10: unnecessary conversion (unconvert)
                uintptr(unsafe.Sizeof(allocInfo)),
                       ^
lib\file\preallocate_windows.go:85:25: unnecessary conversion (unconvert)
                if e1 == syscall.Errno(windows.ERROR_DISK_FULL) || e1 == syscall.Errno(windows.ERROR_HANDLE_DISK_FULL) {
                                      ^
lib\terminal\hidden_windows.go:17:19: Error return value of `showWindow.Call` is not checked (errcheck)
                        showWindow.Call(hwnd, 0)
                                       ^
fs\fserrors\retriable_errors_windows.go:27:2: var-naming: don't use ALL_CAPS in Go names; use CamelCase (revive)
        WSAHOST_NOT_FOUND syscall.Errno = 11001
        ^
fs\fserrors\retriable_errors_windows.go:28:2: var-naming: don't use ALL_CAPS in Go names; use CamelCase (revive)
        WSATRY_AGAIN      syscall.Errno = 11002
        ^
backend\local\remove_windows.go:15:2: exported: exported const ERROR_SHARING_VIOLATION should have comment (or a comment on this block) or be unexported (revive)
        ERROR_SHARING_VIOLATION syscall.Errno = 32
        ^
fs\accounting\token_bucket.go:43:20: func `(*buckets)._isOff` is unused (unused)
func (bs *buckets) _isOff() bool {
                   ^
fs\log\redirect_stderr_windows.go:24:15: SA1019: syscall.Syscall has been deprecated since Go 1.18: Use SyscallN instead. (staticcheck)
        r0, _, e1 := syscall.Syscall(procSetStdHandle.Addr(), 2, uintptr(stdhandle), uintptr(handle), 0)
```


#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
