### PR TITLE
build: remove build constraint syntax for go 1.16 and older

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 // Package azureblob provides an interface to the Microsoft Azure blob object storage system
 package azureblob

--- a/backend/azureblob/azureblob_internal_test.go
+++ b/backend/azureblob/azureblob_internal_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package azureblob
 

--- a/backend/azureblob/azureblob_test.go
+++ b/backend/azureblob/azureblob_test.go
@@ -1,7 +1,6 @@
 // Test AzureBlob filesystem interface
 
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package azureblob
 

--- a/backend/azureblob/azureblob_unsupported.go
+++ b/backend/azureblob/azureblob_unsupported.go
@@ -2,6 +2,5 @@
 // about "no buildable Go source files "
 
 //go:build plan9 || solaris || js
-// +build plan9 solaris js
 
 package azureblob

--- a/backend/azurefiles/azurefiles.go
+++ b/backend/azurefiles/azurefiles.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 // Package azurefiles provides an interface to Microsoft Azure Files
 package azurefiles

--- a/backend/azurefiles/azurefiles_internal_test.go
+++ b/backend/azurefiles/azurefiles_internal_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package azurefiles
 

--- a/backend/azurefiles/azurefiles_test.go
+++ b/backend/azurefiles/azurefiles_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package azurefiles
 

--- a/backend/azurefiles/azurefiles_unsupported.go
+++ b/backend/azurefiles/azurefiles_unsupported.go
@@ -2,6 +2,5 @@
 // about "no buildable Go source files "
 
 //go:build plan9 || js
-// +build plan9 js
 
 package azurefiles

--- a/backend/cache/cache.go
+++ b/backend/cache/cache.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 // Package cache implements a virtual provider to cache existing remotes.
 package cache

--- a/backend/cache/cache_internal_test.go
+++ b/backend/cache/cache_internal_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js && !race
-// +build !plan9,!js,!race
 
 package cache_test
 

--- a/backend/cache/cache_test.go
+++ b/backend/cache/cache_test.go
@@ -1,7 +1,6 @@
 // Test Cache filesystem interface
 
 //go:build !plan9 && !js && !race
-// +build !plan9,!js,!race
 
 package cache_test
 

--- a/backend/cache/cache_unsupported.go
+++ b/backend/cache/cache_unsupported.go
@@ -2,6 +2,5 @@
 // about "no buildable Go source files "
 
 //go:build plan9 || js
-// +build plan9 js
 
 package cache

--- a/backend/cache/cache_upload_test.go
+++ b/backend/cache/cache_upload_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js && !race
-// +build !plan9,!js,!race
 
 package cache_test
 

--- a/backend/cache/directory.go
+++ b/backend/cache/directory.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package cache
 

--- a/backend/cache/handle.go
+++ b/backend/cache/handle.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package cache
 

--- a/backend/cache/object.go
+++ b/backend/cache/object.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package cache
 

--- a/backend/cache/plex.go
+++ b/backend/cache/plex.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package cache
 

--- a/backend/cache/storage_memory.go
+++ b/backend/cache/storage_memory.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package cache
 

--- a/backend/cache/storage_persistent.go
+++ b/backend/cache/storage_persistent.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package cache
 

--- a/backend/hdfs/fs.go
+++ b/backend/hdfs/fs.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package hdfs
 

--- a/backend/hdfs/hdfs.go
+++ b/backend/hdfs/hdfs.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 // Package hdfs provides an interface to the HDFS storage system.
 package hdfs

--- a/backend/hdfs/hdfs_test.go
+++ b/backend/hdfs/hdfs_test.go
@@ -1,7 +1,6 @@
 // Test HDFS filesystem interface
 
 //go:build !plan9
-// +build !plan9
 
 package hdfs_test
 

--- a/backend/hdfs/hdfs_unsupported.go
+++ b/backend/hdfs/hdfs_unsupported.go
@@ -2,6 +2,5 @@
 // about "no buildable Go source files "
 
 //go:build plan9
-// +build plan9
 
 package hdfs

--- a/backend/hdfs/object.go
+++ b/backend/hdfs/object.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package hdfs
 

--- a/backend/local/about_unix.go
+++ b/backend/local/about_unix.go
@@ -1,5 +1,4 @@
 //go:build darwin || dragonfly || freebsd || linux
-// +build darwin dragonfly freebsd linux
 
 package local
 

--- a/backend/local/about_windows.go
+++ b/backend/local/about_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package local
 

--- a/backend/local/fadvise_other.go
+++ b/backend/local/fadvise_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package local
 

--- a/backend/local/fadvise_unix.go
+++ b/backend/local/fadvise_unix.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package local
 

--- a/backend/local/lchtimes.go
+++ b/backend/local/lchtimes.go
@@ -1,5 +1,4 @@
 //go:build windows || plan9 || js
-// +build windows plan9 js
 
 package local
 

--- a/backend/local/lchtimes_unix.go
+++ b/backend/local/lchtimes_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9 && !js
-// +build !windows,!plan9,!js
 
 package local
 

--- a/backend/local/metadata_bsd.go
+++ b/backend/local/metadata_bsd.go
@@ -1,5 +1,4 @@
 //go:build darwin || freebsd || netbsd
-// +build darwin freebsd netbsd
 
 package local
 

--- a/backend/local/metadata_linux.go
+++ b/backend/local/metadata_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package local
 

