### PR TITLE
Minor improvements to command docs layout

### DIFF
--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -159,33 +159,33 @@ rclone.org website.`,
 				}
 				doc := string(b)
 
-				var out strings.Builder
-				if groupsString := cmd.Annotations["groups"]; groupsString != "" {
-					groups := flags.All.Include(groupsString)
-					for _, group := range groups.Groups {
-						if group.Flags.HasFlags() {
-							_, _ = fmt.Fprintf(&out, "\n### %s Options\n\n", group.Name)
-							_, _ = fmt.Fprintf(&out, "%s\n\n", group.Help)
-							_, _ = fmt.Fprintln(&out, "```")
-							_, _ = out.WriteString(group.Flags.FlagUsages())
-							_, _ = fmt.Fprintln(&out, "```")
-						}
-					}
-				}
-				_, _ = out.WriteString(`
-See the [global flags page](/flags/) for global options not listed here.
-
-`)
-
 				startCut := strings.Index(doc, `### Options inherited from parent commands`)
 				endCut := strings.Index(doc, `### SEE ALSO`)
 				if startCut < 0 || endCut < 0 {
-					if name == "rclone.md" {
-						return nil
+					if name != "rclone.md" {
+						return fmt.Errorf("internal error: failed to find cut points: startCut = %d, endCut = %d", startCut, endCut)
 					}
-					return fmt.Errorf("internal error: failed to find cut points: startCut = %d, endCut = %d", startCut, endCut)
+				} else {
+					var out strings.Builder
+					if groupsString := cmd.Annotations["groups"]; groupsString != "" {
+						groups := flags.All.Include(groupsString)
+						for _, group := range groups.Groups {
+							if group.Flags.HasFlags() {
+								_, _ = fmt.Fprintf(&out, "\n### %s Options\n\n", group.Name)
+								_, _ = fmt.Fprintf(&out, "%s\n\n", group.Help)
+								_, _ = fmt.Fprintln(&out, "```")
+								_, _ = out.WriteString(group.Flags.FlagUsages())
+								_, _ = fmt.Fprintln(&out, "```")
+							}
+						}
+					}
+					_, _ = out.WriteString(`
+See the [global flags page](/flags/) for global options not listed here.
+
+`)
+					doc = doc[:startCut] + out.String() + doc[endCut:]
 				}
-				doc = doc[:startCut] + out.String() + doc[endCut:]
+
 				// outdent all the titles by one
 				doc = outdentTitle.ReplaceAllString(doc, `$1`)
 				err = os.WriteFile(path, []byte(doc), 0777)

--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -165,6 +165,9 @@ rclone.org website.`,
 					if name != "rclone.md" {
 						return fmt.Errorf("internal error: failed to find cut points: startCut = %d, endCut = %d", startCut, endCut)
 					}
+					if endCut >= 0 {
+						doc = doc[:endCut] + "### See Also" + doc[endCut+12:]
+					}
 				} else {
 					var out strings.Builder
 					if groupsString := cmd.Annotations["groups"]; groupsString != "" {
@@ -183,7 +186,7 @@ rclone.org website.`,
 See the [global flags page](/flags/) for global options not listed here.
 
 `)
-					doc = doc[:startCut] + out.String() + doc[endCut:]
+					doc = doc[:startCut] + out.String() + "### See Also" + doc[endCut+12:]
 				}
 
 				// outdent all the titles by one

--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -174,7 +174,7 @@ rclone.org website.`,
 						groups := flags.All.Include(groupsString)
 						for _, group := range groups.Groups {
 							if group.Flags.HasFlags() {
-								_, _ = fmt.Fprintf(&out, "\n### %s Options\n\n", group.Name)
+								_, _ = fmt.Fprintf(&out, "\n#### %s Options\n\n", group.Name)
 								_, _ = fmt.Fprintf(&out, "%s\n\n", group.Help)
 								_, _ = fmt.Fprintln(&out, "```")
 								_, _ = out.WriteString(group.Flags.FlagUsages())

--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -178,7 +178,7 @@ See the [global flags page](/flags/) for global options not listed here.
 `)
 
 				startCut := strings.Index(doc, `### Options inherited from parent commands`)
-				endCut := strings.Index(doc, `## SEE ALSO`)
+				endCut := strings.Index(doc, `### SEE ALSO`)
 				if startCut < 0 || endCut < 0 {
 					if name == "rclone.md" {
 						return nil

--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -171,21 +171,21 @@ rclone.org website.`,
 				} else {
 					var out strings.Builder
 					if groupsString := cmd.Annotations["groups"]; groupsString != "" {
+						_, _ = out.WriteString("Options shared with other commands are described next.\n")
+						_, _ = out.WriteString("See the [global flags page](/flags/) for global options not listed here.\n\n")
 						groups := flags.All.Include(groupsString)
 						for _, group := range groups.Groups {
 							if group.Flags.HasFlags() {
-								_, _ = fmt.Fprintf(&out, "\n#### %s Options\n\n", group.Name)
+								_, _ = fmt.Fprintf(&out, "#### %s Options\n\n", group.Name)
 								_, _ = fmt.Fprintf(&out, "%s\n\n", group.Help)
-								_, _ = fmt.Fprintln(&out, "```")
+								_, _ = out.WriteString("```\n")
 								_, _ = out.WriteString(group.Flags.FlagUsages())
-								_, _ = fmt.Fprintln(&out, "```")
+								_, _ = out.WriteString("```\n\n")
 							}
 						}
+					} else {
+						_, _ = out.WriteString("See the [global flags page](/flags/) for global options not listed here.\n\n")
 					}
-					_, _ = out.WriteString(`
-See the [global flags page](/flags/) for global options not listed here.
-
-`)
 					doc = doc[:startCut] + out.String() + "### See Also" + doc[endCut+12:]
 				}
 


### PR DESCRIPTION
#### What is the purpose of this change?

A few minor improvements to command docs layout:
- Command docs for root rclone command (https://rclone.org/commands/rclone/) did not outdent header levels, so it was inconsistent with the rest (including different toc that included the top level command etc).
- Command docs (except root rclone command) had the "# SEE ALSO" header as top level header, same as the primary command header (e.g. "# rclone copy"), and it would therefore not be shown in toc.
- Make option group headers sub-headers of the command's own "Options" header. Previously these were at the same level, e.g. copy command had headers: Headers, Copy Options, Important Options, etc. Then it could be a bit confusing what the first "Headers" section contains compared to the rest.
- The line "See the [global flags page](/flags/) for global options not listed here." was written at the end of all options, but then it was effectively part of the last command group header, e.g. "Listing Options", while it is in fact common to all options. Moved it up to the main "Options" header.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
