### PR TITLE
local: add --skip-specials to ignore special files

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -118,6 +118,17 @@ points, as you explicitly acknowledge that they should be skipped.`,
 				Advanced: true,
 			},
 			{
+				Name: "skip_specials",
+				Help: `Don't warn about skipped pipes, sockets and device objects.
+
+This flag disables warning messages on skipped pipes, sockets and
+device objects, as you explicitly acknowledge that they should be
+skipped.`,
+				Default:  false,
+				NoPrefix: true,
+				Advanced: true,
+			},
+			{
 				Name: "zero_size_links",
 				Help: `Assume the Stat size of links is zero (and read them instead) (deprecated).
 
@@ -324,6 +335,7 @@ type Options struct {
 	FollowSymlinks    bool                 `config:"copy_links"`
 	TranslateSymlinks bool                 `config:"links"`
 	SkipSymlinks      bool                 `config:"skip_links"`
+	SkipSpecials      bool                 `config:"skip_specials"`
 	UTFNorm           bool                 `config:"unicode_normalization"`
 	NoCheckUpdated    bool                 `config:"no_check_updated"`
 	NoUNC             bool                 `config:"nounc"`
@@ -1201,7 +1213,9 @@ func (o *Object) Storable() bool {
 		}
 		return false
 	} else if mode&(os.ModeNamedPipe|os.ModeSocket|os.ModeDevice) != 0 {
-		fs.Logf(o, "Can't transfer non file/directory")
+		if !o.fs.opt.SkipSpecials {
+			fs.Logf(o, "Can't transfer non file/directory")
+		}
 		return false
 	} else if mode&os.ModeDir != 0 {
 		// fs.Debugf(o, "Skipping directory")

--- a/docs/content/commands/rclone.md
+++ b/docs/content/commands/rclone.md
@@ -834,6 +834,7 @@ rclone [flags]
       --sia-user-agent string                               Siad User Agent (default "Sia-Agent")
       --size-only                                           Skip based on size only, not modtime or checksum
       --skip-links                                          Don't warn about skipped symlinks
+      --skip-specials                                       Don't warn about skipped pipes, sockets and device objects
       --smb-case-insensitive                                Whether the server is configured to be case-insensitive (default true)
       --smb-description string                              Description of the remote
       --smb-domain string                                   Domain name for NTLM authentication (default "WORKGROUP")

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -975,6 +975,7 @@ Backend-only flags (these can be set in the config file also).
       --sia-encoding Encoding                               The encoding for the backend (default Slash,Question,Hash,Percent,Del,Ctl,InvalidUtf8,Dot)
       --sia-user-agent string                               Siad User Agent (default "Sia-Agent")
       --skip-links                                          Don't warn about skipped symlinks
+      --skip-specials                                       Don't warn about skipped pipes, sockets and device objects
       --smb-case-insensitive                                Whether the server is configured to be case-insensitive (default true)
       --smb-description string                              Description of the remote
       --smb-domain string                                   Domain name for NTLM authentication (default "WORKGROUP")

--- a/docs/content/local.md
+++ b/docs/content/local.md
@@ -386,6 +386,21 @@ Properties:
 - Type:        bool
 - Default:     false
 
+#### --skip-specials
+
+Don't warn about skipped pipes, sockets and device objects.
+
+This flag disables warning messages on skipped pipes, sockets and
+device objects, as you explicitly acknowledge that they should be
+skipped.`,
+
+Properties:
+
+- Config:      skip_specials
+- Env Var:     RCLONE_LOCAL_SKIP_SPECIALS
+- Type:        bool
+- Default:     false
+
 #### --local-zero-size-links
 
 Assume the Stat size of links is zero (and read them instead) (deprecated).


### PR DESCRIPTION
Give users a way to explicitly acknowledge that pipes, sockets and block devices are to be ignored without warnings.

This follows the precedent set in commit 6152bab28 (local: add --skip-links to suppress symlink warnings, 2017-07-21) for ignoring warnings about symlinks.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

When working on a local filesystem that may contain symlinks, you can already suppress the warnings about not being able follow symlinks.

I've been working on copying a filesystem that has some named pipes, I'm happy for those to be skipped in an `rclone copy` operation, and I'd rather not see warnings about them, so I've emulated the `--skip-symlinks` code to suppress warnings about other filesystem objects that can't be stored by rclone.

#### Was the change discussed in an issue or in the forum before?

No previous discussion of this issue. The code I'm emulating was added in commit 6152bab28, which was added in #1545 to fix issue #1480.

I've not added any tests, as there don't seem to be tests directly for the `--skip-symlinks` function. That said, that function does seem to be tested in passing, as the test code for checking config precedence orders uses that function…

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
