### PR TITLE
In non-interactive mode, set my OneDrive as the default drive

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"path"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -505,6 +506,10 @@ func chooseDrive(ctx context.Context, name string, m configmap.Mapper, srv *rest
 					break
 				}
 			}
+			// my OneDrive as the first drive
+			sort.SliceStable(drives.Drives, func(i, j int) bool {
+				return drives.Drives[i].DriveID == meDrive.DriveID
+			})
 			// add the me drive if not found already
 			if !found {
 				fs.Debugf(nil, "Adding %v to drives list from /me/drive", meDrive)


### PR DESCRIPTION
#### What is the purpose of this change?
When configuring OneDrive in non-interactive mode, the first drive among all drives is selected by default, which can be somewhat random. After the update, all drives will be sorted, and the OneDrive returned by the /me/drive endpoint will be set as the first item, making it the default drive.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
