### PR TITLE
azureblob: allow working with only list+create/write permissions (fix no_head_object/add no_read_for_metadata)

### DIFF
--- a/docs/content/azureblob.md
+++ b/docs/content/azureblob.md
@@ -831,6 +831,17 @@ Properties:
 - Type:        bool
 - Default:     false
 
+#### --azureblob-no-read-for-metadata
+
+If set, use a list operation instead of the HEAD method on objects, to avoid requiring read permissions.
+
+Properties:
+
+- Config:      no_read_for_metadata
+- Env Var:     RCLONE_AZUREBLOB_NO_READ_FOR_METADATA
+- Type:        bool
+- Default:     false
+
 #### --azureblob-delete-snapshots
 
 Set to specify how to deal with snapshots on blob deletion.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

It is now possible to use an azureblob storage without "read" permissions, by getting the metadata from a "list" operation instead. Also, --no-head works now also with a prefix set on the remote.

There are three reasons an option why one would avoid HEAD requests on azureblob, with this now mainly implementing the latter one:

- no_head_object: Don't do a HEAD *before* writing to (or reading from) an object, to reduce the number of transactions and thus increase performance. **This already exists in azureblob, a small issue was fixed here where using a prefix would still require a HEAD request to the prefix itself.**
- no_head: Don't do a HEAD *after* writing to an object, for the same reason but at the cost of "increasing the chance for undetected upload failures".  **This is still not implemented for azureblob yet and quite complex, see s3.Object.Update()!**
- no_read_for_metadata: Instead of doing a HEAD to get metadata, use a list operation, to avoid requiring READ permissions for immutable/append-only applications (this seems to be quite azureblob-specific) - one could also use both no_head_object and no_head together to achieve this, but then uploads wouldn't be verified. **This is the main focus of this PR.**

#### Was the change discussed in an issue or in the forum before?

This fixes #6162 and #7027. The issue with --no-head and a prefix wasn't discussed before AFAIK.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
