### PR TITLE
Implement logger parameters for `copy`, `copyto`, `move` & `moveto`

### DIFF
--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -95,6 +95,47 @@ for more info.
 **Note**: Use the |-P|/|--progress| flag to view real-time transfer statistics.
 
 **Note**: Use the |--dry-run| or the |--interactive|/|-i| flag to test without copying anything.
+
+## Logger Flags
+
+The ` + "`--differ`" + `, ` + "`--missing-on-dst`" + `, ` + "`--missing-on-src`" + `, ` +
+		"`--match`" + ` and ` + "`--error`" + ` flags write paths, one per line, to the file name (or
+stdout if it is ` + "`-`" + `) supplied. What they write is described in the
+help below. For example ` + "`--differ`" + ` will write all paths which are
+present on both the source and destination but different.
+
+The ` + "`--combined`" + ` flag will write a file (or stdout) which contains all
+file paths with a symbol and then a space and then the path to tell
+you what happened to it. These are reminiscent of diff files.
+
+- ` + "`= path`" + ` means path was found in source and destination and was identical
+- ` + "`- path`" + ` means path was missing on the source, so only in the destination
+- ` + "`+ path`" + ` means path was missing on the destination, so only in the source
+- ` + "`* path`" + ` means path was present in source and destination but different.
+- ` + "`! path`" + ` means there was an error reading or hashing the source or dest.
+
+The ` + "`--dest-after`" + ` flag writes a list file using the same format flags
+as [` + "`lsf`" + `](/commands/rclone_lsf/#synopsis) (including [customizable options
+for hash, modtime, etc.](/commands/rclone_lsf/#synopsis))
+Conceptually it is similar to rsync's ` + "`--itemize-changes`" + `, but not identical
+-- it should output an accurate list of what will be on the destination
+after the copy.
+
+When the ` + "`--no-traverse`" + ` flag is set, all logs involving files that exist only
+on the destination will be incomplete or completely missing.
+
+Note that these logger flags have a few limitations, and certain scenarios
+are not currently supported:
+
+- ` + "`--max-duration`" + ` / ` + "`CutoffModeHard`" + `
+- ` + "`--compare-dest`" + ` / ` + "`--copy-dest`" + `
+- server-side moves of an entire dir at once
+- High-level retries, because there would be duplicates (use ` + "`--retries 1`" + ` to disable)
+- Possibly some unusual error scenarios
+
+Note also that each file is logged during the copy, as opposed to after, so it
+is most useful as a predictor of what SHOULD happen to each file
+(which may or may not match what actually DID.)
 `, "|", "`"),
 	Annotations: map[string]string{
 		"groups": "Copy,Filter,Listing,Important",

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -98,39 +98,38 @@ for more info.
 
 ## Logger Flags
 
-The ` + "`--differ`" + `, ` + "`--missing-on-dst`" + `, ` + "`--missing-on-src`" + `, ` +
-		"`--match`" + ` and ` + "`--error`" + ` flags write paths, one per line, to the file name (or
-stdout if it is ` + "`-`" + `) supplied. What they write is described in the
-help below. For example ` + "`--differ`" + ` will write all paths which are
-present on both the source and destination but different.
+The |--differ|, |--missing-on-dst|, |--missing-on-src|, |--match| and |--error| flags write paths,
+one per line, to the file name (or stdout if it is |-|) supplied. What they write is described
+in the help below. For example |--differ| will write all paths which are present
+on both the source and destination but different.
 
-The ` + "`--combined`" + ` flag will write a file (or stdout) which contains all
+The |--combined| flag will write a file (or stdout) which contains all
 file paths with a symbol and then a space and then the path to tell
 you what happened to it. These are reminiscent of diff files.
 
-- ` + "`= path`" + ` means path was found in source and destination and was identical
-- ` + "`- path`" + ` means path was missing on the source, so only in the destination
-- ` + "`+ path`" + ` means path was missing on the destination, so only in the source
-- ` + "`* path`" + ` means path was present in source and destination but different.
-- ` + "`! path`" + ` means there was an error reading or hashing the source or dest.
+- |= path| means path was found in source and destination and was identical
+- |- path| means path was missing on the source, so only in the destination
+- |+ path| means path was missing on the destination, so only in the source
+- |* path| means path was present in source and destination but different.
+- |! path| means there was an error reading or hashing the source or dest.
 
-The ` + "`--dest-after`" + ` flag writes a list file using the same format flags
-as [` + "`lsf`" + `](/commands/rclone_lsf/#synopsis) (including [customizable options
+The |--dest-after| flag writes a list file using the same format flags
+as [|lsf|](/commands/rclone_lsf/#synopsis) (including [customizable options
 for hash, modtime, etc.](/commands/rclone_lsf/#synopsis))
-Conceptually it is similar to rsync's ` + "`--itemize-changes`" + `, but not identical
+Conceptually it is similar to rsync's |--itemize-changes|, but not identical
 -- it should output an accurate list of what will be on the destination
 after the copy.
 
-When the ` + "`--no-traverse`" + ` flag is set, all logs involving files that exist only
+When the |--no-traverse| flag is set, all logs involving files that exist only
 on the destination will be incomplete or completely missing.
 
 Note that these logger flags have a few limitations, and certain scenarios
 are not currently supported:
 
-- ` + "`--max-duration`" + ` / ` + "`CutoffModeHard`" + `
-- ` + "`--compare-dest`" + ` / ` + "`--copy-dest`" + `
+- |--max-duration| / |CutoffModeHard|
+- |--compare-dest| / |--copy-dest|
 - server-side moves of an entire dir at once
-- High-level retries, because there would be duplicates (use ` + "`--retries 1`" + ` to disable)
+- High-level retries, because there would be duplicates (use |--retries 1| to disable)
 - Possibly some unusual error scenarios
 
 Note also that each file is logged during the copy, as opposed to after, so it

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -96,46 +96,7 @@ for more info.
 
 **Note**: Use the |--dry-run| or the |--interactive|/|-i| flag to test without copying anything.
 
-## Logger Flags
-
-The |--differ|, |--missing-on-dst|, |--missing-on-src|, |--match| and |--error| flags write paths,
-one per line, to the file name (or stdout if it is |-|) supplied. What they write is described
-in the help below. For example |--differ| will write all paths which are present
-on both the source and destination but different.
-
-The |--combined| flag will write a file (or stdout) which contains all
-file paths with a symbol and then a space and then the path to tell
-you what happened to it. These are reminiscent of diff files.
-
-- |= path| means path was found in source and destination and was identical
-- |- path| means path was missing on the source, so only in the destination
-- |+ path| means path was missing on the destination, so only in the source
-- |* path| means path was present in source and destination but different.
-- |! path| means there was an error reading or hashing the source or dest.
-
-The |--dest-after| flag writes a list file using the same format flags
-as [|lsf|](/commands/rclone_lsf/#synopsis) (including [customizable options
-for hash, modtime, etc.](/commands/rclone_lsf/#synopsis))
-Conceptually it is similar to rsync's |--itemize-changes|, but not identical
--- it should output an accurate list of what will be on the destination
-after the copy.
-
-When the |--no-traverse| flag is set, all logs involving files that exist only
-on the destination will be incomplete or completely missing.
-
-Note that these logger flags have a few limitations, and certain scenarios
-are not currently supported:
-
-- |--max-duration| / |CutoffModeHard|
-- |--compare-dest| / |--copy-dest|
-- server-side moves of an entire dir at once
-- High-level retries, because there would be duplicates (use |--retries 1| to disable)
-- Possibly some unusual error scenarios
-
-Note also that each file is logged during the copy, as opposed to after, so it
-is most useful as a predictor of what SHOULD happen to each file
-(which may or may not match what actually DID.)
-`, "|", "`"),
+`, "|", "`") + operationsflags.Help(),
 	Annotations: map[string]string{
 		"groups": "Copy,Filter,Listing,Important",
 	},

--- a/cmd/copy/copy.go
+++ b/cmd/copy/copy.go
@@ -3,13 +3,14 @@ package copy
 
 import (
 	"context"
+	"strings"
+
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fs/operations/operationsflags"
 	"github.com/rclone/rclone/fs/sync"
 	"github.com/spf13/cobra"
-	"strings"
 )
 
 var (

--- a/cmd/copyto/copyto.go
+++ b/cmd/copyto/copyto.go
@@ -3,10 +3,10 @@ package copyto
 
 import (
 	"context"
-	"github.com/rclone/rclone/fs/operations/operationsflags"
 
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fs/operations/operationsflags"
 	"github.com/rclone/rclone/fs/sync"
 	"github.com/spf13/cobra"
 )

--- a/cmd/copyto/copyto.go
+++ b/cmd/copyto/copyto.go
@@ -55,7 +55,8 @@ the destination.
 *If you are looking to copy just a byte range of a file, please see 'rclone cat --offset X --count Y'*
 
 **Note**: Use the ` + "`-P`" + `/` + "`--progress`" + ` flag to view real-time transfer statistics
-`,
+
+` + operationsflags.Help(),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.35",
 		"groups":            "Copy,Filter,Listing,Important",

--- a/cmd/move/move.go
+++ b/cmd/move/move.go
@@ -72,46 +72,7 @@ for more info.
 
 **Note**: Use the |-P|/|--progress| flag to view real-time transfer statistics.
 
-## Logger Flags
-
-The |--differ|, |--missing-on-dst|, |--missing-on-src|, |--match| and |--error| flags write paths,
-one per line, to the file name (or stdout if it is |-|) supplied. What they write is described
-in the help below. For example |--differ| will write all paths which are present
-on both the source and destination but different.
-
-The |--combined| flag will write a file (or stdout) which contains all
-file paths with a symbol and then a space and then the path to tell
-you what happened to it. These are reminiscent of diff files.
-
-- |= path| means path was found in source and destination and was identical
-- |- path| means path was missing on the source, so only in the destination
-- |+ path| means path was missing on the destination, so only in the source
-- |* path| means path was present in source and destination but different.
-- |! path| means there was an error reading or hashing the source or dest.
-
-The |--dest-after| flag writes a list file using the same format flags
-as [|lsf|](/commands/rclone_lsf/#synopsis) (including [customizable options
-for hash, modtime, etc.](/commands/rclone_lsf/#synopsis))
-Conceptually it is similar to rsync's |--itemize-changes|, but not identical
--- it should output an accurate list of what will be on the destination
-after the move.
-
-When the |--no-traverse| flag is set, all logs involving files that exist only
-on the destination will be incomplete or completely missing.
-
-Note that these logger flags have a few limitations, and certain scenarios
-are not currently supported:
-
-- |--max-duration| / |CutoffModeHard|
-- |--compare-dest| / |--copy-dest|
-- server-side moves of an entire dir at once
-- High-level retries, because there would be duplicates (use |--retries 1| to disable)
-- Possibly some unusual error scenarios
-
-Note also that each file is logged during the move, as opposed to after, so it
-is most useful as a predictor of what SHOULD happen to each file
-(which may or may not match what actually DID.)
-`, "|", "`"),
+`, "|", "`") + operationsflags.Help(),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.19",
 		"groups":            "Filter,Listing,Important,Copy",

--- a/cmd/move/move.go
+++ b/cmd/move/move.go
@@ -71,6 +71,47 @@ for more info.
 |--dry-run| or the |--interactive|/|-i| flag.
 
 **Note**: Use the |-P|/|--progress| flag to view real-time transfer statistics.
+
+## Logger Flags
+
+The ` + "`--differ`" + `, ` + "`--missing-on-dst`" + `, ` + "`--missing-on-src`" + `, ` +
+		"`--match`" + ` and ` + "`--error`" + ` flags write paths, one per line, to the file name (or
+stdout if it is ` + "`-`" + `) supplied. What they write is described in the
+help below. For example ` + "`--differ`" + ` will write all paths which are
+present on both the source and destination but different.
+
+The ` + "`--combined`" + ` flag will write a file (or stdout) which contains all
+file paths with a symbol and then a space and then the path to tell
+you what happened to it. These are reminiscent of diff files.
+
+- ` + "`= path`" + ` means path was found in source and destination and was identical
+- ` + "`- path`" + ` means path was missing on the source, so only in the destination
+- ` + "`+ path`" + ` means path was missing on the destination, so only in the source
+- ` + "`* path`" + ` means path was present in source and destination but different.
+- ` + "`! path`" + ` means there was an error reading or hashing the source or dest.
+
+The ` + "`--dest-after`" + ` flag writes a list file using the same format flags
+as [` + "`lsf`" + `](/commands/rclone_lsf/#synopsis) (including [customizable options
+for hash, modtime, etc.](/commands/rclone_lsf/#synopsis))
+Conceptually it is similar to rsync's ` + "`--itemize-changes`" + `, but not identical
+-- it should output an accurate list of what will be on the destination
+after the move.
+
+When the ` + "`--no-traverse`" + ` flag is set, all logs involving files that exist only
+on the destination will be incomplete or completely missing.
+
+Note that these logger flags have a few limitations, and certain scenarios
+are not currently supported:
+
+- ` + "`--max-duration`" + ` / ` + "`CutoffModeHard`" + `
+- ` + "`--compare-dest`" + ` / ` + "`--copy-dest`" + `
+- server-side moves of an entire dir at once
+- High-level retries, because there would be duplicates (use ` + "`--retries 1`" + ` to disable)
+- Possibly some unusual error scenarios
+
+Note also that each file is logged during the move, as opposed to after, so it
+is most useful as a predictor of what SHOULD happen to each file
+(which may or may not match what actually DID.)
 `, "|", "`"),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.19",

--- a/cmd/move/move.go
+++ b/cmd/move/move.go
@@ -3,12 +3,12 @@ package move
 
 import (
 	"context"
-	"github.com/rclone/rclone/fs/operations/operationsflags"
 	"strings"
 
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fs/operations/operationsflags"
 	"github.com/rclone/rclone/fs/sync"
 	"github.com/spf13/cobra"
 )
@@ -92,9 +92,9 @@ for more info.
 			}
 
 			if srcFileName == "" {
-				return sync.MoveDir(context.Background(), fdst, fsrc, deleteEmptySrcDirs, createEmptySrcDirs)
+				return sync.MoveDir(ctx, fdst, fsrc, deleteEmptySrcDirs, createEmptySrcDirs)
 			}
-			return operations.MoveFile(context.Background(), fdst, fsrc, srcFileName, srcFileName)
+			return operations.MoveFile(ctx, fdst, fsrc, srcFileName, srcFileName)
 		})
 	},
 }

--- a/cmd/move/move.go
+++ b/cmd/move/move.go
@@ -74,39 +74,38 @@ for more info.
 
 ## Logger Flags
 
-The ` + "`--differ`" + `, ` + "`--missing-on-dst`" + `, ` + "`--missing-on-src`" + `, ` +
-		"`--match`" + ` and ` + "`--error`" + ` flags write paths, one per line, to the file name (or
-stdout if it is ` + "`-`" + `) supplied. What they write is described in the
-help below. For example ` + "`--differ`" + ` will write all paths which are
-present on both the source and destination but different.
+The |--differ|, |--missing-on-dst|, |--missing-on-src|, |--match| and |--error| flags write paths,
+one per line, to the file name (or stdout if it is |-|) supplied. What they write is described
+in the help below. For example |--differ| will write all paths which are present
+on both the source and destination but different.
 
-The ` + "`--combined`" + ` flag will write a file (or stdout) which contains all
+The |--combined| flag will write a file (or stdout) which contains all
 file paths with a symbol and then a space and then the path to tell
 you what happened to it. These are reminiscent of diff files.
 
-- ` + "`= path`" + ` means path was found in source and destination and was identical
-- ` + "`- path`" + ` means path was missing on the source, so only in the destination
-- ` + "`+ path`" + ` means path was missing on the destination, so only in the source
-- ` + "`* path`" + ` means path was present in source and destination but different.
-- ` + "`! path`" + ` means there was an error reading or hashing the source or dest.
+- |= path| means path was found in source and destination and was identical
+- |- path| means path was missing on the source, so only in the destination
+- |+ path| means path was missing on the destination, so only in the source
+- |* path| means path was present in source and destination but different.
+- |! path| means there was an error reading or hashing the source or dest.
 
-The ` + "`--dest-after`" + ` flag writes a list file using the same format flags
-as [` + "`lsf`" + `](/commands/rclone_lsf/#synopsis) (including [customizable options
+The |--dest-after| flag writes a list file using the same format flags
+as [|lsf|](/commands/rclone_lsf/#synopsis) (including [customizable options
 for hash, modtime, etc.](/commands/rclone_lsf/#synopsis))
-Conceptually it is similar to rsync's ` + "`--itemize-changes`" + `, but not identical
+Conceptually it is similar to rsync's |--itemize-changes|, but not identical
 -- it should output an accurate list of what will be on the destination
 after the move.
 
-When the ` + "`--no-traverse`" + ` flag is set, all logs involving files that exist only
+When the |--no-traverse| flag is set, all logs involving files that exist only
 on the destination will be incomplete or completely missing.
 
 Note that these logger flags have a few limitations, and certain scenarios
 are not currently supported:
 
-- ` + "`--max-duration`" + ` / ` + "`CutoffModeHard`" + `
-- ` + "`--compare-dest`" + ` / ` + "`--copy-dest`" + `
+- |--max-duration| / |CutoffModeHard|
+- |--compare-dest| / |--copy-dest|
 - server-side moves of an entire dir at once
-- High-level retries, because there would be duplicates (use ` + "`--retries 1`" + ` to disable)
+- High-level retries, because there would be duplicates (use |--retries 1| to disable)
 - Possibly some unusual error scenarios
 
 Note also that each file is logged during the move, as opposed to after, so it

--- a/cmd/move/move.go
+++ b/cmd/move/move.go
@@ -3,6 +3,7 @@ package move
 
 import (
 	"context"
+	"github.com/rclone/rclone/fs/operations/operationsflags"
 	"strings"
 
 	"github.com/rclone/rclone/cmd"
@@ -16,6 +17,8 @@ import (
 var (
 	deleteEmptySrcDirs = false
 	createEmptySrcDirs = false
+	loggerOpt          = operations.LoggerOpt{}
+	loggerFlagsOpt     = operationsflags.AddLoggerFlagsOptions{}
 )
 
 func init() {
@@ -23,6 +26,8 @@ func init() {
 	cmdFlags := commandDefinition.Flags()
 	flags.BoolVarP(cmdFlags, &deleteEmptySrcDirs, "delete-empty-src-dirs", "", deleteEmptySrcDirs, "Delete empty source dirs after move", "")
 	flags.BoolVarP(cmdFlags, &createEmptySrcDirs, "create-empty-src-dirs", "", createEmptySrcDirs, "Create empty source dirs on destination after move", "")
+	operationsflags.AddLoggerFlags(cmdFlags, &loggerOpt, &loggerFlagsOpt)
+	loggerOpt.LoggerFn = operations.NewDefaultLoggerFn(&loggerOpt)
 }
 
 var commandDefinition = &cobra.Command{
@@ -75,6 +80,17 @@ for more info.
 		cmd.CheckArgs(2, 2, command, args)
 		fsrc, srcFileName, fdst := cmd.NewFsSrcFileDst(args)
 		cmd.Run(true, true, command, func() error {
+			ctx := context.Background()
+			close, err := operationsflags.ConfigureLoggers(ctx, fdst, command, &loggerOpt, loggerFlagsOpt)
+			if err != nil {
+				return err
+			}
+			defer close()
+
+			if loggerFlagsOpt.AnySet() {
+				ctx = operations.WithSyncLogger(ctx, loggerOpt)
+			}
+
 			if srcFileName == "" {
 				return sync.MoveDir(context.Background(), fdst, fsrc, deleteEmptySrcDirs, createEmptySrcDirs)
 			}

--- a/cmd/moveto/moveto.go
+++ b/cmd/moveto/moveto.go
@@ -3,10 +3,10 @@ package moveto
 
 import (
 	"context"
-	"github.com/rclone/rclone/fs/operations/operationsflags"
 
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fs/operations/operationsflags"
 	"github.com/rclone/rclone/fs/sync"
 	"github.com/spf13/cobra"
 )

--- a/cmd/moveto/moveto.go
+++ b/cmd/moveto/moveto.go
@@ -3,6 +3,7 @@ package moveto
 
 import (
 	"context"
+	"github.com/rclone/rclone/fs/operations/operationsflags"
 
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/operations"
@@ -10,8 +11,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	loggerOpt      = operations.LoggerOpt{}
+	loggerFlagsOpt = operationsflags.AddLoggerFlagsOptions{}
+)
+
 func init() {
 	cmd.Root.AddCommand(commandDefinition)
+	cmdFlags := commandDefinition.Flags()
+	operationsflags.AddLoggerFlags(cmdFlags, &loggerOpt, &loggerFlagsOpt)
+	loggerOpt.LoggerFn = operations.NewDefaultLoggerFn(&loggerOpt)
 }
 
 var commandDefinition = &cobra.Command{
@@ -57,10 +66,21 @@ successful transfer.
 		fsrc, srcFileName, fdst, dstFileName := cmd.NewFsSrcDstFiles(args)
 
 		cmd.Run(true, true, command, func() error {
-			if srcFileName == "" {
-				return sync.MoveDir(context.Background(), fdst, fsrc, false, false)
+			ctx := context.Background()
+			close, err := operationsflags.ConfigureLoggers(ctx, fdst, command, &loggerOpt, loggerFlagsOpt)
+			if err != nil {
+				return err
 			}
-			return operations.MoveFile(context.Background(), fdst, fsrc, dstFileName, srcFileName)
+			defer close()
+
+			if loggerFlagsOpt.AnySet() {
+				ctx = operations.WithSyncLogger(ctx, loggerOpt)
+			}
+
+			if srcFileName == "" {
+				return sync.MoveDir(ctx, fdst, fsrc, false, false)
+			}
+			return operations.MoveFile(ctx, fdst, fsrc, dstFileName, srcFileName)
 		})
 	},
 }

--- a/cmd/moveto/moveto.go
+++ b/cmd/moveto/moveto.go
@@ -56,7 +56,8 @@ successful transfer.
 ` + "`--dry-run` or the `--interactive`/`-i`" + ` flag.
 
 **Note**: Use the ` + "`-P`" + `/` + "`--progress`" + ` flag to view real-time transfer statistics.
-`,
+
+` + operationsflags.Help(),
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.35",
 		"groups":            "Filter,Listing,Important,Copy",

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -74,43 +74,7 @@ for more info.
 **Note**: Use the |rclone dedupe| command to deal with "Duplicate object/directory found in source/destination - ignoring" errors.
 See [this forum post](https://forum.rclone.org/t/sync-not-clearing-duplicates/14372) for more info.
 
-## Logger Flags
-
-The |--differ|, |--missing-on-dst|, |--missing-on-src|, |--match| and |--error| flags write paths,
-one per line, to the file name (or stdout if it is |-|) supplied. What they write is described
-in the help below. For example |--differ| will write all paths which are present
-on both the source and destination but different.
-
-The |--combined| flag will write a file (or stdout) which contains all
-file paths with a symbol and then a space and then the path to tell
-you what happened to it. These are reminiscent of diff files.
-
-- |= path| means path was found in source and destination and was identical
-- |- path| means path was missing on the source, so only in the destination
-- |+ path| means path was missing on the destination, so only in the source
-- |* path| means path was present in source and destination but different.
-- |! path| means there was an error reading or hashing the source or dest.
-
-The |--dest-after| flag writes a list file using the same format flags
-as [|lsf|](/commands/rclone_lsf/#synopsis) (including [customizable options
-for hash, modtime, etc.](/commands/rclone_lsf/#synopsis))
-Conceptually it is similar to rsync's |--itemize-changes|, but not identical
--- it should output an accurate list of what will be on the destination
-after the sync.
-
-Note that these logger flags have a few limitations, and certain scenarios
-are not currently supported:
-
-- |--max-duration| / |CutoffModeHard|
-- |--compare-dest| / |--copy-dest|
-- server-side moves of an entire dir at once
-- High-level retries, because there would be duplicates (use |--retries 1| to disable)
-- Possibly some unusual error scenarios
-
-Note also that each file is logged during the sync, as opposed to after, so it
-is most useful as a predictor of what SHOULD happen to each file
-(which may or may not match what actually DID.)
-`, "|", "`"),
+`, "|", "`") + operationsflags.Help(),
 	Annotations: map[string]string{
 		"groups": "Sync,Copy,Filter,Listing,Important",
 	},

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -3,6 +3,7 @@ package sync
 
 import (
 	"context"
+	"strings"
 
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/config/flags"
@@ -29,7 +30,8 @@ func init() {
 var commandDefinition = &cobra.Command{
 	Use:   "sync source:path dest:path",
 	Short: `Make source and dest identical, modifying destination only.`,
-	Long: `Sync the source to the destination, changing the destination
+	// Warning! "|" will be replaced by backticks below
+	Long: strings.ReplaceAll(`Sync the source to the destination, changing the destination
 only.  Doesn't transfer files that are identical on source and
 destination, testing by size and modification time or MD5SUM.
 Destination is updated to match source, including deleting files
@@ -38,7 +40,7 @@ want to delete files from destination, use the
 [copy](/commands/rclone_copy/) command instead.
 
 **Important**: Since this can cause data loss, test first with the
-` + "`--dry-run` or the `--interactive`/`-i`" + ` flag.
+|--dry-run| or the |--interactive|/|i| flag.
 
     rclone sync --interactive SOURCE remote:DESTINATION
 
@@ -61,55 +63,54 @@ destination that is inside the source directory.
 
 Rclone will sync the modification times of files and directories if
 the backend supports it. If metadata syncing is required then use the
-` + "`--metadata`" + ` flag.
+|--metadata| flag.
 
 Note that the modification time and metadata for the root directory
 will **not** be synced. See https://github.com/rclone/rclone/issues/7652
 for more info.
 
-**Note**: Use the ` + "`-P`" + `/` + "`--progress`" + ` flag to view real-time transfer statistics
+**Note**: Use the |-P|/|--progress| flag to view real-time transfer statistics
 
-**Note**: Use the ` + "`rclone dedupe`" + ` command to deal with "Duplicate object/directory found in source/destination - ignoring" errors.
+**Note**: Use the |rclone dedupe| command to deal with "Duplicate object/directory found in source/destination - ignoring" errors.
 See [this forum post](https://forum.rclone.org/t/sync-not-clearing-duplicates/14372) for more info.
 
 ## Logger Flags
 
-The ` + "`--differ`" + `, ` + "`--missing-on-dst`" + `, ` + "`--missing-on-src`" + `, ` +
-		"`--match`" + ` and ` + "`--error`" + ` flags write paths, one per line, to the file name (or
-stdout if it is ` + "`-`" + `) supplied. What they write is described in the
-help below. For example ` + "`--differ`" + ` will write all paths which are
-present on both the source and destination but different.
+The |--differ|, |--missing-on-dst|, |--missing-on-src|, |--match| and |--error| flags write paths,
+one per line, to the file name (or stdout if it is |-|) supplied. What they write is described
+in the help below. For example |--differ| will write all paths which are present
+on both the source and destination but different.
 
-The ` + "`--combined`" + ` flag will write a file (or stdout) which contains all
+The |--combined| flag will write a file (or stdout) which contains all
 file paths with a symbol and then a space and then the path to tell
 you what happened to it. These are reminiscent of diff files.
 
-- ` + "`= path`" + ` means path was found in source and destination and was identical
-- ` + "`- path`" + ` means path was missing on the source, so only in the destination
-- ` + "`+ path`" + ` means path was missing on the destination, so only in the source
-- ` + "`* path`" + ` means path was present in source and destination but different.
-- ` + "`! path`" + ` means there was an error reading or hashing the source or dest.
+- |= path| means path was found in source and destination and was identical
+- |- path| means path was missing on the source, so only in the destination
+- |+ path| means path was missing on the destination, so only in the source
+- |* path| means path was present in source and destination but different.
+- |! path| means there was an error reading or hashing the source or dest.
 
-The ` + "`--dest-after`" + ` flag writes a list file using the same format flags
-as [` + "`lsf`" + `](/commands/rclone_lsf/#synopsis) (including [customizable options
+The |--dest-after| flag writes a list file using the same format flags
+as [|lsf|](/commands/rclone_lsf/#synopsis) (including [customizable options
 for hash, modtime, etc.](/commands/rclone_lsf/#synopsis))
-Conceptually it is similar to rsync's ` + "`--itemize-changes`" + `, but not identical
+Conceptually it is similar to rsync's |--itemize-changes|, but not identical
 -- it should output an accurate list of what will be on the destination
 after the sync.
 
 Note that these logger flags have a few limitations, and certain scenarios
 are not currently supported:
 
-- ` + "`--max-duration`" + ` / ` + "`CutoffModeHard`" + `
-- ` + "`--compare-dest`" + ` / ` + "`--copy-dest`" + `
+- |--max-duration| / |CutoffModeHard|
+- |--compare-dest| / |--copy-dest|
 - server-side moves of an entire dir at once
-- High-level retries, because there would be duplicates (use ` + "`--retries 1`" + ` to disable)
+- High-level retries, because there would be duplicates (use |--retries 1| to disable)
 - Possibly some unusual error scenarios
 
 Note also that each file is logged during the sync, as opposed to after, so it
 is most useful as a predictor of what SHOULD happen to each file
 (which may or may not match what actually DID.)
-`,
+`, "|", "`"),
 	Annotations: map[string]string{
 		"groups": "Sync,Copy,Filter,Listing,Important",
 	},

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -3,6 +3,7 @@ package sync
 
 import (
 	"context"
+
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/operations"

--- a/fs/operations/logger.go
+++ b/fs/operations/logger.go
@@ -107,6 +107,7 @@ type LoggerOpt struct {
 	Absolute  bool
 }
 
+// NewDefaultLoggerFn creates a logger function that writes the sigil and path to configured files that match the sigil
 func NewDefaultLoggerFn(opt *LoggerOpt) LoggerFn {
 	var lock mutex.Mutex
 

--- a/fs/operations/logger.go
+++ b/fs/operations/logger.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	mutex "sync"
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/hash"
@@ -104,6 +105,42 @@ type LoggerOpt struct {
 	DirsOnly  bool
 	Csv       bool
 	Absolute  bool
+}
+
+func NewDefaultLoggerFn(opt *LoggerOpt) LoggerFn {
+	var lock mutex.Mutex
+
+	return func(ctx context.Context, sigil Sigil, src, dst fs.DirEntry, err error) {
+		lock.Lock()
+		defer lock.Unlock()
+
+		if err == fs.ErrorIsDir && !opt.FilesOnly && opt.DestAfter != nil {
+			opt.PrintDestAfter(ctx, sigil, src, dst, err)
+			return
+		}
+
+		_, srcOk := src.(fs.Object)
+		_, dstOk := dst.(fs.Object)
+		var filename string
+		if !srcOk && !dstOk {
+			return
+		} else if srcOk && !dstOk {
+			filename = src.String()
+		} else {
+			filename = dst.String()
+		}
+
+		if sigil.Writer(*opt) != nil {
+			SyncFprintf(sigil.Writer(*opt), "%s\n", filename)
+		}
+		if opt.Combined != nil {
+			SyncFprintf(opt.Combined, "%c %s\n", sigil, filename)
+			fs.Debugf(nil, "Sync Logger: %s: %c %s\n", sigil.String(), sigil, filename)
+		}
+		if opt.DestAfter != nil {
+			opt.PrintDestAfter(ctx, sigil, src, dst, err)
+		}
+	}
 }
 
 // WithLogger stores logger in ctx and returns a copy of ctx in which loggerKey = logger

--- a/fs/operations/operationsflags/operationsflags.go
+++ b/fs/operations/operationsflags/operationsflags.go
@@ -4,14 +4,15 @@ package operationsflags
 
 import (
 	"context"
+	"io"
+	"os"
+
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"io"
-	"os"
 )
 
 // AddLoggerFlagsOptions contains options for the Logger Flags
@@ -25,6 +26,7 @@ type AddLoggerFlagsOptions struct {
 	DestAfter    string // files that exist on the destination post-sync
 }
 
+// AnySet checks if any of the logger flags have a non-blank value
 func (o AddLoggerFlagsOptions) AnySet() bool {
 	return anyNotBlank(o.Combined, o.MissingOnSrc, o.MissingOnDst, o.Match, o.Differ, o.ErrFile, o.DestAfter)
 }
@@ -62,6 +64,7 @@ func AddLoggerFlags(cmdFlags *pflag.FlagSet, opt *operations.LoggerOpt, flagsOpt
 	// flags.BoolVarP(cmdFlags, &recurse, "recursive", "R", false, "Recurse into the listing", "")
 }
 
+// ConfigureLoggers verifies and sets up writers for log files requested via CLI flags
 func ConfigureLoggers(ctx context.Context, fdst fs.Fs, command *cobra.Command, opt *operations.LoggerOpt, flagsOpt AddLoggerFlagsOptions) (func(), error) {
 	closers := []io.Closer{}
 

--- a/fs/operations/operationsflags/operationsflags.go
+++ b/fs/operations/operationsflags/operationsflags.go
@@ -119,5 +119,16 @@ func ConfigureLoggers(ctx context.Context, fdst fs.Fs, command *cobra.Command, o
 		}
 	}
 
+	ci := fs.GetConfig(ctx)
+	if ci.NoTraverse && opt.Combined != nil {
+		fs.LogPrintf(fs.LogLevelWarning, nil, "--no-traverse does not list any deletes (-) in --combined output\n")
+	}
+	if ci.NoTraverse && opt.MissingOnSrc != nil {
+		fs.LogPrintf(fs.LogLevelWarning, nil, "--no-traverse makes --missing-on-src produce empty output\n")
+	}
+	if ci.NoTraverse && opt.DestAfter != nil {
+		fs.LogPrintf(fs.LogLevelWarning, nil, "--no-traverse makes --dest-after produce incomplete output\n")
+	}
+
 	return close, nil
 }

--- a/fs/operations/operationsflags/operationsflags.go
+++ b/fs/operations/operationsflags/operationsflags.go
@@ -3,10 +3,15 @@
 package operationsflags
 
 import (
+	"context"
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"io"
+	"os"
 )
 
 // AddLoggerFlagsOptions contains options for the Logger Flags
@@ -18,6 +23,19 @@ type AddLoggerFlagsOptions struct {
 	Differ       string // differing files
 	ErrFile      string // files with errors of some kind
 	DestAfter    string // files that exist on the destination post-sync
+}
+
+func (o AddLoggerFlagsOptions) AnySet() bool {
+	return anyNotBlank(o.Combined, o.MissingOnSrc, o.MissingOnDst, o.Match, o.Differ, o.ErrFile, o.DestAfter)
+}
+
+func anyNotBlank(s ...string) bool {
+	for _, x := range s {
+		if x != "" {
+			return true
+		}
+	}
+	return false
 }
 
 // AddLoggerFlags adds the logger flags to the cmdFlags command
@@ -42,4 +60,64 @@ func AddLoggerFlags(cmdFlags *pflag.FlagSet, opt *operations.LoggerOpt, flagsOpt
 	flags.BoolVarP(cmdFlags, &opt.Csv, "csv", "", false, "Output in CSV format", "Sync")
 	flags.BoolVarP(cmdFlags, &opt.Absolute, "absolute", "", false, "Put a leading / in front of path names", "Sync")
 	// flags.BoolVarP(cmdFlags, &recurse, "recursive", "R", false, "Recurse into the listing", "")
+}
+
+func ConfigureLoggers(ctx context.Context, fdst fs.Fs, command *cobra.Command, opt *operations.LoggerOpt, flagsOpt AddLoggerFlagsOptions) (func(), error) {
+	closers := []io.Closer{}
+
+	if opt.TimeFormat == "max" {
+		opt.TimeFormat = operations.FormatForLSFPrecision(fdst.Precision())
+	}
+	opt.SetListFormat(ctx, command.Flags())
+	opt.NewListJSON(ctx, fdst, "")
+
+	open := func(name string, pout *io.Writer) error {
+		if name == "" {
+			return nil
+		}
+		if name == "-" {
+			*pout = os.Stdout
+			return nil
+		}
+		out, err := os.Create(name)
+		if err != nil {
+			return err
+		}
+		*pout = out
+		closers = append(closers, out)
+		return nil
+	}
+
+	if err := open(flagsOpt.Combined, &opt.Combined); err != nil {
+		return nil, err
+	}
+	if err := open(flagsOpt.MissingOnSrc, &opt.MissingOnSrc); err != nil {
+		return nil, err
+	}
+	if err := open(flagsOpt.MissingOnDst, &opt.MissingOnDst); err != nil {
+		return nil, err
+	}
+	if err := open(flagsOpt.Match, &opt.Match); err != nil {
+		return nil, err
+	}
+	if err := open(flagsOpt.Differ, &opt.Differ); err != nil {
+		return nil, err
+	}
+	if err := open(flagsOpt.ErrFile, &opt.Error); err != nil {
+		return nil, err
+	}
+	if err := open(flagsOpt.DestAfter, &opt.DestAfter); err != nil {
+		return nil, err
+	}
+
+	close := func() {
+		for _, closer := range closers {
+			err := closer.Close()
+			if err != nil {
+				fs.Errorf(nil, "Failed to close report output: %v", err)
+			}
+		}
+	}
+
+	return close, nil
 }

--- a/fs/operations/operationsflags/operationsflags.go
+++ b/fs/operations/operationsflags/operationsflags.go
@@ -4,8 +4,10 @@ package operationsflags
 
 import (
 	"context"
+	_ "embed"
 	"io"
 	"os"
+	"strings"
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/flags"
@@ -14,6 +16,14 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
+
+//go:embed operationsflags.md
+var help string
+
+// Help returns the help string cleaned up to simplify appending
+func Help() string {
+	return strings.TrimSpace(help) + "\n\n"
+}
 
 // AddLoggerFlagsOptions contains options for the Logger Flags
 type AddLoggerFlagsOptions struct {

--- a/fs/operations/operationsflags/operationsflags.md
+++ b/fs/operations/operationsflags/operationsflags.md
@@ -1,0 +1,39 @@
+## Logger Flags
+
+The `--differ`, `--missing-on-dst`, `--missing-on-src`, `--match` and `--error` flags write paths,
+one per line, to the file name (or stdout if it is `-`) supplied. What they write is described
+in the help below. For example `--differ` will write all paths which are present
+on both the source and destination but different.
+
+The `--combined` flag will write a file (or stdout) which contains all
+file paths with a symbol and then a space and then the path to tell
+you what happened to it. These are reminiscent of diff files.
+
+- `= path` means path was found in source and destination and was identical
+- `- path` means path was missing on the source, so only in the destination
+- `+ path` means path was missing on the destination, so only in the source
+- `* path` means path was present in source and destination but different.
+- `! path` means there was an error reading or hashing the source or dest.
+
+The `--dest-after` flag writes a list file using the same format flags
+as [`lsf`](/commands/rclone_lsf/#synopsis) (including [customizable options
+for hash, modtime, etc.](/commands/rclone_lsf/#synopsis))
+Conceptually it is similar to rsync's `--itemize-changes`, but not identical
+-- it should output an accurate list of what will be on the destination
+after the command is finished.
+
+When the `--no-traverse` flag is set, all logs involving files that exist only
+on the destination will be incomplete or completely missing.
+
+Note that these logger flags have a few limitations, and certain scenarios
+are not currently supported:
+
+- `--max-duration` / `CutoffModeHard`
+- `--compare-dest` / `--copy-dest`
+- server-side moves of an entire dir at once
+- High-level retries, because there would be duplicates (use `--retries 1` to disable)
+- Possibly some unusual error scenarios
+
+Note also that each file is logged during execution, as opposed to after, so it
+is most useful as a predictor of what SHOULD happen to each file
+(which may or may not match what actually DID.)


### PR DESCRIPTION
#### What is the purpose of this change?

This enables the logger parameters (`--combined`, `--missing-on-src` etc.) for the `rclone copy` and `move` commands (as well as their `copyto` and `moveto` variants) akin to `rclone sync`. Warnings for unsupported/wonky flag combinations are also printed, e.g. when the destination is not traversed but `--dest-after` is specified.

I have not yet added the requisite documentation to the features yet as I wanted to check back whether this is a good way to go about it first. I aimed for factoring out the commonalities for this feature rather than copying it all over the place, but I'm not sure if I put things in the best spot they can be.

#### Was the change discussed in an issue or in the forum before?

Issue: #8115

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate. - I didn't find any tests for this integration for `sync`, so I think this is okay?
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
