### PR TITLE
Disable Automatic Authentication Skipping for Unix Sockets

### DIFF
--- a/lib/http/context.go
+++ b/lib/http/context.go
@@ -36,12 +36,6 @@ func IsAuthenticated(r *http.Request) bool {
 	return false
 }
 
-// IsUnixSocket checks if the request was received on a unix socket, used to skip auth & CORS
-func IsUnixSocket(r *http.Request) bool {
-	v, _ := r.Context().Value(ctxKeyUnixSock).(bool)
-	return v
-}
-
 // PublicURL returns the URL defined in NewBaseContext, used for logging & CORS
 func PublicURL(r *http.Request) string {
 	v, _ := r.Context().Value(ctxKeyPublicURL).(string)

--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -57,11 +57,6 @@ func NewLoggedBasicAuthenticator(realm string, secrets goauth.SecretProvider) *L
 func basicAuth(authenticator *LoggedBasicAuth) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// skip auth for unix socket
-			if IsUnixSocket(r) {
-				next.ServeHTTP(w, r)
-				return
-			}
 			// skip auth for CORS preflight
 			if r.Method == "OPTIONS" {
 				next.ServeHTTP(w, r)
@@ -123,11 +118,6 @@ func MiddlewareAuthBasic(user, pass, realm, salt string) Middleware {
 func MiddlewareAuthCustom(fn CustomAuthFn, realm string, userFromContext bool) Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// skip auth for unix socket
-			if IsUnixSocket(r) {
-				next.ServeHTTP(w, r)
-				return
-			}
 			// skip auth for CORS preflight
 			if r.Method == "OPTIONS" {
 				next.ServeHTTP(w, r)
@@ -175,11 +165,6 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			// skip cors for unix sockets
-			if IsUnixSocket(r) {
-				next.ServeHTTP(w, r)
-				return
-			}
 
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)

--- a/lib/http/server.go
+++ b/lib/http/server.go
@@ -39,8 +39,7 @@ If you set ` + "`--{{ .Prefix }}addr`" + ` to listen on a public or LAN accessib
 then using Authentication is advised - see the next section for info.
 
 You can use a unix socket by setting the url to ` + "`unix:///path/to/socket`" + `
-or just by using an absolute path name. Note that unix sockets bypass the
-authentication - this is expected to be done with file system permissions.
+or just by using an absolute path name.
 
 ` + "`--{{ .Prefix }}addr`" + ` may be repeated to listen on multiple IPs/ports/sockets.
 Socket activation, described further below, can also be used to accomplish the same.


### PR DESCRIPTION
#### What is the purpose of this change?

This commit removes the bypass of authentication for requests coming from Unix sockets in the rclone serve functionality. This change addresses security concerns when behind a reverse proxy, where skipping authentication can expose sensitive endpoints. It ensures that authentication checks are consistently applied

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
