### PR TITLE
fs/log: decouple `logrus` dependency -fixes #3426

### DIFF
--- a/cmd/bisync/bilib/output.go
+++ b/cmd/bisync/bilib/output.go
@@ -6,13 +6,13 @@ import (
 	"log"
 
 	"github.com/rclone/rclone/fs"
-	"github.com/sirupsen/logrus"
+	"github.com/rclone/rclone/fs/logrus"
 )
 
 // CaptureOutput runs a function capturing its output.
 func CaptureOutput(fun func()) []byte {
 	logSave := log.Writer()
-	logrusSave := logrus.StandardLogger().Writer()
+	logrusSave := logrus.GetStandardLoggerWriter()
 	defer func() {
 		err := logrusSave.Close()
 		if err != nil {

--- a/fs/log/caller_hook.go
+++ b/fs/log/caller_hook.go
@@ -1,106 +1,11 @@
 package log
 
 import (
-	"fmt"
-	"runtime"
-	"strings"
-
 	"github.com/rclone/rclone/fs"
-	"github.com/sirupsen/logrus"
+	"github.com/rclone/rclone/fs/logrus"
 )
-
-var loggerInstalled = false
-
-// InstallJSONLogger installs the JSON logger at the specified log level
-func InstallJSONLogger(logLevel fs.LogLevel) {
-	if !loggerInstalled {
-		logrus.AddHook(NewCallerHook())
-		loggerInstalled = true
-	}
-	logrus.SetFormatter(&logrus.JSONFormatter{
-		TimestampFormat: "2006-01-02T15:04:05.999999-07:00",
-	})
-	logrus.SetLevel(logrus.DebugLevel)
-	switch logLevel {
-	case fs.LogLevelEmergency, fs.LogLevelAlert:
-		logrus.SetLevel(logrus.PanicLevel)
-	case fs.LogLevelCritical:
-		logrus.SetLevel(logrus.FatalLevel)
-	case fs.LogLevelError:
-		logrus.SetLevel(logrus.ErrorLevel)
-	case fs.LogLevelWarning, fs.LogLevelNotice:
-		logrus.SetLevel(logrus.WarnLevel)
-	case fs.LogLevelInfo:
-		logrus.SetLevel(logrus.InfoLevel)
-	case fs.LogLevelDebug:
-		logrus.SetLevel(logrus.DebugLevel)
-	}
-}
 
 // install hook in fs to call to avoid circular dependency
 func init() {
-	fs.InstallJSONLogger = InstallJSONLogger
-}
-
-// CallerHook for log the calling file and line of the fine
-type CallerHook struct {
-	Field  string
-	Skip   int
-	levels []logrus.Level
-}
-
-// NewCallerHook use to make a hook
-func NewCallerHook(levels ...logrus.Level) logrus.Hook {
-	hook := CallerHook{
-		Field:  "source",
-		Skip:   7,
-		levels: levels,
-	}
-	if len(hook.levels) == 0 {
-		hook.levels = logrus.AllLevels
-	}
-	return &hook
-}
-
-// Levels implement applied hook to which levels
-func (h *CallerHook) Levels() []logrus.Level {
-	return logrus.AllLevels
-}
-
-// Fire logs the information of context (filename and line)
-func (h *CallerHook) Fire(entry *logrus.Entry) error {
-	entry.Data[h.Field] = findCaller(h.Skip)
-	return nil
-}
-
-// findCaller ignores the caller relevant to logrus or fslog then find out the exact caller
-func findCaller(skip int) string {
-	file := ""
-	line := 0
-	for i := 0; i < 10; i++ {
-		file, line = getCaller(skip + i)
-		if !strings.HasPrefix(file, "logrus") && !strings.Contains(file, "log.go") {
-			break
-		}
-	}
-	return fmt.Sprintf("%s:%d", file, line)
-}
-
-func getCaller(skip int) (string, int) {
-	_, file, line, ok := runtime.Caller(skip)
-	// fmt.Println(file,":",line)
-	if !ok {
-		return "", 0
-	}
-	n := 0
-	for i := len(file) - 1; i > 0; i-- {
-		if file[i] == '/' {
-			n++
-			if n >= 2 {
-				file = file[i+1:]
-				break
-			}
-		}
-	}
-	return file, line
+	fs.InstallJSONLogger = logrus.InstallJSONLogger
 }

--- a/fs/log/log.go
+++ b/fs/log/log.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 
 	"github.com/rclone/rclone/fs"
-	"github.com/sirupsen/logrus"
+	"github.com/rclone/rclone/fs/logrus"
 )
 
 // OptionsInfo descripts the Options in use

--- a/fs/logrus/caller_hook.go
+++ b/fs/logrus/caller_hook.go
@@ -1,0 +1,102 @@
+package logrus
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/rclone/rclone/fs"
+)
+
+var loggerInstalled = false
+
+// InstallJSONLogger installs the JSON logger at the specified log level
+func InstallJSONLogger(logLevel fs.LogLevel) {
+	if !loggerInstalled {
+		logrus.AddHook(NewCallerHook())
+		loggerInstalled = true
+	}
+	logrus.SetFormatter(&logrus.JSONFormatter{
+		TimestampFormat: "2006-01-02T15:04:05.999999-07:00",
+	})
+	logrus.SetLevel(logrus.DebugLevel)
+	switch logLevel {
+	case fs.LogLevelEmergency, fs.LogLevelAlert:
+		logrus.SetLevel(logrus.PanicLevel)
+	case fs.LogLevelCritical:
+		logrus.SetLevel(logrus.FatalLevel)
+	case fs.LogLevelError:
+		logrus.SetLevel(logrus.ErrorLevel)
+	case fs.LogLevelWarning, fs.LogLevelNotice:
+		logrus.SetLevel(logrus.WarnLevel)
+	case fs.LogLevelInfo:
+		logrus.SetLevel(logrus.InfoLevel)
+	case fs.LogLevelDebug:
+		logrus.SetLevel(logrus.DebugLevel)
+	}
+}
+
+// CallerHook for log the calling file and line of the fine
+type CallerHook struct {
+	Field  string
+	Skip   int
+	levels []logrus.Level
+}
+
+// Levels implement applied hook to which levels
+func (h *CallerHook) Levels() []logrus.Level {
+	return logrus.AllLevels
+}
+
+// Fire logs the information of context (filename and line)
+func (h *CallerHook) Fire(entry *logrus.Entry) error {
+	entry.Data[h.Field] = findCaller(h.Skip)
+	return nil
+}
+
+// NewCallerHook use to make a hook
+func NewCallerHook(levels ...logrus.Level) logrus.Hook {
+	hook := CallerHook{
+		Field:  "source",
+		Skip:   7,
+		levels: levels,
+	}
+	if len(hook.levels) == 0 {
+		hook.levels = logrus.AllLevels
+	}
+	return &hook
+}
+
+// findCaller ignores the caller relevant to logrus or fslog then find out the exact caller
+func findCaller(skip int) string {
+	file := ""
+	line := 0
+	for i := 0; i < 10; i++ {
+		file, line = getCaller(skip + i)
+		if !strings.HasPrefix(file, "logrus") && !strings.Contains(file, "log.go") {
+			break
+		}
+	}
+	return fmt.Sprintf("%s:%d", file, line)
+}
+
+func getCaller(skip int) (string, int) {
+	_, file, line, ok := runtime.Caller(skip)
+	// fmt.Println(file,":",line)
+	if !ok {
+		return "", 0
+	}
+	n := 0
+	for i := len(file) - 1; i > 0; i-- {
+		if file[i] == '/' {
+			n++
+			if n >= 2 {
+				file = file[i+1:]
+				break
+			}
+		}
+	}
+	return file, line
+}

--- a/fs/logrus/logrus.go
+++ b/fs/logrus/logrus.go
@@ -1,0 +1,61 @@
+// Package logrus provides abstraction for logrus for rclone
+package logrus
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/rclone/rclone/fs"
+)
+
+// LogPrintf produces a log string from the arguments passed in
+var LogPrintf = func(level fs.LogLevel, o interface{}, text string, args ...interface{}) {
+	out := fmt.Sprintf(text, args...)
+
+	if fs.GetConfig(context.TODO()).UseJSONLog {
+		fields := logrus.Fields{}
+		if o != nil {
+			fields = logrus.Fields{
+				"object":     fmt.Sprintf("%+v", o),
+				"objectType": fmt.Sprintf("%T", o),
+			}
+		}
+		for _, arg := range args {
+			if item, ok := arg.(fs.LogValueItem); ok {
+				fields[item.Key] = item.Value
+			}
+		}
+		switch level {
+		case fs.LogLevelDebug:
+			logrus.WithFields(fields).Debug(out)
+		case fs.LogLevelInfo:
+			logrus.WithFields(fields).Info(out)
+		case fs.LogLevelNotice, fs.LogLevelWarning:
+			logrus.WithFields(fields).Warn(out)
+		case fs.LogLevelError:
+			logrus.WithFields(fields).Error(out)
+		case fs.LogLevelCritical:
+			logrus.WithFields(fields).Fatal(out)
+		case fs.LogLevelEmergency, fs.LogLevelAlert:
+			logrus.WithFields(fields).Panic(out)
+		}
+	} else {
+		if o != nil {
+			out = fmt.Sprintf("%v: %s", o, out)
+		}
+		fs.LogPrint(level, out)
+	}
+}
+
+// SetOutput sets output for logrus Standard Logger
+func SetOutput(out io.Writer) {
+	logrus.SetOutput(out)
+}
+
+// GetStandardLoggerWriter returns the Writer for the Standard Logger
+func GetStandardLoggerWriter() *io.PipeWriter {
+	return logrus.StandardLogger().Writer()
+}


### PR DESCRIPTION
fs/log.go logging methods now use slog package instead of logrus, All the logrus config has been moved to fs/logrus package No external package will now be using logrus directly instead should use fs/logrus package

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
- Decouple the `logrus` from `fs/log.go`
- All the `logrus` helper functions moved to `fs/logrus` package

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

#3426

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