--- a/backend/local/metadata_other.go
+++ b/backend/local/metadata_other.go
@@ -1,5 +1,4 @@
 //go:build plan9 || js
-// +build plan9 js
 
 package local
 

--- a/backend/local/metadata_unix.go
+++ b/backend/local/metadata_unix.go
@@ -1,5 +1,4 @@
 //go:build openbsd || solaris
-// +build openbsd solaris
 
 package local
 

--- a/backend/local/metadata_windows.go
+++ b/backend/local/metadata_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package local
 

--- a/backend/local/read_device_other.go
+++ b/backend/local/read_device_other.go
@@ -1,7 +1,6 @@
 // Device reading functions
 
 //go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
-// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
 
 package local
 

--- a/backend/local/read_device_unix.go
+++ b/backend/local/read_device_unix.go
@@ -1,7 +1,6 @@
 // Device reading functions
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package local
 

--- a/backend/local/remove_other.go
+++ b/backend/local/remove_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package local
 

--- a/backend/local/remove_windows.go
+++ b/backend/local/remove_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package local
 

--- a/backend/local/setbtime.go
+++ b/backend/local/setbtime.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package local
 

--- a/backend/local/setbtime_windows.go
+++ b/backend/local/setbtime_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package local
 

--- a/backend/local/symlink.go
+++ b/backend/local/symlink.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9 && !js
-// +build !windows,!plan9,!js
 
 package local
 

--- a/backend/local/symlink_other.go
+++ b/backend/local/symlink_other.go
@@ -1,5 +1,4 @@
 //go:build windows || plan9 || js
-// +build windows plan9 js
 
 package local
 

--- a/backend/local/xattr.go
+++ b/backend/local/xattr.go
@@ -1,5 +1,4 @@
 //go:build !openbsd && !plan9
-// +build !openbsd,!plan9
 
 package local
 

--- a/backend/local/xattr_unsupported.go
+++ b/backend/local/xattr_unsupported.go
@@ -1,5 +1,4 @@
 //go:build openbsd || plan9
-// +build openbsd plan9
 
 // The pkg/xattr module doesn't compile for openbsd or plan9
 package local

--- a/backend/oracleobjectstorage/byok.go
+++ b/backend/oracleobjectstorage/byok.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package oracleobjectstorage
 

--- a/backend/oracleobjectstorage/client.go
+++ b/backend/oracleobjectstorage/client.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package oracleobjectstorage
 

--- a/backend/oracleobjectstorage/command.go
+++ b/backend/oracleobjectstorage/command.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package oracleobjectstorage
 

--- a/backend/oracleobjectstorage/copy.go
+++ b/backend/oracleobjectstorage/copy.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package oracleobjectstorage
 

--- a/backend/oracleobjectstorage/multipart.go
+++ b/backend/oracleobjectstorage/multipart.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package oracleobjectstorage
 

--- a/backend/oracleobjectstorage/object.go
+++ b/backend/oracleobjectstorage/object.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package oracleobjectstorage
 

--- a/backend/oracleobjectstorage/options.go
+++ b/backend/oracleobjectstorage/options.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package oracleobjectstorage
 

--- a/backend/oracleobjectstorage/oracleobjectstorage.go
+++ b/backend/oracleobjectstorage/oracleobjectstorage.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 // Package oracleobjectstorage provides an interface to the OCI object storage system.
 package oracleobjectstorage

--- a/backend/oracleobjectstorage/oracleobjectstorage_test.go
+++ b/backend/oracleobjectstorage/oracleobjectstorage_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package oracleobjectstorage
 

--- a/backend/oracleobjectstorage/oracleobjectstorage_unsupported.go
+++ b/backend/oracleobjectstorage/oracleobjectstorage_unsupported.go
@@ -2,6 +2,5 @@
 // about "no buildable Go source files "
 
 //go:build plan9 || solaris || js
-// +build plan9 solaris js
 
 package oracleobjectstorage

--- a/backend/oracleobjectstorage/waiter.go
+++ b/backend/oracleobjectstorage/waiter.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !solaris && !js
-// +build !plan9,!solaris,!js
 
 package oracleobjectstorage
 

--- a/backend/qingstor/qingstor.go
+++ b/backend/qingstor/qingstor.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 // Package qingstor provides an interface to QingStor object storage
 // Home: https://www.qingcloud.com/

--- a/backend/qingstor/qingstor_test.go
+++ b/backend/qingstor/qingstor_test.go
@@ -1,7 +1,6 @@
 // Test QingStor filesystem interface
 
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package qingstor
 

--- a/backend/qingstor/qingstor_unsupported.go
+++ b/backend/qingstor/qingstor_unsupported.go
@@ -2,6 +2,5 @@
 // about "no buildable Go source files "
 
 //go:build plan9 || js
-// +build plan9 js
 
 package qingstor

--- a/backend/qingstor/upload.go
+++ b/backend/qingstor/upload.go
@@ -1,7 +1,6 @@
 // Upload object to QingStor
 
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package qingstor
 

--- a/backend/s3/gen_setfrom.go
+++ b/backend/s3/gen_setfrom.go
@@ -1,7 +1,6 @@
 // Generate boilerplate code for setting similar structs from each other
 
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 // Package sftp provides a filesystem interface using github.com/pkg/sftp
 package sftp

--- a/backend/sftp/sftp_internal_test.go
+++ b/backend/sftp/sftp_internal_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/backend/sftp/sftp_test.go
+++ b/backend/sftp/sftp_test.go
@@ -1,7 +1,6 @@
 // Test Sftp filesystem interface
 
 //go:build !plan9
