### PR TITLE
ssh_external: associate new session with client

### DIFF
--- a/backend/sftp/ssh_external.go
+++ b/backend/sftp/ssh_external.go
@@ -47,11 +47,11 @@ func (s *sshClientExternal) Close() error {
 
 // NewSession makes a new external SSH connection
 func (s *sshClientExternal) NewSession() (sshSession, error) {
-	session := s.f.newSSHSessionExternal()
 	if s.session == nil {
+		s.session = s.f.newSSHSessionExternal()
 		fs.Debugf(s.f, "ssh external: creating additional session")
 	}
-	return session, nil
+	return s.session, nil
 }
 
 // CanReuse indicates if this client can be reused


### PR DESCRIPTION
#### What is the purpose of this change?

When creating an SSH Session it should be associated with the external client so that it is cleaned up
when closed. This prevents zombie ssh sessions from piling up.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
