### PR TITLE
Remove publish app mention

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -1797,7 +1797,8 @@ create and delete files with RClone.
 "Save and continue" to add test users. Be sure to add your own account to
 the test users. Once you've added yourself as a test user and saved the
 changes, click again on "Credentials" on the left panel to go back to
-the "Credentials" screen.
+the "Credentials" screen. You can add up to 100 test users, to whom you
+must share the id and secret to be able to use it.
 
    (PS: if you are a GSuite user, you could also select "Internal" instead
 of "External" above, but this will restrict API use to Google Workspace 
@@ -1814,10 +1815,7 @@ then select "OAuth client ID".
    If you chose "Internal" you don't need to publish and can skip straight to
    Step 11 but your destination drive must be part of the same Google Workspace.)
 
-10. Go to "Oauth consent screen" and then click "PUBLISH APP" button and confirm.
-   You will also want to add yourself as a test user.
-
-11. Provide the noted client ID and client secret to rclone.
+10. Provide the noted client ID and client secret to rclone.
 
 Be aware that, due to the "enhanced security" recently introduced by
 Google, you are theoretically expected to "submit your app for verification"


### PR DESCRIPTION
This is not required to use the application for yourself or a small group of trusted people.

#### What is the purpose of this change?

Removes the mention to publish the application in Google Cloud as it is not required for personal use, including if id and secret is shared with a small group of trusted people included in the testing users.

#### Was the change discussed in an issue or in the forum before?

N/A

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