-// +build !plan9
 
 package sftp_test
 

--- a/backend/sftp/sftp_unsupported.go
+++ b/backend/sftp/sftp_unsupported.go
@@ -2,6 +2,5 @@
 // about "no buildable Go source files "
 
 //go:build plan9
-// +build plan9
 
 package sftp

--- a/backend/sftp/ssh.go
+++ b/backend/sftp/ssh.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/backend/sftp/ssh_external.go
+++ b/backend/sftp/ssh_external.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/backend/sftp/ssh_internal.go
+++ b/backend/sftp/ssh_internal.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/backend/sftp/stringlock.go
+++ b/backend/sftp/stringlock.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/backend/sftp/stringlock_test.go
+++ b/backend/sftp/stringlock_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/backend/sharefile/generate_tzdata.go
+++ b/backend/sharefile/generate_tzdata.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/backend/storj/fs.go
+++ b/backend/storj/fs.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 // Package storj provides an interface to Storj decentralized object storage.
 package storj

--- a/backend/storj/object.go
+++ b/backend/storj/object.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package storj
 

--- a/backend/storj/storj_test.go
+++ b/backend/storj/storj_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 // Test Storj filesystem interface
 package storj_test

--- a/backend/storj/storj_unsupported.go
+++ b/backend/storj/storj_unsupported.go
@@ -1,4 +1,3 @@
 //go:build plan9
-// +build plan9
 
 package storj

--- a/backend/union/errors_test.go
+++ b/backend/union/errors_test.go
@@ -1,5 +1,4 @@
 //go:build go1.20
-// +build go1.20
 
 package union
 

--- a/bin/check-merged.go
+++ b/bin/check-merged.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Attempt to work out if branches have already been merged
 package main

--- a/bin/cross-compile.go
+++ b/bin/cross-compile.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Cross compile rclone - in go because I hate bash ;-)
 

--- a/bin/get-github-release.go
+++ b/bin/get-github-release.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Get the latest release from a github project
 //

--- a/bin/resource_windows.go
+++ b/bin/resource_windows.go
@@ -16,7 +16,6 @@
 
 //go:generate go run resource_windows.go
 //go:build tools
-// +build tools
 
 package main
 

--- a/bin/test_independence.go
+++ b/bin/test_independence.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Test that the tests in the suite passed in are independent
 

--- a/cmd/cachestats/cachestats.go
+++ b/cmd/cachestats/cachestats.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 // Package cachestats provides the cachestats command.
 package cachestats

--- a/cmd/cachestats/cachestats_unsupported.go
+++ b/cmd/cachestats/cachestats_unsupported.go
@@ -2,6 +2,5 @@
 // about "no buildable Go source files "
 
 //go:build plan9 || js
-// +build plan9 js
 
 package cachestats

--- a/cmd/cmount/fs.go
+++ b/cmd/cmount/fs.go
@@ -1,6 +1,4 @@
 //go:build cmount && ((linux && cgo) || (darwin && cgo) || (freebsd && cgo) || windows)
-// +build cmount
-// +build linux,cgo darwin,cgo freebsd,cgo windows
 
 package cmount
 

--- a/cmd/cmount/mount.go
+++ b/cmd/cmount/mount.go
@@ -1,6 +1,4 @@
 //go:build cmount && ((linux && cgo) || (darwin && cgo) || (freebsd && cgo) || windows)
-// +build cmount
-// +build linux,cgo darwin,cgo freebsd,cgo windows
 
 // Package cmount implements a FUSE mounting system for rclone remotes.
 //

--- a/cmd/cmount/mount_brew.go
+++ b/cmd/cmount/mount_brew.go
@@ -1,5 +1,4 @@
 //go:build brew && darwin
-// +build brew,darwin
 
 // Package cmount implements a FUSE mounting system for rclone remotes.
 //

--- a/cmd/cmount/mount_test.go
+++ b/cmd/cmount/mount_test.go
@@ -1,7 +1,4 @@
 //go:build cmount && ((linux && cgo) || (darwin && cgo) || (freebsd && cgo) || windows) && (!race || !windows)
-// +build cmount
-// +build linux,cgo darwin,cgo freebsd,cgo windows
-// +build !race !windows
 
 // Package cmount implements a FUSE mounting system for rclone remotes.
 //

--- a/cmd/cmount/mount_unsupported.go
+++ b/cmd/cmount/mount_unsupported.go
@@ -1,8 +1,4 @@
 //go:build !((linux && cgo && cmount) || (darwin && cgo && cmount) || (freebsd && cgo && cmount) || (windows && cmount))
-// +build !linux !cgo !cmount
-// +build !darwin !cgo !cmount
-// +build !freebsd !cgo !cmount
-// +build !windows !cmount
 
 // Package cmount implements a FUSE mounting system for rclone remotes.
 //

--- a/cmd/cmount/mountpoint_other.go
+++ b/cmd/cmount/mountpoint_other.go
@@ -1,5 +1,4 @@
 //go:build cmount && cgo && !windows
-// +build cmount,cgo,!windows
 
 package cmount
 

--- a/cmd/cmount/mountpoint_windows.go
+++ b/cmd/cmount/mountpoint_windows.go
@@ -1,5 +1,4 @@
 //go:build cmount && windows
-// +build cmount,windows
 
 package cmount
 

