### PR TITLE
cmd/gitannex: Port unit tests to fstest

### DIFF
--- a/cmd/gitannex/e2e_test.go
+++ b/cmd/gitannex/e2e_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/lib/buildinfo"
 )
 
@@ -181,6 +182,11 @@ func (e *e2eTestingContext) createGitRepo(t *testing.T) {
 func skipE2eTestIfNecessary(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping due to short mode.")
+	}
+
+	// TODO(#7984): Port e2e tests to `fstest` framework.
+	if *fstest.RemoteName != "" {
+		t.Skip("Skipping because fstest remote was specified.")
 	}
 
 	// TODO: Support e2e tests on Windows. Need to evaluate the semantics of the

--- a/cmd/gitannex/e2e_test.go
+++ b/cmd/gitannex/e2e_test.go
@@ -31,9 +31,7 @@ func checkRcloneBinaryVersion(t *testing.T) error {
 
 	cmd := exec.Command("rclone", "rc", "--loopback", "core/version")
 	stdout, err := cmd.Output()
-	if err != nil {
-		return fmt.Errorf("failed to get rclone version: %w", err)
-	}
+	require.NoError(t, err)
 
 	var parsed versionInfo
 	if err := json.Unmarshal(stdout, &parsed); err != nil {

--- a/cmd/gitannex/gitannex_test.go
+++ b/cmd/gitannex/gitannex_test.go
@@ -456,10 +456,7 @@ var fstestTestCases = []testCase{
 			h.requireWriteLine("EXTENSIONS INFO") // Advertise that we support the INFO extension
 			h.requireReadLineExact("EXTENSIONS")
 
-			if !h.server.extensionInfo {
-				t.Errorf("expected INFO extension to be enabled")
-				return
-			}
+			require.True(t, h.server.extensionInfo)
 
 			h.requireWriteLine("PREPARE")
 			h.requireReadLineExact("GETCONFIG rcloneremotename")
@@ -484,10 +481,7 @@ var fstestTestCases = []testCase{
 			h.requireWriteLine("EXTENSIONS INFO") // Advertise that we support the INFO extension
 			h.requireReadLineExact("EXTENSIONS")
 
-			if !h.server.extensionInfo {
-				t.Errorf("expected INFO extension to be enabled")
-				return
-			}
+			require.True(t, h.server.extensionInfo)
 
 			h.requireWriteLine("PREPARE")
 			h.requireReadLineExact("GETCONFIG rcloneremotename")
@@ -516,10 +510,7 @@ var fstestTestCases = []testCase{
 			h.requireWriteLine("EXTENSIONS INFO") // Advertise that we support the INFO extension
 			h.requireReadLineExact("EXTENSIONS")
 
-			if !h.server.extensionInfo {
-				t.Errorf("expected INFO extension to be enabled")
-				return
-			}
+			require.True(t, h.server.extensionInfo)
 
 			h.requireWriteLine("PREPARE")
 			h.requireReadLineExact("GETCONFIG rcloneremotename")
@@ -552,10 +543,7 @@ var fstestTestCases = []testCase{
 			h.requireWriteLine("EXTENSIONS INFO") // Advertise that we support the INFO extension
 			h.requireReadLineExact("EXTENSIONS")
 
-			if !h.server.extensionInfo {
-				t.Errorf("expected INFO extension to be enabled")
-				return
-			}
+			require.True(t, h.server.extensionInfo)
 
 			h.requireWriteLine("PREPARE")
 			h.requireReadLineExact("GETCONFIG rcloneremotename")
@@ -584,10 +572,7 @@ var fstestTestCases = []testCase{
 			h.requireWriteLine("EXTENSIONS INFO") // Advertise that we support the INFO extension
 			h.requireReadLineExact("EXTENSIONS")
 
-			if !h.server.extensionInfo {
-				t.Errorf("expected INFO extension to be enabled")
-				return
-			}
+			require.True(t, h.server.extensionInfo)
 
 			h.requireWriteLine("PREPARE")
 			h.requireReadLineExact("GETCONFIG rcloneremotename")

--- a/cmd/gitannex/layout.go
+++ b/cmd/gitannex/layout.go
@@ -3,6 +3,8 @@ package gitannex
 import (
 	"fmt"
 	"strings"
+
+	"github.com/rclone/rclone/fs/fspath"
 )
 
 type layoutMode string
@@ -39,8 +41,11 @@ func parseLayoutMode(mode string) layoutMode {
 type queryDirhashFunc func(msg string) (string, error)
 
 func buildFsString(queryDirhash queryDirhashFunc, mode layoutMode, key, remoteName, prefix string) (string, error) {
+	remoteName = strings.TrimSuffix(remoteName, ":") + ":"
+	remoteString := fspath.JoinRootPath(remoteName, prefix)
+
 	if mode == layoutModeNodir {
-		return fmt.Sprintf("%s:%s", remoteName, prefix), nil
+		return remoteString, nil
 	}
 
 	var dirhash string
@@ -59,13 +64,13 @@ func buildFsString(queryDirhash queryDirhashFunc, mode layoutMode, key, remoteNa
 
 	switch mode {
 	case layoutModeLower:
-		return fmt.Sprintf("%s:%s/%s", remoteName, prefix, dirhash), nil
+		return fmt.Sprintf("%s/%s", remoteString, dirhash), nil
 	case layoutModeDirectory:
-		return fmt.Sprintf("%s:%s/%s%s", remoteName, prefix, dirhash, key), nil
+		return fmt.Sprintf("%s/%s%s", remoteString, dirhash, key), nil
 	case layoutModeMixed:
-		return fmt.Sprintf("%s:%s/%s", remoteName, prefix, dirhash), nil
+		return fmt.Sprintf("%s/%s", remoteString, dirhash), nil
 	case layoutModeFrankencase:
-		return fmt.Sprintf("%s:%s/%s", remoteName, prefix, strings.ToLower(dirhash)), nil
+		return fmt.Sprintf("%s/%s", remoteString, strings.ToLower(dirhash)), nil
 	default:
 		panic("unreachable")
 	}

--- a/fstest/test_all/config.yaml
+++ b/fstest/test_all/config.yaml
@@ -8,6 +8,7 @@ tests:
  - path: fs/sync
    fastlist: true
  - path: cmd/bisync
+ - path: cmd/gitannex
  - path: vfs
  - path: cmd/serve/restic
    localonly: true


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

This enables the unit tests to run on any given backend, via the `-remote` flag, e.g. `go test -v ./cmd/gitannex/... -remote dropbox:`.

We should also port the gitannex e2e tests at some point.




#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

Issue: #7984

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
