### PR TITLE
bisync: don't convert modtime precision in listings - fixes #8025

### DIFF
--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -1812,6 +1812,12 @@ about _Unison_ and synchronization in general.
 
 ## Changelog
 
+### `v1.68`
+* Fixed an issue affecting backends that round modtimes to a lower precision.
+
+### `v1.67`
+* Added integration tests against all backends.
+
 ### `v1.66`
 * Copies and deletes are now handled in one operation instead of two
 * `--track-renames` and `--backup-dir` are now supported


### PR DESCRIPTION
#### What is the purpose of this change?

Before this change, bisync proactively converted modtime precision when greater than what the destination backend supported. 

This dates back to a time before bisync considered the `modifyWindow` for same-side comparisons. Back then, it was problematic to save a listing with `12:54:49.7` for a backend that can't handle that precision, as on the next run the backend would report the time as `12:54:50` and bisync would think the file had changed. So the truncation was a workaround to anticipate this and proactively record the time with the precision we expect to receive next time.

However, this caused problems for backends (such as `dropbox`) that round instead of truncating as bisync expected.

After this change, bisync preserves the original precision in the listing (without conversion), even when greater than what the backend supports, to avoid rounding error. On the next run, bisync will compare it to the rounded time reported by the backend, and if it's within the `modifyWindow`, it will treat them as equivalent.

#### Was the change discussed in an issue or in the forum before?

- #8025 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
