### PR TITLE
cmd/gitannex: Add config parameter synonyms for compat, update command documentation

### DIFF
--- a/cmd/gitannex/gitannex.md
+++ b/cmd/gitannex/gitannex.md
@@ -1,49 +1,69 @@
-Rclone's gitannex subcommand enables git-annex to store and retrieve content
-from an rclone remote. It expects to be run by git-annex, not directly by users.
-It is an "external special remote program" as defined by git-annex.
+Rclone's `gitannex` subcommand enables [git-annex] to store and retrieve content
+from an rclone remote. It is meant to be run by git-annex, not directly by
+users.
+
+[git-annex]: https://git-annex.branchable.com/
 
 Installation on Linux
 ---------------------
 
-1. Create a symlink and ensure it's on your PATH. For example:
+1. Skip this step if your version of git-annex is [10.20240430] or newer.
+   Otherwise, you must create a symlink somewhere on your PATH with a particular
+   name. This symlink helps git-annex tell rclone it wants to run the "gitannex"
+   subcommand.
 
-        ln -s "$(realpath rclone)" "$HOME/bin/git-annex-remote-rclone-builtin"
+   ```sh
+   # Create the helper symlink in "$HOME/bin".
+   ln -s "$(realpath rclone)" "$HOME/bin/git-annex-remote-rclone-builtin"
 
-2. Add a new external remote to your git-annex repo.
+   # Verify the new symlink is on your PATH.
+   which git-annex-remote-rclone-builtin
+   ```
 
-   The new remote's type should be "rclone-builtin". When git-annex interacts
-   with remotes of this type, it will try to run a command named
-   "git-annex-remote-rclone-builtin", so the symlink from the previous step
-   should be on your PATH.
+   [10.20240430]: https://git-annex.branchable.com/news/version_10.20240430/
 
-   * NOTE: If you are porting a remote from git-annex-remote-rclone, first
-     change the externaltype from "rclone" to "rclone-builtin". Watch out, our
-     configs have slightly different names:
+2. Add a new remote to your git-annex repo. This new remote will connect
+   git-annex with the `rclone gitannex` subcommand.
 
-      | config for "rclone" | config for "rclone-builtin" |
-      |:--------------------|:----------------------------|
-      | `prefix`            | `rcloneprefix`              |
-      | `target`            | `rcloneremotename`          |
-      | `rclone_layout`     | `rclonelayout`              |
+   Start by asking git-annex to describe the remote's available configuration
+   parameters.
+
+   ```sh
+   # If you skipped step 1:
+   git annex initremote MyRemote type=rclone --whatelse
+
+   # If you created a symlink in step 1:
+   git annex initremote MyRemote type=external externaltype=rclone-builtin --whatelse
+    ```
+
+   > **NOTE**: If you're porting an existing [git-annex-remote-rclone] remote to
+   > use `rclone gitannex`, you can probably reuse the configuration parameters
+   > verbatim without renaming them. Check parameter synonyms with `--whatelse`
+   > as shown above.
+   >
+   > [git-annex-remote-rclone]: https://github.com/git-annex-remote-rclone/git-annex-remote-rclone
 
    The following example creates a new git-annex remote named "MyRemote" that
-   will use the rclone remote named "SomeRcloneRemote". This rclone remote must
-   be configured in your rclone.conf file, wherever that is located on your
-   system. The rcloneprefix value ensures that content is only written into the
-   rclone remote underneath the "git-annex-content" directory.
+   will use the rclone remote named "SomeRcloneRemote". That rclone remote must
+   be one configured in your rclone.conf file, which can be located with `rclone
+   config file`.
 
-        git annex initremote MyRemote         \
-            type=external                     \
-            externaltype=rclone-builtin       \
-            encryption=none                   \
-            rcloneremotename=SomeRcloneRemote \
-            rcloneprefix=git-annex-content    \
-            rclonelayout=nodir
+   ```sh
+   git annex initremote MyRemote         \
+       type=external                     \
+       externaltype=rclone-builtin       \
+       encryption=none                   \
+       rcloneremotename=SomeRcloneRemote \
+       rcloneprefix=git-annex-content    \
+       rclonelayout=nodir
+   ```
 
 3. Before you trust this command with your precious data, be sure to **test the
    remote**. This command is very new and has not been tested on many rclone
    backends. Caveat emptor!
 
-        git annex testremote my-rclone-remote
+   ```sh
+   git annex testremote MyRemote
+   ```
 
 Happy annexing!


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

The main purpose is to simplify setup for users.

First, this PR adds aliases to the existing config parameters so users can use the same config names as <https://github.com/git-annex-remote-rclone/git-annex-remote-rclone>.

Secondly, this updates the command documentation.

* It mentions that new versions of git-annex support `type=rclone`, so it's possible to skip the whole symlink business.
* It drops duplicative description of config parameters, instead showing users how to use the `--whatelse` option of `git annex initremote`.
* It rewrites setup steps for clarity, improves formatting, etc.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

Issue #7625 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
