### PR TITLE
operations: copy: generate stable partial suffix

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1345,11 +1345,12 @@ flag set) such as:
 - local
 - ftp
 - sftp
+- pcloud
 
 Without `--inplace` (the default) rclone will first upload to a
 temporary file with an extension like this, where `XXXXXX` represents a
-random string and `.partial` is [--partial-suffix](#partial-suffix) value
-(`.partial` by default).
+hash of the source file's fingerprint and `.partial` is 
+[--partial-suffix](#partial-suffix) value (`.partial` by default).
 
     original-file-name.XXXXXX.partial
 

--- a/fs/operations/copy.go
+++ b/fs/operations/copy.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"hash/crc32"
 	"io"
 	"path"
 	"strings"
@@ -20,7 +21,6 @@ import (
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/lib/atexit"
 	"github.com/rclone/rclone/lib/pacer"
-	"github.com/rclone/rclone/lib/random"
 )
 
 // State of the copy
@@ -87,7 +87,7 @@ func TruncateString(s string, n int) string {
 }
 
 // Check to see if we should be using a partial name and return the name for the copy and the inplace flag
-func (c *copy) checkPartial() (remoteForCopy string, inplace bool, err error) {
+func (c *copy) checkPartial(ctx context.Context) (remoteForCopy string, inplace bool, err error) {
 	remoteForCopy = c.remote
 	if c.ci.Inplace || c.dstFeatures.Move == nil || !c.dstFeatures.PartialUploads || strings.HasSuffix(c.remote, ".rclonelink") {
 		return remoteForCopy, true, nil
@@ -97,7 +97,11 @@ func (c *copy) checkPartial() (remoteForCopy string, inplace bool, err error) {
 	}
 	// Avoid making the leaf name longer if it's already lengthy to avoid
 	// trouble with file name length limits.
-	suffix := "." + random.String(8) + c.ci.PartialSuffix
+
+	// generate a stable random suffix by hashing the fingerprint
+	hash := crc32.ChecksumIEEE([]byte(fs.Fingerprint(ctx, c.src, true)))
+
+	suffix := fmt.Sprintf(".%x%s", hash, c.ci.PartialSuffix)
 	base := path.Base(remoteForCopy)
 	if len(base) > 100 {
 		remoteForCopy = TruncateString(remoteForCopy, len(remoteForCopy)-len(suffix)) + suffix
@@ -400,7 +404,7 @@ func Copy(ctx context.Context, f fs.Fs, dst fs.Object, remote string, src fs.Obj
 	// Are we using partials?
 	//
 	// If so set the flag and update the name we use for the copy
-	c.remoteForCopy, c.inplace, err = c.checkPartial()
+	c.remoteForCopy, c.inplace, err = c.checkPartial(ctx)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This PR changes the randomly generated suffix for partial files into stable ones, based on the sources fingerprint.
This brings some advantages:

- Less duplicated partial files by SIGTERM interrupts & re-runs
- Enables the possibility to [resume uploads](https://github.com/rclone/rclone/issues/87#issuecomment-2305902532)

#### Was the change discussed in an issue or in the forum before?

- Part of [this comment](https://github.com/rclone/rclone/issues/87#issuecomment-2305902532) of #87 
- Was initially part of #7949 but [splitted out during discussion](https://github.com/rclone/rclone/pull/7949#issuecomment-2227520700)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
