### PR TITLE
Fixed missing `state` parameter in `/auth` link in instructions

### DIFF
--- a/docs/content/box.md
+++ b/docs/content/box.md
@@ -64,7 +64,7 @@ If not sure try Y. If Y failed, try N.
 y) Yes
 n) No
 y/n> y
-If your browser doesn't open automatically go to the following link: http://127.0.0.1:53682/auth
+If your browser doesn't open automatically go to the following link: http://127.0.0.1:53682/auth?state=XXXXXXXXXXXXXXXXXXXXXX
 Log in and authorize rclone for access
 Waiting for code...
 Got code


### PR DESCRIPTION
When the `state` token was redacted the instructions implied that you could simply go to `/auth` without the `state` parameter.  _This does not work._  The redacted `state` parameter is the key to the entire process and was the cause of my frustration.  Since, I was doing an SSH tunnel headless installation, the missing `state` parameter made me doubt other parts of the process.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix box instructions for `/auth` url had redacted `state` parameter 

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [n/a] I have added tests for all changes in this PR if appropriate.
- [n/a] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
