### PR TITLE
Revert "help: global flags help command now takes glob filter"

### DIFF
--- a/cmd/help.go
+++ b/cmd/help.go
@@ -12,7 +12,6 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/configflags"
 	"github.com/rclone/rclone/fs/config/flags"
-	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/filter/filterflags"
 	"github.com/rclone/rclone/fs/log/logflags"
 	"github.com/rclone/rclone/fs/rc/rcflags"
@@ -67,12 +66,12 @@ var (
 
 // Show the flags
 var helpFlags = &cobra.Command{
-	Use:   "flags [<filter>]",
+	Use:   "flags [<regexp to match>]",
 	Short: "Show the global flags for rclone",
 	Run: func(command *cobra.Command, args []string) {
 		command.Flags()
 		if len(args) > 0 {
-			re, err := filter.GlobStringToRegexp(args[0], false)
+			re, err := regexp.Compile(`(?i)` + args[0])
 			if err != nil {
 				log.Fatalf("Invalid flag filter: %v", err)
 			}


### PR DESCRIPTION
This reverts commit c6352231e43c32bf139cea64d69a4528ef93dedb from https://github.com/rclone/rclone/pull/7404.

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

See https://github.com/rclone/rclone/pull/7404#issuecomment-2276089200 and below.

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
