### PR TITLE
sftp: use uint32 for mtime

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -1972,7 +1972,7 @@ func (o *Object) shellPath() string {
 
 // setMetadata updates the info in the object from the stat result passed in
 func (o *Object) setMetadata(info os.FileInfo) {
-	o.modTime = uint32(info.ModTime().Unix())
+	o.modTime = info.Sys().(*sftp.FileStat).Mtime
 	o.size = info.Size()
 	o.mode = info.Mode()
 }


### PR DESCRIPTION
The SFTP protocol (and the golang sftp package) internally uses uint32 unix time for expressing mtime. Hence it is a waste of memory to store it as 24-byte time.Time data structure in long-lived data structures. So despite that the golang sftp package uses time.Time as external interface, we can re-encode the value back to the original format and save memory.

#### What is the purpose of this change?

Save memory when mounting sftp backends. In my specific circumstances this simple change saves hundreds of MB of RAM.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)

I do not believe tests are necessary, as the only values that make sense in the context of sftp would already be within the range of uint32. As such, there should be no externally observable changes.