--- a/cmd/mount/dir.go
+++ b/cmd/mount/dir.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package mount
 

--- a/cmd/mount/file.go
+++ b/cmd/mount/file.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package mount
 

--- a/cmd/mount/fs.go
+++ b/cmd/mount/fs.go
@@ -1,7 +1,6 @@
 // FUSE main Fs
 
 //go:build linux
-// +build linux
 
 package mount
 

--- a/cmd/mount/handle.go
+++ b/cmd/mount/handle.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package mount
 

--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 // Package mount implements a FUSE mounting system for rclone remotes.
 package mount

--- a/cmd/mount/mount_test.go
+++ b/cmd/mount/mount_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package mount
 

--- a/cmd/mount/mount_unsupported.go
+++ b/cmd/mount/mount_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 // Package mount implements a FUSE mounting system for rclone remotes.
 //

--- a/cmd/mount/test/seek_speed.go
+++ b/cmd/mount/test/seek_speed.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Read blocks out of a single file to time the seeking code
 package main

--- a/cmd/mount/test/seeker.go
+++ b/cmd/mount/test/seeker.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Read two files with lots of seeking to stress test the seek code
 package main

--- a/cmd/mount/test/seekers.go
+++ b/cmd/mount/test/seekers.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // Read lots files with lots of simultaneous seeking to stress test the seek code
 package main

--- a/cmd/mount2/file.go
+++ b/cmd/mount2/file.go
@@ -1,5 +1,4 @@
 //go:build linux || (darwin && amd64)
-// +build linux darwin,amd64
 
 package mount2
 

--- a/cmd/mount2/fs.go
+++ b/cmd/mount2/fs.go
@@ -1,7 +1,6 @@
 // FUSE main Fs
 
 //go:build linux || (darwin && amd64)
-// +build linux darwin,amd64
 
 package mount2
 

--- a/cmd/mount2/mount.go
+++ b/cmd/mount2/mount.go
@@ -1,5 +1,4 @@
 //go:build linux || (darwin && amd64)
-// +build linux darwin,amd64
 
 // Package mount2 implements a FUSE mounting system for rclone remotes.
 package mount2

--- a/cmd/mount2/mount_test.go
+++ b/cmd/mount2/mount_test.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package mount2
 

--- a/cmd/mount2/mount_unsupported.go
+++ b/cmd/mount2/mount_unsupported.go
@@ -1,6 +1,4 @@
 //go:build !linux && (!darwin || !amd64)
-// +build !linux
-// +build !darwin !amd64
 
 // Package mount2 implements a FUSE mounting system for rclone remotes.
 //

--- a/cmd/mount2/node.go
+++ b/cmd/mount2/node.go
@@ -1,5 +1,4 @@
 //go:build linux || (darwin && amd64)
-// +build linux darwin,amd64
 
 package mount2
 

--- a/cmd/mountlib/check_linux.go
+++ b/cmd/mountlib/check_linux.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package mountlib
 

--- a/cmd/mountlib/check_other.go
+++ b/cmd/mountlib/check_other.go
@@ -1,5 +1,4 @@
 //go:build !linux
-// +build !linux
 
 package mountlib
 

--- a/cmd/mountlib/sighup.go
+++ b/cmd/mountlib/sighup.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package mountlib
 

--- a/cmd/mountlib/sighup_unsupported.go
+++ b/cmd/mountlib/sighup_unsupported.go
@@ -1,5 +1,4 @@
 //go:build plan9 || js
-// +build plan9 js
 
 package mountlib
 

--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 // Package ncdu implements a text based user interface for exploring a remote
 package ncdu

--- a/cmd/ncdu/ncdu_unsupported.go
+++ b/cmd/ncdu/ncdu_unsupported.go
@@ -2,6 +2,5 @@
 // about "no buildable Go source files "
 
 //go:build plan9 || js
-// +build plan9 js
 
 package ncdu

--- a/cmd/nfsmount/nfsmount.go
+++ b/cmd/nfsmount/nfsmount.go
@@ -1,5 +1,4 @@
 //go:build unix
-// +build unix
 
 // Package nfsmount implements mounting functionality using serve nfs command
 //

--- a/cmd/nfsmount/nfsmount_test.go
+++ b/cmd/nfsmount/nfsmount_test.go
@@ -1,5 +1,4 @@
 //go:build darwin && !cmount
-// +build darwin,!cmount
 
 package nfsmount
 

--- a/cmd/nfsmount/nfsmount_unsupported.go
+++ b/cmd/nfsmount/nfsmount_unsupported.go
@@ -2,7 +2,6 @@
 // about "no buildable Go source files "
 
 //go:build !unix
-// +build !unix
 
 // Package nfsmount implements mount command using NFS.
 package nfsmount

--- a/cmd/selfupdate/noselfupdate.go
+++ b/cmd/selfupdate/noselfupdate.go
@@ -1,5 +1,4 @@
 //go:build noselfupdate
-// +build noselfupdate
 
 package selfupdate
 

--- a/cmd/selfupdate/selfupdate.go
+++ b/cmd/selfupdate/selfupdate.go
@@ -1,5 +1,4 @@
 //go:build !noselfupdate
-// +build !noselfupdate
 
 // Package selfupdate provides the selfupdate command.
 package selfupdate

--- a/cmd/selfupdate/selfupdate_test.go
+++ b/cmd/selfupdate/selfupdate_test.go
@@ -1,5 +1,4 @@
 //go:build !noselfupdate
