### PR TITLE
Document that paths using volume guids are supported

### DIFF
--- a/docs/content/local.md
+++ b/docs/content/local.md
@@ -130,12 +130,8 @@ This format requires absolute paths and the use of prefix `\\?\`,
 e.g. `\\?\D:\some\very\long\path`. For convenience rclone will automatically
 convert regular paths into the corresponding extended-length paths,
 so in most cases you do not have to worry about this (read more [below](#long-paths)).
-
-Note that Windows supports using the same prefix `\\?\` to
-specify path to volumes identified by their GUID, e.g.
-`\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\some\path`.
-This is *not* supported in rclone, due to an [issue](https://github.com/golang/go/issues/39785)
-in go.
+Using the same prefix `\\?\` it is also possible to specify path to volumes
+identified by their GUID, e.g. `\\?\Volume{b75e2c83-0000-0000-0000-602f00000000}\some\path`.
 
 #### Long paths ####
 


### PR DESCRIPTION
#### What is the purpose of this change?

Paths referring to volume name/guid was documented as not supported, but actually it became supported with our custom MkdirAll introduced with https://github.com/rclone/rclone/pull/5401 first included in rclone v1.57.0. Example usage:

```
rclone sync folder "\\?\Volume{a224c74f-da87-c295-3b90-cde0f64a29cc}\folder"
```

This PR updates the documentation accordingly. We have an open issue where the example above came from, reporting it does not work - but now it does.

In other words:

Closes https://github.com/rclone/rclone/issues/3864

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/3864

https://forum.rclone.org/t/using-hash-instead-of-drive-letters/47553

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
