### PR TITLE
fs: adding warning to user that rclone config is not encrypted by default. fixes #7314

### DIFF
--- a/fs/config.go
+++ b/fs/config.go
@@ -3,6 +3,7 @@ package fs
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"os"
 	"strconv"
@@ -200,6 +201,9 @@ func NewConfig() *ConfigInfo {
 	c.KvLockTime = 1 * time.Second
 	c.DefaultTime = Time(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
 	c.PartialSuffix = ".partial"
+
+	// Display a general warning about the default unencrypted configuration behavior
+	fmt.Fprintln(os.Stderr, "WARNING: By default, rclone configuration files are not encrypted, which may pose a security risk. It is highly recommended to encrypt your configuration file to protect sensitive information. For details on how to encrypt your configuration, visit https://rclone.org/docs/#configuration-encryption.")
 
 	// Perform a simple check for debug flags to enable debug logging during the flag initialization
 	for argIndex, arg := range os.Args {


### PR DESCRIPTION
#### What is the purpose of this change?

<!--
Adding a default warning to the config command that lets users know rclone config is not encrypted by default. Fix for issue #7314 
-->

#### Was the change discussed in an issue or in the forum before?

<!--
issue #7314 
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
