### PR TITLE
lib/batcher: Deprecate unused option: batch_commit_timeout

### DIFF
--- a/lib/batcher/options.go
+++ b/lib/batcher/options.go
@@ -66,8 +66,9 @@ default based on the batch_mode in use.
 		Advanced: true,
 	}, {
 		Name:     "batch_commit_timeout",
-		Help:     `Max time to wait for a batch to finish committing`,
+		Help:     `Max time to wait for a batch to finish committing. (no longer used)`,
 		Default:  fs.Duration(10 * time.Minute),
 		Advanced: true,
+		Hide:     fs.OptionHideBoth,
 	}}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

To ~~delete~~ deprecate an unused option in lib/batcher/.

I found that lib/batcher/ defines a `batch_commit_timeout` config, which is picked up by the dropbox and googlephotos backends, but couldn't find a struct field anywhere that hooks up to it.

With `git log -S`, I found that the code using the `BatchCommitTimeout` field was deleted in a1a8c21c709c1051df18d2b94e9eeecc158c7bc2, and then the struct field itself was deleted in b94806a1430172419bd945340611068bcaf6ff00. But the option's definition stuck around and so did the documentation, e.g. [RCLONE_DROPBOX_BATCH_COMMIT_TIMEOUT](https://github.com/rclone/rclone/blob/f8d782c02de5e42c354f281b4f32c4128fa5db1e/docs/content/dropbox.md?plain=1#L466-L469)!

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
