### PR TITLE
fix issues related to encoding

### DIFF
--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -348,8 +348,8 @@ have a Windows file system with Unicode fullwidth characters
 remote rather than being translated to regular (halfwidth) `*`, `?` and `:`.
 
 The `--backend-encoding` flags allow you to change that. You can
-disable the encoding completely with `--backend-encoding None` or set
-`encoding = None` in the config file.
+disable the encoding completely with `--backend-encoding Raw` or set
+`encoding = Raw` in the config file.
 
 Encoding takes a comma separated list of encodings. You can see the
 list of all possible values by passing an invalid value to this
@@ -375,7 +375,7 @@ will show you the defaults for the backends.
 | LeftSpace | SPACE on the left of a string | `␠` |
 | LeftTilde | `~` on the left of a string | `～` |
 | LtGt | `<`, `>` | `＜`, `＞` |
-| None | No characters are encoded | |
+| None ¹ | NUL 0x00 | ␀ |
 | Percent | `%` | `％` |
 | Pipe | \| | `｜` |
 | Question | `?` | `？` |
@@ -386,6 +386,10 @@ will show you the defaults for the backends.
 | SingleQuote | `'` | `＇` |
 | Slash | `/` | `／` |
 | SquareBracket | `[`, `]` | `［`, `］` |
+
+¹ Encoding from NUL 0x00 to ␀ is always implicit except when using Raw.
+It was previously incorrectly documented as disabling encoding,
+and to maintain backward compatibility, its behavior has not been changed.
 
 ##### Encoding example: FTP
 
@@ -430,7 +434,7 @@ the default value but without `Colon,Question,Asterisk`:
 --local-encoding "Slash,LtGt,DoubleQuote,Pipe,BackSlash,Ctl,RightSpace,RightPeriod,InvalidUtf8,Dot"
 ```
 
-Alternatively, you can disable the conversion of any characters with `--local-encoding None`.
+Alternatively, you can disable the conversion of any characters with `--local-encoding Raw`.
 
 Instead of using command-line argument `--local-encoding`, you may also set it
 as [environment variable](/docs/#environment-variables) `RCLONE_LOCAL_ENCODING`,

--- a/lib/encoder/encoder.go
+++ b/lib/encoder/encoder.go
@@ -35,34 +35,35 @@ const (
 
 // Possible flags for the MultiEncoder
 const (
-	EncodeZero          MultiEncoder = 0         // NUL(0x00)
-	EncodeSlash         MultiEncoder = 1 << iota // /
-	EncodeLtGt                                   // <>
-	EncodeDoubleQuote                            // "
-	EncodeSingleQuote                            // '
-	EncodeBackQuote                              // `
-	EncodeDollar                                 // $
-	EncodeColon                                  // :
-	EncodeQuestion                               // ?
-	EncodeAsterisk                               // *
-	EncodePipe                                   // |
-	EncodeHash                                   // #
-	EncodePercent                                // %
-	EncodeBackSlash                              // \
-	EncodeCrLf                                   // CR(0x0D), LF(0x0A)
-	EncodeDel                                    // DEL(0x7F)
-	EncodeCtl                                    // CTRL(0x01-0x1F)
-	EncodeLeftSpace                              // Leading SPACE
-	EncodeLeftPeriod                             // Leading .
-	EncodeLeftTilde                              // Leading ~
-	EncodeLeftCrLfHtVt                           // Leading CR LF HT VT
-	EncodeRightSpace                             // Trailing SPACE
-	EncodeRightPeriod                            // Trailing .
-	EncodeRightCrLfHtVt                          // Trailing CR LF HT VT
-	EncodeInvalidUtf8                            // Invalid UTF-8 bytes
-	EncodeDot                                    // . and .. names
-	EncodeSquareBracket                          // []
-	EncodeSemicolon                              // ;
+	EncodeZero          MultiEncoder = 0 // NUL(0x00)
+	EncodeRaw           MultiEncoder = 1 << (iota - 1)
+	EncodeSlash                      // /
+	EncodeLtGt                       // <>
+	EncodeDoubleQuote                // "
+	EncodeSingleQuote                // '
+	EncodeBackQuote                  // `
+	EncodeDollar                     // $
+	EncodeColon                      // :
+	EncodeQuestion                   // ?
+	EncodeAsterisk                   // *
+	EncodePipe                       // |
+	EncodeHash                       // #
+	EncodePercent                    // %
+	EncodeBackSlash                  // \
+	EncodeCrLf                       // CR(0x0D), LF(0x0A)
+	EncodeDel                        // DEL(0x7F)
+	EncodeCtl                        // CTRL(0x01-0x1F)
+	EncodeLeftSpace                  // Leading SPACE
+	EncodeLeftPeriod                 // Leading .
+	EncodeLeftTilde                  // Leading ~
+	EncodeLeftCrLfHtVt               // Leading CR LF HT VT
+	EncodeRightSpace                 // Trailing SPACE
+	EncodeRightPeriod                // Trailing .
+	EncodeRightCrLfHtVt              // Trailing CR LF HT VT
+	EncodeInvalidUtf8                // Invalid UTF-8 bytes
+	EncodeDot                        // . and .. names
+	EncodeSquareBracket              // []
+	EncodeSemicolon                  // ;
 
 	// Synthetic
 	EncodeWin         = EncodeColon | EncodeQuestion | EncodeDoubleQuote | EncodeAsterisk | EncodeLtGt | EncodePipe // :?"*<>|
