### PR TITLE
oauthutil: clear client secret if client ID is set

### DIFF
--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -376,6 +376,9 @@ func overrideCredentials(name string, m configmap.Mapper, origConfig *oauth2.Con
 	ClientID, ok := m.Get(config.ConfigClientID)
 	if ok && ClientID != "" {
 		newConfig.ClientID = ClientID
+		// Clear out any existing client secret since the ID changed.
+		// (otherwise it's impossible for a config to clear the secret)
+		newConfig.ClientSecret = ""
 		changed = true
 	}
 	ClientSecret, ok := m.Get(config.ConfigClientSecret)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
When an external OAuth flow is being used (i.e. a client ID and an OAuth token are set in the config), a client secret should not be set. If one is, the server may reject a token refresh attempt.

But there's no way to clear out a backend's default client secret via configuration, since empty-string config values are ignored.

So instead, when a client ID is set, we should clear out any default client secret, since it wouldn't apply anyway.


<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No - I was just debugging why my OAuth tokens weren't being refreshed correctly when using the Drive backend, and it led me here.

I did file #7825 for tracking purposes though.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
