### PR TITLE
Change SendFilePayloadResponse.size type to int64

### DIFF
--- a/backend/ulozto/api/types.go
+++ b/backend/ulozto/api/types.go
@@ -163,7 +163,7 @@ type BatchUpdateFilePropertiesRequest struct {
 // SendFilePayloadResponse represents the JSON API object that's received
 // in response to uploading a file's body to the CDN URL.
 type SendFilePayloadResponse struct {
-	Size        int    `json:"size"`
+	Size        int64  `json:"size"`
 	ContentType string `json:"contentType"`
 	Md5         string `json:"md5"`
 	Message     string `json:"message"`


### PR DESCRIPTION
Fixes #7960

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Uploading large files to uloz.to yielded an error message because the actual size was larger than could be possibly stored in the Size field.

I will check the checklist later.

#### Was the change discussed in an issue or in the forum before?

#7960

#### Checklist

- [] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [] I have added tests for all changes in this PR if appropriate.
- [] I have added documentation for the changes if appropriate.
- [] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [] I'm done, this Pull Request is ready for review :-)
