### PR TITLE
s3: Storj provider: fix server-side copy of files bigger than 5GB

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -3447,6 +3447,10 @@ func setQuirks(opt *Options) {
 			opt.ChunkSize = 64 * fs.Mebi
 		}
 		useAlreadyExists = false // returns BucketAlreadyExists
+		// Storj doesn't support multi-part server side copy:
+		// https://github.com/storj/roadmap/issues/40
+		// So make cutoff very large which it does support
+		opt.CopyCutoff = math.MaxInt64
 	case "Synology":
 		useMultipartEtag = false
 		useAlreadyExists = false // untested


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Like some other S3-compatible providers, Storj does not currently implements UploadPartCopy and returns NotImplemented errors for multi-part server side copies.

This patch works around the problem by raising --s3-copy-cutoff for Storj to the maximum. This means that rclone will never use multi-part copies for files in Storj. This includes files larger than 5GB which (according to AWS documentation) must be copied with multi-part copy. This works fine for Storj.

See https://github.com/storj/roadmap/issues/40

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
