### PR TITLE
ChangeNotify() for local backend using fsnotify

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1305,11 +1305,13 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 				entryPath := event.Name
 				entryType := fs.EntryObject
 
-				info, err := os.Stat(entryPath)
-				if err != nil {
-					fs.Debugf(f, "Failed to stat %s", entryPath)
-				} else if info.IsDir() {
-					entryType = fs.EntryDirectory
+				if event.Op != fsnotify.Remove {
+					info, err := os.Stat(entryPath)
+					if err != nil {
+						fs.Debugf(f, "Failed to stat %s", entryPath)
+					} else if info.IsDir() {
+						entryType = fs.EntryDirectory
+					}
 				}
 
 				switch event.Op {

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1302,36 +1302,44 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 					return
 				}
 
+				entryPath := event.Name
+				entryType := fs.EntryObject
+
+				info, err := os.Stat(entryPath)
+				if err != nil {
+					fs.Debugf(f, "Failed to stat %s", entryPath)
+				} else if info.IsDir() {
+					entryType = fs.EntryDirectory
+				}
+
 				switch event.Op {
 				case fsnotify.Create:
-					fs.Debugf(f, "Create: %s", event.Name)
-					info, err := os.Stat(event.Name)
-					if err != nil {
-						fs.Debugf(f, "Failed to stat %s", event.Name)
-					} else if info.IsDir() {
-						err := watcher.Add(event.Name)
+					fs.Debugf(f, "Create: %s", entryPath)
+					if entryType == fs.EntryDirectory {
+						err := watcher.Add(entryPath)
 						if err != nil {
-							fs.Debugf(f, "Failed to start watching %s", event.Name)
+							fs.Debugf(f, "Failed to start watching %s", entryPath)
 						} else {
-							fs.Debugf(f, "Started watching %s", event.Name)
+							fs.Debugf(f, "Started watching %s", entryPath)
 						}
 					}
 				case fsnotify.Write:
-					fs.Debugf(f, "Write: %s", event.Name)
+					fs.Debugf(f, "Write: %s", entryPath)
 				case fsnotify.Remove:
-					fs.Debugf(f, "Remove: %s", event.Name)
-					// No need to stop watching directories when removed, handled by
-					// fsnotify
+					// No need to stop watching removed directories, handled by fsnotify
+					fs.Debugf(f, "Remove: %s", entryPath)
 				case fsnotify.Rename:
-					fs.Debugf(f, "Rename: %s", event.Name)
+					fs.Debugf(f, "Rename: %s", entryPath)
 				case fsnotify.Chmod:
-					fs.Debugf(f, "Chmod: %s", event.Name)
+					fs.Debugf(f, "Chmod: %s", entryPath)
 				}
+				notifyFunc(entryPath, entryType)
+
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					return
 				}
-				fs.Debugf(f, "Received error: %s", err.Error())
+				fs.Debugf(f, "Error: %s", err.Error())
 			}
 		}
 	}()

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1277,22 +1277,7 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 			return
 		}
 		defer watcher.Close()
-
-		// Add root path, recursively
-		//
-		// For a directory, WalkDir() makes the callback before listing, so
-		// watching for changes can begin before the initial listing
-		filepath.WalkDir(f.root, func(path string, d os.DirEntry, err error) error {
-			if d.IsDir() {
-				err := watcher.Add(path)
-				if err != nil {
-					fs.Debugf(f, "Failed to start watching %s", path)
-				} else {
-					fs.Debugf(f, "Started watching %s", path)
-				}
-			}
-			return nil
-		})
+		f.watchPath(watcher, f.root)
 
 		// Process events and errors
 		for {
@@ -1318,12 +1303,7 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 				case fsnotify.Create:
 					fs.Debugf(f, "Create: %s", entryPath)
 					if entryType == fs.EntryDirectory {
-						err := watcher.Add(entryPath)
-						if err != nil {
-							fs.Debugf(f, "Failed to start watching %s", entryPath)
-						} else {
-							fs.Debugf(f, "Started watching %s", entryPath)
-						}
+						f.watchPath(watcher, entryPath)
 					}
 				case fsnotify.Write:
 					fs.Debugf(f, "Write: %s", entryPath)
@@ -1345,6 +1325,23 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 			}
 		}
 	}()
