### PR TITLE
Implement missing Docker volume plugin mount and VFS options

### DIFF
--- a/cmd/serve/docker/options.go
+++ b/cmd/serve/docker/options.go
@@ -216,6 +216,14 @@ func getMountOption(mntOpt *mountlib.Options, opt rc.Params, key string) (ok boo
 		mntOpt.NoAppleXattr, err = opt.GetBool(key)
 	case "network-mode":
 		mntOpt.NetworkMode, err = opt.GetBool(key)
+	case "daemon-wait":
+		mntOpt.DaemonWait, err = opt.GetDuration(key)
+	case "devname":
+		mntOpt.DeviceName, err = opt.GetString(key)
+	case "direct-io":
+		mntOpt.DirectIO, err = opt.GetBool(key)
+	case "mount-case-insensitive":
+		err = getFVarP(&mntOpt.CaseInsensitive, opt, key)
 	default:
 		ok = false
 	}
@@ -252,6 +260,16 @@ func getVFSOption(vfsOpt *vfscommon.Options, opt rc.Params, key string) (ok bool
 		err = getFVarP(&vfsOpt.ReadAhead, opt, key)
 	case "vfs-used-is-size":
 		vfsOpt.UsedIsSize, err = opt.GetBool(key)
+	case "vfs-refresh":
+		vfsOpt.Refresh, err = opt.GetBool(key)
+	case "vfs-cache-min-free-space":
+		err = getFVarP(&vfsOpt.CacheMinFreeSpace, opt, key)
+	case "vfs-block-norm-dupes":
+		vfsOpt.BlockNormDupes, err = opt.GetBool(key)
+	case "vfs-fast-fingerprint":
+		vfsOpt.FastFingerprint, err = opt.GetBool(key)
+	case "vfs-disk-space-total-size":
+		err = getFVarP(&vfsOpt.DiskSpaceTotalSize, opt, key)
 
 	// unprefixed vfs options
 	case "no-modtime":
@@ -270,6 +288,8 @@ func getVFSOption(vfsOpt *vfscommon.Options, opt rc.Params, key string) (ok bool
 	case "file-perms":
 		perms := &vfsflags.FileMode{Mode: &vfsOpt.FilePerms}
 		err = getFVarP(perms, opt, key)
+	case "no-seek":
+		vfsOpt.NoSeek, err = opt.GetBool(key)
 
 	// unprefixed unix-only vfs options
 	case "umask":


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

I have noticed that some options were missing when using rclone as a Docker volume plugin, like `vfs-fast-fingerprint` or `vfs-cache-min-free-space`, so I went through the `mountlib.Options` and `vfscommon.Options` structs and implemented all the missing ones.
I hope that all these options are supposed to be supported, and they won't break something with Docker or similar, but at the end this would be a user problem I guess, since you don't *have* to set them :)

New mount options:
- `daemon-wait`
- `devname`
- `direct-io`
- `mount-case-insensitive`

New VFS options:
- `vfs-refresh`
- `vfs-cache-min-free-space`
- `vfs-block-norm-dupes`
- `vfs-fast-fingerprint`
- `vfs-disk-space-total-size`
- `no-seek`

All of these are even documented here: https://rclone.org/commands/rclone_serve_docker/#options
But they did not actually work until now.

#### Was the change discussed in an issue or in the forum before?

Unfortunately I did not get any feedback on my forum post: https://forum.rclone.org/t/docker-volume-plugin-is-apparently-missing-some-vfs-options/45794
But since it's a pretty minor change I decided to just open a PR.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