-// +build !noselfupdate
 
 package selfupdate
 

--- a/cmd/selfupdate/verify.go
+++ b/cmd/selfupdate/verify.go
@@ -1,5 +1,4 @@
 //go:build !noselfupdate
-// +build !noselfupdate
 
 package selfupdate
 

--- a/cmd/selfupdate/verify_test.go
+++ b/cmd/selfupdate/verify_test.go
@@ -1,5 +1,4 @@
 //go:build !noselfupdate
-// +build !noselfupdate
 
 package selfupdate
 

--- a/cmd/selfupdate/writable_unix.go
+++ b/cmd/selfupdate/writable_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9 && !js && !noselfupdate
-// +build !windows,!plan9,!js,!noselfupdate
 
 package selfupdate
 

--- a/cmd/selfupdate/writable_unsupported.go
+++ b/cmd/selfupdate/writable_unsupported.go
@@ -1,6 +1,4 @@
 //go:build (plan9 || js) && !noselfupdate
-// +build plan9 js
-// +build !noselfupdate
 
 package selfupdate
 

--- a/cmd/selfupdate/writable_windows.go
+++ b/cmd/selfupdate/writable_windows.go
@@ -1,5 +1,4 @@
 //go:build windows && !noselfupdate
-// +build windows,!noselfupdate
 
 package selfupdate
 

--- a/cmd/selfupdate_disabled.go
+++ b/cmd/selfupdate_disabled.go
@@ -1,5 +1,4 @@
 //go:build noselfupdate
-// +build noselfupdate
 
 package cmd
 

--- a/cmd/selfupdate_enabled.go
+++ b/cmd/selfupdate_enabled.go
@@ -1,5 +1,4 @@
 //go:build !noselfupdate
-// +build !noselfupdate
 
 package cmd
 

--- a/cmd/serve/dlna/data/assets_generate.go
+++ b/cmd/serve/dlna/data/assets_generate.go
@@ -1,7 +1,6 @@
 //go:generate go run assets_generate.go
 // The "go:generate" directive compiles static assets by running assets_generate.go
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/cmd/serve/docker/docker_test.go
+++ b/cmd/serve/docker/docker_test.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 package docker_test
 

--- a/cmd/serve/docker/systemd.go
+++ b/cmd/serve/docker/systemd.go
@@ -1,5 +1,4 @@
 //go:build linux && !android
-// +build linux,!android
 
 package docker
 

--- a/cmd/serve/docker/systemd_unsupported.go
+++ b/cmd/serve/docker/systemd_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux || android
-// +build !linux android
 
 package docker
 

--- a/cmd/serve/docker/unix.go
+++ b/cmd/serve/docker/unix.go
@@ -1,5 +1,4 @@
 //go:build linux || freebsd
-// +build linux freebsd
 
 package docker
 

--- a/cmd/serve/docker/unix_unsupported.go
+++ b/cmd/serve/docker/unix_unsupported.go
@@ -1,5 +1,4 @@
 //go:build !linux && !freebsd
-// +build !linux,!freebsd
 
 package docker
 

--- a/cmd/serve/ftp/ftp.go
+++ b/cmd/serve/ftp/ftp.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 // Package ftp implements an FTP server for rclone
 package ftp

--- a/cmd/serve/ftp/ftp_test.go
+++ b/cmd/serve/ftp/ftp_test.go
@@ -4,7 +4,6 @@
 // We skip tests on platforms with troublesome character mappings
 
 //go:build !windows && !darwin && !plan9
-// +build !windows,!darwin,!plan9
 
 package ftp
 

--- a/cmd/serve/ftp/ftp_unsupported.go
+++ b/cmd/serve/ftp/ftp_unsupported.go
@@ -2,7 +2,6 @@
 // about "no buildable Go source files "
 
 //go:build plan9
-// +build plan9
 
 package ftp
 

--- a/cmd/serve/nfs/filesystem.go
+++ b/cmd/serve/nfs/filesystem.go
@@ -1,5 +1,4 @@
 //go:build unix
-// +build unix
 
 package nfs
 

--- a/cmd/serve/nfs/handler.go
+++ b/cmd/serve/nfs/handler.go
@@ -1,5 +1,4 @@
 //go:build unix
-// +build unix
 
 package nfs
 

--- a/cmd/serve/nfs/nfs.go
+++ b/cmd/serve/nfs/nfs.go
@@ -1,5 +1,4 @@
 //go:build unix
-// +build unix
 
 // Package nfs implements a server to serve a VFS remote over NFSv3 protocol
 //

--- a/cmd/serve/nfs/nfs_unsupported.go
+++ b/cmd/serve/nfs/nfs_unsupported.go
@@ -1,6 +1,5 @@
 // For unsupported architectures
 //go:build !unix
-// +build !unix
 
 // Package nfs is not supported on non-Unix platforms
 package nfs

--- a/cmd/serve/nfs/server.go
+++ b/cmd/serve/nfs/server.go
@@ -1,5 +1,4 @@
 //go:build unix
-// +build unix
 
 package nfs
 

--- a/cmd/serve/proxy/proxy_code.go
+++ b/cmd/serve/proxy/proxy_code.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // A simple auth proxy for testing purposes
 package main

--- a/cmd/serve/servetest/proxy_code.go
+++ b/cmd/serve/servetest/proxy_code.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // A simple auth proxy for testing purposes
 package main

