### PR TITLE
vfs: with --vfs-used-is-size value is calculated and then thrown away - fixes #8220

### DIFF
--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -626,6 +626,10 @@ func (vfs *VFS) Statfs() (total, used, free int64) {
 				return nil
 			})
 			vfs.usage.Used = &usedBySizeAlgorithm
+			// if we read a Total size then we should calculate Free from it
+			if vfs.usage.Total != nil {
+				vfs.usage.Free = nil
+			}
 		}
 		vfs.usageTime = time.Now()
 		if err != nil {


### PR DESCRIPTION
#### What is the purpose of this change?

--vfs-used-is-size is broken. This PR fixes it.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/8220

#### Checklist

- [x ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ x] I have added tests for all changes in this PR if appropriate.
- [x ] I have added documentation for the changes if appropriate.
- [ x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)
