### PR TITLE
Add Wasabi eu-south-1 region

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1424,6 +1424,10 @@ func init() {
 				Help:     "Wasabi EU West 2 (Paris)",
 				Provider: "Wasabi",
 			}, {
+				Value:    "s3.eu-south-1.wasabisys.com",
+				Help:     "Wasabi EU South 1 (Milan)",
+				Provider: "Wasabi",
+			}, {
 				Value:    "s3.ap-northeast-1.wasabisys.com",
 				Help:     "Wasabi AP Northeast 1 (Tokyo) endpoint",
 				Provider: "Wasabi",


### PR DESCRIPTION
#### What is the purpose of this change?

Added `eu-south-1` to Wasabi region list. Reference: https://docs.wasabi.com/docs/what-are-the-service-urls-for-wasabi-s-different-storage-regions

#### Was the change discussed in an issue or in the forum before?

I'm not aware of any discussion.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