--- a/cmd/serve/sftp/connection.go
+++ b/cmd/serve/sftp/connection.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/cmd/serve/sftp/connection_test.go
+++ b/cmd/serve/sftp/connection_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/cmd/serve/sftp/handler.go
+++ b/cmd/serve/sftp/handler.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/cmd/serve/sftp/server.go
+++ b/cmd/serve/sftp/server.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package sftp
 

--- a/cmd/serve/sftp/sftp.go
+++ b/cmd/serve/sftp/sftp.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 // Package sftp implements an SFTP server to serve an rclone VFS
 package sftp

--- a/cmd/serve/sftp/sftp_test.go
+++ b/cmd/serve/sftp/sftp_test.go
@@ -4,7 +4,6 @@
 // We skip tests on platforms with troublesome character mappings
 
 //go:build !windows && !darwin && !plan9
-// +build !windows,!darwin,!plan9
 
 package sftp
 

--- a/cmd/serve/sftp/sftp_unsupported.go
+++ b/cmd/serve/sftp/sftp_unsupported.go
@@ -2,7 +2,6 @@
 // about "no buildable Go source files "
 
 //go:build plan9
-// +build plan9
 
 package sftp
 

--- a/cmd/serve/webdav/webdav_test.go
+++ b/cmd/serve/webdav/webdav_test.go
@@ -4,7 +4,6 @@
 // We skip tests on platforms with troublesome character mappings
 
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 package webdav
 

--- a/cmd/siginfo_bsd.go
+++ b/cmd/siginfo_bsd.go
@@ -1,5 +1,4 @@
 //go:build darwin || freebsd || netbsd || dragonfly || openbsd
-// +build darwin freebsd netbsd dragonfly openbsd
 
 package cmd
 

--- a/cmd/siginfo_others.go
+++ b/cmd/siginfo_others.go
@@ -1,5 +1,4 @@
 //go:build !darwin && !freebsd && !netbsd && !dragonfly && !openbsd
-// +build !darwin,!freebsd,!netbsd,!dragonfly,!openbsd
 
 package cmd
 

--- a/fs/accounting/accounting_other.go
+++ b/fs/accounting/accounting_other.go
@@ -2,7 +2,6 @@
 // Non-unix specific functions.
 
 //go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
-// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
 
 package accounting
 

--- a/fs/accounting/accounting_unix.go
+++ b/fs/accounting/accounting_unix.go
@@ -2,7 +2,6 @@
 // Unix specific functions.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package accounting
 

--- a/fs/config/config_read_password.go
+++ b/fs/config/config_read_password.go
@@ -2,7 +2,6 @@
 // See https://github.com/golang/go/issues/14441 - plan9
 
 //go:build !plan9
-// +build !plan9
 
 package config
 

--- a/fs/config/config_read_password_unsupported.go
+++ b/fs/config/config_read_password_unsupported.go
@@ -2,7 +2,6 @@
 // See https://github.com/golang/go/issues/14441 - plan9
 
 //go:build plan9
-// +build plan9
 
 package config
 

--- a/fs/config/configfile/configfile_other.go
+++ b/fs/config/configfile/configfile_other.go
@@ -2,7 +2,6 @@
 // Non-unix specific functions.
 
 //go:build !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd && !solaris
-// +build !darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd,!solaris
 
 package configfile
 

--- a/fs/config/configfile/configfile_unix.go
+++ b/fs/config/configfile/configfile_unix.go
@@ -2,7 +2,6 @@
 // Unix specific functions.
 
 //go:build darwin || dragonfly || freebsd || linux || netbsd || openbsd || solaris
-// +build darwin dragonfly freebsd linux netbsd openbsd solaris
 
 package configfile
 

--- a/fs/daemon_other.go
+++ b/fs/daemon_other.go
@@ -1,7 +1,6 @@
 // Daemonization stub for non-Unix platforms (common definitions)
 
 //go:build windows || plan9 || js
-// +build windows plan9 js
 
 package fs
 

--- a/fs/daemon_unix.go
+++ b/fs/daemon_unix.go
@@ -1,7 +1,6 @@
 // Daemonization interface for Unix platforms (common definitions)
 
 //go:build !windows && !plan9 && !js
-// +build !windows,!plan9,!js
 
 package fs
 

--- a/fs/driveletter/driveletter.go
+++ b/fs/driveletter/driveletter.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 // Package driveletter returns whether a name is a valid drive letter
 package driveletter

--- a/fs/driveletter/driveletter_windows.go
+++ b/fs/driveletter/driveletter_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 // Package driveletter returns whether a name is a valid drive letter
 package driveletter

--- a/fs/fserrors/enospc_error.go
+++ b/fs/fserrors/enospc_error.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package fserrors
 

--- a/fs/fserrors/enospc_error_notsupported.go
+++ b/fs/fserrors/enospc_error_notsupported.go
@@ -1,5 +1,4 @@
 //go:build plan9
-// +build plan9
 
 package fserrors
 

--- a/fs/fserrors/retriable_errors.go
+++ b/fs/fserrors/retriable_errors.go
@@ -1,5 +1,4 @@
 //go:build !plan9
-// +build !plan9
 
 package fserrors
 

--- a/fs/fserrors/retriable_errors_windows.go
+++ b/fs/fserrors/retriable_errors_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package fserrors
 

