### PR TITLE
docs: Docker mount docs with compose example

### DIFF
--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -294,7 +294,7 @@ docker run --rm \
     listremotes
 
 # perform mount inside Docker container, expose result to host
-mkdir -p ~/data/mount
+mkdir -p ~/data
 docker run --rm \
     --volume ~/.config/rclone:/config/rclone \
     --volume ~/data:/data:shared \
@@ -302,8 +302,8 @@ docker run --rm \
     --volume /etc/passwd:/etc/passwd:ro --volume /etc/group:/etc/group:ro \
     --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined \
     rclone/rclone \
-    mount dropbox:Photos /data/mount &
-ls ~/data/mount
+    mount dropbox:Photos /data &
+ls ~/data
 kill %1
 ```
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This is a PR to provide clearer documentation for running rclone mounts in Docker. The PR adds a full example of a Docker Compose with best practices discussed in [this forum post](https://forum.rclone.org/t/propogating-rclone-mounts-to-docker-containers-without-transport-endpoint-going-stale/48112?u=eliasbenb).

It also slightly modifies the existing instructions for rclone mounts with `docker run` to be a little more consistent with other sections of documentation. The documentation mentions that the mount point would be "on host at  \~/data". However, the example run command mounted the data at "\~/data/mount" instead. I removed the "/mount" to make things a little more consistent and clear.


#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/propogating-rclone-mounts-to-docker-containers-without-transport-endpoint-going-stale/48112?u=eliasbenb

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
