### PR TITLE
Progress: add continuous stats printing

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -246,7 +246,7 @@ func Run(Retry bool, showStats bool, cmd *cobra.Command, f func() error) {
 		showStats = true
 	}
 	if ci.Progress {
-		stopStats = startProgress()
+		stopStats = startProgress(ci.StatsPrintContinuous)
 	} else if showStats {
 		stopStats = StartStats()
 	}

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1937,6 +1937,12 @@ Any log messages will scroll above the static block.  Log messages
 will push the static block down to the bottom of the terminal where it
 will stay.
 
+In-place printing to a static block may be overridden by setting
+the `--stats-print-continuous` flag - this will print continuous
+lines of progress interleaved with log messages. Useful e.g. when capturing
+long-running rclone output in log files, or when running rclone from
+a systemd unit.
+
 Normally this is updated every 500mS but this period can be overridden
 with the `--stats` flag.
 
@@ -2080,6 +2086,14 @@ When this is specified, rclone enables the single-line stats and prepends
 the display with a user-supplied date string. The date string MUST be
 enclosed in quotes. Follow [golang specs](https://golang.org/pkg/time/#Time.Format) for
 date formatting syntax.
+
+### --stats--print-continuous ###
+
+When this is specified, stats information is printed contonuously, with line breaks, instead
+of a static block.
+
+This is useful e.g. when capturing long-running rclone output in logfiles
+and when running rclone from a systemd unit and capturing output in the system journal.
 
 ### --stats-unit=bits|bytes ###
 

--- a/fs/config.go
+++ b/fs/config.go
@@ -120,6 +120,7 @@ type ConfigInfo struct {
 	StatsOneLine               bool
 	StatsOneLineDate           bool   // If we want a date prefix at all
 	StatsOneLineDateFormat     string // If we want to customize the prefix
+	StatsPrintContinuous       bool   // Print stats continuously instead of a static block
 	ErrorOnNoTransfer          bool   // Set appropriate exit code if no files transferred
 	Progress                   bool
 	ProgressTerminalTitle      bool
@@ -183,6 +184,7 @@ func NewConfig() *ConfigInfo {
 	c.StreamingUploadCutoff = SizeSuffix(100 * 1024)
 	c.MaxStatsGroups = 1000
 	c.StatsFileNameLength = 45
+	c.StatsPrintContinuous = false
 	c.AskPassword = true
 	c.TPSLimitBurst = 1
 	c.MaxTransfer = -1

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -121,6 +121,7 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.BoolVarP(flagSet, &ci.StatsOneLine, "stats-one-line", "", ci.StatsOneLine, "Make the stats fit on one line", "Logging")
 	flags.BoolVarP(flagSet, &ci.StatsOneLineDate, "stats-one-line-date", "", ci.StatsOneLineDate, "Enable --stats-one-line and add current date/time prefix", "Logging")
 	flags.StringVarP(flagSet, &ci.StatsOneLineDateFormat, "stats-one-line-date-format", "", ci.StatsOneLineDateFormat, "Enable --stats-one-line-date and use custom formatted date: Enclose date string in double quotes (\"), see https://golang.org/pkg/time/#Time.Format", "Logging")
+	flags.BoolVarP(flagSet, &ci.StatsPrintContinuous, "stats-print-continuous", "", ci.StatsPrintContinuous, "Print stats continuously (interleaved with log messages) instead of in-place in a static block", "Logging")
 	flags.BoolVarP(flagSet, &ci.ErrorOnNoTransfer, "error-on-no-transfer", "", ci.ErrorOnNoTransfer, "Sets exit code 9 if no files are transferred, useful in scripts", "Config")
 	flags.BoolVarP(flagSet, &ci.Progress, "progress", "P", ci.Progress, "Show progress during transfer", "Logging")
 	flags.BoolVarP(flagSet, &ci.ProgressTerminalTitle, "progress-terminal-title", "", ci.ProgressTerminalTitle, "Show progress on the terminal title (requires -P/--progress)", "Logging")


### PR DESCRIPTION
#### What is the purpose of this change?

This change adds a new flag,`--stats--print-continuous`, which will cause progress stats to be printed continuously instead of a static block. Stats may be interleaved with log messages in that case.

I'm using a long-running (hours) rclone systemd job to regularly pull backups, with both `--progress` and `--stats-one-line`. This new option allows for checking progress via the rclone systemd unit's journal; before, output was mangled.

#### Was the change discussed in an issue or in the forum before?

Not to my knowledge. A search did not come up with anything.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- N/A I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
