### PR TITLE
crypt.go Implement V2 cipher version with MD5 hash support

### DIFF
--- a/backend/crypt/cipher.go
+++ b/backend/crypt/cipher.go
@@ -18,6 +18,7 @@ import (
 	"unicode/utf8"
 
 	"github.com/Max-Sum/base32768"
+	keywrap "github.com/nickball/go-aes-key-wrap"
 	"github.com/rclone/rclone/backend/crypt/pkcs7"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/accounting"
@@ -35,9 +36,19 @@ const (
 	fileMagicSize       = len(fileMagic)
 	fileNonceSize       = 24
 	fileHeaderSize      = fileMagicSize + fileNonceSize
-	blockHeaderSize     = secretbox.Overhead
-	blockDataSize       = 64 * 1024
-	blockSize           = blockHeaderSize + blockDataSize
+
+	fileMagicV2         = "RCLONE\x00\x01"
+	fileMagicSizeV2     = len(fileMagicV2)
+	fileNonceSizeV2     = 23
+	fileReservedBytesV2 = 4
+	fileHeaderSizeV2    = fileMagicSizeV2 + fileNonceSizeV2 + fileWrappedCekSize + fileReservedBytesV2
+	fileCekSize         = 32
+	fileWrappedCekSize  = fileCekSize + 8 // Some overhead of AES RFC 3394 Key Wrapping
+
+	blockHeaderSize      = secretbox.Overhead
+	blockDataSize        = 64 * 1024
+	blockSize            = blockHeaderSize + blockDataSize
+	lastBlockFlag   byte = 1 // Corresponds to: `last_block` https://github.com/miscreant/meta/wiki/STREAM
 )
 
 // Errors returned by cipher
@@ -47,8 +58,9 @@ var (
 	ErrorNotAMultipleOfBlocksize = errors.New("not a multiple of blocksize")
 	ErrorTooShortAfterDecode     = errors.New("too short after base32 decode")
 	ErrorTooLongAfterDecode      = errors.New("too long after base32 decode")
-	ErrorEncryptedFileTooShort   = errors.New("file is too short to be encrypted")
+	ErrorEncryptedFileTooShort   = errors.New("file is too short to be decrypted")
 	ErrorEncryptedFileBadHeader  = errors.New("file has truncated block header")
+	ErrorEncryptedCekInvalid     = errors.New("file encryption key is invalid")
 	ErrorEncryptedBadMagic       = errors.New("not an encrypted file - bad magic string")
 	ErrorEncryptedBadBlock       = errors.New("failed to authenticate decrypted block - bad password?")
 	ErrorBadBase32Encoding       = errors.New("bad base32 filename encoding")
@@ -62,7 +74,8 @@ var (
 
 // Global variables
 var (
-	fileMagicBytes = []byte(fileMagic)
+	fileMagicBytes   = []byte(fileMagic)
+	fileMagicBytesV2 = []byte(fileMagicV2)
 )
 
 // ReadSeekCloser is the interface of the read handles
@@ -84,6 +97,15 @@ const (
 	NameEncryptionOff NameEncryptionMode = iota
 	NameEncryptionStandard
 	NameEncryptionObfuscated
+)
+const (
+	CipherVersionV1 = "1"
+	CipherVersionV2 = "2"
+)
+
+const (
+	BlockCipherXSalsa20 = 0x01 // Used currently
+	BlockCipherAESGCM   = 0x02 // Not used, possible future use (increase web performance): https://github.com/rclone/rclone/issues/7192#issuecomment-2353617267
 )
 
 // NewNameEncryptionMode turns a string into a NameEncryptionMode
@@ -181,6 +203,7 @@ type Cipher struct {
 	dirNameEncrypt  bool
 	passBadBlocks   bool // if set passed bad blocks as zeroed blocks
 	encryptedSuffix string
+	version         string
 }
 
 // newCipher initialises the cipher.  If salt is "" then it uses a built in salt val
@@ -191,6 +214,7 @@ func newCipher(mode NameEncryptionMode, password, salt string, dirNameEncrypt bo
 		cryptoRand:      rand.Reader,
 		dirNameEncrypt:  dirNameEncrypt,
 		encryptedSuffix: ".bin",
+		version:         CipherVersionV1, // Default to satisfy existing: `cipher_test.go`. For Rclone overridden by: `setCipherVersion` inside `newCipherForConfig` call.
 	}
 	c.buffers.New = func() interface{} {
 		return new([blockSize]byte)
@@ -218,6 +242,42 @@ func (c *Cipher) setEncryptedSuffix(suffix string) {
 // Call to set bad block pass through
 func (c *Cipher) setPassBadBlocks(passBadBlocks bool) {
 	c.passBadBlocks = passBadBlocks
+}
+
+func (c *Cipher) setCipherVersion(cipherVersion string) {
+	c.version = cipherVersion
+}
+
+func (c *Cipher) getFileHeaderSize() int {
+	if c.version == CipherVersionV2 {
+		return fileHeaderSizeV2
+	} else { // CipherVersionV1
+		return fileHeaderSize
+	}
+}
+
+func (c *Cipher) getFileMagicSize() int {
+	if c.version == CipherVersionV2 {
+		return fileMagicSizeV2
+	} else { // CipherVersionV1
+		return fileMagicSize
+	}
+}
+
+func (c *Cipher) getFileMagicBytes() []byte {
+	if c.version == CipherVersionV2 {
+		return fileMagicBytesV2
+	} else { // CipherVersionV1
+		return fileMagicBytes
+	}
+}
+
+func (c *Cipher) getFileNonceSize() int { // Effective nonce size. Both V1 and V2 use 24 bytes, but V2 consists 23+1 bytes nonce, where last byte is calculated dynamically depending if the processing block is last (truncation protection)
+	if c.version == CipherVersionV2 {
+		return fileNonceSizeV2
+	} else { // CipherVersionV1
+		return fileNonceSize
+	}
 }
 
 // Key creates all the internal keys from the password passed in using
@@ -619,6 +679,8 @@ func (c *Cipher) NameEncryptionMode() NameEncryptionMode {
 
 // nonce is an NACL secretbox nonce
 type nonce [fileNonceSize]byte
+type cek [fileCekSize]byte
+type wrappedCek [fileWrappedCekSize]byte
 
 // pointer returns the nonce as a *[24]byte for secretbox
 func (n *nonce) pointer() *[fileNonceSize]byte {
@@ -627,18 +689,33 @@ func (n *nonce) pointer() *[fileNonceSize]byte {
 
 // fromReader fills the nonce from an io.Reader - normally the OSes
 // crypto random number generator
-func (n *nonce) fromReader(in io.Reader) error {
-	read, err := readers.ReadFill(in, (*n)[:])
-	if read != fileNonceSize {
+func (n *nonce) fromReader(in io.Reader, expectedNonceSize int) error {
+	read, err := readers.ReadFill(in, (*n)[:expectedNonceSize])
+	if read != expectedNonceSize {
 		return fmt.Errorf("short read of nonce: %w", err)
 	}
 	return nil
 }
 
-// fromBuf fills the nonce from the buffer passed in
-func (n *nonce) fromBuf(buf []byte) {
+func (n *cek) fromReader(in io.Reader) error {
+	read, err := readers.ReadFill(in, (*n)[:])
+	if read != fileCekSize {
+		return fmt.Errorf("short read of CEK: %w", err)
+	}
+	return nil
+}
+
+func (n *wrappedCek) fromBuf(buf []byte) {
 	read := copy((*n)[:], buf)
-	if read != fileNonceSize {
+	if read != fileWrappedCekSize {
+		panic("buffer to short to read wrapped CEK")
+	}
+}
+
+// fromBuf fills the nonce from the buffer passed in
+func (n *nonce) fromBuf(buf []byte, expectedNonceSize int) {
+	read := copy((*n)[:], buf)
+	if read != expectedNonceSize {
 		panic("buffer to short to read nonce")
 	}
 }
@@ -681,6 +758,7 @@ func (n *nonce) add(x uint64) {
 type encrypter struct {
 	mu       sync.Mutex
 	in       io.Reader
+	cek      cek // File contents encryption key
 	c        *Cipher
 	nonce    nonce
 	buf      *[blockSize]byte
@@ -691,27 +769,67 @@ type encrypter struct {
 }
 
 // newEncrypter creates a new file handle encrypting on the fly
-func (c *Cipher) newEncrypter(in io.Reader, nonce *nonce) (*encrypter, error) {
+func (c *Cipher) newEncrypter(in io.Reader, nonce *nonce, cek *cek) (*encrypter, error) {
 	fh := &encrypter{
 		in:      in,
 		c:       c,
 		buf:     c.getBlock(),
 		readBuf: c.getBlock(),
-		bufSize: fileHeaderSize,
+		bufSize: c.getFileHeaderSize(),
 	}
 	// Initialise nonce
 	if nonce != nil {
 		fh.nonce = *nonce
 	} else {
-		err := fh.nonce.fromReader(c.cryptoRand)
+		err := fh.nonce.fromReader(c.cryptoRand, c.getFileNonceSize())
 		if err != nil {
 			return nil, err
 		}
 	}
 	// Copy magic into buffer
-	copy((*fh.buf)[:], fileMagicBytes)
+	copy((*fh.buf)[:], c.getFileMagicBytes())
+
 	// Copy nonce into buffer
-	copy((*fh.buf)[fileMagicSize:], fh.nonce[:])
+	copy((*fh.buf)[c.getFileMagicSize():], fh.nonce[:c.getFileNonceSize()])
+
+	if c.version == CipherVersionV1 {
+		fh.cek = fh.c.dataKey
+	}
+
+	if c.version == CipherVersionV2 {
+		if cek != nil {
+			fh.cek = *cek
+		} else { // Generate random CEK
+			err := fh.cek.fromReader(c.cryptoRand)
+			if err != nil {
+				return nil, err
+			}
+		}
+
+		// WRAP KEY - START
+		kek := fh.c.dataKey[:]
+		cipher, err := aes.NewCipher(kek)
+		if err != nil {
+			return nil, err
+		}
+
+		wrappedCek, err := keywrap.Wrap(cipher, fh.cek[:]) // Wrap encryption key, 32 bytes cek, will result in 40 bytes ciphertext
+		if err != nil {
+			return nil, err
+		}
+		// WRAP KEY - END
+
+		// Copy file encryption key
+		copy((*fh.buf)[c.getFileMagicSize()+c.getFileNonceSize():], wrappedCek)
+
+		// Copy 4 reserved bytes:
+		//	- cipher type (XSalsa20, AES-GCM etc.),
+		//	- not used,
+		//	- not used,
+		//	- not used
+		copy((*fh.buf)[c.getFileMagicSize()+c.getFileNonceSize()+fileWrappedCekSize:], []byte{BlockCipherXSalsa20, 0x00, 0x00, 0x00})
+	}
+
 	return fh, nil
 }
 
@@ -731,10 +849,17 @@ func (fh *encrypter) Read(p []byte) (n int, err error) {
 		if n == 0 {
 			return fh.finish(err)
 		}
+
+		isLastBlock := n < blockDataSize
+
+		if fh.c.version == CipherVersionV2 && isLastBlock {
+			fh.nonce[len(fh.nonce)-1] = lastBlockFlag // Set last block flag as the last byte of nonce
+		}
+
 		// possibly err != nil here, but we will process the
 		// data and the next call to ReadFill will return 0, err
 		// Encrypt the block using the nonce
-		secretbox.Seal((*fh.buf)[:0], readBuf[:n], fh.nonce.pointer(), &fh.c.dataKey)
+		secretbox.Seal((*fh.buf)[:0], readBuf[:n], fh.nonce.pointer(), (*[32]byte)(&fh.cek))
 		fh.bufIndex = 0
 		fh.bufSize = blockHeaderSize + n
 		fh.nonce.increment()
@@ -760,7 +885,7 @@ func (fh *encrypter) finish(err error) (int, error) {
 // Encrypt data encrypts the data stream
 func (c *Cipher) encryptData(in io.Reader) (io.Reader, *encrypter, error) {
 	in, wrap := accounting.UnWrap(in) // unwrap the accounting off the Reader
-	out, err := c.newEncrypter(in, nil)
+	out, err := c.newEncrypter(in, nil, nil)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -779,6 +904,7 @@ type decrypter struct {
 	rc           io.ReadCloser
 	nonce        nonce
 	initialNonce nonce
+	cek          [32]byte // File contents decryption key
 	c            *Cipher
 	buf          *[blockSize]byte
 	readBuf      *[blockSize]byte
@@ -787,6 +913,77 @@ type decrypter struct {
 	err          error
 	limit        int64 // limit of bytes to read, -1 for unlimited
 	open         OpenRangeSeek
+}
+
+// newDecrypter creates a new file handle decrypting on the fly
+func (c *Cipher) newDecrypter2(rc io.ReadCloser) (*decrypter, error) {
+	fh := &decrypter{
+		rc:      rc,
+		c:       c,
+		buf:     c.getBlock(),
+		readBuf: c.getBlock(),
+		limit:   -1,
+	}
+
+	// Read magic bytes to determine cipher version is used to configure valid decryption method
+	magicBuf := (*fh.readBuf)[:max(fileMagicSize, fileMagicSizeV2)] // Both fileMagicSize and fileMagicSizeV2 are the same size, however technically we need to read the longer one in order to determine cipher version
+	nMagic, err := readers.ReadFill(fh.rc, magicBuf)
+	if err != io.EOF && err != nil {
+		return nil, fh.finishAndClose(err)
+	}
+
+	isMagicHeader := bytes.Equal(magicBuf[:fileMagicSize], fileMagicBytes)
+	isMagicHeaderV2 := bytes.Equal(magicBuf[:fileMagicSizeV2], fileMagicBytesV2)
+	if !isMagicHeader && !isMagicHeaderV2 {
+		return nil, fh.finishAndClose(ErrorEncryptedBadMagic)
+	}
+
+	if isMagicHeader {
+		c.setCipherVersion(CipherVersionV1)
+		fh.cek = fh.c.dataKey
+	}
+
+	if isMagicHeaderV2 {
+		c.setCipherVersion(CipherVersionV2)
+	}
+
+	readBuf := (*fh.readBuf)[:c.getFileHeaderSize()-nMagic] // Skip magic bytes and read remaining part of the header: `nonce` (for V1); `nonce` and `cek` (for V2)
+	n, err := readers.ReadFill(fh.rc, readBuf)
+
+	totalBytesRead := nMagic + n
+	if totalBytesRead < c.getFileHeaderSize() && err == io.EOF {
+		// This read from 0..fileHeaderSize-1 bytes
+		return nil, fh.finishAndClose(ErrorEncryptedFileTooShort)
+	} else if err != io.EOF && err != nil {
+		return nil, fh.finishAndClose(err)
+	}
+	// check the magic
+
+	nonceStart := 0
+	nonceEnd := c.getFileNonceSize()
+
+	fh.nonce.fromBuf(readBuf[nonceStart:nonceEnd], c.getFileNonceSize()) // retrieve the nonce
+
+	if c.version == CipherVersionV2 {
+		var wrappedCek wrappedCek
+		wrappedCek.fromBuf(readBuf[nonceEnd:]) // retrieve wrapped file encryption key
+
+		kek := fh.c.dataKey[:]
+		cipher, err := aes.NewCipher(kek)
+		if err != nil {
+			return nil, fh.finishAndClose(err)
+		}
+
+		fileKey, err := keywrap.Unwrap(cipher, wrappedCek[:])
+		if err != nil {
+			return nil, fh.finishAndClose(ErrorEncryptedCekInvalid)
+		}
+
+		fh.cek = [32]byte(fileKey)
+	}
+
+	fh.initialNonce = fh.nonce
+	return fh, nil
 }
 
 // newDecrypter creates a new file handle decrypting on the fly
@@ -799,7 +996,7 @@ func (c *Cipher) newDecrypter(rc io.ReadCloser) (*decrypter, error) {
 		limit:   -1,
 	}
 	// Read file header (magic + nonce)
-	readBuf := (*fh.readBuf)[:fileHeaderSize]
+	readBuf := (*fh.readBuf)[:fileHeaderSize] // We read the `fileHeaderSize` first to determine the cipher version and get the nonce, then if it's V2 we read remaining bytes to satisfy `fileHeaderSizeV2`
 	n, err := readers.ReadFill(fh.rc, readBuf)
 	if n < fileHeaderSize && err == io.EOF {
 		// This read from 0..fileHeaderSize-1 bytes
@@ -807,13 +1004,59 @@ func (c *Cipher) newDecrypter(rc io.ReadCloser) (*decrypter, error) {
 	} else if err != io.EOF && err != nil {
 		return nil, fh.finishAndClose(err)
 	}
-	// check the magic
-	if !bytes.Equal(readBuf[:fileMagicSize], fileMagicBytes) {
+
+	isMagicHeader := bytes.Equal(readBuf[:fileMagicSize], fileMagicBytes)
+	isMagicHeaderV2 := bytes.Equal(readBuf[:fileMagicSizeV2], fileMagicBytesV2)
+
+	if isMagicHeader {
+		c.setCipherVersion(CipherVersionV1)
+		fh.cek = fh.c.dataKey
+	} else if isMagicHeaderV2 {
+		c.setCipherVersion(CipherVersionV2)
+	} else {
 		return nil, fh.finishAndClose(ErrorEncryptedBadMagic)
 	}
-	// retrieve the nonce
-	fh.nonce.fromBuf(readBuf[fileMagicSize:])
+
+	offsetStart := c.getFileMagicSize()
+	offsetEnd := offsetStart + c.getFileNonceSize()
+	fh.nonce.fromBuf(readBuf[offsetStart:offsetEnd], c.getFileNonceSize())
 	fh.initialNonce = fh.nonce
+
+	if c.version == CipherVersionV2 { // V2 cipher has a longer header, so after reading V1 header, we need to read remaining bytes from the reader to finialize V2 cipher initialization
+		remainingBytesFromV1Buffer := fileNonceSize - fileNonceSizeV2 // V2 nonce is 1 byte shorter, but this byte was already read to the `readBuf`, we use: `combinedBuffer` to append it to the beginning.
+		lastByte := readBuf[:len(readBuf)-remainingBytesFromV1Buffer]
+
+		remainingBytesReadSize := fileHeaderSizeV2 - fileHeaderSize
+		offsetStart = n // Previously read: `fileHeaderSize` bytes
+		offsetEnd = offsetStart + remainingBytesReadSize
+		readBuf = (*fh.readBuf)[offsetStart:offsetEnd]
+		n, err = readers.ReadFill(fh.rc, readBuf)
+
+		if n < remainingBytesReadSize && err == io.EOF {
+			return nil, fh.finishAndClose(ErrorEncryptedFileTooShort)
+		} else if err != io.EOF && err != nil {
+			return nil, fh.finishAndClose(err)
+		}
+
+		combinedBuffer := append(lastByte, readBuf...)
+
+		var wrappedCek wrappedCek
+		wrappedCek.fromBuf(combinedBuffer[:]) // retrieve wrapped file encryption key
+
+		kek := fh.c.dataKey[:]
+		cipher, err := aes.NewCipher(kek)
+		if err != nil {
+			return nil, fh.finishAndClose(err)
+		}
+
+		fileKey, err := keywrap.Unwrap(cipher, wrappedCek[:])
+		if err != nil {
+			return nil, fh.finishAndClose(ErrorEncryptedCekInvalid)
+		}
+
+		fh.cek = [32]byte(fileKey)
+	}
+
 	return fh, nil
 }
 
@@ -828,12 +1071,12 @@ func (c *Cipher) newDecrypterSeek(ctx context.Context, open OpenRangeSeek, offse
 		rc, err = open(ctx, 0, -1)
 	} else if offset == 0 {
 		// If no offset open the header + limit worth of the file
-		_, underlyingLimit, _, _ := calculateUnderlying(offset, limit)
-		rc, err = open(ctx, 0, int64(fileHeaderSize)+underlyingLimit)
+		_, underlyingLimit, _, _ := calculateUnderlying(offset, limit, c.getFileHeaderSize())
+		rc, err = open(ctx, 0, int64(c.getFileHeaderSize())+underlyingLimit)
 		setLimit = true
 	} else {
 		// Otherwise just read the header to start with
-		rc, err = open(ctx, 0, int64(fileHeaderSize))
+		rc, err = open(ctx, 0, int64(c.getFileHeaderSize()))
 		doRangeSeek = true
 	}
 	if err != nil {
@@ -876,8 +1119,13 @@ func (fh *decrypter) fillBuffer() (err error) {
 		}
 		return ErrorEncryptedFileBadHeader
 	}
+
+	if fh.c.version == CipherVersionV2 && n < blockDataSize { // last block
+		fh.nonce[len(fh.nonce)-1] = lastBlockFlag // Set last block flag at the last byte
+	}
+
 	// Decrypt the block using the nonce
-	_, ok := secretbox.Open((*fh.buf)[:0], (*readBuf)[:n], fh.nonce.pointer(), &fh.c.dataKey)
+	_, ok := secretbox.Open((*fh.buf)[:0], (*readBuf)[:n], fh.nonce.pointer(), &fh.cek)
 	if !ok {
 		if err != nil && err != io.EOF {
 			return err // return pending error as it is likely more accurate
@@ -926,18 +1174,18 @@ func (fh *decrypter) Read(p []byte) (n int, err error) {
 	return n, nil
 }
 
-// calculateUnderlying converts an (offset, limit) in an encrypted file
+// calculateUnderlying converts an (offset, limit, headerSize) in an encrypted file
 // into an (underlyingOffset, underlyingLimit) for the underlying file.
 //
 // It also returns number of bytes to discard after reading the first
 // block and number of blocks this is from the start so the nonce can
 // be incremented.
-func calculateUnderlying(offset, limit int64) (underlyingOffset, underlyingLimit, discard, blocks int64) {
+func calculateUnderlying(offset, limit int64, headerSize int) (underlyingOffset, underlyingLimit, discard, blocks int64) {
 	// blocks we need to seek, plus bytes we need to discard
 	blocks, discard = offset/blockDataSize, offset%blockDataSize
 
 	// Offset in underlying stream we need to seek
-	underlyingOffset = int64(fileHeaderSize) + blocks*(blockHeaderSize+blockDataSize)
+	underlyingOffset = int64(headerSize) + blocks*(blockHeaderSize+blockDataSize)
 
 	// work out how many blocks we need to read
 	underlyingLimit = int64(-1)
@@ -987,7 +1235,7 @@ func (fh *decrypter) RangeSeek(ctx context.Context, offset int64, whence int, li
 		return 0, fh.err
 	}
 
-	underlyingOffset, underlyingLimit, discard, blocks := calculateUnderlying(offset, limit)
+	underlyingOffset, underlyingLimit, discard, blocks := calculateUnderlying(offset, limit, fh.c.getFileHeaderSize())
 
 	// Move the nonce on the correct number of blocks from the start
 	fh.nonce = fh.initialNonce
@@ -1120,7 +1368,12 @@ func (c *Cipher) DecryptDataSeek(ctx context.Context, open OpenRangeSeek, offset
 // EncryptedSize calculates the size of the data when encrypted
 func (c *Cipher) EncryptedSize(size int64) int64 {
 	blocks, residue := size/blockDataSize, size%blockDataSize
-	encryptedSize := int64(fileHeaderSize) + blocks*(blockHeaderSize+blockDataSize)
+	encryptedSize := int64(c.getFileHeaderSize()) + blocks*(blockHeaderSize+blockDataSize)
+
+	if c.version == CipherVersionV2 {
+		encryptedSize += HashEncryptedSizeWithHeader
+	}
+
 	if residue != 0 {
 		encryptedSize += blockHeaderSize + residue
 	}
@@ -1129,10 +1382,27 @@ func (c *Cipher) EncryptedSize(size int64) int64 {
 
 // DecryptedSize calculates the size of the data when decrypted
 func (c *Cipher) DecryptedSize(size int64) (int64, error) {
-	size -= int64(fileHeaderSize)
-	if size < 0 {
+	size -= int64(c.getFileHeaderSize()) // WARNING: DecryptedSize might return invalid value before `newDecrypter()` is called if V2 cipher is enabled and user tries to read V1 object. Eventually `newDecrypter()` will be called, which will then call: `setCipherVersion()` which would then configure: `getFileHeaderSize()` effectively making subsequent calls to `DecryptedSize()` return exact value.
+	if c.version == CipherVersionV1 && size < 0 {
 		return 0, ErrorEncryptedFileTooShort
 	}
+
+	if c.version == CipherVersionV2 {
+		size -= HashEncryptedSizeWithHeader
+	}
+
+	v1CipherOverhead := int64(fileHeaderSize)
+	v2CipherOverhead := int64(fileHeaderSizeV2) + HashEncryptedSizeWithHeader
+	sizeDiff := v1CipherOverhead - v2CipherOverhead
+	// Below check was "loosened" to prevent code from return ErrorEncryptedFileTooShort when reading small `CipherVersionV1` encrypted object when `CipherVersionV2` is enabled as a config.
+	// If V2 cipher is enabled then we assume file was encrypted using V2 header (but this is just assumption we can't be sure until `setCipherVersion()` is called).
+	// V2 format has longer header and introduces concept of a footer. If we by any chance read small V1 object and assume it's a V2 header we may end up getting the negative decrypted size and trigger this check - preventing reading the file.
+	// The `setCipherVersion()` is called once we actually read the file contents.
+	// @TODO Don't use: "loosened" approach once: `setCipherVersion()` is called. Distinct implicit (assumed from config) cipher version assumption and explicit (set by setCipherVersion())
+	if c.version == CipherVersionV2 && size < sizeDiff {
+		return 0, ErrorEncryptedFileTooShort
+	}
+
 	blocks, residue := size/blockSize, size%blockSize
 	decryptedSize := blocks * blockDataSize
 	if residue != 0 {

--- a/backend/crypt/cipher.go
+++ b/backend/crypt/cipher.go
@@ -951,8 +951,8 @@ func (c *Cipher) newDecrypter(rc io.ReadCloser) (*decrypter, error) {
 	fh.initialNonce = fh.nonce
 
 	if c.version == CipherVersionV2 { // V2 cipher has a longer header, so after reading V1 header, we need to read remaining bytes from the reader to finialize V2 cipher initialization
-		remainingBytesFromV1Buffer := fileNonceSize - fileNonceSizeV2 // V2 nonce is 1 byte shorter, but this byte was already read to the `readBuf`, we use: `combinedBuffer` to append it to the beginning.
-		lastByte := readBuf[:len(readBuf)-remainingBytesFromV1Buffer]
+		remainingBytesFromV1Buffer := fileNonceSize - fileNonceSizeV2 // V2 nonce is 1 byte shorter, so by reading the V1 header size (fileHeaderSize - 32 bytes), we've actually read 1 byte of wrapped CEK. We need to preserve that byte, so we prepend to next: `combinedBuffer`
+		lastByte := readBuf[len(readBuf)-remainingBytesFromV1Buffer:]
 
 		remainingBytesReadSize := fileHeaderSizeV2 - fileHeaderSize
 		offsetStart = n // Previously read: `fileHeaderSize` bytes

--- a/backend/crypt/cipher.go
+++ b/backend/crypt/cipher.go
@@ -916,7 +916,7 @@ type decrypter struct {
 }
 
 // newDecrypter creates a new file handle decrypting on the fly
-func (c *Cipher) newDecrypter(rc io.ReadCloser) (*decrypter, error) {
+func (c *Cipher) newDecrypter(rc io.ReadCloser, customCek *cek) (*decrypter, error) {
 	fh := &decrypter{
 		rc:      rc,
 		c:       c,
@@ -969,30 +969,34 @@ func (c *Cipher) newDecrypter(rc io.ReadCloser) (*decrypter, error) {
 
 		combinedBuffer := append(lastByte, readBuf...)
 
-		var wrappedCek wrappedCek
-		wrappedCek.fromBuf(combinedBuffer) // retrieve wrapped file encryption key
+		if customCek != nil { // This satisfy requirements of `rclone backend decrypt` where cek is externally provided to a file. There is a "sharing file" use case where user may want to decrypt a file without possessing master key required to unwrap CEK. It's possible of sender provides them the unwrapped CEK.
+			fh.cek = *customCek
+		} else {
+			var wrappedCek wrappedCek
+			wrappedCek.fromBuf(combinedBuffer) // retrieve wrapped file encryption key
 
-		// After reading wrappedCek, combinedBuffer's last 4 bytes aren't used at the moment.
+			// After reading wrappedCek, combinedBuffer's last 4 bytes aren't used at the moment.
 
-		kek := fh.c.dataKey[:]
-		cipher, err := aes.NewCipher(kek)
-		if err != nil {
-			return nil, fh.finishAndClose(err)
+			kek := fh.c.dataKey[:]
+			cipher, err := aes.NewCipher(kek)
+			if err != nil {
+				return nil, fh.finishAndClose(err)
+			}
+
+			fileKey, err := keywrap.Unwrap(cipher, wrappedCek[:])
+			if err != nil {
+				return nil, fh.finishAndClose(ErrorEncryptedCekInvalid)
+			}
+
+			fh.cek = [32]byte(fileKey)
 		}
-
-		fileKey, err := keywrap.Unwrap(cipher, wrappedCek[:])
-		if err != nil {
-			return nil, fh.finishAndClose(ErrorEncryptedCekInvalid)
-		}
-
-		fh.cek = [32]byte(fileKey)
 	}
 
 	return fh, nil
 }
 
 // newDecrypterSeek creates a new file handle decrypting on the fly
-func (c *Cipher) newDecrypterSeek(ctx context.Context, open OpenRangeSeek, offset, limit int64) (fh *decrypter, err error) {
+func (c *Cipher) newDecrypterSeek(ctx context.Context, open OpenRangeSeek, offset, limit int64, customCek *cek) (fh *decrypter, err error) {
 	var rc io.ReadCloser
 	doRangeSeek := false
 	setLimit := false
@@ -1014,7 +1018,7 @@ func (c *Cipher) newDecrypterSeek(ctx context.Context, open OpenRangeSeek, offse
 		return nil, err
 	}
 	// Open the stream which fills in the nonce
-	fh, err = c.newDecrypter(rc)
+	fh, err = c.newDecrypter(rc, customCek)
 	if err != nil {
 		return nil, err
 	}
@@ -1279,7 +1283,7 @@ func (fh *decrypter) finishAndClose(err error) error {
 
 // DecryptData decrypts the data stream
 func (c *Cipher) DecryptData(rc io.ReadCloser) (io.ReadCloser, error) {
-	out, err := c.newDecrypter(rc)
+	out, err := c.newDecrypter(rc, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1291,8 +1295,8 @@ func (c *Cipher) DecryptData(rc io.ReadCloser) (io.ReadCloser, error) {
 // The open function must return a ReadCloser opened to the offset supplied.
 //
 // You must use this form of DecryptData if you might want to Seek the file handle
-func (c *Cipher) DecryptDataSeek(ctx context.Context, open OpenRangeSeek, offset, limit int64) (ReadSeekCloser, error) {
-	out, err := c.newDecrypterSeek(ctx, open, offset, limit)
+func (c *Cipher) DecryptDataSeek(ctx context.Context, open OpenRangeSeek, offset, limit int64, customCek *cek) (ReadSeekCloser, error) {
+	out, err := c.newDecrypterSeek(ctx, open, offset, limit, customCek)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/crypt/cipher.go
+++ b/backend/crypt/cipher.go
@@ -1048,8 +1048,11 @@ func (fh *decrypter) fillBuffer() (err error) {
 		return ErrorEncryptedFileBadHeader
 	}
 
-	if fh.c.version == CipherVersionV2 && n < blockDataSize { // last block
+	isLastBlock := n < blockDataSize
+
+	if fh.c.version == CipherVersionV2 && isLastBlock { // last block
 		fh.nonce[len(fh.nonce)-1] = lastBlockFlag // Set last block flag at the last byte
+		n -= int(HashEncryptedSizeWithHeader)     // Skip last bytes with encrypted hash
 	}
 
 	// Decrypt the block using the nonce

--- a/backend/crypt/cipher.go
+++ b/backend/crypt/cipher.go
@@ -1060,6 +1060,10 @@ func (fh *decrypter) fillBuffer() (err error) {
 	if fh.c.version == CipherVersionV2 && isLastBlock { // last block
 		fh.nonce[len(fh.nonce)-1] = lastBlockFlag // Set last block flag at the last byte
 		n -= int(HashEncryptedSizeWithHeader)     // Skip last bytes with encrypted hash
+
+		if n == 0 { // If we subtract footer and end up with no data to decrypt, let's return EOF instead
+			return err
+		}
 	}
 
 	// Decrypt the block using the nonce

--- a/backend/crypt/cipher_test.go
+++ b/backend/crypt/cipher_test.go
@@ -8,13 +8,13 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/rclone/rclone/fs/hash"
 	"io"
 	"strings"
 	"testing"
 
 	"github.com/Max-Sum/base32768"
 	"github.com/rclone/rclone/backend/crypt/pkcs7"
+	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/lib/readers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1206,17 +1206,17 @@ func TestNewEncrypterV2(t *testing.T) {
 	var preHasher *hash.MultiHasher
 	var wrappedIn io.Reader
 	if c.version == CipherVersionV2 {
-		wrappedIn, preHasher, err = wrapReaderCalculatePlaintextHash(in)
+		wrappedIn, preHasher, _ = wrapReaderCalculatePlaintextHash(in)
 	} else {
 		wrappedIn = in
 	}
 
 	sampleNonce := append(nonceUsed, []byte{0}...) // We append one bogus byte to match the 24 bytes nonce requirement. This byte isn't used for V2, as it's derived internally dynamically (last_block)
-	encrypter, err := c.newEncrypter(wrappedIn, (*nonce)(sampleNonce), (*cek)(unwrappedCek))
+	encrypter, _ := c.newEncrypter(wrappedIn, (*nonce)(sampleNonce), (*cek)(unwrappedCek))
 
 	// Encrypt
 	buffer := new(bytes.Buffer)
-	_, err = io.Copy(buffer, encrypter)
+	_, _ = io.Copy(buffer, encrypter)
 
 	if c.version == CipherVersionV2 { // Append hash to the end
 		emptyReader := bytes.NewReader([]byte{})

--- a/backend/crypt/cipher_test.go
+++ b/backend/crypt/cipher_test.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/base32"
 	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/rclone/rclone/fs/hash"
 	"io"
 	"strings"
 	"testing"
@@ -734,24 +736,24 @@ func TestNoncePointer(t *testing.T) {
 func TestNonceFromReader(t *testing.T) {
 	var x nonce
 	buf := bytes.NewBufferString("123456789abcdefghijklmno")
-	err := x.fromReader(buf)
+	err := x.fromReader(buf, fileNonceSize)
 	assert.NoError(t, err)
 	assert.Equal(t, nonce{'1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'}, x)
 	buf = bytes.NewBufferString("123456789abcdefghijklmn")
-	err = x.fromReader(buf)
+	err = x.fromReader(buf, fileNonceSize)
 	assert.EqualError(t, err, "short read of nonce: EOF")
 }
 
 func TestNonceFromBuf(t *testing.T) {
 	var x nonce
 	buf := []byte("123456789abcdefghijklmnoXXXXXXXX")
-	x.fromBuf(buf)
+	x.fromBuf(buf, fileNonceSize)
 	assert.Equal(t, nonce{'1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o'}, x)
 	buf = []byte("0123456789abcdefghijklmn")
-	x.fromBuf(buf)
+	x.fromBuf(buf, fileNonceSize)
 	assert.Equal(t, nonce{'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n'}, x)
 	buf = []byte("0123456789abcdefghijklm")
-	assert.Panics(t, func() { x.fromBuf(buf) })
+	assert.Panics(t, func() { x.fromBuf(buf, fileNonceSize) })
 }
 
 func TestNonceIncrement(t *testing.T) {
@@ -1083,7 +1085,7 @@ func testEncryptDecrypt(t *testing.T, bufSize int, copySize int64) {
 	c.cryptoRand = &zeroes{} // zero out the nonce
 	buf := make([]byte, bufSize)
 	source := newRandomSource(copySize)
-	encrypted, err := c.newEncrypter(source, nil)
+	encrypted, err := c.newEncrypter(source, nil, nil)
 	assert.NoError(t, err)
 	decrypted, err := c.newDecrypter(io.NopCloser(encrypted))
 	assert.NoError(t, err)
@@ -1177,16 +1179,88 @@ func TestNewEncrypter(t *testing.T) {
 
 	z := &zeroes{}
 
-	fh, err := c.newEncrypter(z, nil)
+	fh, err := c.newEncrypter(z, nil, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, nonce{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}, fh.nonce)
 	assert.Equal(t, []byte{'R', 'C', 'L', 'O', 'N', 'E', 0x00, 0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18}, (*fh.buf)[:32])
 
 	// Test error path
 	c.cryptoRand = bytes.NewBufferString("123456789abcdefghijklmn")
-	fh, err = c.newEncrypter(z, nil)
+	fh, err = c.newEncrypter(z, nil, nil)
 	assert.Nil(t, fh)
 	assert.EqualError(t, err, "short read of nonce: EOF")
+}
+
+func TestNewEncrypterV2(t *testing.T) {
+	unwrappedCek, _ := hex.DecodeString("a4c3b031b646ebefb79e26c6a05195a924e926e69248aec84f78a396fc979eea")
+	encryptionPassword := "potato"
+	plaintextToEncrypt := []byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+	nonceUsed := []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17}
+
+	c, err := newCipher(NameEncryptionStandard, encryptionPassword, "", true, nil)
+	c.setCipherVersion(CipherVersionV2)
+	assert.NoError(t, err)
+
+	in := bytes.NewReader(plaintextToEncrypt)
+
+	var preHasher *hash.MultiHasher
+	var wrappedIn io.Reader
+	if c.version == CipherVersionV2 {
+		wrappedIn, preHasher, err = wrapReaderCalculatePlaintextHash(in)
+	} else {
+		wrappedIn = in
+	}
+
+	sampleNonce := append(nonceUsed, []byte{0}...) // We append one bogus byte to match the 24 bytes nonce requirement. This byte isn't used for V2, as it's derived internally dynamically (last_block)
+	encrypter, err := c.newEncrypter(wrappedIn, (*nonce)(sampleNonce), (*cek)(unwrappedCek))
+
+	// Encrypt
+	buffer := new(bytes.Buffer)
+	_, err = io.Copy(buffer, encrypter)
+
+	if c.version == CipherVersionV2 { // Append hash to the end
+		emptyReader := bytes.NewReader([]byte{})
+		hashReader := wrapReaderAppendPlaintextHash(emptyReader, preHasher, encrypter)
+		_, err = io.Copy(buffer, hashReader)
+	}
+
+	assert.NoError(t, err)
+
+	expectedMagicBytes := []byte{'R', 'C', 'L', 'O', 'N', 'E', 0x00, 0x01}
+	expectedWrappedCek, _ := hex.DecodeString("4a00a0325e6a3ee54c60b6a3ae2359f8c805fcc2b56a1f9f1364aff501553ec44d522d5a84c3b4ca")
+	expectedCiphertextWithAuth, _ := hex.DecodeString("3c82b21b5311907aa26b7d77acfe01342bbb8bd5d28a0c57f04f0dfe66fc65ab")
+	expectedReservedBytes := []byte{BlockCipherXSalsa20, 0x00, 0x00, 0x00}
+
+	expectedHashHeader := HashHeaderMD5
+	expectedEncryptedHashWithAuth, _ := hex.DecodeString("72361bff7da6ad45fd3d63509b831e870d2d62e09684b903041b8832039a20d5")
+
+	offsetStart := 0
+	offsetEnd := offsetStart + fileMagicSizeV2
+	assert.Equal(t, expectedMagicBytes, buffer.Bytes()[offsetStart:offsetEnd])
+
+	offsetStart = offsetEnd
+	offsetEnd = offsetStart + fileNonceSizeV2
+	assert.Equal(t, nonceUsed, buffer.Bytes()[offsetStart:offsetEnd])
+
+	offsetStart = offsetEnd
+	offsetEnd = offsetStart + len(expectedWrappedCek)
+	assert.Equal(t, expectedWrappedCek, buffer.Bytes()[offsetStart:offsetEnd])
+
+	offsetStart = offsetEnd
+	offsetEnd = offsetStart + len(expectedReservedBytes)
+	assert.Equal(t, expectedReservedBytes, buffer.Bytes()[offsetStart:offsetEnd])
+
+	offsetStart = offsetEnd
+	offsetEnd = offsetStart + len(expectedCiphertextWithAuth)
+	assert.Equal(t, expectedCiphertextWithAuth, buffer.Bytes()[offsetStart:offsetEnd])
+
+	offsetStart = offsetEnd
+	offsetEnd = offsetStart + len(expectedHashHeader)
+	assert.Equal(t, expectedHashHeader, buffer.Bytes()[offsetStart:offsetEnd])
+
+	offsetStart = offsetEnd
+	offsetEnd = offsetStart + len(expectedEncryptedHashWithAuth)
+	assert.Equal(t, expectedEncryptedHashWithAuth, buffer.Bytes()[offsetStart:offsetEnd])
 }
 
 // Test the stream returning 0, io.ErrUnexpectedEOF - this used to
@@ -1196,7 +1270,7 @@ func TestNewEncrypterErrUnexpectedEOF(t *testing.T) {
 	assert.NoError(t, err)
 
 	in := &readers.ErrorReader{Err: io.ErrUnexpectedEOF}
-	fh, err := c.newEncrypter(in, nil)
+	fh, err := c.newEncrypter(in, nil, nil)
 	assert.NoError(t, err)
 
 	n, err := io.CopyN(io.Discard, fh, 1e6)
@@ -1256,7 +1330,11 @@ func TestNewDecrypter(t *testing.T) {
 		cd := newCloseDetector(bytes.NewBuffer(file0copy))
 		fh, err := c.newDecrypter(cd)
 		assert.Nil(t, fh)
-		assert.EqualError(t, err, ErrorEncryptedBadMagic.Error())
+		if i == 7 { // This test accidentally swaps last byte and converts `fileMagic` (RCLONE\x00\x00") into `fileMagicV2` ("RCLONE\x00\x01") resulting in a different than: "ErrorEncryptedBadMagic" error.
+			assert.EqualError(t, err, ErrorEncryptedFileTooShort.Error())
+		} else {
+			assert.EqualError(t, err, ErrorEncryptedBadMagic.Error())
+		}
 		file0copy[i] ^= 0x1
 		assert.Equal(t, 1, cd.closed)
 	}
@@ -1477,7 +1555,7 @@ func TestDecrypterCalculateUnderlying(t *testing.T) {
 		{blockDataSize + 1, blockDataSize + 1, int64(fileHeaderSize) + blockSize, 2 * blockSize, 1, 1},
 	} {
 		what := fmt.Sprintf("offset = %d, limit = %d", test.offset, test.limit)
-		underlyingOffset, underlyingLimit, discard, blocks := calculateUnderlying(test.offset, test.limit)
+		underlyingOffset, underlyingLimit, discard, blocks := calculateUnderlying(test.offset, test.limit, fileHeaderSize)
 		assert.Equal(t, test.wantOffset, underlyingOffset, what)
 		assert.Equal(t, test.wantLimit, underlyingLimit, what)
 		assert.Equal(t, test.wantDiscard, discard, what)

--- a/backend/crypt/cipher_test.go
+++ b/backend/crypt/cipher_test.go
@@ -1229,7 +1229,7 @@ func TestNewEncrypterV2(t *testing.T) {
 	expectedMagicBytes := []byte{'R', 'C', 'L', 'O', 'N', 'E', 0x00, 0x01}
 	expectedWrappedCek, _ := hex.DecodeString("4a00a0325e6a3ee54c60b6a3ae2359f8c805fcc2b56a1f9f1364aff501553ec44d522d5a84c3b4ca")
 	expectedCiphertextWithAuth, _ := hex.DecodeString("3c82b21b5311907aa26b7d77acfe01342bbb8bd5d28a0c57f04f0dfe66fc65ab")
-	expectedReservedBytes := []byte{BlockCipherXSalsa20, 0x00, 0x00, 0x00}
+	expectedReservedBytes := fileReservedBytesV2
 
 	expectedHashHeader := HashHeaderMD5
 	expectedEncryptedHashWithAuth, _ := hex.DecodeString("72361bff7da6ad45fd3d63509b831e870d2d62e09684b903041b8832039a20d5")

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -879,12 +879,6 @@ func (f *Fs) ComputeHash(ctx context.Context, o *Object, src fs.Object, hashType
 		fs.Errorf(o, "empty nonce read")
 	}
 
-	// Close d (and hence in) once we have read the nonce
-	err = d.Close()
-	if err != nil {
-		return "", fmt.Errorf("failed to close nonce read: %w", err)
-	}
-
 	return f.computeHashWithNonce(ctx, nonce, cek, src, hashType)
 }
 

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -1009,6 +1009,18 @@ Usage Example:
     rclone rc backend/command command=decode fs=crypt: encryptedfile1 [encryptedfile2...]
 `,
 	},
+	{
+		Name:  "show-cek",
+		Short: "Displays the content encryption key (CEK) for a given encrypted filepath",
+		Long: `This queries file header to get the encrypted/wrapped CEK and then uses your master key to unwrap it. 
+Obtained CEK could be used to decrypt the encrypted resource without needing the master key.
+
+Usage Example:
+
+    rclone backend show-cek crypt: encryptedfile1 [encryptedfile2...]
+    rclone rc backend/command command=show-cek fs=crypt: encryptedfile1 [encryptedfile2...]
+`,
+	},
 }
 
 // Command the backend to run a named command
@@ -1039,6 +1051,24 @@ func (f *Fs) Command(ctx context.Context, name string, arg []string, opt map[str
 			out = append(out, encryptedFileName)
 		}
 		return out, nil
+	case "show-cek":
+		out := make([]string, 0, len(arg))
+		for _, fileName := range arg {
+			encryptedFileName := f.EncryptFileName(fileName)
+			object, err := f.Fs.NewObject(ctx, encryptedFileName)
+			if err != nil {
+				return "", err
+			}
+
+			d, err := f.getDecrypter(ctx, &Object{Object: object})
+			if err != nil {
+				return "", err
+			}
+
+			out = append(out, hex.EncodeToString(d.cek[:]))
+		}
+		return out, nil
+
 	default:
 		return nil, fs.ErrorCommandNotFound
 	}

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -2,10 +2,14 @@
 package crypt
 
 import (
+	"bytes"
 	"context"
+	"encoding/hex"
 	"errors"
 	"fmt"
+	"github.com/rclone/rclone/lib/readers"
 	"io"
+	"math"
 	"path"
 	"strings"
 	"time"
@@ -18,6 +22,19 @@ import (
 	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/rclone/rclone/fs/fspath"
 	"github.com/rclone/rclone/fs/hash"
+	"github.com/spatialcurrent/go-lazy/pkg/lazy"
+	"golang.org/x/crypto/nacl/secretbox"
+)
+
+// Footer
+var (
+	HashCryptType               = hash.MD5 // Starting from V2 version we calculate hash of plaintext and store it encrypted at the end of file contents
+	HashCryptSize               = int64(16)
+	HashEncryptedSize           = HashCryptSize + secretbox.Overhead
+	HashEncryptedSizeWithHeader = 1 + HashEncryptedSize
+
+	HashHeaderNoHash = []byte{0x00} // Future use, in case user doesn't want to store encrypted MD5 at the end of file. We would then store 16 NULL bytes (since we want to keep the decrypted/encrypted size calculations intact).
+	HashHeaderMD5    = []byte{0x01} // Used by default
 )
 
 // Globals
@@ -171,7 +188,24 @@ Setting suffix to "none" will result in an empty suffix. This may be useful
 when the path length is critical.`,
 			Default:  ".bin",
 			Advanced: true,
-		}},
+		},
+			{
+				Name:    "cipher_version",
+				Help:    `Choose cipher version. This determines cipher version used for newly written objects. Rclone will detect cipher version for existing objects when reading.`,
+				Default: CipherVersionV1,
+				Examples: []fs.OptionExample{
+					{
+						Value: CipherVersionV1,
+						Help:  "File contents encrypted using single master key.",
+					},
+					{
+						Value: CipherVersionV2,
+						Help:  "(Experimental) Each file contents encrypted using separate encryption key. Truncation protection. Hash support. Has at least 55 bytes (40 bytes cek, 16 bytes hash, 1 byte shorter nonce) overhead over cipher V1.",
+					},
+				},
+				Advanced: true,
+			},
+		},
 	})
 }
 
@@ -205,6 +239,7 @@ func newCipherForConfig(opt *Options) (*Cipher, error) {
 	}
 	cipher.setEncryptedSuffix(opt.Suffix)
 	cipher.setPassBadBlocks(opt.PassBadBlocks)
+	cipher.setCipherVersion(opt.CipherVersion)
 	return cipher, nil
 }
 
@@ -310,6 +345,7 @@ type Options struct {
 	FilenameEncoding        string `config:"filename_encoding"`
 	Suffix                  string `config:"suffix"`
 	StrictNames             bool   `config:"strict_names"`
+	CipherVersion           string `config:"cipher_version"`
 }
 
 // Fs represents a wrapped fs.Fs
@@ -465,17 +501,33 @@ func (f *Fs) put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options [
 	ci := fs.GetConfig(ctx)
 
 	if f.opt.NoDataEncryption {
-		o, err := put(ctx, in, f.newObjectInfo(src, nonce{}), options...)
+		o, err := put(ctx, in, f.newObjectInfo(src, nonce{}, cek{}), options...)
 		if err == nil && o != nil {
 			o = f.newObject(o)
 		}
 		return o, err
 	}
 
+	var plaintextHasher *hash.MultiHasher
+	var wrappedIn io.Reader
+	var err error
+	if f.cipher.version == CipherVersionV2 {
+		wrappedIn, plaintextHasher, err = wrapReaderCalculatePlaintextHash(in)
+		if err != nil {
+			return nil, fmt.Errorf("failed to wrap the reader: %w", err)
+		}
+	} else {
+		wrappedIn = in
+	}
+
 	// Encrypt the data into wrappedIn
-	wrappedIn, encrypter, err := f.cipher.encryptData(in)
+	wrappedIn, encrypter, err := f.cipher.encryptData(wrappedIn)
 	if err != nil {
 		return nil, err
+	}
+
+	if f.cipher.version == CipherVersionV2 {
+		wrappedIn = wrapReaderAppendPlaintextHash(wrappedIn, plaintextHasher, encrypter)
 	}
 
 	// Find a hash the destination supports to compute a hash of
@@ -500,7 +552,7 @@ func (f *Fs) put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options [
 	}
 
 	// Transfer the data
-	o, err := put(ctx, wrappedIn, f.newObjectInfo(src, encrypter.nonce), options...)
+	o, err := put(ctx, wrappedIn, f.newObjectInfo(src, encrypter.nonce, encrypter.cek), options...)
 	if err != nil {
 		return nil, err
 	}
@@ -545,7 +597,11 @@ func (f *Fs) PutStream(ctx context.Context, in io.Reader, src fs.ObjectInfo, opt
 
 // Hashes returns the supported hash sets.
 func (f *Fs) Hashes() hash.Set {
-	return hash.Set(hash.None)
+	if f.cipher.version == CipherVersionV2 {
+		return hash.Set(hash.MD5)
+	} else {
+		return hash.Set(hash.None)
+	}
 }
 
 // Mkdir makes the directory (container, bucket)
@@ -691,7 +747,7 @@ func (f *Fs) PutUnchecked(ctx context.Context, in io.Reader, src fs.ObjectInfo, 
 	if err != nil {
 		return nil, err
 	}
-	o, err := do(ctx, wrappedIn, f.newObjectInfo(src, encrypter.nonce))
+	o, err := do(ctx, wrappedIn, f.newObjectInfo(src, encrypter.nonce, encrypter.cek))
 	if err != nil {
 		return nil, err
 	}
@@ -748,7 +804,7 @@ func (f *Fs) DecryptFileName(encryptedFileName string) (string, error) {
 // src with it, and calculates the hash given by HashType on the fly
 //
 // Note that we break lots of encapsulation in this function.
-func (f *Fs) computeHashWithNonce(ctx context.Context, nonce nonce, src fs.Object, hashType hash.Type) (hashStr string, err error) {
+func (f *Fs) computeHashWithNonce(ctx context.Context, nonce nonce, cek cek, src fs.Object, hashType hash.Type) (hashStr string, err error) {
 	// Open the src for input
 	in, err := src.Open(ctx)
 	if err != nil {
@@ -756,8 +812,19 @@ func (f *Fs) computeHashWithNonce(ctx context.Context, nonce nonce, src fs.Objec
 	}
 	defer fs.CheckClose(in, &err)
 
+	var plaintextHasher *hash.MultiHasher
+	var wrappedIn io.Reader
+	if f.cipher.version == CipherVersionV2 {
+		wrappedIn, plaintextHasher, err = wrapReaderCalculatePlaintextHash(in)
+		if err != nil {
+			return "", fmt.Errorf("failed to wrap the reader: %w", err)
+		}
+	} else {
+		wrappedIn = in
+	}
+
 	// Now encrypt the src with the nonce
-	out, err := f.cipher.newEncrypter(in, &nonce)
+	out, err := f.cipher.newEncrypter(wrappedIn, &nonce, &cek)
 	if err != nil {
 		return "", fmt.Errorf("failed to make encrypter: %w", err)
 	}
@@ -768,6 +835,13 @@ func (f *Fs) computeHashWithNonce(ctx context.Context, nonce nonce, src fs.Objec
 		return "", fmt.Errorf("failed to make hasher: %w", err)
 	}
 	_, err = io.Copy(m, out)
+
+	if f.cipher.version == CipherVersionV2 { // Append hash to the end
+		emptyReader := bytes.NewReader([]byte{})
+		hashReader := wrapReaderAppendPlaintextHash(emptyReader, plaintextHasher, out)
+		_, err = io.Copy(m, hashReader)
+	}
+
 	if err != nil {
 		return "", fmt.Errorf("failed to hash data: %w", err)
 	}
@@ -784,19 +858,15 @@ func (f *Fs) ComputeHash(ctx context.Context, o *Object, src fs.Object, hashType
 		return src.Hash(ctx, hashType)
 	}
 
-	// Read the nonce - opening the file is sufficient to read the nonce in
-	// use a limited read so we only read the header
-	in, err := o.Object.Open(ctx, &fs.RangeOption{Start: 0, End: int64(fileHeaderSize) - 1})
+	d, err := f.getDecrypter(ctx, o)
 	if err != nil {
-		return "", fmt.Errorf("failed to open object to read nonce: %w", err)
+		return "", err
 	}
-	d, err := f.cipher.newDecrypter(in)
-	if err != nil {
-		_ = in.Close()
-		return "", fmt.Errorf("failed to open object to read nonce: %w", err)
-	}
+
 	nonce := d.nonce
 	// fs.Debugf(o, "Read nonce % 2x", nonce)
+
+	cek := d.cek
 
 	// Check nonce isn't all zeros
 	isZero := true
@@ -815,7 +885,40 @@ func (f *Fs) ComputeHash(ctx context.Context, o *Object, src fs.Object, hashType
 		return "", fmt.Errorf("failed to close nonce read: %w", err)
 	}
 
-	return f.computeHashWithNonce(ctx, nonce, src, hashType)
+	return f.computeHashWithNonce(ctx, nonce, cek, src, hashType)
+}
+
+func (f *Fs) getDecrypter(ctx context.Context, o *Object) (*decrypter, error) {
+	// Read the nonce - opening the file is sufficient to read the nonce in
+	// use a limited read so we only read the header
+	in, err := o.Object.Open(ctx, &fs.RangeOption{Start: 0, End: int64(max(fileHeaderSize, fileHeaderSizeV2)) - 1}) // We read longer of two header we support at the moment, so we can obtain `cek` in case object is encrypted using V2
+	if err != nil {
+		return nil, fmt.Errorf("failed to open object to read nonce: %w", err)
+	}
+	d, err := f.cipher.newDecrypter(in)
+	if err != nil {
+		_ = in.Close()
+		return nil, fmt.Errorf("failed to open object to read nonce: %w", err)
+	}
+
+	// Check nonce isn't all zeros
+	isZero := true
+	for i := range d.nonce {
+		if d.nonce[i] != 0 {
+			isZero = false
+		}
+	}
+	if isZero {
+		fs.Errorf(o, "empty nonce read")
+	}
+
+	// Close d (and hence in) once we have read the nonce
+	err = d.Close()
+	if err != nil {
+		return nil, fmt.Errorf("failed to close nonce read: %w", err)
+	}
+
+	return d, nil
 }
 
 // MergeDirs merges the contents of all the directories passed
@@ -1003,7 +1106,69 @@ func (o *Object) Size() int64 {
 // Hash returns the selected checksum of the file
 // If no checksum is available it returns ""
 func (o *Object) Hash(ctx context.Context, ht hash.Type) (string, error) {
-	return "", hash.ErrUnsupported
+	// Immediate ErrUnsupported if `CipherVersionV1` is used (as used in the config), without the HTTP call (getDecrypter). Commented out, as we want to detect cipher version of a specific object instead of relying on global config.
+	//if (o.f.cipher.version == CipherVersionV1) {
+	//	return "", hash.ErrUnsupported
+	//}
+
+	// This reads nonce and cek from the header
+	d, err := o.f.getDecrypter(ctx, o)
+	if err != nil {
+		return "", err
+	}
+
+	// Objects encrypted with V1 doesn't support hash
+	if d.c.version == CipherVersionV1 {
+		return "", hash.ErrUnsupported
+	}
+
+	// This reads the encrypted hash from the footer
+	encryptedSize := o.Object.Size()
+	in, err := o.Object.Open(ctx, &fs.RangeOption{Start: encryptedSize - HashEncryptedSizeWithHeader, End: encryptedSize - 1}) // We read file last HashCryptSize bytes to get the hash out
+	if err != nil {
+		return "", fmt.Errorf("failed to open object to read hash: %w", err)
+	}
+
+	encryptedHashWithHeader := make([]byte, HashEncryptedSizeWithHeader)
+	n, err := readers.ReadFill(in, encryptedHashWithHeader)
+	if n != int(HashEncryptedSizeWithHeader) {
+		return "", fmt.Errorf("Incorrect encrypted hash size: %d", n)
+	}
+
+	hashHeader := encryptedHashWithHeader[0:1]
+	encryptedHash := encryptedHashWithHeader[1:]
+
+	if bytes.Equal(hashHeader, HashHeaderNoHash) {
+		return "", hash.ErrUnsupported
+	}
+
+	// We need to get the decrypted size, to workout the amount of blocks, so we can workout the nonce that was used to encrypt the hash.
+	decryptedSize, err := o.f.cipher.DecryptedSize(encryptedSize)
+	if err != nil {
+		return "", err
+	}
+
+	// After we've read nonce from the header, we need to calculate the nonce used at the end of file, so we can calculate the nonce that was used to encrypt the hash
+	totalBlocks := uint64(math.Ceil(float64(decryptedSize) / float64(blockSize)))
+	d.nonce.add(totalBlocks)
+	d.nonce[len(d.nonce)-1] = lastBlockFlag
+
+	decryptedHash, ok := secretbox.Open(nil, encryptedHash, d.nonce.pointer(), &d.cek)
+	if !ok {
+		if err != nil && err != io.EOF {
+			return "", err // return pending error as it is likely more accurate
+		}
+		if !d.c.passBadBlocks {
+			return "", fmt.Errorf("Hash decryption error: %s", ErrorEncryptedBadBlock)
+		}
+
+		fs.Errorf(nil, "crypt: ignoring hash decryption error: %v", ErrorEncryptedBadBlock)
+	}
+
+	hashString := hex.EncodeToString(decryptedHash)
+	fs.Debugf("Crypt hash %s", hashString)
+
+	return hashString, nil
 }
 
 // UnWrap returns the wrapped Object
@@ -1102,6 +1267,34 @@ func (f *Fs) Shutdown(ctx context.Context) error {
 	return do(ctx)
 }
 
+// This will intercept the unencrypted data and forward it to hasher, so we can calculate plaintext hash
+func wrapReaderCalculatePlaintextHash(in io.Reader) (io.Reader, *hash.MultiHasher, error) {
+	hasher, err := hash.NewMultiHasherTypes(hash.NewHashSet(HashCryptType))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return io.TeeReader(in, hasher), hasher, nil
+}
+
+// This concatenates the ciphertext reader (in) with the plaintext hasher output. We encrypt the hash and prepend with the header identifying hash type
+func wrapReaderAppendPlaintextHash(in io.Reader, hasher *hash.MultiHasher, encrypter *encrypter) io.Reader {
+	hashEndReaderLazy := lazy.NewLazyReader(func() (io.Reader, error) {
+		hash := hasher.Sums()[HashCryptType]
+		fs.Debugf("Hash unencrypted %s", hash)
+		byteHash, err := hex.DecodeString(hash)
+		if err != nil {
+			return nil, err
+		}
+
+		encryptedHash := secretbox.Seal(nil, byteHash, encrypter.nonce.pointer(), (*[32]byte)(&encrypter.cek))
+		encryptedHashWithHeader := append(HashHeaderMD5, encryptedHash[:]...)
+		hashEndReader := io.LimitReader(bytes.NewReader(encryptedHashWithHeader), HashEncryptedSizeWithHeader)
+		return hashEndReader, nil
+	})
+	return io.MultiReader(in, hashEndReaderLazy)
+}
+
 // ObjectInfo describes a wrapped fs.ObjectInfo for being the source
 //
 // This encrypts the remote name and adjusts the size
@@ -1109,13 +1302,15 @@ type ObjectInfo struct {
 	fs.ObjectInfo
 	f     *Fs
 	nonce nonce
+	cek   cek
 }
 
-func (f *Fs) newObjectInfo(src fs.ObjectInfo, nonce nonce) *ObjectInfo {
+func (f *Fs) newObjectInfo(src fs.ObjectInfo, nonce nonce, cek cek) *ObjectInfo {
 	return &ObjectInfo{
 		ObjectInfo: src,
 		f:          f,
 		nonce:      nonce,
+		cek:        cek,
 	}
 }
 
@@ -1160,7 +1355,7 @@ func (o *ObjectInfo) Hash(ctx context.Context, hash hash.Type) (string, error) {
 	if srcObj.Fs().Features().IsLocal {
 		// Read the data and encrypt it to calculate the hash
 		fs.Debugf(o, "Computing %v hash of encrypted source", hash)
-		return o.f.computeHashWithNonce(ctx, o.nonce, srcObj, hash)
+		return o.f.computeHashWithNonce(ctx, o.nonce, o.cek, srcObj, hash)
 	}
 	return "", nil
 }

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -1141,8 +1141,10 @@ func (o *Object) Hash(ctx context.Context, ht hash.Type) (string, error) {
 	}
 
 	// Objects encrypted with V1 doesn't support hash
+	// Since V2 supports hashes, we would like to skip hash verifications (It seems that: `operations.go:checkHashes()` is fine with empty string.) instead of failing with hash.ErrUnsupported, so both V1 and V2 objects can be used interchangeably
+	// @TODO Shall we return "" instead of hash.ErrUnsupported only if CipherVersionV2 is enabled globally in the setting? How to detect that? It seems that: `o.f.cipher.version` returns "1" for V1 object even if V2 is enabled for remote.
 	if d.c.version == CipherVersionV1 {
-		return "", hash.ErrUnsupported
+		return "", nil
 	}
 
 	// This reads the encrypted hash from the footer

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/rclone/rclone/fs/object"
 	"io"
 	"math"
 	"path"
@@ -22,7 +21,7 @@ import (
 	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/rclone/rclone/fs/fspath"
 	"github.com/rclone/rclone/fs/hash"
-	//"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fs/object"
 	"github.com/rclone/rclone/lib/readers"
 	"github.com/spatialcurrent/go-lazy/pkg/lazy"
 	"golang.org/x/crypto/nacl/secretbox"
@@ -496,8 +495,7 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	return f.newObject(o), nil
 }
 
-// Copy of the above: NewObject but without EncryptFileName function calls.
-// Returns directly: *Object instead of its parent fs.Object, as we're not limited by the interface and can return more specific type
+// NewObjectEncryptedName, copy of the above: NewObject but without EncryptFileName function calls. Returns directly: *Object instead of its parent fs.Object, as we're not limited by the interface and can return more specific type
 func (f *Fs) NewObjectEncryptedName(ctx context.Context, encryptedRemote string) (*Object, error) {
 	o, err := f.Fs.NewObject(ctx, encryptedRemote)
 	if err != nil {

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -495,7 +495,7 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	return f.newObject(o), nil
 }
 
-// NewObjectEncryptedName, copy of the above: NewObject but without EncryptFileName function calls. Returns directly: *Object instead of its parent fs.Object, as we're not limited by the interface and can return more specific type
+// NewObjectEncryptedName - copy of the above: NewObject but without EncryptFileName function calls. Returns directly: *Object instead of its parent fs.Object, as we're not limited by the interface and can return more specific type
 func (f *Fs) NewObjectEncryptedName(ctx context.Context, encryptedRemote string) (*Object, error) {
 	o, err := f.Fs.NewObject(ctx, encryptedRemote)
 	if err != nil {

--- a/backend/crypt/crypt_internal_test.go
+++ b/backend/crypt/crypt_internal_test.go
@@ -59,7 +59,7 @@ func testObjectInfo(t *testing.T, f *Fs, wrap bool) {
 	// encrypt the data
 	inBuf := bytes.NewBufferString(contents)
 	var outBuf bytes.Buffer
-	enc, err := f.cipher.newEncrypter(inBuf, nil)
+	enc, err := f.cipher.newEncrypter(inBuf, nil, nil)
 	require.NoError(t, err)
 	nonce := enc.nonce // read the nonce at the start
 	_, err = io.Copy(&outBuf, enc)
@@ -73,7 +73,7 @@ func testObjectInfo(t *testing.T, f *Fs, wrap bool) {
 
 	// wrap the object in a crypt for upload using the nonce we
 	// saved from the encrypter
-	src := f.newObjectInfo(oi, nonce)
+	src := f.newObjectInfo(oi, nonce, cek{})
 
 	// Test ObjectInfo methods
 	if !f.opt.NoDataEncryption {

--- a/backend/crypt/crypt_internal_test.go
+++ b/backend/crypt/crypt_internal_test.go
@@ -59,10 +59,27 @@ func testObjectInfo(t *testing.T, f *Fs, wrap bool) {
 	// encrypt the data
 	inBuf := bytes.NewBufferString(contents)
 	var outBuf bytes.Buffer
-	enc, err := f.cipher.newEncrypter(inBuf, nil, nil)
+
+	var preHasher *hash.MultiHasher
+	var wrappedIn io.Reader
+	if f.cipher.version == CipherVersionV2 {
+		wrappedIn, preHasher, _ = wrapReaderCalculatePlaintextHash(inBuf)
+	} else {
+		wrappedIn = inBuf
+	}
+
+	enc, err := f.cipher.newEncrypter(wrappedIn, nil, nil)
 	require.NoError(t, err)
 	nonce := enc.nonce // read the nonce at the start
+	cek := enc.cek
 	_, err = io.Copy(&outBuf, enc)
+
+	if f.cipher.version == CipherVersionV2 { // Append hash to the end
+		emptyReader := bytes.NewReader([]byte{})
+		hashReader := wrapReaderAppendPlaintextHash(emptyReader, preHasher, enc)
+		_, err = io.Copy(&outBuf, hashReader)
+	}
+
 	require.NoError(t, err)
 
 	var oi fs.ObjectInfo = obj
@@ -73,7 +90,7 @@ func testObjectInfo(t *testing.T, f *Fs, wrap bool) {
 
 	// wrap the object in a crypt for upload using the nonce we
 	// saved from the encrypter
-	src := f.newObjectInfo(oi, nonce, cek{})
+	src := f.newObjectInfo(oi, nonce, cek)
 
 	// Test ObjectInfo methods
 	if !f.opt.NoDataEncryption {

--- a/backend/crypt/crypt_test.go
+++ b/backend/crypt/crypt_test.go
@@ -51,6 +51,28 @@ func TestStandardBase32(t *testing.T) {
 	})
 }
 
+func TestStandardBase32V2(t *testing.T) {
+	if *fstest.RemoteName != "" {
+		t.Skip("Skipping as -remote set")
+	}
+	tempdir := filepath.Join(os.TempDir(), "rclone-crypt-test-standard")
+	name := "TestCrypt"
+	fstests.Run(t, &fstests.Opt{
+		RemoteName: name + ":",
+		NilObject:  (*crypt.Object)(nil),
+		ExtraConfig: []fstests.ExtraConfigItem{
+			{Name: name, Key: "type", Value: "crypt"},
+			{Name: name, Key: "remote", Value: tempdir},
+			{Name: name, Key: "password", Value: obscure.MustObscure("potato")},
+			{Name: name, Key: "filename_encryption", Value: "standard"},
+			{Name: name, Key: "cipher_version", Value: crypt.CipherVersionV2},
+		},
+		UnimplementableFsMethods:     []string{"OpenWriterAt", "OpenChunkWriter"},
+		UnimplementableObjectMethods: []string{"MimeType"},
+		QuickTestOK:                  true,
+	})
+}
+
 func TestStandardBase64(t *testing.T) {
 	if *fstest.RemoteName != "" {
 		t.Skip("Skipping as -remote set")

--- a/fs/open_options.go
+++ b/fs/open_options.go
@@ -306,6 +306,26 @@ func (o *ChunkOption) String() string {
 	return fmt.Sprintf("ChunkOption(%v)", o.ChunkSize)
 }
 
+// CekOption allows to provide custom CEK to decrypter
+type CekOption struct {
+	Cek [32]byte
+}
+
+// Header formats the option as an http header
+func (o *CekOption) Header() (key string, value string) {
+	return "", ""
+}
+
+// String formats the option into human-readable form
+func (o *CekOption) String() string {
+	return fmt.Sprintf("CekOption(%v)", o.Cek)
+}
+
+// Mandatory returns whether the option must be parsed or can be ignored
+func (o *CekOption) Mandatory() bool {
+	return false
+}
+
 // OpenOptionAddHeaders adds each header found in options to the
 // headers map provided the key was non empty.
 func OpenOptionAddHeaders(options []OpenOption, headers map[string]string) {

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/ncw/swift/v2 v2.0.3
+	github.com/nickball/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5
 	github.com/oracle/oci-go-sdk/v65 v65.69.2
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/sftp v1.13.6
@@ -98,6 +99,7 @@ require (
 	cloud.google.com/go/compute/metadata v0.4.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.10.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.2 // indirect
+	github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5 // indirect
 	github.com/ProtonMail/bcrypt v0.0.0-20211005172633-e235017c1baf // indirect
 	github.com/ProtonMail/gluon v0.17.1-0.20230724134000-308be39be96e // indirect
 	github.com/ProtonMail/go-mime v0.0.0-20230322103455-7d82a3887f2f // indirect
@@ -194,6 +196,7 @@ require (
 	github.com/shoenig/go-m1cpu v0.1.6 // indirect
 	github.com/sony/gobreaker v0.5.0 // indirect
 	github.com/spacemonkeygo/monkit/v3 v3.0.22 // indirect
+	github.com/spatialcurrent/go-lazy v0.0.0-20211115014721-47315cc003d1 // indirect
 	github.com/tklauser/go-sysconf v0.3.13 // indirect
 	github.com/tklauser/numcpus v0.7.0 // indirect
 	github.com/willscott/go-nfs-client v0.0.0-20240104095149-b44639837b00 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd/go.mod h1:C8yoIf
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5 h1:5BIUS5hwyLM298mOf8e8TEgD3cCYqc86uaJdQCYZo/o=
+github.com/NickBall/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5/go.mod h1:w5D10RxC0NmPYxmQ438CC1S07zaC1zpvuNW7s5sUk2Q=
 github.com/ProtonMail/bcrypt v0.0.0-20210511135022-227b4adcab57/go.mod h1:HecWFHognK8GfRDGnFQbW/LiV7A3MX3gZVs45vk5h8I=
 github.com/ProtonMail/bcrypt v0.0.0-20211005172633-e235017c1baf h1:yc9daCCYUefEs69zUkSzubzjBbL+cmOXgnmt9Fyd9ug=
 github.com/ProtonMail/bcrypt v0.0.0-20211005172633-e235017c1baf/go.mod h1:o0ESU9p83twszAU8LBeJKFAAMX14tISa0yk4Oo5TOqo=
@@ -463,6 +465,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/ncw/swift/v2 v2.0.3 h1:8R9dmgFIWs+RiVlisCEfiQiik1hjuR0JnOkLxaP9ihg=
 github.com/ncw/swift/v2 v2.0.3/go.mod h1:cbAO76/ZwcFrFlHdXPjaqWZ9R7Hdar7HpjRXBfbjigk=
+github.com/nickball/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5 h1:eQr2od6dyd9gCLYHgMX2TlAYQtMUpxK7S0nsZXyH0L8=
+github.com/nickball/go-aes-key-wrap v0.0.0-20170929221519-1c3aa3e4dfc5/go.mod h1:1VYCE0dvZM9Y2q8kcAHdXZB6YwfrCUQDeSJ2DuIiA4k=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
@@ -567,6 +571,8 @@ github.com/sony/gobreaker v0.5.0 h1:dRCvqm0P490vZPmy7ppEk2qCnCieBooFJ+YoXGYB+yg=
 github.com/sony/gobreaker v0.5.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spacemonkeygo/monkit/v3 v3.0.22 h1:4/g8IVItBDKLdVnqrdHZrCVPpIrwDBzl1jrV0IHQHDU=
 github.com/spacemonkeygo/monkit/v3 v3.0.22/go.mod h1:XkZYGzknZwkD0AKUnZaSXhRiVTLCkq7CWVa3IsE72gA=
+github.com/spatialcurrent/go-lazy v0.0.0-20211115014721-47315cc003d1 h1:lQ3JvmcVO1/AMFbabvUSJ4YtJRpEAX9Qza73p5j03sw=
+github.com/spatialcurrent/go-lazy v0.0.0-20211115014721-47315cc003d1/go.mod h1:4aKqcbhASNqjbrG0h9BmkzcWvPJGxbef4B+j0XfFrZo=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Cipher improvements and MD5 hash support to crypt.
Commit description: "In V2 version each file encrypted using separate CEK (wrapped with AES Keywrap RFC3394). Truncation protection uses last byte of nonce to indicate last encryption block. Added MD5 hash support for crypt.go (only if V2 cipher is used), MD5 of plaintext is encrypted and authenticated at the end of file. Added 4 reserved bytes at the beginning for future use. Added 1 hash type byte in the footer to allow upgrade to different than MD5 hash. cipher_version setting determines hash version used for writes. For reads we determine cipher version by reading header magic bytes, that's regardless of cipher_version setting. A Added TestNewEncrypterV2 test to demonstrate the outputs and make sure that outputs match the expected hardcoded values. Modified other tests to satisfy newly added params (e.g. cek). Related to: https://github.com/rclone/rclone/issues/7192"

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/7192

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
