### PR TITLE
`s3`: fix 405 error on `HEAD` for delete marker with `versionId`

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -5422,7 +5422,7 @@ func (f *Fs) headObject(ctx context.Context, req *s3.HeadObjectInput) (resp *s3.
 	})
 	if err != nil {
 		if awsErr, ok := err.(awserr.RequestFailure); ok {
-			if awsErr.StatusCode() == http.StatusNotFound {
+			if awsErr.StatusCode() == http.StatusNotFound || awsErr.StatusCode() == http.StatusMethodNotAllowed {
 				return nil, fs.ErrorObjectNotFound
 			}
 		}


### PR DESCRIPTION
#### What is the purpose of this change?

When getting an object by specifying a `versionId` in the request, if the specified version is a delete marker, it returns `405 (Method Not Allowed)`, instead of `404 (Not Found)` which would be returned without a `versionId`.
See https://docs.aws.amazon.com/AmazonS3/latest/userguide/DeleteMarker.html

Before this change, we were only looking for `404` (and not `405`) to determine whether the object exists. This meant that in some circumstances (ex. when Versioning is enabled for the bucket and we have a non-null `X-Amz-Version-Id`), we deemed the object to exist when we should not have.

After this change, `405 (Method Not Allowed)` is treated the same as `404 (Not Found)` for the purposes of `headObject`.

#### Was the change discussed in an issue or in the forum before?

- https://forum.rclone.org/t/bisync-rename-failed-method-not-allowed/45723/13

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
