### PR TITLE
ulozto: Fix handling of root paths with leading / trailing slashes.

### DIFF
--- a/backend/ulozto/ulozto.go
+++ b/backend/ulozto/ulozto.go
@@ -121,6 +121,9 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return nil, err
 	}
 
+	// Strip leading and trailing slashes, see https://github.com/rclone/rclone/issues/7796 for details.
+	root = strings.Trim(root, "/")
+
 	client := fshttp.NewClient(ctx)
 
 	f := &Fs{


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The change fixes uloz.to's handling of leading and trailing slashes in root paths, as reported in #7796.

#### Was the change discussed in an issue or in the forum before?

Yes, said #7796.

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
