### PR TITLE
tree-wide: replace /bin/bash with /usr/bin/env bash

### DIFF
--- a/backend/sharefile/update-timezone.sh
+++ b/backend/sharefile/update-timezone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/bin/backend-versions.sh
+++ b/bin/backend-versions.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # This adds the version each backend was released to its docs page
 set -e
 for backend in $( find backend -maxdepth 1 -type d ); do

--- a/bin/bisect-go-rclone.sh
+++ b/bin/bisect-go-rclone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # An example script to run when bisecting go with git bisect -run when
 # looking for an rclone regression

--- a/bin/bisect-rclone.sh
+++ b/bin/bisect-rclone.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Example script for git bisect run
 #

--- a/bin/build-xgo-cgofuse.sh
+++ b/bin/build-xgo-cgofuse.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 docker build -t rclone/xgo-cgofuse https://github.com/winfsp/cgofuse.git
 docker images

--- a/bin/make_rc_docs.sh
+++ b/bin/make_rc_docs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Insert the rc docs into docs/content/rc.md
 
 set -e

--- a/bin/test-repeat-vfs.sh
+++ b/bin/test-repeat-vfs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Thrash the VFS tests
 
 set -e

--- a/bin/test-repeat.sh
+++ b/bin/test-repeat.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # defaults
 buildflags=""

--- a/bin/use-deadlock-detector
+++ b/bin/use-deadlock-detector
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 if [[ ! -z $(git status --short --untracked-files=no) ]]; then
    echo "Detected uncommitted changes - commit before running this"

--- a/cmd/serve/restic/restic-test.sh
+++ b/cmd/serve/restic/restic-test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test all the remotes against restic integration test
 # Run with: screen -S restic-test -L ./restic-test.sh

--- a/docs/content/oracleobjectstorage/tutorial_mount.md
+++ b/docs/content/oracleobjectstorage/tutorial_mount.md
@@ -330,7 +330,7 @@ then auto-mounting.
 Content of /etc/rclone/scripts/rclone_nanny_script.sh
 ```shell
 
-#!/bin/bash
+#!/usr/bin/env bash
 erroneous_list=$(df 2>&1 | grep -i 'Transport endpoint is not connected' | awk '{print ""$2"" }' | tr -d \:)
 rclone_list=$(findmnt -t fuse.rclone -n 2>&1 | awk '{print ""$1"" }' | tr -d \:)
 IFS=$'\n'; set -f

--- a/fstest/testserver/images/test-hdfs/run.sh
+++ b/fstest/testserver/images/test-hdfs/run.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 KERBEROS=${KERBEROS-"false"}
 

--- a/fstest/testserver/init.d/TestFTPProftpd
+++ b/fstest/testserver/init.d/TestFTPProftpd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestFTPPureftpd
+++ b/fstest/testserver/init.d/TestFTPPureftpd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestFTPRclone
+++ b/fstest/testserver/init.d/TestFTPRclone
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestFTPVsftpd
+++ b/fstest/testserver/init.d/TestFTPVsftpd
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestFTPVsftpdTLS
+++ b/fstest/testserver/init.d/TestFTPVsftpdTLS
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestHdfs
+++ b/fstest/testserver/init.d/TestHdfs
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestS3Minio
+++ b/fstest/testserver/init.d/TestS3Minio
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestS3MinioEdge
+++ b/fstest/testserver/init.d/TestS3MinioEdge
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestS3Rclone
+++ b/fstest/testserver/init.d/TestS3Rclone
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestSFTPOpenssh
+++ b/fstest/testserver/init.d/TestSFTPOpenssh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestSFTPRclone
+++ b/fstest/testserver/init.d/TestSFTPRclone
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestSFTPRcloneSSH
+++ b/fstest/testserver/init.d/TestSFTPRcloneSSH
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestSMB
+++ b/fstest/testserver/init.d/TestSMB
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestSeafile
+++ b/fstest/testserver/init.d/TestSeafile
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestSeafileEncrypted
+++ b/fstest/testserver/init.d/TestSeafileEncrypted
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestSeafileV6
+++ b/fstest/testserver/init.d/TestSeafileV6
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestSia
+++ b/fstest/testserver/init.d/TestSia
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestSwiftAIO
+++ b/fstest/testserver/init.d/TestSwiftAIO
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestWebdavNextcloud
+++ b/fstest/testserver/init.d/TestWebdavNextcloud
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestWebdavOwncloud
+++ b/fstest/testserver/init.d/TestWebdavOwncloud
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/TestWebdavRclone
+++ b/fstest/testserver/init.d/TestWebdavRclone
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/fstest/testserver/init.d/docker.bash
+++ b/fstest/testserver/init.d/docker.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 stop() {
     if status ; then

--- a/fstest/testserver/init.d/rclone-serve.bash
+++ b/fstest/testserver/init.d/rclone-serve.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # start an "rclone serve" server
 

--- a/fstest/testserver/init.d/run.bash
+++ b/fstest/testserver/init.d/run.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 case "$1" in 
     start)


### PR DESCRIPTION
The latter is more portable, while the former only works on systems where /bin/bash exists (or is symlinked appropriately).

#### What is the purpose of this change?

Make more of `go test` work on systems where `/bin/bash` does not exist, like NixOS.

#### Was the change discussed in an issue or in the forum before?
No, but I ran into it a bunch of times and decided to fix it :-)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
