### PR TITLE
s3: object lock integration

### DIFF
--- a/backend/s3/s3_test.go
+++ b/backend/s3/s3_test.go
@@ -2,10 +2,16 @@
 package s3
 
 import (
+	"bytes"
 	"context"
 	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/rclone/rclone/fs/operations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fstest"
@@ -69,6 +75,83 @@ func TestAWSDualStackOption(t *testing.T) {
 			t.Fail()
 		}
 	}
+}
+
+func TestIntegrationObjectLocking(t *testing.T) {
+	var bucketName = "rclone-integration-test-object-locking"
+	fstest.Initialise()
+	ctx := context.Background()
+	ci := fs.GetConfig(ctx)
+	ci.Dump = fs.DumpBodies
+	ci.LogLevel = fs.LogLevelDebug
+
+	remote, err := fs.NewFs(ctx, *fstest.RemoteName)
+	require.NoError(t, err, "remote not configured")
+	f, ok := remote.(*Fs)
+	if !ok {
+		require.Fail(t, "remote is not of type s3")
+	}
+
+	f.opt.BucketObjectLockEnabled = true
+	require.NoError(t, f.makeBucket(ctx, bucketName), "failed to create bucket")
+	f.setRoot(bucketName)
+
+	supported, enabled, err := f.setObjectLockingStatus(ctx)
+	require.NoError(t, err, "failed to check object-locking configuration")
+	require.True(t, supported, "object locking should be supported")
+	require.True(t, enabled, "object locking should be enabled")
+
+	// PutObject with GOVERNANCE + Legal Hold
+	testContent := "Test content"
+	testFile := bytes.NewReader([]byte(testContent))
+	testFilePath := "testFile"
+	retention, _ := fs.ParseTime("1M", true)
+	f.opt.ObjectLockRetainUntil = fs.TimeFuture(retention)
+	f.opt.ObjectLockMode = s3.ObjectLockModeGovernance
+	f.opt.ObjectLockLegalHold = fs.Tristate{Value: true, Valid: true}
+
+	object, err := f.Put(ctx, testFile, &Object{remote: testFilePath, fs: f, bytes: int64(len(testContent))})
+	require.NoError(t, err, "upload failed")
+	o := object.(*Object)
+	require.Equal(t, s3.ObjectLockModeGovernance, *o.objectLockMode)
+	require.True(t, retention.Equal(*o.objectLockRetainUntil)) // ignores timezone
+	assert.Equal(t, s3.ObjectLockLegalHoldStatusOn, *o.objectLockLegalHoldStatus, "legal hold not supported by server")
+
+	// PutObjectMultipart
+	testFile = bytes.NewReader([]byte(testContent))
+	testFilePath = "testFileMultipart"
+	_, _ = f.SetUploadCutoff(0) // force multipart
+
+	object, err = f.Put(ctx, testFile, &Object{remote: testFilePath, fs: f, bytes: int64(len(testContent))})
+	require.NoError(t, err, "multipart upload failed")
+	o2 := object.(*Object)
+	require.Equal(t, s3.ObjectLockModeGovernance, *o2.objectLockMode)
+	require.True(t, retention.Equal(*o2.objectLockRetainUntil)) // ignores timezone
+	assert.Equal(t, s3.ObjectLockLegalHoldStatusOn, *o2.objectLockLegalHoldStatus, "legal hold not supported by server")
+
+	// Server-Side Copy
+	retention, _ = fs.ParseTime("2M", true) // different retention time is used here just in case it got copied
+	f.opt.ObjectLockRetainUntil = fs.TimeFuture(retention)
+
+	copied, err := f.Copy(ctx, o, "copy")
+	require.NoError(t, err, "failed server-side copy")
+	o3 := copied.(*Object)
+	require.Equal(t, s3.ObjectLockModeGovernance, *o3.objectLockMode)
+	require.True(t, retention.Equal(*o3.objectLockRetainUntil))
+	assert.Equal(t, s3.ObjectLockLegalHoldStatusOn, *o3.objectLockLegalHoldStatus, "legal hold not supported by server")
+
+	require.NoError(t, o.SetLegalHold(ctx, false))
+	require.NoError(t, o2.SetLegalHold(ctx, false))
+	require.NoError(t, o3.SetLegalHold(ctx, false))
+	// Convert everything to delete marker
+	require.NoError(t, operations.Delete(ctx, f))
+	// Real Delete
+	f.opt.BypassGovernanceRetention = true
+	err = f.CleanUpHidden(ctx)
+	require.NoError(t, err)
+
+	_, err = f.c.DeleteBucketWithContext(ctx, &s3.DeleteBucketInput{Bucket: &bucketName})
+	require.NoError(t, err, "cleanup failed")
 }
 
 func (f *Fs) SetUploadChunkSize(cs fs.SizeSuffix) (fs.SizeSuffix, error) {

--- a/fs/parsetime.go
+++ b/fs/parsetime.go
@@ -6,16 +6,46 @@ import (
 	"time"
 )
 
-// Time is a time.Time with some more parsing options
-type Time time.Time
-
 // For overriding in unittests.
 var (
 	timeNowFunc = time.Now
 )
 
+type timeInferer interface {
+	isDurationInFuture() bool
+}
+type timeInfererFuture struct {
+}
+
+func (t timeInfererFuture) isDurationInFuture() bool {
+	return true
+}
+
+type timeInfererPast struct {
+}
+
+func (t timeInfererPast) isDurationInFuture() bool {
+	return false
+}
+
+type timeInfererUnion interface {
+	timeInfererFuture | timeInfererPast
+	timeInferer
+}
+
+type timeParent[I timeInfererUnion] time.Time
+
+// TimeFuture is a time.Time wrapper that provides more parsing options. Duration is treated as in the future.
+type TimeFuture = timeParent[timeInfererFuture]
+
+// TimePast is a time.Time wrapper that provides more parsing options. Duration is treated as in the past.
+type TimePast = timeParent[timeInfererPast]
+
+// Time is TimePast. kept for compatibility
+type Time = TimePast
+
 // Turn Time into a string
-func (t Time) String() string {
+func (t timeParent[I]) String() string {
 	if !t.IsSet() {
 		return "off"
 	}
@@ -23,12 +53,12 @@ func (t Time) String() string {
 }
 
 // IsSet returns if the time is not zero
-func (t Time) IsSet() bool {
+func (t timeParent[I]) IsSet() bool {
 	return !time.Time(t).IsZero()
 }
 
 // ParseTime parses a time or duration string as a Time.
-func ParseTime(date string) (t time.Time, err error) {
+func ParseTime(date string, durationInFuture bool) (t time.Time, err error) {
 	if date == "off" {
 		return time.Time{}, nil
 	}
@@ -41,37 +71,41 @@ func ParseTime(date string) (t time.Time, err error) {
 		return t, nil
 	}
 
+	mul := time.Duration(-1)
+	if durationInFuture {
+		mul = 1
+	}
 	// Attempt to parse as a time.Duration offset from now
 	d, err := time.ParseDuration(date)
 	if err == nil {
-		return now.Add(-d), nil
+		return now.Add(d * mul), nil
 	}
 
 	d, err = parseDurationSuffixes(date)
 	if err == nil {
-		return now.Add(-d), nil
+		return now.Add(d * mul), nil
 	}
 
 	return t, err
 }
 
 // Set a Time
-func (t *Time) Set(s string) error {
-	parsedTime, err := ParseTime(s)
+func (t *timeParent[I]) Set(s string) error {
+	parsedTime, err := ParseTime(s, (any(new(I)).(timeInferer)).isDurationInFuture())
 	if err != nil {
 		return err
 	}
-	*t = Time(parsedTime)
+	*t = timeParent[I](parsedTime)
 	return nil
 }
 
 // Type of the value
-func (t Time) Type() string {
+func (t timeParent[I]) Type() string {
 	return "Time"
 }
 
 // UnmarshalJSON makes sure the value can be parsed as a string in JSON
-func (t *Time) UnmarshalJSON(in []byte) error {
+func (t *timeParent[I]) UnmarshalJSON(in []byte) error {
 	var s string
 	err := json.Unmarshal(in, &s)
 	if err != nil {
@@ -82,12 +116,12 @@ func (t *Time) UnmarshalJSON(in []byte) error {
 }
 
 // MarshalJSON marshals as a time.Time value
-func (t Time) MarshalJSON() ([]byte, error) {
+func (t timeParent[I]) MarshalJSON() ([]byte, error) {
 	return json.Marshal(time.Time(t))
 }
 
 // Scan implements the fmt.Scanner interface
-func (t *Time) Scan(s fmt.ScanState, ch rune) error {
+func (t *timeParent[I]) Scan(s fmt.ScanState, ch rune) error {
 	token, err := s.Token(true, func(rune) bool { return true })
 	if err != nil {
 		return err


### PR DESCRIPTION
#### What is the purpose of this change?
Add object lock support for individual objects.

Object lock will be applied to newly added object. Governance mode can be bypassed with option.

### New Options
#### Bucket creation:
`bucket_object_lock_enabled`: create with object-lock flag and turn the object-lock configuration on

#### Object:
`object_lock_mode`: same as issue
`object_lock_retain_until`: differs from issue. merged the originally proposed `until-date` and `period` into one option, reusing fs.Time to accept date/datetime/duration
`object_lock_legal_hold`: same as issue

#### Deletion:
`bypass_governance_retention`: same as issue

#### Quirk:
`manually_set_object_lock`: currently enable for all providers. most s3 providers other than aws requires setting the object lock and legal hold using separate requests. Ideally a maintainer can run `TestIntegrationObjectLocking` in `s3_test.go` on every supported provider to figure this out. 

#### Was the change discussed in an issue or in the forum before?
See issue #4683
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