+}
+
+// Watch a path, recursively
+func (f *Fs) watchPath(watcher *fsnotify.Watcher, path string) {
+	// For a directory, WalkDir() makes the callback before listing, so the
+	// watching begins before listing and recursing into subdirectories
+	filepath.WalkDir(path, func(path string, d os.DirEntry, err error) error {
+		if d.IsDir() {
+			err := watcher.Add(path)
+			if err != nil {
+				fs.Debugf(f, "Failed to start watching %s", path)
+			} else {
+				fs.Debugf(f, "Started watching %s", path)
+			}
+		}
+		return nil
+	})
 }
 
 // Returns a ReadCloser() object that contains the contents of a symbolic link

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1287,13 +1287,16 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 					return
 				}
 
-				entryPath := event.Name
+				rootSlash := strings.TrimSuffix(f.root, "/")
+				rootSlash += "/"
+
+				entryPath := strings.TrimPrefix(event.Name, rootSlash)
 				entryType := fs.EntryObject
 
 				if event.Op != fsnotify.Remove {
-					info, err := os.Stat(entryPath)
+					info, err := os.Stat(event.Name)
 					if err != nil {
-						fs.Debugf(f, "Failed to stat %s", entryPath)
+						fs.Debugf(f, "Failed to stat %s", event.Name)
 					} else if info.IsDir() {
 						entryType = fs.EntryDirectory
 					}
@@ -1303,7 +1306,7 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 				case fsnotify.Create:
 					fs.Debugf(f, "Create: %s", entryPath)
 					if entryType == fs.EntryDirectory {
-						f.watchPath(watcher, entryPath)
+						f.watchPath(watcher, event.Name)
 					}
 				case fsnotify.Write:
 					fs.Debugf(f, "Write: %s", entryPath)

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1284,28 +1284,56 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 		// watching for changes can begin before the initial listing
 		filepath.WalkDir(f.root, func(path string, d os.DirEntry, err error) error {
 			if d.IsDir() {
-				fs.Infof(f, "watching: %s", path)
-				var err = watcher.Add(path)
+				err := watcher.Add(path)
 				if err != nil {
-					fs.Debugf(f, "Failed to add root path to watcher of local filesystem")
+					fs.Debugf(f, "Failed to start watching %s", path)
+				} else {
+					fs.Debugf(f, "Started watching %s", path)
 				}
 			}
 			return nil
 		})
 
-		// Process events
+		// Process events and errors
 		for {
 			select {
 			case event, ok := <-watcher.Events:
 				if !ok {
 					return
 				}
-				fs.Infof(f, "event: %s", event.Name)
+				fs.Debugf(f, "Received event: %s", event.Name)
+
+				switch event.Op {
+				case fsnotify.Create:
+					info, err := os.Stat(event.Name)
+					if err != nil {
+						fs.Debugf(f, "Failed to stat %s", event.Name)
+					} else if info.IsDir() {
+						err := watcher.Add(event.Name)
+						if err != nil {
+							fs.Debugf(f, "Failed to start watching %s", event.Name)
+						} else {
+							fs.Debugf(f, "Started watching %s", event.Name)
+						}
+					}
+				case fsnotify.Remove:
+					info, err := os.Stat(event.Name)
+					if err != nil {
+						fs.Debugf(f, "Failed to stat %s", event.Name)
+					} else if info.IsDir() {
+						err := watcher.Remove(event.Name)
+						if err != nil {
+							fs.Debugf(f, "Failed to stop watching %s", event.Name)
+						} else {
+							fs.Debugf(f, "Stopped watching %s", event.Name)
+						}
+					}
+				}
 			case err, ok := <-watcher.Errors:
 				if !ok {
 					return
 				}
-				fs.Infof(f, "error: %s", err.Error())
+				fs.Debugf(f, "Received error: %s", err.Error())
 			}
 		}
 	}()

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1270,7 +1270,7 @@ func (file *localOpenFile) Close() (err error) {
 // Close the returned channel to stop being notified.
 func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryType), pollIntervalChan <-chan time.Duration) {
 	go func() {
-		// Create new watcher.
+		// Create new watcher
 		watcher, err := fsnotify.NewWatcher()
 		if err != nil {
 			fs.Debugf(f, "Failed to create watcher for local filesystem")
@@ -1278,12 +1278,17 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 		}
 		defer watcher.Close()
 
-		// Add a path.
-		err = watcher.Add(f.root)
-		if err != nil {
-			fs.Debugf(f, "Failed to add root path to watcher of local filesystem")
-			return
-		}
+		// Add root path, recursively
+		filepath.WalkDir(f.root, func(path string, d os.DirEntry, err error) error {
+			if d.IsDir() {
+				fs.Infof(f, "watching: %s", path)
+				var err = watcher.Add(path)
+				if err != nil {
+					fs.Debugf(f, "Failed to add root path to watcher of local filesystem")
+				}
+			}
+			return nil
+		})
 
 		// Process events
 		for {

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1279,6 +1279,9 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 		defer watcher.Close()
 
 		// Add root path, recursively
+		//
+		// For a directory, WalkDir() makes the callback before listing, so
+		// watching for changes can begin before the initial listing
 		filepath.WalkDir(f.root, func(path string, d os.DirEntry, err error) error {
 			if d.IsDir() {
 				fs.Infof(f, "watching: %s", path)

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -17,6 +17,7 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/fsnotify/fsnotify"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/accounting"
 	"github.com/rclone/rclone/fs/config"
@@ -1260,6 +1261,46 @@ func (file *localOpenFile) Close() (err error) {
 		}
 	}
 	return err
+}
+
+// ChangeNotify calls the passed function with a path that has had changes.
+// The implementation does not use polling, such that the given poll interval
+// is ignored.
+//
+// Close the returned channel to stop being notified.
+func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryType), pollIntervalChan <-chan time.Duration) {
+	go func() {
+		// Create new watcher.
+		watcher, err := fsnotify.NewWatcher()
+		if err != nil {
+			fs.Debugf(f, "Failed to create watcher for local filesystem")
+			return
+		}
+		defer watcher.Close()
+
+		// Add a path.
+		err = watcher.Add(f.root)
+		if err != nil {
+			fs.Debugf(f, "Failed to add root path to watcher of local filesystem")
+			return
+		}
+
+		// Process events
+		for {
+			select {
+			case event, ok := <-watcher.Events:
+				if !ok {
+					return
+				}
+				fs.Infof(f, "event: %s", event.Name)
+			case err, ok := <-watcher.Errors:
+				if !ok {
+					return
+				}
+				fs.Infof(f, "error: %s", err.Error())
+			}
+		}
+	}()
 }
 
 // Returns a ReadCloser() object that contains the contents of a symbolic link

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1301,10 +1301,10 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 				if !ok {
 					return
 				}
-				fs.Debugf(f, "Received event: %s", event.Name)
 
 				switch event.Op {
 				case fsnotify.Create:
+					fs.Debugf(f, "Create: %s", event.Name)
 					info, err := os.Stat(event.Name)
 					if err != nil {
 						fs.Debugf(f, "Failed to stat %s", event.Name)
@@ -1316,18 +1316,16 @@ func (f *Fs) ChangeNotify(ctx context.Context, notifyFunc func(string, fs.EntryT
 							fs.Debugf(f, "Started watching %s", event.Name)
 						}
 					}
+				case fsnotify.Write:
+					fs.Debugf(f, "Write: %s", event.Name)
 				case fsnotify.Remove:
-					info, err := os.Stat(event.Name)
-					if err != nil {
-						fs.Debugf(f, "Failed to stat %s", event.Name)
-					} else if info.IsDir() {
-						err := watcher.Remove(event.Name)
-						if err != nil {
-							fs.Debugf(f, "Failed to stop watching %s", event.Name)
-						} else {
-							fs.Debugf(f, "Stopped watching %s", event.Name)
-						}
-					}
+					fs.Debugf(f, "Remove: %s", event.Name)
+					// No need to stop watching directories when removed, handled by
+					// fsnotify
+				case fsnotify.Rename:
+					fs.Debugf(f, "Rename: %s", event.Name)
+				case fsnotify.Chmod:
+					fs.Debugf(f, "Chmod: %s", event.Name)
 				}
 			case err, ok := <-watcher.Errors:
 				if !ok {

--- a/go.mod
+++ b/go.mod
@@ -136,6 +136,7 @@ require (
 	github.com/emersion/go-vcard v0.0.0-20230815062825-8fda7d206ec9 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/flynn/noise v1.0.1 // indirect
+	github.com/fsnotify/fsnotify v1.8.0 // indirect
 	github.com/gdamore/encoding v1.0.0 // indirect
 	github.com/geoffgarside/ber v1.1.0 // indirect
 	github.com/go-ini/ini v1.67.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,6 +231,8 @@ github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
+github.com/fsnotify/fsnotify v1.8.0 h1:dAwr6QBTBZIkG8roQaJjGof0pp0EeF+tNV7YBP3F/8M=
+github.com/fsnotify/fsnotify v1.8.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/gabriel-vasile/mimetype v1.4.7 h1:SKFKl7kD0RiPdbht0s7hFtjl489WcQ1VyPW8ZzUMYCA=
 github.com/gabriel-vasile/mimetype v1.4.7/go.mod h1:GDlAgAyIRT27BhFl53XNAFtfjzOkLaF35JdEG0P7LtU=
 github.com/gdamore/encoding v1.0.0 h1:+7OoQ1Bc6eTm5niUzBa0Ctsh6JbMW6Ra+YNuAtDBdko=


### PR DESCRIPTION
#### What is the purpose of this change?

This is an initial implementation of `ChangeNotify()` for the local backend, using [fsnotify](https://github.com/fsnotify/fsnotify). I expect that some further discussion and iteration and testing will be needed, but hope this implementation is a useful starting point for that.

#### Was the change discussed in an issue or in the forum before?

Related issues: #249 #4152

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate. **Ran `rclone test changenotify` but further tests may be warranted yet**
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)

#### Further notes

fsnotify does not support recursive watching of a directory, and it seems that it will not (fsnotify/fsnotify#18) until there is support for all platforms that it targets. There is some work for specific platforms, such as Linux with inotify, although this is not yet released (fsnotify/fsnotify#472).

So at this stage, rather than relying on fsnotify for recursive support, I've implemented that in rclone itself, using `filepath.WalkDir()` (which is what fsnotify/fsnotify#472 is doing anyway), including watching new directories when created. Watching a directory is initiated before listing and recursing into it, which should eliminate race conditions if changes are made while the watchers are established (but further thinking and testing would be worthwhile!).

I've tested this on Linux only. It will need testing on other platforms.

An interactive test routine is to run `rclone test changenotify . -vv` to watch the current working directory, then perform some file operations and see what is logged. The debug logging is verbose for this purpose (it reports all events; this could be reduced eventually). Something like `mkdir -p a/b/c` makes for an interesting test (turns out that an event is produced only for `a`, so it's necessary to then recursively watch `a` to keep the watch list up to date). Perhaps some fuzzing tests with random timings would be useful for race conditions, which may be platform specific.

I hope this is useful, and very happy for others to help with this as well, of course.