### PR TITLE
protondrive: don't auth with an empty access token

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -285,6 +285,9 @@ func getConfigMap(m configmap.Mapper) (uid, accessToken, refreshToken, saltedKey
 	}
 	_saltedKeyPass = saltedKeyPass
 
+	// empty strings are considered "ok" by m.Get, which is not true business-wise
+	ok = accessToken != "" && uid != "" && refreshToken != "" && saltedKeyPass != ""
+
 	return
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Improves the authentication flow. Previously it considered empty strings as proper values, which led to a wrong attempt ending with HTTP error 401.

#### Was the change discussed in an issue or in the forum before?

Related to #7864. It does not fix the final problem with HTTP error 422, but not having 401 beforehand helps staying under the radar of incorrect API usage.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
