### PR TITLE
docs: more secure two-step signature and hash validation

### DIFF
--- a/docs/content/release_signing.md
+++ b/docs/content/release_signing.md
@@ -149,7 +149,7 @@ $ rclone hashsum sha256 -C SHA256SUMS rclone-v1.63.1-windows-amd64.zip
 You can verify the signatures and hashes in one command line like this:
 
 ```
-$ gpg --decrypt SHA256SUMS | sha256sum -c --ignore-missing
+$ h=$(gpg --decrypt SHA256SUMS) && echo "$h" | sha256sum - -c --ignore-missing
 gpg: Signature made Mon 17 Jul 2023 15:03:17 BST
 gpg:                using DSA key FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA
 gpg: Good signature from "Nick Craig-Wood <nick@craig-wood.com>" [ultimate]


### PR DESCRIPTION
#### What is the purpose of this change?

Ensure that the status code return when verifying gpg signature is not swallowed when verifyin file hashes

#### Was the change discussed in an issue or in the forum before?

Propose a fix for issue #8024 

Same result in the "good" case :

```
gpg: Signature made Fri Jun 14 18:37:03 2024
gpg:                using DSA key FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA
gpg: Good signature from "Nick Craig-Wood <nick@craig-wood.com>" [unknown]
Primary key fingerprint: FBF7 37EC E9F8 AB18 604B  D2AC 9393 5E02 FF3B 54FA
rclone-v1.67.0.tar.gz: OK

$ echo $?
0
```

Same result in the "bad hash" case :

```
gpg: Signature made Fri Jun 14 18:37:03 2024
gpg:                using DSA key FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA
gpg: Good signature from "Nick Craig-Wood <nick@craig-wood.com>" [unknown]
Primary key fingerprint: FBF7 37EC E9F8 AB18 604B  D2AC 9393 5E02 FF3B 54FA
rclone-v1.67.0.tar.gz: FAILED
sha256sum: WARNING: 1 computed checksum did NOT match
sha256sum: 'standard input': no file was verified

$ echo $?
1
```

And a new result in the "bad signature" case :

```
gpg: Signature made Fri Jun 14 18:37:03 2024
gpg:                using DSA key FBF737ECE9F8AB18604BD2AC93935E02FF3B54FA
gpg: BAD signature from "Nick Craig-Wood <nick@craig-wood.com>" [unknown]

$ echo $?
1
```

#### Another feedback

The page at https://downloads.rclone.org/ does not list hash filed (md5, sha1, sha256) for `*-current-*` files, while all `vX.YY.z` sub-directories have hash files. So no signature is available directly from "current files" set. Using `VERSION` as a first stop, to then go in nested directories works but might seem counter-intuitive in contrast with the "current" files


