### PR TITLE
docs: instructs avoiding inline comments in a filter-file

### DIFF
--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -505,8 +505,8 @@ processed in.
 Arrange the order of filter rules with the most restrictive first and
 work down.
 
-Avoid inline comments. These can remove the filtering action of the
-associated filter.
+Inline comments are not supported. These comments alter the filtering action of the
+associated filter. _Use `-vv --dump filters` to see how they appear in the final regexp._
 
 E.g. for `filter-file.txt`:
 
@@ -515,7 +515,7 @@ E.g. for `filter-file.txt`:
     + *.jpg
     + *.png
     + file2.avi
-    - /dir/tmp/** # inline comment nullifies this exclusion
+    - /dir/tmp/** # WARNING! The inline comment nullifies this exclusion.
     - /dir/Trash/**
     + /dir/**
     # exclude everything else

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -505,8 +505,7 @@ processed in.
 Arrange the order of filter rules with the most restrictive first and
 work down.
 
-Inline comments are not supported. These comments alter the filtering action of the
-associated filter. _Use `-vv --dump filters` to see how they appear in the final regexp._
+Lines starting with # or ; are ignored, and can be used to write comments. Inline comments are not supported. _Use `-vv --dump filters` to see how they appear in the final regexp._
 
 E.g. for `filter-file.txt`:
 

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -505,6 +505,9 @@ processed in.
 Arrange the order of filter rules with the most restrictive first and
 work down.
 
+Avoid inline comments. These can remove the filtering action of the
+associated filter.
+
 E.g. for `filter-file.txt`:
 
     # a sample filter rule file
@@ -512,6 +515,7 @@ E.g. for `filter-file.txt`:
     + *.jpg
     + *.png
     + file2.avi
+    - /dir/tmp/** # inline comment nullifies this exclusion
     - /dir/Trash/**
     + /dir/**
     # exclude everything else

--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -515,7 +515,7 @@ E.g. for `filter-file.txt`:
     + *.jpg
     + *.png
     + file2.avi
-    - /dir/tmp/** # WARNING! The inline comment nullifies this exclusion.
+    - /dir/tmp/** # WARNING! This text will be treated as part of the path.
     - /dir/Trash/**
     + /dir/**
     # exclude everything else


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Inline comments in a "--filter-from" file effectively remove the filter on that line (with directories in my hands). As far as I can tell this behavior isn't documented/warned and doesn't throw errors.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

[PR requested](https://forum.rclone.org/t/inline-comments-effectively-remove-filter-in-filter-from/48301) in forum.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
