### PR TITLE
Fix incorrect region on Magalu provider Help value

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1415,8 +1415,8 @@ func init() {
 				Help:     "Magalu BR Southeast 1 endpoint",
 				Provider: "Magalu",
 			}, {
-				Value:    "br-se1.magaluobjects.com",
-				Help:     "Magalu BR Northest 1 endpoint",
+				Value:    "br-ne1.magaluobjects.com",
+				Help:     "Magalu BR Northeast 1 endpoint",
 				Provider: "Magalu",
 			}},
 		}, {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fixes incorrect region on Magalu provider for br-ne1 in s3.go.

Looks like there was a typo in the word `Northeast` and the incorrect subdomain for the region as per https://docs.magalu.cloud/docs/terraform/how-to/provider-region/

#### Was the change discussed in an issue or in the forum before?

I don't know, I just stumbled upon it by accident and decided to propose a fix because it seemed quick while I had the context.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
