### PR TITLE
Consistent newline of first line in command help output

### DIFF
--- a/cmd/about/about.go
+++ b/cmd/about/about.go
@@ -46,8 +46,7 @@ func printValue(what string, uv *int64, isSize bool) {
 var commandDefinition = &cobra.Command{
 	Use:   "about remote:",
 	Short: `Get quota information from the remote.`,
-	Long: `
-` + "`rclone about`" + ` prints quota information about a remote to standard
+	Long: `Prints quota information about a remote to standard
 output. The output is typically used, free, quota and trash contents.
 
 E.g. Typical output from ` + "`rclone about remote:`" + ` is:

--- a/cmd/authorize/authorize.go
+++ b/cmd/authorize/authorize.go
@@ -25,8 +25,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "authorize",
 	Short: `Remote authorization.`,
-	Long: `
-Remote authorization. Used to authorize a remote or headless
+	Long: `Remote authorization. Used to authorize a remote or headless
 rclone from a machine with a browser - use as instructed by
 rclone config.
 

--- a/cmd/backend/backend.go
+++ b/cmd/backend/backend.go
@@ -31,8 +31,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "backend <command> remote:path [opts] <args>",
 	Short: `Run a backend-specific command.`,
-	Long: `
-This runs a backend-specific command. The commands themselves (except
+	Long: `This runs a backend-specific command. The commands themselves (except
 for "help" and "features") are defined by the backends and you should
 see the backend docs for definitions.
 

--- a/cmd/cachestats/cachestats.go
+++ b/cmd/cachestats/cachestats.go
@@ -20,8 +20,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "cachestats source:",
 	Short: `Print cache stats for a remote`,
-	Long: `
-Print cache stats for a remote in JSON format
+	Long: `Print cache stats for a remote in JSON format
 `,
 	Hidden: true,
 	Annotations: map[string]string{

--- a/cmd/cat/cat.go
+++ b/cmd/cat/cat.go
@@ -39,8 +39,7 @@ var commandDefinition = &cobra.Command{
 	Use:   "cat remote:path",
 	Short: `Concatenates any files and sends them to stdout.`,
 	// Warning! "|" will be replaced by backticks below
-	Long: strings.ReplaceAll(`
-rclone cat sends any files to standard output.
+	Long: strings.ReplaceAll(`Sends any files to standard output.
 
 You can use it like this to output a single file
 

--- a/cmd/check/check.go
+++ b/cmd/check/check.go
@@ -138,8 +138,7 @@ func GetCheckOpt(fsrc, fdst fs.Fs) (opt *operations.CheckOpt, close func(), err 
 var commandDefinition = &cobra.Command{
 	Use:   "check source:path dest:path",
 	Short: `Checks the files in the source and destination match.`,
-	Long: strings.ReplaceAll(`
-Checks the files in the source and destination match.  It compares
+	Long: strings.ReplaceAll(`Checks the files in the source and destination match.  It compares
 sizes and hashes (MD5 or SHA1) and logs a report of files that don't
 match.  It doesn't alter the source or destination.
 

--- a/cmd/checksum/checksum.go
+++ b/cmd/checksum/checksum.go
@@ -26,8 +26,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "checksum <hash> sumfile dst:path",
 	Short: `Checks the files in the destination against a SUM file.`,
-	Long: strings.ReplaceAll(`
-Checks that hashsums of destination files match the SUM file.
+	Long: strings.ReplaceAll(`Checks that hashsums of destination files match the SUM file.
 It compares hashes (MD5, SHA1, etc) and logs a report of files which
 don't match.  It doesn't alter the file system.
 

--- a/cmd/cleanup/cleanup.go
+++ b/cmd/cleanup/cleanup.go
@@ -16,8 +16,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "cleanup remote:path",
 	Short: `Clean up the remote if possible.`,
-	Long: `
-Clean up the remote if possible.  Empty the trash or delete old file
+	Long: `Clean up the remote if possible.  Empty the trash or delete old file
 versions. Not supported by all remotes.
 `,
 	Annotations: map[string]string{

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -268,8 +268,7 @@ as a readable demonstration.
 var configCreateCommand = &cobra.Command{
 	Use:   "create name type [key value]*",
 	Short: `Create a new remote with name, type and options.`,
-	Long: strings.ReplaceAll(`
-Create a new remote of |name| with |type| and options.  The options
+	Long: strings.ReplaceAll(`Create a new remote of |name| with |type| and options.  The options
 should be passed in pairs of |key| |value| or as |key=value|.
 
 For example, to make a swift remote of name myremote using auto config
@@ -334,8 +333,7 @@ func init() {
 var configUpdateCommand = &cobra.Command{
 	Use:   "update name [key value]+",
 	Short: `Update options in an existing remote.`,
-	Long: strings.ReplaceAll(`
-Update an existing remote's options. The options should be passed in
+	Long: strings.ReplaceAll(`Update an existing remote's options. The options should be passed in
 pairs of |key| |value| or as |key=value|.
 
 For example, to update the env_auth field of a remote of name myremote
@@ -379,8 +377,7 @@ var configDeleteCommand = &cobra.Command{
 var configPasswordCommand = &cobra.Command{
 	Use:   "password name [key value]+",
 	Short: `Update password in an existing remote.`,
-	Long: strings.ReplaceAll(`
-Update an existing remote's password. The password
+	Long: strings.ReplaceAll(`Update an existing remote's password. The password
 should be passed in pairs of |key| |password| or as |key=password|.
 The |password| should be passed in in clear (unobscured).
 
@@ -435,8 +432,7 @@ func argsToMap(args []string) (out rc.Params, err error) {
 var configReconnectCommand = &cobra.Command{
 	Use:   "reconnect remote:",
 	Short: `Re-authenticates user with remote.`,
-	Long: `
-This reconnects remote: passed in to the cloud storage system.
+	Long: `This reconnects remote: passed in to the cloud storage system.
 
 To disconnect the remote use "rclone config disconnect".
 
@@ -456,8 +452,7 @@ This normally means going through the interactive oauth flow again.
 var configDisconnectCommand = &cobra.Command{
 	Use:   "disconnect remote:",
 	Short: `Disconnects user from remote`,
-	Long: `
-This disconnects the remote: passed in to the cloud storage system.
+	Long: `This disconnects the remote: passed in to the cloud storage system.
 
 This normally means revoking the oauth token.
 
@@ -489,8 +484,7 @@ func init() {
 var configUserInfoCommand = &cobra.Command{
 	Use:   "userinfo remote:",
 	Short: `Prints info about logged in user of remote.`,
-	Long: `
-This prints the details of the person logged in to the cloud storage
+	Long: `This prints the details of the person logged in to the cloud storage
 system.
 `,
 	RunE: func(command *cobra.Command, args []string) error {

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -26,8 +26,7 @@ var commandDefinition = &cobra.Command{
 	Use:   "copy source:path dest:path",
 	Short: `Copy files from source to dest, skipping identical files.`,
 	// Note: "|" will be replaced by backticks below
-	Long: strings.ReplaceAll(`
-Copy the source to the destination.  Does not transfer files that are
+	Long: strings.ReplaceAll(`Copy the source to the destination.  Does not transfer files that are
 identical on source and destination, testing by size and modification
 time or MD5SUM.  Doesn't delete files from the destination. If you
 want to also delete files from destination, to make it match source,

--- a/cmd/copyto/copyto.go
+++ b/cmd/copyto/copyto.go
@@ -17,8 +17,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "copyto source:path dest:path",
 	Short: `Copy files from source to dest, skipping identical files.`,
-	Long: `
-If source:path is a file or directory then it copies it to a file or
+	Long: `If source:path is a file or directory then it copies it to a file or
 directory named dest:path.
 
 This can be used to upload single files to other than their current

--- a/cmd/copyurl/copyurl.go
+++ b/cmd/copyurl/copyurl.go
@@ -36,8 +36,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "copyurl https://example.com dest:path",
 	Short: `Copy the contents of the URL supplied content to dest:path.`,
-	Long: strings.ReplaceAll(`
-Download a URL's content and copy it to the destination without saving
+	Long: strings.ReplaceAll(`Download a URL's content and copy it to the destination without saving
 it in temporary storage.
 
 Setting |--auto-filename| will attempt to automatically determine the

--- a/cmd/cryptcheck/cryptcheck.go
+++ b/cmd/cryptcheck/cryptcheck.go
@@ -23,10 +23,9 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "cryptcheck remote:path cryptedremote:path",
 	Short: `Cryptcheck checks the integrity of an encrypted remote.`,
-	Long: `
-rclone cryptcheck checks a remote against a [crypted](/crypt/) remote.
-This is the equivalent of running rclone [check](/commands/rclone_check/),
-but able to check the checksums of the encrypted remote.
+	Long: `Checks a remote against a [crypted](/crypt/) remote. This is the equivalent
+of running rclone [check](/commands/rclone_check/), but able to check the
+checksums of the encrypted remote.
 
 For it to work the underlying remote of the cryptedremote must support
 some kind of checksum.

--- a/cmd/cryptdecode/cryptdecode.go
+++ b/cmd/cryptdecode/cryptdecode.go
@@ -26,9 +26,8 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "cryptdecode encryptedremote: encryptedfilename",
 	Short: `Cryptdecode returns unencrypted file names.`,
-	Long: `
-rclone cryptdecode returns unencrypted file names when provided with
-a list of encrypted file names. List limit is 10 items.
+	Long: `Returns unencrypted file names when provided with a list of encrypted file
+names. List limit is 10 items.
 
 If you supply the ` + "`--reverse`" + ` flag, it will return encrypted file names.
 

--- a/cmd/dedupe/dedupe.go
+++ b/cmd/dedupe/dedupe.go
@@ -27,9 +27,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "dedupe [mode] remote:path",
 	Short: `Interactively find duplicate filenames and delete/rename them.`,
-	Long: `
-
-By default ` + "`dedupe`" + ` interactively finds files with duplicate
+	Long: `By default ` + "`dedupe`" + ` interactively finds files with duplicate
 names and offers to delete all but one or rename them to be
 different. This is known as deduping by name.
 

--- a/cmd/delete/delete.go
+++ b/cmd/delete/delete.go
@@ -25,8 +25,7 @@ var commandDefinition = &cobra.Command{
 	Use:   "delete remote:path",
 	Short: `Remove the files in path.`,
 	// Warning! "|" will be replaced by backticks below
-	Long: strings.ReplaceAll(`
-Remove the files in path.  Unlike [purge](/commands/rclone_purge/) it
+	Long: strings.ReplaceAll(`Remove the files in path.  Unlike [purge](/commands/rclone_purge/) it
 obeys include/exclude filters so can be used to selectively delete files.
 
 |rclone delete| only deletes files but leaves the directory structure

--- a/cmd/deletefile/deletefile.go
+++ b/cmd/deletefile/deletefile.go
@@ -18,8 +18,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "deletefile remote:path",
 	Short: `Remove a single file from remote.`,
-	Long: `
-Remove a single file from remote.  Unlike ` + "`" + `delete` + "`" + ` it cannot be used to
+	Long: `Remove a single file from remote.  Unlike ` + "`" + `delete` + "`" + ` it cannot be used to
 remove a directory and it doesn't obey include/exclude filters - if the specified file exists,
 it will always be removed.
 `,

--- a/cmd/genautocomplete/genautocomplete.go
+++ b/cmd/genautocomplete/genautocomplete.go
@@ -13,8 +13,7 @@ func init() {
 var completionDefinition = &cobra.Command{
 	Use:   "completion [shell]",
 	Short: `Output completion script for a given shell.`,
-	Long: `
-Generates a shell completion script for rclone.
+	Long: `Generates a shell completion script for rclone.
 Run with ` + "`--help`" + ` to list the supported shells.
 `,
 	Annotations: map[string]string{

--- a/cmd/genautocomplete/genautocomplete_bash.go
+++ b/cmd/genautocomplete/genautocomplete_bash.go
@@ -15,8 +15,7 @@ func init() {
 var bashCommandDefinition = &cobra.Command{
 	Use:   "bash [output_file]",
 	Short: `Output bash completion script for rclone.`,
-	Long: `
-Generates a bash shell autocompletion script for rclone.
+	Long: `Generates a bash shell autocompletion script for rclone.
 
 By default, when run without any arguments, 
 

--- a/cmd/genautocomplete/genautocomplete_fish.go
+++ b/cmd/genautocomplete/genautocomplete_fish.go
@@ -15,8 +15,7 @@ func init() {
 var fishCommandDefinition = &cobra.Command{
 	Use:   "fish [output_file]",
 	Short: `Output fish completion script for rclone.`,
-	Long: `
-Generates a fish autocompletion script for rclone.
+	Long: `Generates a fish autocompletion script for rclone.
 
 This writes to /etc/fish/completions/rclone.fish by default so will
 probably need to be run with sudo or as root, e.g.

--- a/cmd/genautocomplete/genautocomplete_powershell.go
+++ b/cmd/genautocomplete/genautocomplete_powershell.go
@@ -15,8 +15,7 @@ func init() {
 var powershellCommandDefinition = &cobra.Command{
 	Use:   "powershell [output_file]",
 	Short: `Output powershell completion script for rclone.`,
-	Long: `
-Generate the autocompletion script for powershell.
+	Long: `Generate the autocompletion script for powershell.
 
 To load completions in your current shell session:
 

--- a/cmd/genautocomplete/genautocomplete_zsh.go
+++ b/cmd/genautocomplete/genautocomplete_zsh.go
@@ -15,8 +15,7 @@ func init() {
 var zshCommandDefinition = &cobra.Command{
 	Use:   "zsh [output_file]",
 	Short: `Output zsh completion script for rclone.`,
-	Long: `
-Generates a zsh autocompletion script for rclone.
+	Long: `Generates a zsh autocompletion script for rclone.
 
 This writes to /usr/share/zsh/vendor-completions/_rclone by default so will
 probably need to be run with sudo or as root, e.g.

--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -53,8 +53,7 @@ aliases:
 var commandDefinition = &cobra.Command{
 	Use:   "gendocs output_directory",
 	Short: `Output markdown docs for rclone to the directory supplied.`,
-	Long: `
-This produces markdown docs for the rclone commands to the directory
+	Long: `This produces markdown docs for the rclone commands to the directory
 supplied.  These are in a format suitable for hugo to render into the
 rclone.org website.`,
 	Annotations: map[string]string{

--- a/cmd/hashsum/hashsum.go
+++ b/cmd/hashsum/hashsum.go
@@ -84,8 +84,7 @@ func CreateFromStdinArg(ht hash.Type, args []string, startArg int) (bool, error)
 var commandDefinition = &cobra.Command{
 	Use:   "hashsum [<hash> remote:path]",
 	Short: `Produces a hashsum file for all the objects in the path.`,
-	Long: `
-Produces a hash file for all the objects in the path using the hash
+	Long: `Produces a hash file for all the objects in the path using the hash
 named.  The output is in the same format as the standard
 md5sum/sha1sum tool.
 

--- a/cmd/help.go
+++ b/cmd/help.go
@@ -27,8 +27,7 @@ import (
 var Root = &cobra.Command{
 	Use:   "rclone",
 	Short: "Show help for rclone commands, flags and backends.",
-	Long: `
-Rclone syncs files to and from cloud storage providers as well as
+	Long: `Rclone syncs files to and from cloud storage providers as well as
 mounting them, listing them in lots of different ways.
 
 See the home page (https://rclone.org/) for installation, usage,

--- a/cmd/link/link.go
+++ b/cmd/link/link.go
@@ -27,8 +27,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "link remote:path",
 	Short: `Generate public link to file/folder.`,
-	Long: `rclone link will create, retrieve or remove a public link to the given
-file or folder.
+	Long: `Create, retrieve or remove a public link to the given file or folder.
 
     rclone link remote:path/to/file
     rclone link remote:path/to/folder/

--- a/cmd/listremotes/listremotes.go
+++ b/cmd/listremotes/listremotes.go
@@ -115,8 +115,8 @@ var commandDefinition = &cobra.Command{
 	Use:   "listremotes [<filter>]",
 	Short: `List all the remotes in the config file and defined in environment variables.`,
 	Long: `
-rclone listremotes lists all the available remotes from the config file,
-or the remotes matching an optional filter.
+Lists all the available remotes from the config file, or the remotes matching
+an optional filter.
 
 Prints the result in human-readable format by default, and as a simple list of
 remote names, or if used with flag ` + "`--long`" + ` a tabular format including

--- a/cmd/ls/ls.go
+++ b/cmd/ls/ls.go
@@ -18,8 +18,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "ls remote:path",
 	Short: `List the objects in the path with size and path.`,
-	Long: `
-Lists the objects in the source path to standard output in a human
+	Long: `Lists the objects in the source path to standard output in a human
 readable format with size and path. Recurses by default.
 
 Eg

--- a/cmd/lsd/lsd.go
+++ b/cmd/lsd/lsd.go
@@ -26,8 +26,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "lsd remote:path",
 	Short: `List all directories/containers/buckets in the path.`,
-	Long: `
-Lists the directories in the source path to standard output. Does not
+	Long: `Lists the directories in the source path to standard output. Does not
 recurse by default.  Use the ` + "`-R`" + ` flag to recurse.
 
 This command lists the total size of the directory (if known, -1 if

--- a/cmd/lsf/lsf.go
+++ b/cmd/lsf/lsf.go
@@ -47,8 +47,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "lsf remote:path",
 	Short: `List directories and objects in remote:path formatted for parsing.`,
-	Long: `
-List the contents of the source path (directories and objects) to
+	Long: `List the contents of the source path (directories and objects) to
 standard output in a form which is easy to parse by scripts.  By
 default this will just be the names of the objects and directories,
 one per line.  The directories will have a / suffix.

--- a/cmd/lsl/lsl.go
+++ b/cmd/lsl/lsl.go
@@ -18,8 +18,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "lsl remote:path",
 	Short: `List the objects in path with modification time, size and path.`,
-	Long: `
-Lists the objects in the source path to standard output in a human
+	Long: `Lists the objects in the source path to standard output in a human
 readable format with modification time, size and path. Recurses by default.
 
 Eg

--- a/cmd/md5sum/md5sum.go
+++ b/cmd/md5sum/md5sum.go
@@ -20,8 +20,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "md5sum remote:path",
 	Short: `Produces an md5sum file for all the objects in the path.`,
-	Long: `
-Produces an md5sum file for all the objects in the path.  This
+	Long: `Produces an md5sum file for all the objects in the path.  This
 is in the same format as the standard md5sum tool produces.
 
 By default, the hash is requested from the remote.  If MD5 is

--- a/cmd/move/move.go
+++ b/cmd/move/move.go
@@ -29,8 +29,7 @@ var commandDefinition = &cobra.Command{
 	Use:   "move source:path dest:path",
 	Short: `Move files from source to dest.`,
 	// Warning! "|" will be replaced by backticks below
-	Long: strings.ReplaceAll(`
-Moves the contents of the source directory to the destination
+	Long: strings.ReplaceAll(`Moves the contents of the source directory to the destination
 directory. Rclone will error if the source and destination overlap and
 the remote does not support a server-side directory move operation.
 

--- a/cmd/moveto/moveto.go
+++ b/cmd/moveto/moveto.go
@@ -17,8 +17,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "moveto source:path dest:path",
 	Short: `Move file or directory from source to dest.`,
-	Long: `
-If source:path is a file or directory then it moves it to a file or
+	Long: `If source:path is a file or directory then it moves it to a file or
 directory named dest:path.
 
 This can be used to rename files or upload single files to other than

--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -31,8 +31,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "ncdu remote:path",
 	Short: `Explore a remote with a text based user interface.`,
-	Long: `
-This displays a text based user interface allowing the navigation of a
+	Long: `This displays a text based user interface allowing the navigation of a
 remote. It is most useful for answering the question - "What is using
 all my disk space?".
 

--- a/cmd/purge/purge.go
+++ b/cmd/purge/purge.go
@@ -16,8 +16,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "purge remote:path",
 	Short: `Remove the path and all of its contents.`,
-	Long: `
-Remove the path and all of its contents.  Note that this does not obey
+	Long: `Remove the path and all of its contents.  Note that this does not obey
 include/exclude filters - everything will be removed.  Use the
 [delete](/commands/rclone_delete/) command if you want to selectively
 delete files. To delete empty directories only, use command

--- a/cmd/rc/rc.go
+++ b/cmd/rc/rc.go
@@ -51,9 +51,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "rc commands parameter",
 	Short: `Run a command against a running rclone.`,
-	Long: strings.ReplaceAll(`
-
-This runs a command against a running rclone.  Use the |--url| flag to
+	Long: strings.ReplaceAll(`This runs a command against a running rclone.  Use the |--url| flag to
 specify an non default URL to connect on.  This can be either a
 ":port" which is taken to mean "http://localhost:port" or a
 "host:port" which is taken to mean "http://host:port"

--- a/cmd/rcat/rcat.go
+++ b/cmd/rcat/rcat.go
@@ -26,9 +26,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "rcat remote:path",
 	Short: `Copies standard input to file on remote.`,
-	Long: `
-rclone rcat reads from standard input (stdin) and copies it to a
-single remote file.
+	Long: `Reads from standard input (stdin) and copies it to a single remote file.
 
     echo "hello world" | rclone rcat remote:path/to/file
     ffmpeg - | rclone rcat remote:path/to/file

--- a/cmd/rmdir/rmdir.go
+++ b/cmd/rmdir/rmdir.go
@@ -16,8 +16,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "rmdir remote:path",
 	Short: `Remove the empty directory at path.`,
-	Long: `
-This removes empty directory given by path. Will not remove the path if it
+	Long: `This removes empty directory given by path. Will not remove the path if it
 has any objects in it, not even empty subdirectories. Use
 command [rmdirs](/commands/rclone_rmdirs/) (or [delete](/commands/rclone_delete/)
 with option ` + "`--rmdirs`" + `) to do that.

--- a/cmd/rmdirs/rmdirs.go
+++ b/cmd/rmdirs/rmdirs.go
@@ -21,8 +21,7 @@ func init() {
 var rmdirsCmd = &cobra.Command{
 	Use:   "rmdirs remote:path",
 	Short: `Remove empty directories under the path.`,
-	Long: `
-This recursively removes any empty directories (including directories
+	Long: `This recursively removes any empty directories (including directories
 that only contain empty directories), that it finds under the path.
 The root path itself will also be removed if it is empty, unless
 you supply the ` + "`--leave-root`" + ` flag.

--- a/cmd/settier/settier.go
+++ b/cmd/settier/settier.go
@@ -17,10 +17,9 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "settier tier remote:path",
 	Short: `Changes storage class/tier of objects in remote.`,
-	Long: `
-rclone settier changes storage tier or class at remote if supported.
-Few cloud storage services provides different storage classes on objects,
-for example AWS S3 and Glacier, Azure Blob storage - Hot, Cool and Archive,
+	Long: `Changes storage tier or class at remote if supported. Few cloud storage
+services provides different storage classes on objects, for example
+AWS S3 and Glacier, Azure Blob storage - Hot, Cool and Archive,
 Google Cloud Storage, Regional Storage, Nearline, Coldline etc.
 
 Note that, certain tier changes make objects not available to access immediately.

--- a/cmd/sha1sum/sha1sum.go
+++ b/cmd/sha1sum/sha1sum.go
@@ -20,8 +20,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "sha1sum remote:path",
 	Short: `Produces an sha1sum file for all the objects in the path.`,
-	Long: `
-Produces an sha1sum file for all the objects in the path.  This
+	Long: `Produces an sha1sum file for all the objects in the path.  This
 is in the same format as the standard sha1sum tool produces.
 
 By default, the hash is requested from the remote.  If SHA-1 is

--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -26,8 +26,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "size remote:path",
 	Short: `Prints the total size and number of objects in remote:path.`,
-	Long: `
-Counts objects in the path and calculates the total size. Prints the
+	Long: `Counts objects in the path and calculates the total size. Prints the
 result to standard output.
 
 By default the output is in human-readable format, but shows values in

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -139,8 +139,7 @@ func anyNotBlank(s ...string) bool {
 var commandDefinition = &cobra.Command{
 	Use:   "sync source:path dest:path",
 	Short: `Make source and dest identical, modifying destination only.`,
-	Long: `
-Sync the source to the destination, changing the destination
+	Long: `Sync the source to the destination, changing the destination
 only.  Doesn't transfer files that are identical on source and
 destination, testing by size and modification time or MD5SUM.
 Destination is updated to match source, including deleting files

--- a/cmd/test/info/info.go
+++ b/cmd/test/info/info.go
@@ -64,10 +64,10 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "info [remote:path]+",
 	Short: `Discovers file name or other limitations for paths.`,
-	Long: `rclone info discovers what filenames and upload methods are possible
-to write to the paths passed in and how long they can be.  It can take some
-time.  It will write test files into the remote:path passed in.  It outputs
-a bit of go code for each one.
+	Long: `Discovers what filenames and upload methods are possible to write to the
+paths passed in and how long they can be.  It can take some time.  It will
+write test files into the remote:path passed in.  It outputs a bit of go
+code for each one.
 
 **NB** this can create undeletable files and other hazards - use with care
 `,

--- a/cmd/touch/touch.go
+++ b/cmd/touch/touch.go
@@ -43,8 +43,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "touch remote:path",
 	Short: `Create new file or change file modification time.`,
-	Long: `
-Set the modification time on file(s) as specified by remote:path to
+	Long: `Set the modification time on file(s) as specified by remote:path to
 have the current time.
 
 If remote:path does not exist then a zero sized file will be created,

--- a/cmd/tree/tree.go
+++ b/cmd/tree/tree.go
@@ -69,9 +69,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "tree remote:path",
 	Short: `List the contents of the remote in a tree like fashion.`,
-	Long: `
-rclone tree lists the contents of a remote in a similar way to the
-unix tree command.
+	Long: `Lists the contents of a remote in a similar way to the unix tree command.
 
 For example
 

--- a/cmd/version/version.go
+++ b/cmd/version/version.go
@@ -31,8 +31,7 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "version",
 	Short: `Show the version number.`,
-	Long: `
-Show the rclone version number, the go version, the build target
+	Long: `Show the rclone version number, the go version, the build target
 OS and architecture, the runtime OS and kernel version and bitness,
 build tags and the type of executable (static or dynamic).
 


### PR DESCRIPTION
#### What is the purpose of this change?

Currently the command help of some subcommands start with a blank line, while others not, e.g. `ls` did but not `lsjson`:

```
> rclone.exe ls -h

Lists the objects in the source path to standard output in a human
readable format with size and path. Recurses by default.
...

> rclone.exe lsjson -h
List directories and objects in the path in JSON format.
...
```

This PR makes it consistent with no empty line.

Also did some small rewording to make first sentence more clean and consistent. The following show some of the variants:

```
Rclone test is used ....
rclone rcat reads ....
`rclone about`" + ` prints ...
Prints quota information about ...
This runs a ...
This command outputs ...
```

The different formatting of the ones starting with "rclone" hurt my eyes, so I changed those to the form most commonly used:
```
Prints quota information about ...
```

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
