### PR TITLE
fs: adding warning to user that rclone config is not encrypted by default. fixes #7314

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -265,6 +265,7 @@ defaults for questions as usual.
 Note that |bin/config.py| in the rclone source implements this protocol
 as a readable demonstration.
 `, "|", "`")
+
 var configCreateCommand = &cobra.Command{
 	Use:   "create name type [key value]*",
 	Short: `Create a new remote with name, type and options.`,
@@ -292,9 +293,17 @@ using remote authorization you would do this:
 		if err != nil {
 			return err
 		}
-		return doConfig(args[0], in, func(opts config.UpdateRemoteOpt) (*fs.ConfigOut, error) {
+		err = doConfig(args[0], in, func(opts config.UpdateRemoteOpt) (*fs.ConfigOut, error) {
 			return config.CreateRemote(context.Background(), args[0], args[1], in, opts)
 		})
+		if err != nil {
+			return err
+		}
+
+		// Append the security warning about unencrypted configurations
+		fmt.Fprintln(os.Stderr, "\nWARNING: By default, rclone configuration files are not encrypted, which may pose a security risk. It is highly recommended to encrypt your configuration file to protect sensitive information. For details on how to encrypt your configuration, visit https://rclone.org/docs/#configuration-encryption.")
+
+		return nil
 	},
 }
 


### PR DESCRIPTION
#### What is the purpose of this change?

adds a simple warning message to create new config flow so users know default behavior is to use unencrypted config files. 

#### Was the change discussed in an issue or in the forum before?

issue #7314 


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
