### PR TITLE
pikpak: improve upload reliability and resolve potential file conflicts

### DIFF
--- a/backend/pikpak/api/types.go
+++ b/backend/pikpak/api/types.go
@@ -251,10 +251,12 @@ type Media struct {
 
 // FileParams includes parameters for instant open
 type FileParams struct {
+	DeviceID     string `json:"device_id,omitempty"`
 	Duration     int64  `json:"duration,omitempty,string"` // in seconds
 	Height       int    `json:"height,omitempty,string"`
 	Platform     string `json:"platform,omitempty"` // "Upload"
 	PlatformIcon string `json:"platform_icon,omitempty"`
+	TaskID       string `json:"task_id"`
 	URL          string `json:"url,omitempty"`
 	Width        int    `json:"width,omitempty,string"`
 }

--- a/backend/pikpak/helper.go
+++ b/backend/pikpak/helper.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
+	"strconv"
 
 	"github.com/rclone/rclone/backend/pikpak/api"
 	"github.com/rclone/rclone/lib/rest"
@@ -141,10 +143,6 @@ func (f *Fs) getFile(ctx context.Context, ID string) (info *api.File, err error)
 	var resp *http.Response
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.rst.CallJSON(ctx, &opts, nil, &info)
-		if err == nil && info.Phase != api.PhaseTypeComplete {
-			// could be pending right after file is created/uploaded.
-			return true, errors.New("not PHASE_TYPE_COMPLETE")
-		}
 		return f.shouldRetry(ctx, resp, err)
 	})
 	return
@@ -162,6 +160,45 @@ func (f *Fs) patchFile(ctx context.Context, ID string, req *api.File) (info *api
 	var resp *http.Response
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.rst.CallJSON(ctx, &opts, &req, &info)
+		return f.shouldRetry(ctx, resp, err)
+	})
+	return
+}
+
+// getTask gets api.Task from API for the ID passed
+func (f *Fs) getTask(ctx context.Context, ID string, checkPhase bool) (info *api.Task, err error) {
+	opts := rest.Opts{
+		Method: "GET",
+		Path:   "/drive/v1/tasks/" + ID,
+	}
+	var resp *http.Response
+	err = f.pacer.Call(func() (bool, error) {
+		resp, err = f.rst.CallJSON(ctx, &opts, nil, &info)
+		if checkPhase {
+			if err == nil && info.Phase != api.PhaseTypeComplete {
+				// could be pending right after file is created/uploaded.
+				return true, errors.New(info.Phase)
+			}
+		}
+		return f.shouldRetry(ctx, resp, err)
+	})
+	return
+}
+
+// deleteTask remove a task having the specified ID
+func (f *Fs) deleteTask(ctx context.Context, ID string, deleteFiles bool) (err error) {
+	params := url.Values{}
+	params.Set("delete_files", strconv.FormatBool(deleteFiles))
+	params.Set("task_ids", ID)
+	opts := rest.Opts{
+		Method:     "DELETE",
+		Path:       "/drive/v1/tasks",
+		Parameters: params,
+		NoResponse: true,
+	}
+	var resp *http.Response
+	err = f.pacer.Call(func() (bool, error) {
+		resp, err = f.rst.CallJSON(ctx, &opts, nil, nil)
 		return f.shouldRetry(ctx, resp, err)
 	})
 	return

--- a/backend/pikpak/helper.go
+++ b/backend/pikpak/helper.go
@@ -143,6 +143,9 @@ func (f *Fs) getFile(ctx context.Context, ID string) (info *api.File, err error)
 	var resp *http.Response
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.rst.CallJSON(ctx, &opts, nil, &info)
+		if err == nil && !info.Links.ApplicationOctetStream.Valid() {
+			return true, errors.New("no link")
+		}
 		return f.shouldRetry(ctx, resp, err)
 	})
 	return


### PR DESCRIPTION
#### What is the purpose of this change?

This PR includes several attempts to improve upload reliability and to resolve potential file conflicts:

* Checking upload status: Implemented `getTask()` to verify successful completion on the server-side for each upload.
* Cancelling uploads on errors: Uploads encountering errors are cancelled to remove residual files.
* Forced & Minimum Sleep:
  * Based on experiments, a forced delay(500ms) is introduced after uploads to ensure server-side updates register (minimal impact on total execution time).
  * Minimum sleep for pacer increased from 10ms to 100ms to resolve server errors.
* Removed `uploadByForm()`: This method is less reliable for a large number of small files. We now solely use `uploadByResumable()`.

#### Was the change discussed in an issue or in the forum before?

#7787

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
