### PR TITLE
cmd mountlib: adding remount option for linux systems - fixes #6488

### DIFF
--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -89,6 +89,15 @@ Flags used for `rclone check`.
 ```
 
 
+## Mount
+
+Flags specifically used for mounting operations with rclone.
+
+```
+      --remount Attempt to remount an already-mounted filesystem. This is useful for changing mount flags without unmounting. Supported only on Linux.
+```
+
+
 ## Networking
 
 General networking and HTTP stuff.


### PR DESCRIPTION
#### What is the purpose of this change?

Added a --remount option as requested in issue #6488 . option only works on linux systems. Updated documentation to reflect this optional flag.

#### Was the change discussed in an issue or in the forum before?

Issue #6488 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
