### PR TITLE
Make listremotes long output backwards compatible - fixes #7995

### DIFF
--- a/cmd/listremotes/listremotes.go
+++ b/cmd/listremotes/listremotes.go
@@ -30,11 +30,11 @@ var (
 func init() {
 	cmd.Root.AddCommand(commandDefinition)
 	cmdFlags := commandDefinition.Flags()
-	flags.BoolVarP(cmdFlags, &listLong, "long", "", false, "Show type, source and description in addition to name", "")
+	flags.BoolVarP(cmdFlags, &listLong, "long", "", false, "Show type and description in addition to name", "")
 	flags.StringVarP(cmdFlags, &filterName, "name", "", "", "Filter remotes by name", "")
 	flags.StringVarP(cmdFlags, &filterType, "type", "", "", "Filter remotes by type", "")
-	flags.StringVarP(cmdFlags, &filterSource, "source", "", "", "filter remotes by source", "")
-	flags.StringVarP(cmdFlags, &filterDescription, "description", "", "", "filter remotes by description", "")
+	flags.StringVarP(cmdFlags, &filterSource, "source", "", "", "Filter remotes by source, e.g. 'file' or 'environment'", "")
+	flags.StringVarP(cmdFlags, &filterDescription, "description", "", "", "Filter remotes by description", "")
 	flags.StringVarP(cmdFlags, &orderBy, "order-by", "", "", "Instructions on how to order the result, e.g. 'type,name=descending'", "")
 	flags.BoolVarP(cmdFlags, &jsonOutput, "json", "", false, "Format output as JSON", "")
 }
@@ -120,9 +120,9 @@ or the remotes matching an optional filter.
 
 Prints the result in human-readable format by default, and as a simple list of
 remote names, or if used with flag ` + "`--long`" + ` a tabular format including
-all attributes of the remotes: name, type, source and description. Using flag
-` + "`--json`" + ` produces machine-readable output instead, which always includes
-all attributes.
+the remote names, types and descriptions. Using flag ` + "`--json`" + ` produces
+machine-readable output instead, which always includes all attributes - including
+the source (file or environment).
 
 Result can be filtered by a filter argument which applies to all attributes,
 and/or filter flags specific for each attribute. The values must be specified
@@ -157,7 +157,6 @@ according to regular rclone filtering pattern syntax.
 		remotes := config.GetRemotes()
 		maxName := 0
 		maxType := 0
-		maxSource := 0
 		i := 0
 		for _, remote := range remotes {
 			include := true
@@ -180,9 +179,6 @@ according to regular rclone filtering pattern syntax.
 				}
 				if len(remote.Type) > maxType {
 					maxType = len(remote.Type)
-				}
-				if len(remote.Source) > maxSource {
-					maxSource = len(remote.Source)
 				}
 				remotes[i] = remote
 				i++
@@ -225,7 +221,7 @@ according to regular rclone filtering pattern syntax.
 			fmt.Println("]")
 		} else if listLong {
 			for _, remote := range remotes {
-				fmt.Printf("%-*s %-*s %-*s %s\n", maxName+1, remote.Name+":", maxType, remote.Type, maxSource, remote.Source, remote.Description)
+				fmt.Printf("%-*s %-*s %s\n", maxName+1, remote.Name+":", maxType, remote.Type, remote.Description)
 			}
 		} else {
 			for _, remote := range remotes {


### PR DESCRIPTION
The format was changed to include the source attribute in #7404, but that is now reverted and the source information is only shown in json output.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
