### PR TITLE
docs: fix incorrect terminology - key-derivation term (salt) used in place …

### DIFF
--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -182,7 +182,7 @@ A long passphrase is recommended, or `rclone config` can generate a
 random one.
 
 The obscured password is created using AES-CTR with a static key. The
-salt is stored verbatim at the beginning of the obscured password. This
+IV (nonce) is stored verbatim at the beginning of the obscured password. This
 static key is shared between all versions of rclone.
 
 If you reconfigure rclone with the same passwords/passphrases


### PR DESCRIPTION
…of symmetric cipher nonce (IV) in crypt remote documentation.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
In the crypt remote documentation the term "Salt" (used in hashing or Key-Derivation situations) is used incorrectly. The proper term is IV (initialization vector or nonce) - as can be seen from the source code where, indeed, the secretbox is initialized using hashed password and this IV (nonce).
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Discussed only via email with Nick.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