@@ -117,6 +118,7 @@ func alias(name string, mask MultiEncoder) {
 }
 
 func init() {
+	alias("Raw", EncodeRaw)
 	alias("None", EncodeZero)
 	alias("Slash", EncodeSlash)
 	alias("LtGt", EncodeLtGt)
@@ -214,6 +216,10 @@ func (mask *MultiEncoder) Scan(s fmt.ScanState, ch rune) error {
 // Encode takes a raw name and substitutes any reserved characters and
 // patterns in it
 func (mask MultiEncoder) Encode(in string) string {
+	if mask == EncodeRaw {
+		return in
+	}
+
 	if in == "" {
 		return ""
 	}
@@ -671,6 +677,10 @@ func (mask MultiEncoder) Encode(in string) string {
 
 // Decode takes a name and undoes any substitutions made by Encode
 func (mask MultiEncoder) Decode(in string) string {
+	if mask == EncodeRaw {
+		return in
+	}
+
 	if mask.Has(EncodeDot) {
 		switch in {
 		case "．":

--- a/lib/encoder/encoder_test.go
+++ b/lib/encoder/encoder_test.go
@@ -22,7 +22,7 @@ func TestEncodeString(t *testing.T) {
 		mask MultiEncoder
 		want string
 	}{
-		{0, "None"},
+		{EncodeRaw, "Raw"},
 		{EncodeZero, "None"},
 		{EncodeDoubleQuote, "DoubleQuote"},
 		{EncodeDot, "Dot"},
@@ -44,7 +44,7 @@ func TestEncodeSet(t *testing.T) {
 		wantErr bool
 	}{
 		{"", 0, true},
-		{"None", 0, false},
+		{"Raw", EncodeRaw, false},
 		{"None", EncodeZero, false},
 		{"DoubleQuote", EncodeDoubleQuote, false},
 		{"Dot", EncodeDot, false},
@@ -178,7 +178,7 @@ func TestEncodeInvalidUnicode(t *testing.T) {
 func TestEncodeDot(t *testing.T) {
 	for i, tc := range []testCase{
 		{
-			mask: 0,
+			mask: EncodeZero,
 			in:   ".",
 			out:  ".",
 		}, {
@@ -186,7 +186,7 @@ func TestEncodeDot(t *testing.T) {
 			in:   ".",
 			out:  "．",
 		}, {
-			mask: 0,
+			mask: EncodeZero,
 			in:   "..",
 			out:  "..",
 		}, {
@@ -224,7 +224,7 @@ func TestDecodeHalf(t *testing.T) {
 			in:   "‛",
 			out:  "‛",
 		}, {
-			mask: 0,
+			mask: EncodeZero,
 			in:   "‛‛",
 			out:  "‛",
 		}, {

--- a/lib/encoder/internal/gen/main.go
+++ b/lib/encoder/internal/gen/main.go
@@ -229,8 +229,8 @@ func main() {
 			fatalW(fd.WriteString(" "))("Write:")
 		}
 		in, out := buildTestString(
-			[]mapping{getMapping(m.mask)},                               // pick
-			[]mapping{getMapping(encoder.EncodeZero)},                   // quote
+			[]mapping{getMapping(m.mask)},             // pick
+			[]mapping{getMapping(encoder.EncodeZero)}, // quote
 			printables, fullwidthPrintables, encodables, encoded, greek) // fill
 		fatalW(fmt.Fprintf(fd, `{ // %d
 		mask: %s,

--- a/lib/encoder/internal/gen/main.go
+++ b/lib/encoder/internal/gen/main.go
@@ -230,7 +230,7 @@ func main() {
 		}
 		in, out := buildTestString(
 			[]mapping{getMapping(m.mask)},                               // pick
-			[]mapping{getMapping(0)},                                    // quote
+			[]mapping{getMapping(encoder.EncodeZero)},                   // quote
 			printables, fullwidthPrintables, encodables, encoded, greek) // fill
 		fatalW(fmt.Fprintf(fd, `{ // %d
 		mask: %s,
@@ -262,7 +262,7 @@ var testCasesSingleEdge = []testCase{
 			for idx, orig := range e.orig {
 				replace := e.replace[idx]
 				pairs := buildEdgeTestString(
-					[]edge{e}, []mapping{getMapping(0), getMapping(m.mask)}, // quote
+					[]edge{e}, []mapping{getMapping(encoder.EncodeZero), getMapping(m.mask)}, // quote
 					[][]rune{printables, fullwidthPrintables, encodables, encoded, greek}, // fill
 					func(rIn, rOut []rune, quoteOut []bool, testMappings []mapping) (out []stringPair) {
 						testL := len(rIn)
@@ -386,7 +386,7 @@ var testCasesDoubleEdge = []testCase{
 				orig, replace := e1.orig[0], e1.replace[0]
 				edges := []edge{e1, e2}
 				pairs := buildEdgeTestString(
-					edges, []mapping{getMapping(0), getMapping(m.mask)}, // quote
+					edges, []mapping{getMapping(encoder.EncodeZero), getMapping(m.mask)}, // quote
 					[][]rune{printables, fullwidthPrintables, encodables, encoded, greek}, // fill
 					func(rIn, rOut []rune, quoteOut []bool, testMappings []mapping) (out []stringPair) {
 						testL := len(rIn)

--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -212,7 +212,7 @@ func (c *Cache) createItemDir(name string) (string, error) {
 
 // getBackend gets a backend for a cache root dir
 func getBackend(ctx context.Context, parentPath string, name string, relativeDirPath string) (fs.Fs, error) {
-	path := fmt.Sprintf("%s/%s/%s", parentPath, name, relativeDirPath)
+	path := fmt.Sprintf(":local,encoding='%v':%s/%s/%s", encoder.OS, parentPath, name, relativeDirPath)
 	return fscache.Get(ctx, path)
 }
 


### PR DESCRIPTION
Fix the way to disable encoding by introducing a new type `Raw` to solve #7456 and #6098.
See #7456 and the changes on the document for details.
The behavior of `None` was not changed to keep backward compatibility.

And fix vfs cache encoding described in #7760
The problem is when we create and write cache, we use the "OS" encoded ("OS" encoding is hardcoded for different operating systems, not specified by users).
But when we copy it to the remote (backend), we use local.Fs, which accept a name already encoded in "Standard" way.
So we need to send a "Standard" encoded name.

However, the "minimum setup" mentioned in #7760 has not been resolved. See my comment in it for details.
But it's an edge case.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
