### PR TITLE
serve docker: send systemd READY=1 message after socket is ready

### DIFF
--- a/cmd/serve/docker/docker.go
+++ b/cmd/serve/docker/docker.go
@@ -4,6 +4,7 @@ package docker
 import (
 	"context"
 	_ "embed"
+	"net"
 	"path/filepath"
 	"strings"
 	"syscall"
@@ -13,6 +14,7 @@ import (
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/cmd/mountlib"
 	"github.com/rclone/rclone/fs/config/flags"
+	"github.com/rclone/rclone/lib/systemd"
 	"github.com/rclone/rclone/vfs"
 	"github.com/rclone/rclone/vfs/vfsflags"
 )
@@ -70,15 +72,25 @@ var Command = &cobra.Command{
 				return err
 			}
 			srv := NewServer(drv)
+
+			var listener net.Listener
 			if socketAddr == "" {
 				// Listen on unix socket at /run/docker/plugins/<pluginName>.sock
-				return srv.ServeUnix(pluginName, socketGid)
-			}
-			if filepath.IsAbs(socketAddr) {
+				listener, err = srv.ListenUnix(pluginName, socketGid)
+			} else if filepath.IsAbs(socketAddr) {
 				// Listen on unix socket at given path
-				return srv.ServeUnix(socketAddr, socketGid)
+				listener, err = srv.ListenUnix(socketAddr, socketGid)
+			} else {
+				listener, err = srv.ListenTCP(socketAddr, "", nil, noSpec)
 			}
-			return srv.ServeTCP(socketAddr, "", nil, noSpec)
+			if err != nil {
+				return err
+			}
+
+			// notify systemd
+			defer systemd.Notify()()
+
+			return srv.Serve(listener)
 		})
 	},
 }

--- a/cmd/serve/docker/docker_test.go
+++ b/cmd/serve/docker/docker_test.go
@@ -342,13 +342,16 @@ func testMountAPI(t *testing.T, sockAddr string) {
 
 	srv := docker.NewServer(drv)
 	go func() {
-		var errServe error
+		var listener net.Listener
+		var err error
 		if unixPath != "" {
-			errServe = srv.ServeUnix(unixPath, os.Getgid())
+			listener, err = srv.ListenUnix(unixPath, os.Getgid())
 		} else {
-			errServe = srv.ServeTCP(sockAddr, testDir, nil, false)
+			listener, err = srv.ListenTCP(sockAddr, testDir, nil, false)
 		}
-		assert.ErrorIs(t, errServe, http.ErrServerClosed)
+		assert.NoError(t, err)
+		err = srv.Serve(listener)
+		assert.ErrorIs(t, err, http.ErrServerClosed)
 	}()
 	defer func() {
 		err := srv.Shutdown(ctx)

--- a/cmd/serve/docker/driver.go
+++ b/cmd/serve/docker/driver.go
@@ -12,7 +12,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/coreos/go-systemd/v22/daemon"
 	"github.com/rclone/rclone/cmd/mountlib"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config"
@@ -84,11 +83,6 @@ func NewDriver(ctx context.Context, root string, mntOpt *mountlib.Options, vfsOp
 		drv.exitOnce.Do(drv.Exit)
 	})
 
-	// notify systemd
-	if _, err := daemon.SdNotify(false, daemon.SdNotifyReady); err != nil {
-		return nil, fmt.Errorf("failed to notify systemd: %w", err)
-	}
-
 	return drv, nil
 }
 
@@ -98,10 +92,6 @@ func (drv *Driver) Exit() {
 	drv.mu.Lock()
 	defer drv.mu.Unlock()
 
-	reportErr(func() error {
-		_, err := daemon.SdNotify(false, daemon.SdNotifyStopping)
-		return err
-	}())
 	drv.monChan <- true // ask monitor to exit
 	for _, vol := range drv.volumes {
 		reportErr(vol.unmountAll())


### PR DESCRIPTION
#### What is the purpose of this change?

In the `serve docker` command, the `READY=1` sd-notify notification is currently sent just before `NewDriver` returns. At this point, rclone has not yet created or started listening on the socket. This change moves the ready notification later, until after the socket has been created and opened. This means any units with an After dependency on the rclone service can reliably expect the served socket to exist and be accepting connections.

#### Was the change discussed in an issue or in the forum before?

Split from #7953

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
