### PR TITLE
webdav backend: retry propfind on 425 status

### DIFF
--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -82,26 +82,37 @@ type Prop struct {
 // Parse a status of the form "HTTP/1.1 200 OK" or "HTTP/1.1 200"
 var parseStatus = regexp.MustCompile(`^HTTP/[0-9.]+\s+(\d+)`)
 
-// StatusOK examines the Status and returns an OK flag
-func (p *Prop) StatusOK() bool {
-	// Assume OK if no statuses received
+// Code extracts the status code from the first status
+func (p *Prop) Code() int {
 	if len(p.Status) == 0 {
-		return true
+		return -1
 	}
 	match := parseStatus.FindStringSubmatch(p.Status[0])
 	if len(match) < 2 {
-		return false
+		return 0
 	}
 	code, err := strconv.Atoi(match[1])
 	if err != nil {
+		return 0
+	}
+	return code
+}
+
+// StatusOK examines the Status and returns an OK flag
+func (p *Prop) StatusOK() bool {
+	// Fetch status code as int
+	c := p.Code()
+
+	// Assume OK if no statuses received
+	if c == -1 {
+		return true
+	}
+	if c == 0 {
 		return false
 	}
-	// allow status 425 "too early" for files still in postprocessing
-	if code == 425 {
+	if c >= 200 && c < 300 {
 		return true
-	}
-	if code >= 200 && code < 300 {
-		return true
+
 	}
 	return false
 }

--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -96,6 +96,10 @@ func (p *Prop) StatusOK() bool {
 	if err != nil {
 		return false
 	}
+	// allow status 425 "too early" for files still in postprocessing
+	if code == 425 {
+		return true
+	}
 	if code >= 200 && code < 300 {
 		return true
 	}

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -356,7 +356,8 @@ func (f *Fs) readMetaDataForPath(ctx context.Context, path string, depth string)
 		return nil, fs.ErrorObjectNotFound
 	}
 	item := result.Responses[0]
-	if !item.Props.StatusOK() {
+	// status code 425 is accepted here as well
+	if !(item.Props.StatusOK() || item.Props.Code() == 425) {
 		return nil, fs.ErrorObjectNotFound
 	}
 	if itemIsDir(&item) {

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -244,6 +244,7 @@ func (f *Fs) Features() *fs.Features {
 // retryErrorCodes is a slice of error codes that we will retry
 var retryErrorCodes = []int{
 	423, // Locked
+	425, // Too Early
 	429, // Too Many Requests.
 	500, // Internal Server Error
 	502, // Bad Gateway


### PR DESCRIPTION
#### What is the purpose of this change?

Retry PROPFINDS when the server returns 425 Too Early.

#### Was the change discussed in an issue or in the forum before?

Debugging an rclone mount with oCIS we were seeing rclone trying to delete files that were fully uploaded, but had not yet been virus scanned. oCIS returns a 425 Too Early response in that case.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
