### PR TITLE
lib/oauthutil: add configurable bind address for callback server

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -49,6 +49,9 @@ const (
 	// ConfigClientCredentials - use OAUTH2 client credentials
 	ConfigClientCredentials = "client_credentials"
 
+	// ConfigAuthServerBindAddress is the local bind address for OAuth callback server
+	ConfigAuthServerBindAddress = "auth_bind_addr"
+
 	// ConfigEncoding is the config key to change the encoding for a backend
 	ConfigEncoding = "encoding"
 

--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -41,11 +41,8 @@ const (
 	// bindPort is the port that we bind the local webserver to
 	bindPort = "53682"
 
-	// bindAddress is binding for local webserver when active
-	bindAddress = "127.0.0.1:" + bindPort
-
 	// RedirectURL is redirect to local webserver when active
-	RedirectURL = "http://" + bindAddress + "/"
+	RedirectURL = "http://127.0.0.1:" + bindPort + "/"
 
 	// RedirectPublicURL is redirect to local webserver when active with public name
 	RedirectPublicURL = "http://localhost.rclone.org:" + bindPort + "/"
@@ -156,6 +153,11 @@ var SharedOptions = []fs.Option{{
 	Name:     config.ConfigClientCredentials,
 	Default:  false,
 	Help:     "Use client credentials OAuth flow.\n\nThis will use the OAUTH2 client Credentials Flow as described in RFC 6749.",
+	Advanced: true,
+}, {
+	Name:     config.ConfigAuthServerBindAddress,
+	Default:  "127.0.0.1",
+	Help:     "Local bind address for OAuth callback server.\n\nLeave blank to use the default of 127.0.0.1",
 	Advanced: true,
 }}
 
@@ -772,6 +774,15 @@ func noWebserverNeeded(oauthConfig *Config) bool {
 	return oauthConfig.RedirectURL == TitleBarRedirectURL
 }
 
+// get the bind address for the OAuth callback server
+func getBindAddress(m configmap.Mapper) string {
+	bindAddr, ok := m.Get("auth_bind_addr")
+	if !ok || bindAddr == "" {
+		bindAddr = "127.0.0.1"
+	}
+	return bindAddr + ":" + bindPort
+}
+
 // get the URL we need to send the user to
 func getAuthURL(name string, m configmap.Mapper, oauthConfig *Config, opt *Options) (authURL string, state string, err error) {
 	oauthConfig, _ = OverrideCredentials(name, m, oauthConfig)
@@ -846,6 +857,7 @@ func configSetup(ctx context.Context, id, name string, m configmap.Mapper, oauth
 	}
 
 	// Prepare webserver
+	bindAddress := getBindAddress(m)
 	server := newAuthServer(opt, bindAddress, state, authURL)
 	err = server.Init()
 	if err != nil {


### PR DESCRIPTION
Add new config option auth_bind_addr to allow users to configure the bind address for the OAuth callback server.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Add the auth_bind_addr configuration entry to the oauth util so that you can easily use an ssh tunnel to expose the port when configuring rclone in the container.

#### Was the change discussed in an issue or in the forum before?

#469 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
