### PR TITLE
cmd/mountlib: better snap mount error message

### DIFF
--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -373,6 +373,9 @@ func (m *MountPoint) Mount() (mountDaemon *os.Process, err error) {
 
 	m.ErrChan, m.UnmountFn, err = m.MountFn(m.VFS, m.MountPoint, &m.MountOpt)
 	if err != nil {
+	        if len(os.Args) > 0 && strings.HasPrefix(os.Args[0], "/snap/") {
+        	    return nil, fmt.Errorf("mounting is not supported when running from snap")
+        	}
 		return nil, fmt.Errorf("failed to mount FUSE fs: %w", err)
 	}
 	m.MountedOn = time.Now()

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -373,9 +373,9 @@ func (m *MountPoint) Mount() (mountDaemon *os.Process, err error) {
 
 	m.ErrChan, m.UnmountFn, err = m.MountFn(m.VFS, m.MountPoint, &m.MountOpt)
 	if err != nil {
-	        if len(os.Args) > 0 && strings.HasPrefix(os.Args[0], "/snap/") {
-        	    return nil, fmt.Errorf("mounting is not supported when running from snap")
-        	}
+		if len(os.Args) > 0 && strings.HasPrefix(os.Args[0], "/snap/") {
+			return nil, fmt.Errorf("mounting is not supported when running from snap")
+		}
 		return nil, fmt.Errorf("failed to mount FUSE fs: %w", err)
 	}
 	m.MountedOn = time.Now()


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

mounting will always fail when rclone is installed from the snap package manager.
But the error message generated when trying to mount from a snap install was not
very good. Improve the error message.
Should prevent more bugreports like https://github.com/rclone/rclone/issues/8208
(I spent an hour on that bugreport.. Time wasted that wouldn't be if the error message was better)
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

discussed in issue #8208.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
