### PR TITLE
Draft: Allow setting filter/include/exclude from the auth-proxy script 

### DIFF
--- a/fs/config/configmap/configmap.go
+++ b/fs/config/configmap/configmap.go
@@ -125,6 +125,33 @@ func (c *Map) Set(key, value string) {
 // Simple is a simple Mapper for testing
 type Simple map[string]string
 
+// UnmarshalJSON customizes the JSON unmarshaling for the Simple type to
+// support _filter and custom types extensions.
+func (s *Simple) UnmarshalJSON(data []byte) error {
+	tmp := make(map[string]interface{})
+	if err := json.Unmarshal(data, &tmp); err != nil {
+		return err
+	}
+	if *s == nil {
+		*s = make(Simple)
+	}
+
+	for key, value := range tmp {
+		if key == "_filter" {
+			// Marshal the _filter value to a JSON string
+			filterData, err := json.Marshal(value)
+			if err != nil {
+				return err
+			}
+			(*s)[key] = string(filterData)
+		} else {
+			(*s)[key] = value.(string)
+		}
+	}
+
+	return nil
+}
+
 // Get the value
 func (c Simple) Get(key string) (value string, ok bool) {
 	value, ok = c[key]

--- a/fs/config/configmap/configmap_test.go
+++ b/fs/config/configmap/configmap_test.go
@@ -2,6 +2,7 @@ package configmap
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -356,4 +357,25 @@ func TestSimpleDecode(t *testing.T) {
 			assert.Contains(t, err.Error(), test.wantErr, test.in)
 		}
 	}
+}
+
+func TestConfiMapWithFilter(t *testing.T) {
+	in := `{
+"type": "local",
+"_root": "/",
+"_filter":{ "IncludeRule":["testing2/**"] }
+}`
+	var simple Simple
+	err := json.Unmarshal([]byte(in), &simple)
+
+	assert.NoError(t, err, "Unable to unmarshal simple config map")
+
+	rootConfig, _ := simple.Get("_root")
+	assert.Equal(t, "/", rootConfig)
+
+	typeConfig, _ := simple.Get("type")
+	assert.Equal(t, "local", typeConfig)
+
+	filterConfig, _ := simple.Get("_filter")
+	assert.Equal(t, "{\"IncludeRule\":[\"testing2/**\"]}", filterConfig)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The aim is to be able to specify include and exclude rules in auth-proxy scripts. The following format is supported:
```
{
"type": "local",
"_root": "/",
"_filter":{ "ExcludeRule": [ "data/**","backup/**" ] }
}
```

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#6704

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
