### PR TITLE
googlecloudstorage: add example values for endpoint with help on avoiding transfer fees

### DIFF
--- a/backend/googlecloudstorage/googlecloudstorage.go
+++ b/backend/googlecloudstorage/googlecloudstorage.go
@@ -337,8 +337,9 @@ can't check the size and hash but the file contents will be decompressed.
 			Default:  false,
 		}, {
 			Name:     "endpoint",
-			Help:     "Endpoint for the service.\n\nLeave blank normally.",
+			Help:     "Endpoint for the service. Use a regional endpoint (storage.REGION.rep.googleapis.com) to reduce transfer fees",
 			Advanced: true,
+			Examples: getHelpForEndpoints(),
 		}, {
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,

--- a/backend/googlecloudstorage/googlecloudstorageendpoints.go
+++ b/backend/googlecloudstorage/googlecloudstorageendpoints.go
@@ -1,0 +1,35 @@
+package googlecloudstorage
+
+import (
+	"fmt"
+
+	"github.com/rclone/rclone/fs"
+)
+
+type endpointRecord struct {
+	endpointURL, Location, Description string
+}
+
+var endpoints = []endpointRecord{
+	{"https://storage.europe-west3.rep.googleapis.com/storage/v1/", "europe-west3", "Frankfurt"},
+	{"https://storage.europe-west8.rep.googleapis.com/storage/v1/", "europe-west8", "Milan"},
+	{"https://storage.europe-west9.rep.googleapis.com/storage/v1/", "europe-west9", "Paris"},
+	{"https://storage.me-central2.rep.googleapis.com/storage/v1/", "me-central2", "Doha"},
+	{"https://storage.us-central1.rep.googleapis.com/storage/v1/", "us-central1", "Iowa"},
+	{"https://storage.us-east1.rep.googleapis.com/storage/v1/", "us-east1", "South Carolina"},
+	{"https://storage.us-east4.rep.googleapis.com/storage/v1/", "us-east4", "Northern Virgina"},
+	{"https://storage.us-east5.rep.googleapis.com/storage/v1/", "us-east5", "Columbus"},
+	{"https://storage.us-south1.rep.googleapis.com/storage/v1/", "us-south1", "Dallas"},
+	{"https://storage.us-west1.rep.googleapis.com/storage/v1/", "us-west1", "Oregon"},
+	{"https://storage.us-west2.rep.googleapis.com/storage/v1/", "us-west2", "Los Angeles"},
+	{"https://storage.us-west3.rep.googleapis.com/storage/v1/", "us-west3", "Salt Lake City"},
+	{"https://storage.us-west4.rep.googleapis.com/storage/v1/", "us-west4", "Las Vegas"},
+}
+
+func getHelpForEndpoints() (r []fs.OptionExample) {
+	r = make([]fs.OptionExample, 0, len(endpoints))
+	for _, ep := range endpoints {
+		r = append(r, fs.OptionExample{Value: ep.endpointURL, Help: fmt.Sprintf("%s : %s", ep.Location, ep.Description)})
+	}
+	return r
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
For *googlecloudstorage* backend, the default global endpoint `storage.googleapis.com` may lead to significant transfer fees of $10-$100/TB when calling rclone from GCE (Compute Engine VM) , even when both the VM & bucket are in the same region.  This should help rclone users who may not be familiar with some of the nuances of GCE region transfer fees.  Region-specific endpoints will also improve latency & throughput.

This change adds help text to the advanced option `endpoint` , along with example values to allow users to select a region-specific endpoint. 

<!--
Describe the changes here
-->
Added example values & help text to endpoint option to simplify setting region-specific endpoint for the users. 

e.g. 

```
Option endpoint.
Endpoint for the service. Use a regional endpoint (storage.REGION.rep.googleapis.com) to reduce transfer fees
Choose a number from below, or type in your own string value.
Press Enter for the default (https://storage.us-west1.rep.googleapis.com/storage/v1/).
 1 / europe-west3 : Frankfurt
   \ (https://storage.europe-west3.rep.googleapis.com/storage/v1/)
 2 / europe-west8 : Milan
   \ (https://storage.europe-west8.rep.googleapis.com/storage/v1/)
 3 / europe-west9 : Paris
   \ (https://storage.europe-west9.rep.googleapis.com/storage/v1/)
 4 / me-central2 : Doha
   \ (https://storage.me-central2.rep.googleapis.com/storage/v1/)
 5 / us-central1 : Iowa

```


#### Was the change discussed in an issue or in the forum before?
Yes, there seemed to be consensus on the approach. 

https://forum.rclone.org/t/gcs-use-region-specific-endpoints-to-avoid-inter-region-transfer-fees-of-20-tb/48155
<!--
Link issues and relevant forum posts here.
-->

#### Example tests

```
go run . ls dev-gcs://dev-xxxx-us/ 
endpoint: https://storage.us-west1.rep.googleapis.com/storage/v1/
   92997 images/2024-11-11-git-recompose-pattern.png
```
```
golangci-lint run ./... 
```
```
go vet ./...
```

#### Checklist

- [ ✅] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [✅ ] I have added tests for all changes in this PR if appropriate.
- [✅ ] I have added documentation for the changes if appropriate.
- [✅ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
