### PR TITLE
dlna: fix loggingResponseWriter disregarding log level

### DIFF
--- a/cmd/serve/dlna/dlna_util.go
+++ b/cmd/serve/dlna/dlna_util.go
@@ -108,7 +108,7 @@ func (lrw *loggingResponseWriter) logRequest(code int, err interface{}) {
 		err = ""
 	}
 
-	fs.LogPrintf(level, lrw.request.URL, "%s %s %d %s %s",
+	fs.LogLevelPrintf(level, lrw.request.URL, "%s %s %d %s %s",
 		lrw.request.RemoteAddr, lrw.request.Method, code,
 		lrw.request.Header.Get("SOAPACTION"), err)
 }


### PR DESCRIPTION
#### What is the purpose of this change?
On the current master (4db09331c), the DLNA `loggingResponseWriter` prints output disregarding the configured log level. For example (the default log level is `NOTICE`):

```
$ go run . serve dlna ~/Videos
2024/10/06 14:03:25 NOTICE: Config file "/home/simon/.config/rclone/rclone.conf" not found - using defaults
2024/10/06 14:03:25 NOTICE: Local file system at /home/simon/Videos: Serving HTTP on 0.0.0.0:7879
2024/10/06 14:03:25 NOTICE: DLNA server on :7879: Started SSDP on wlp2s0
2024/10/06 14:03:25 NOTICE: DLNA server on :7879: Started SSDP on enp1s0f0
2024/10/06 14:03:45 INFO  : /ctl: <redacted>:35340 POST 200 "urn:schemas-upnp-org:service:ContentDirectory:1#Browse" 
2024/10/06 14:03:45 INFO  : /static/rclone-120x120.png: <redacted>:35342 GET 206
```

After the change in this PR, the `INFO` logs are not outputted with a `NOTICE` log level:
```
$ go run . serve dlna ~/Videos
2024/10/06 14:04:54 NOTICE: Config file "/home/simon/.config/rclone/rclone.conf" not found - using defaults
2024/10/06 14:04:54 NOTICE: Local file system at /home/simon/Videos: Serving HTTP on 0.0.0.0:7879
2024/10/06 14:04:54 NOTICE: DLNA server on :7879: Started SSDP on wlp2s0
2024/10/06 14:04:54 NOTICE: DLNA server on :7879: Started SSDP on enp1s0f0
```

Setting the log level to `INFO` does output the logs:
```
go run . --log-level INFO serve dlna ~/Videos
2024/10/06 14:05:41 NOTICE: Config file "/home/simon/.config/rclone/rclone.conf" not found - using defaults
2024/10/06 14:05:41 INFO  : Local file system at /home/simon/Videos: poll-interval is not supported by this remote
2024/10/06 14:05:41 NOTICE: Local file system at /home/simon/Videos: Serving HTTP on 0.0.0.0:7879
2024/10/06 14:05:41 NOTICE: DLNA server on :7879: Started SSDP on enp1s0f0
2024/10/06 14:05:41 NOTICE: DLNA server on :7879: Started SSDP on wlp2s0
2024/10/06 14:05:41 INFO  : DLNA server on :7879: Started SSDP on enp1s0f0
2024/10/06 14:05:41 INFO  : DLNA server on :7879: Started SSDP on wlp2s0
2024/10/06 14:05:58 INFO  : /ctl: <redacted>:43648 POST 200 "urn:schemas-upnp-org:service:ContentDirectory:1#Browse" 
2024/10/06 14:05:58 INFO  : /static/rclone-120x120.png: <redacted>:43650 GET 206
```

#### Was the change discussed in an issue or in the forum before?
No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)