### PR TITLE
webdav: introduce unix_socket_path

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -159,7 +159,9 @@ Set to 0 to disable chunked uploading.
 			Help:     "Exclude ownCloud mounted storages",
 			Advanced: true,
 			Default:  false,
-		}},
+		},
+			fshttp.UnixSocketConfig,
+		},
 	})
 }
 
@@ -177,6 +179,7 @@ type Options struct {
 	ChunkSize          fs.SizeSuffix        `config:"nextcloud_chunk_size"`
 	ExcludeShares      bool                 `config:"owncloud_exclude_shares"`
 	ExcludeMounts      bool                 `config:"owncloud_exclude_mounts"`
+	UnixSocket         string               `config:"unix_socket"`
 }
 
 // Fs represents a remote webdav
@@ -458,7 +461,12 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		precision:   fs.ModTimeNotSupported,
 	}
 
-	client := fshttp.NewClient(ctx)
+	var client *http.Client
+	if opt.UnixSocket == "" {
+		client = fshttp.NewClient(ctx)
+	} else {
+		client = fshttp.NewClientWithUnixSocket(ctx, opt.UnixSocket)
+	}
 	if opt.Vendor == "sharepoint-ntlm" {
 		// Disable transparent HTTP/2 support as per https://golang.org/pkg/net/http/ ,
 		// otherwise any connection to IIS 10.0 fails with 'stream error: stream ID 39; HTTP_1_1_REQUIRED'

--- a/cmd/rc/rc.go
+++ b/cmd/rc/rc.go
@@ -23,14 +23,15 @@ import (
 )
 
 var (
-	noOutput  = false
-	url       = "http://localhost:5572/"
-	jsonInput = ""
-	authUser  = ""
-	authPass  = ""
-	loopback  = false
-	options   []string
-	arguments []string
+	noOutput   = false
+	url        = "http://localhost:5572/"
+	unixSocket = ""
+	jsonInput  = ""
+	authUser   = ""
+	authPass   = ""
+	loopback   = false
+	options    []string
+	arguments  []string
 )
 
 func init() {
@@ -38,6 +39,7 @@ func init() {
 	cmdFlags := commandDefinition.Flags()
 	flags.BoolVarP(cmdFlags, &noOutput, "no-output", "", noOutput, "If set, don't output the JSON result", "")
 	flags.StringVarP(cmdFlags, &url, "url", "", url, "URL to connect to rclone remote control", "")
+	flags.StringVarP(cmdFlags, &unixSocket, "unix-socket", "", unixSocket, "Path to a unix domain socket to dial to, instead of opening a TCP connection directly", "")
 	flags.StringVarP(cmdFlags, &jsonInput, "json", "", jsonInput, "Input JSON - use instead of key=value args", "")
 	flags.StringVarP(cmdFlags, &authUser, "user", "", "", "Username to use to rclone remote control", "")
 	flags.StringVarP(cmdFlags, &authPass, "pass", "", "", "Password to use to connect to rclone remote control", "")
@@ -49,28 +51,35 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "rc commands parameter",
 	Short: `Run a command against a running rclone.`,
-	Long: `
+	Long: strings.ReplaceAll(`
 
-This runs a command against a running rclone.  Use the ` + "`--url`" + ` flag to
+This runs a command against a running rclone.  Use the |--url| flag to
 specify an non default URL to connect on.  This can be either a
 ":port" which is taken to mean "http://localhost:port" or a
 "host:port" which is taken to mean "http://host:port"
 
-A username and password can be passed in with ` + "`--user`" + ` and ` + "`--pass`" + `.
+A username and password can be passed in with |--user| and |--pass|.
 
-Note that ` + "`--rc-addr`, `--rc-user`, `--rc-pass`" + ` will be read also for
-` + "`--url`, `--user`, `--pass`" + `.
+Note that |--rc-addr|, |--rc-user|, |--rc-pass| will be read also for
+|--url|, |--user|, |--pass|.
+
+The |--unix-socket| flag can be used to connect over a unix socket like this
+
+    # start server on /tmp/my.socket
+    rclone rcd --rc-addr unix:///tmp/my.socket
+    # Connect to it
+    rclone rc --unix-socket /tmp/my.socket core/stats
 
 Arguments should be passed in as parameter=value.
 
 The result will be returned as a JSON object by default.
 
-The ` + "`--json`" + ` parameter can be used to pass in a JSON blob as an input
+The |--json| parameter can be used to pass in a JSON blob as an input
 instead of key=value arguments.  This is the only way of passing in
 more complicated values.
 
-The ` + "`-o`/`--opt`" + ` option can be used to set a key "opt" with key, value
-options in the form ` + "`-o key=value` or `-o key`" + `. It can be repeated as
+The |-o|/|--opt| option can be used to set a key "opt" with key, value
+options in the form |-o key=value| or |-o key|. It can be repeated as
 many times as required. This is useful for rc commands which take the
 "opt" parameter which by convention is a dictionary of strings.
 
@@ -81,7 +90,7 @@ Will place this in the "opt" value
     {"key":"value", "key2","")
 
 
-The ` + "`-a`/`--arg`" + ` option can be used to set strings in the "arg" value. It
+The |-a|/|--arg| option can be used to set strings in the "arg" value. It
 can be repeated as many times as required. This is useful for rc
 commands which take the "arg" parameter which by convention is a list
 of strings.
@@ -92,13 +101,13 @@ Will place this in the "arg" value
 
     ["value", "value2"]
 
-Use ` + "`--loopback`" + ` to connect to the rclone instance running ` + "`rclone rc`" + `.
+Use |--loopback| to connect to the rclone instance running |rclone rc|.
 This is very useful for testing commands without having to run an
 rclone rc server, e.g.:
 
     rclone rc --loopback operations/about fs=/
 
-Use ` + "`rclone rc`" + ` to see a list of all possible commands.`,
+Use |rclone rc| to see a list of all possible commands.`, "|", "`"),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.40",
 	},
@@ -201,7 +210,12 @@ func doCall(ctx context.Context, path string, in rc.Params) (out rc.Params, err 
 	}
 
 	// Do HTTP request
-	client := fshttp.NewClient(ctx)
+	var client *http.Client
+	if unixSocket == "" {
+		client = fshttp.NewClient(ctx)
+	} else {
+		client = fshttp.NewClientWithUnixSocket(ctx, unixSocket)
+	}
 	url += path
 	data, err := json.Marshal(in)
 	if err != nil {

--- a/cmd/serve/webdav/webdav.go
+++ b/cmd/serve/webdav/webdav.go
@@ -115,6 +115,19 @@ Create a new DWORD BasicAuthLevel with value 2.
 
 https://learn.microsoft.com/en-us/office/troubleshoot/powerpoint/office-opens-blank-from-sharepoint
 
+### Serving over a unix socket
+
+You can serve the webdav on a unix socket like this:
+
+    rclone serve webdav --addr unix:///tmp/my.socket remote:path
+
+and connect to it like this using rclone and the webdav backend:
+
+    rclone --webdav-unix-socket /tmp/my.socket --webdav-url http://localhost lsf :webdav:
+
+Note that there is no authentication on http protocol - this is expected to be
+done by the permissions on the socket.
+
 ` + libhttp.Help(flagPrefix) + libhttp.TemplateHelp(flagPrefix) + libhttp.AuthHelp(flagPrefix) + vfs.Help() + proxy.Help,
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.39",

--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -294,6 +294,17 @@ Properties:
 - Type:        bool
 - Default:     false
 
+#### --webdav-unix-socket
+
+Path to a unix domain socket to dial to, instead of opening a TCP connection directly
+
+Properties:
+
+- Config:      unix_socket
+- Env Var:     RCLONE_WEBDAV_UNIX_SOCKET
+- Type:        string
+- Required:    false
+
 #### --webdav-description
 
 Description of the remote.


### PR DESCRIPTION
This adds a new optional parameter to the backend, allowing to specify a path to a unix domain socket to connect to, instead the specified URL.

If the parameter is set, we use `fshttp.NewClientCustom` to modify the HTTP transport, to use a dialer connecting to the unix domain socket path specified for that backend.

The URL itself is still used for the rest of the HTTP client, allowing host and subpath to stay intact.

This allows using rclone with the webdav backend to connect to a WebDAV server provided at a Unix Domain socket:

```
RCLONE_WEBDAV_UNIX_SOCKET_PATH=/path/to/my.sock \
RCLONE_WEBDAV_URL=http://localhost \
rclone sync mydir :webdav:/somewhere
```

#### What is the purpose of this change?
This allows using rclone with the webdav backend to connect to a WebDAV server provided at a Unix Domain socket.

#### Was the change discussed in an issue or in the forum before?
https://forum.rclone.org/t/support-connecting-to-unix-sockets/46161

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
