### PR TITLE
refactor: replace min/max helpers with built-in min/max

### DIFF
--- a/backend/swift/swift.go
+++ b/backend/swift/swift.go
@@ -1410,14 +1410,6 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	return
 }
 
-// min returns the smallest of x, y
-func min(x, y int64) int64 {
-	if x < y {
-		return x
-	}
-	return y
-}
-
 // Get the segments for a large object
 //
 // It returns the names of the segments and the container that they live in

--- a/lib/ranges/ranges.go
+++ b/lib/ranges/ranges.go
@@ -36,20 +36,6 @@ func (r *Range) Clip(offset int64) {
 	}
 }
 
-func min(a, b int64) int64 {
-	if a < b {
-		return a
-	}
-	return b
-}
-
-func max(a, b int64) int64 {
-	if a > b {
-		return a
-	}
-	return b
-}
-
 // Intersection returns the common Range for two Range~s
 //
 // If there is no intersection then the Range returned will have


### PR DESCRIPTION
#### What is the purpose of this change?

We upgraded our minimum Go version in commit ca24447090. We can now use the built-in `min` and `max` functions directly.

Reference: https://go.dev/ref/spec#Min_and_max

#### Was the change discussed in an issue or in the forum before?

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
