### PR TITLE
Added content-length header when html file is served

### DIFF
--- a/lib/http/serve/dir.go
+++ b/lib/http/serve/dir.go
@@ -235,6 +235,7 @@ func (d *Directory) Serve(w http.ResponseWriter, r *http.Request) {
 		Error(d.DirRemote, w, "Failed to render template", err)
 		return
 	}
+	w.Header().Set("Content-Length", fmt.Sprintf("%d", buf.Len()))
 	_, err = buf.WriteTo(w)
 	if err != nil {
 		Error(d.DirRemote, nil, "Failed to drain template buffer", err)


### PR DESCRIPTION
#### What is the purpose of this change?

Add the `Content-Length` to the html response when `http serve http ...` is executed

#### Was the change discussed in an issue or in the forum before?

NA

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
