### PR TITLE
Fix new lint issues reported by golangci-lint v1.59.0

### DIFF
--- a/backend/webdav/webdav_internal_test.go
+++ b/backend/webdav/webdav_internal_test.go
@@ -29,7 +29,7 @@ func prepareServer(t *testing.T) (configmap.Simple, func()) {
 		what := fmt.Sprintf("%s %s: Header ", r.Method, r.URL.Path)
 		assert.Equal(t, headers[1], r.Header.Get(headers[0]), what+headers[0])
 		assert.Equal(t, headers[3], r.Header.Get(headers[2]), what+headers[2])
-		fmt.Fprintf(w, `<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
+		_, err := fmt.Fprintf(w, `<d:multistatus xmlns:d="DAV:" xmlns:s="http://sabredav.org/ns" xmlns:oc="http://owncloud.org/ns" xmlns:nc="http://nextcloud.org/ns">
 <d:response>
  <d:href>/remote.php/webdav/</d:href>
  <d:propstat>
@@ -41,8 +41,8 @@ func prepareServer(t *testing.T) (configmap.Simple, func()) {
  </d:propstat>
 </d:response>
 </d:multistatus>`)
+		require.NoError(t, err)
 	})
-
 	// Make the test server
 	ts := httptest.NewServer(handler)
 

--- a/fs/config/configfile/configfile_test.go
+++ b/fs/config/configfile/configfile_test.go
@@ -190,7 +190,8 @@ func TestConfigFileReload(t *testing.T) {
 	// Now write a new value on the end
 	out, err := os.OpenFile(config.GetConfigPath(), os.O_APPEND|os.O_WRONLY, 0777)
 	require.NoError(t, err)
-	fmt.Fprintln(out, "appended = what magic")
+	_, err = fmt.Fprintln(out, "appended = what magic")
+	require.NoError(t, err)
 	require.NoError(t, out.Close())
 
 	// And check we magically reloaded it


### PR DESCRIPTION
#### What is the purpose of this change?

Fix new lint issues reported by golangci-lint v1.59.0:

> Error return value of `fmt.Fprintf` is not checked (errcheck)

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
