### PR TITLE
systemd: prevent unmount rc command from sending a STOPPING=1 sd-notify message

### DIFF
--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -18,11 +18,11 @@ import (
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/lib/atexit"
 	"github.com/rclone/rclone/lib/daemonize"
+	"github.com/rclone/rclone/lib/systemd"
 	"github.com/rclone/rclone/vfs"
 	"github.com/rclone/rclone/vfs/vfscommon"
 	"github.com/rclone/rclone/vfs/vfsflags"
 
-	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -307,6 +307,7 @@ func NewMountCommand(commandName string, hidden bool, mount MountFn) *cobra.Comm
 			// Wait for foreground mount, if any...
 			if mountDaemon == nil {
 				if err == nil {
+					defer systemd.Notify()()
 					err = mnt.Wait()
 				}
 				if err != nil {
@@ -385,7 +386,6 @@ func (m *MountPoint) Wait() error {
 	var finaliseOnce sync.Once
 	finalise := func() {
 		finaliseOnce.Do(func() {
-			_, _ = daemon.SdNotify(false, daemon.SdNotifyStopping)
 			// Unmount only if directory was mounted by rclone, e.g. don't unmount autofs hooks.
 			if err := CheckMountReady(m.MountPoint); err != nil {
 				fs.Debugf(m.MountPoint, "Unmounted externally. Just exit now.")
@@ -400,11 +400,6 @@ func (m *MountPoint) Wait() error {
 	}
 	fnHandle := atexit.Register(finalise)
 	defer atexit.Unregister(fnHandle)
-
-	// Notify systemd
-	if _, err := daemon.SdNotify(false, daemon.SdNotifyReady); err != nil {
-		return fmt.Errorf("failed to notify systemd: %w", err)
-	}
 
 	// Reload VFS cache on SIGHUP
 	sigHup := make(chan os.Signal, 1)

--- a/lib/systemd/notify.go
+++ b/lib/systemd/notify.go
@@ -9,10 +9,13 @@ import (
 	"github.com/rclone/rclone/lib/atexit"
 )
 
-// Notify systemd that the service is starting. This returns a
+// Notify systemd that the service is ready. This returns a
 // function which should be called to notify that the service is
 // stopping. This function will be called on exit if the service exits
 // on a signal.
+// NOTE: this function should only be called once, and so it
+// should generally only be used directly in a command's Run handler.
+// It should not be called as a result of rc commands. See #7540.
 func Notify() func() {
 	if _, err := daemon.SdNotify(false, daemon.SdNotifyReady); err != nil {
 		log.Printf("failed to notify ready to systemd: %v", err)


### PR DESCRIPTION
#### What is the purpose of this change?

#7540 has been annoying me for quite a long time, so I decided to try my hand at a fix. It turned out to be surprisingly simple - just move the sd-notify calls out of `(m *MountPoint) Wait()` and into the command `Run` handlers used by the `mount` commands in `NewMountCommand`. 

~~I also made some minor changes to the `serve docker` command, so that the `READY=1` notification is only sent _after_ the socket is created and a connection is made. This means that if there are any units with an `After` dependency on the rclone unit, they will only be started once the socket exists and is accepting connections.~~ Split to #7954

#### Was the change discussed in an issue or in the forum before?

Fixes #7540

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