--- a/fs/fspath/fuzz.go
+++ b/fs/fspath/fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 /*
    Fuzz test the Parse function

--- a/fs/log/redirect_stderr.go
+++ b/fs/log/redirect_stderr.go
@@ -1,7 +1,6 @@
 // Log the panic to the log file - for oses which can't do this
 
 //go:build !windows && !darwin && !dragonfly && !freebsd && !linux && !nacl && !netbsd && !openbsd
-// +build !windows,!darwin,!dragonfly,!freebsd,!linux,!nacl,!netbsd,!openbsd
 
 package log
 

--- a/fs/log/redirect_stderr_unix.go
+++ b/fs/log/redirect_stderr_unix.go
@@ -1,7 +1,6 @@
 // Log the panic under unix to the log file
 
 //go:build !windows && !solaris && !plan9 && !js
-// +build !windows,!solaris,!plan9,!js
 
 package log
 

--- a/fs/log/redirect_stderr_windows.go
+++ b/fs/log/redirect_stderr_windows.go
@@ -5,7 +5,6 @@
 // https://play.golang.org/p/kLtct7lSUg
 
 //go:build windows
-// +build windows
 
 package log
 

--- a/fs/log/syslog.go
+++ b/fs/log/syslog.go
@@ -1,7 +1,6 @@
 // Syslog interface for non-Unix variants only
 
 //go:build windows || nacl || plan9
-// +build windows nacl plan9
 
 package log
 

--- a/fs/log/syslog_unix.go
+++ b/fs/log/syslog_unix.go
@@ -1,7 +1,6 @@
 // Syslog interface for Unix variants only
 
 //go:build !windows && !nacl && !plan9
-// +build !windows,!nacl,!plan9
 
 package log
 

--- a/fs/log/systemd.go
+++ b/fs/log/systemd.go
@@ -1,7 +1,6 @@
 // Systemd interface for non-Unix variants only
 
 //go:build !unix
-// +build !unix
 
 package log
 

--- a/fs/log/systemd_unix.go
+++ b/fs/log/systemd_unix.go
@@ -1,7 +1,6 @@
 // Systemd interface for Unix variants only
 
 //go:build unix
-// +build unix
 
 package log
 

--- a/fs/metadata_mapper_code.go
+++ b/fs/metadata_mapper_code.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 // A simple metadata mapper for testing purposes
 package main

--- a/fs/rc/js/main.go
+++ b/fs/rc/js/main.go
@@ -3,7 +3,6 @@
 // This library exports the core rc functionality
 
 //go:build js
-// +build js
 
 package main
 

--- a/fs/rc/js/serve.go
+++ b/fs/rc/js/serve.go
@@ -1,5 +1,4 @@
 //go:build none
-// +build none
 
 package main
 

--- a/fs/versioncheck.go
+++ b/fs/versioncheck.go
@@ -1,5 +1,4 @@
 //go:build !go1.20
-// +build !go1.20
 
 package fs
 

--- a/lib/atexit/atexit_other.go
+++ b/lib/atexit/atexit_other.go
@@ -1,5 +1,4 @@
 //go:build windows || plan9
-// +build windows plan9
 
 package atexit
 

--- a/lib/atexit/atexit_unix.go
+++ b/lib/atexit/atexit_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows && !plan9
-// +build !windows,!plan9
 
 package atexit
 

--- a/lib/buildinfo/cgo.go
+++ b/lib/buildinfo/cgo.go
@@ -1,5 +1,4 @@
 //go:build cgo
-// +build cgo
 
 package buildinfo
 

--- a/lib/buildinfo/osversion.go
+++ b/lib/buildinfo/osversion.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package buildinfo
 

--- a/lib/buildinfo/snap.go
+++ b/lib/buildinfo/snap.go
@@ -1,5 +1,4 @@
 //go:build snap
-// +build snap
 
 package buildinfo
 

--- a/lib/encoder/filename/fuzz.go
+++ b/lib/encoder/filename/fuzz.go
@@ -1,5 +1,4 @@
 //go:build gofuzz
-// +build gofuzz
 
 package filename
 

--- a/lib/encoder/filename/gentable.go
+++ b/lib/encoder/filename/gentable.go
@@ -1,5 +1,4 @@
 //go:build ignore
-// +build ignore
 
 package main
 

--- a/lib/encoder/os_darwin.go
+++ b/lib/encoder/os_darwin.go
@@ -1,5 +1,4 @@
 //go:build darwin
-// +build darwin
 
 package encoder
 

--- a/lib/encoder/os_other.go
+++ b/lib/encoder/os_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !darwin
-// +build !windows,!darwin
 
 package encoder
 

--- a/lib/encoder/os_windows.go
+++ b/lib/encoder/os_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package encoder
 

--- a/lib/file/driveletter_other.go
+++ b/lib/file/driveletter_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package file
 

--- a/lib/file/driveletter_windows.go
+++ b/lib/file/driveletter_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package file
 

--- a/lib/file/file_other.go
+++ b/lib/file/file_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package file
 

--- a/lib/file/file_windows.go
+++ b/lib/file/file_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package file
 

--- a/lib/file/mkdir_other.go
+++ b/lib/file/mkdir_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package file
 

--- a/lib/file/mkdir_windows.go
+++ b/lib/file/mkdir_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package file
 

--- a/lib/file/mkdir_windows_test.go
+++ b/lib/file/mkdir_windows_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package file
 

--- a/lib/file/preallocate_other.go
+++ b/lib/file/preallocate_other.go
@@ -1,5 +1,4 @@
 //go:build !windows && !linux
-// +build !windows,!linux
 
 package file
 

--- a/lib/file/preallocate_unix.go
+++ b/lib/file/preallocate_unix.go
@@ -1,5 +1,4 @@
 //go:build linux
-// +build linux
 
 package file
 

--- a/lib/file/preallocate_windows.go
+++ b/lib/file/preallocate_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package file
 

--- a/lib/file/unc.go
+++ b/lib/file/unc.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package file
 

--- a/lib/file/unc_test.go
+++ b/lib/file/unc_test.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package file
 

--- a/lib/file/unc_windows.go
+++ b/lib/file/unc_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package file
 

--- a/lib/israce/israce.go
+++ b/lib/israce/israce.go
@@ -1,5 +1,4 @@
 //go:build race
-// +build race
 
 // Package israce reports if the Go race detector is enabled.
 //

--- a/lib/israce/norace.go
+++ b/lib/israce/norace.go
@@ -1,5 +1,4 @@
 //go:build !race
-// +build !race
 
 // Package israce reports if the Go race detector is enabled.
 //

--- a/lib/kv/bolt.go
+++ b/lib/kv/bolt.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 // Package kv provides key/value database.
 package kv

--- a/lib/kv/internal_test.go
+++ b/lib/kv/internal_test.go
@@ -1,5 +1,4 @@
 //go:build !plan9 && !js
-// +build !plan9,!js
 
 package kv
 

--- a/lib/kv/unsupported.go
+++ b/lib/kv/unsupported.go
@@ -1,5 +1,4 @@
 //go:build plan9 || js
-// +build plan9 js
 
 package kv
 

--- a/lib/mmap/mmap_unix.go
+++ b/lib/mmap/mmap_unix.go
@@ -2,7 +2,6 @@
 // anonymous memory maps.
 
 //go:build !plan9 && !windows && !js
-// +build !plan9,!windows,!js
 
 package mmap
 

--- a/lib/mmap/mmap_unsupported.go
+++ b/lib/mmap/mmap_unsupported.go
@@ -1,7 +1,6 @@
 // Fallback Alloc and Free for unsupported OSes
 
 //go:build plan9 || js
-// +build plan9 js
 
 package mmap
 

--- a/lib/mmap/mmap_windows.go
+++ b/lib/mmap/mmap_windows.go
@@ -2,7 +2,6 @@
 // anonymous memory maps.
 
 //go:build windows
-// +build windows
 
 package mmap
 

--- a/lib/plugin/plugin.go
+++ b/lib/plugin/plugin.go
@@ -1,6 +1,4 @@
 //go:build (darwin || linux) && !gccgo
-// +build darwin linux
-// +build !gccgo
 
 package plugin
 

--- a/lib/terminal/hidden_other.go
+++ b/lib/terminal/hidden_other.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package terminal
 

--- a/lib/terminal/hidden_windows.go
+++ b/lib/terminal/hidden_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package terminal
 

--- a/lib/terminal/terminal_normal.go
+++ b/lib/terminal/terminal_normal.go
@@ -1,5 +1,4 @@
 //go:build !js
-// +build !js
 
 package terminal
 

--- a/lib/terminal/terminal_unsupported.go
+++ b/lib/terminal/terminal_unsupported.go
@@ -1,5 +1,4 @@
 //go:build js
-// +build js
 
 package terminal
 

--- a/vfs/make_open_tests.go
+++ b/vfs/make_open_tests.go
@@ -8,7 +8,6 @@
 // Run with go generate (defined in vfs.go)
 //
 //go:build none
-// +build none
 
 // FIXME include read too?
 

--- a/vfs/vfsflags/vfsflags_non_unix.go
+++ b/vfs/vfsflags/vfsflags_non_unix.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin && !freebsd
-// +build !linux,!darwin,!freebsd
 
 package vfsflags
 

--- a/vfs/vfsflags/vfsflags_unix.go
+++ b/vfs/vfsflags/vfsflags_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd
-// +build linux darwin freebsd
 
 package vfsflags
 

--- a/vfs/vfstest/read_non_unix.go
+++ b/vfs/vfstest/read_non_unix.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin && !freebsd
-// +build !linux,!darwin,!freebsd
 
 package vfstest
 

--- a/vfs/vfstest/read_unix.go
+++ b/vfs/vfstest/read_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd
-// +build linux darwin freebsd
 
 package vfstest
 

--- a/vfs/vfstest/write_non_unix.go
+++ b/vfs/vfstest/write_non_unix.go
@@ -1,5 +1,4 @@
 //go:build !linux && !darwin && !freebsd
-// +build !linux,!darwin,!freebsd
 
 package vfstest
 

--- a/vfs/vfstest/write_unix.go
+++ b/vfs/vfstest/write_unix.go
@@ -1,5 +1,4 @@
 //go:build linux || darwin || freebsd
-// +build linux darwin freebsd
 
 package vfstest
 


### PR DESCRIPTION
#### What is the purpose of this change?

Is it time to get rid of the duplicated GOOS build constraints? Its been a long time since a go version officially supported by rclone needed the old syntax. Or are there a reason to keep it still, e.g. some tools, IDEs or something that wants both or the old syntax?

> Go versions 1.16 and earlier used a different syntax for build constraints, with a "// +build" prefix.

(https://pkg.go.dev/cmd/go#hdr-Build_constraints)


#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
