### PR TITLE
gcs: add access token authentication

### DIFF
--- a/docs/content/googlecloudstorage.md
+++ b/docs/content/googlecloudstorage.md
@@ -363,6 +363,20 @@ Properties:
 - Type:        string
 - Required:    false
 
+#### --gcs-access-token
+
+Short-lived access token.
+
+Leave blank normally.
+Needed only if you want use short-lived access tokens instead of interactive login.
+
+Properties:
+
+- Config:      access_token
+- Env Var:     RCLONE_GCS_ACCESS_TOKEN
+- Type:        string
+- Required:    false
+
 #### --gcs-anonymous
 
 Access public buckets and objects without credentials.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

To be able to use short-lived [access tokens](https://cloud.google.com/docs/authentication/token-types#access) with the gcs backend.  
GCP documentation about short-lived tokens can be found here: [Create short-lived credentials](https://cloud.google.com/iam/docs/create-short-lived-credentials-direct)  

This feature is used by our systems using [Vault/OpenBao](https://developer.hashicorp.com/vault/docs/secrets/gcp#impersonated-accounts) as the token generator.  

#### Was the change discussed in an issue or in the forum before?

I didn't find any discussion or issue open

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
