### PR TITLE
ci: build beta for docker volume plugins

### DIFF
--- a/.github/workflows/build_publish_beta_docker_image.yml
+++ b/.github/workflows/build_publish_beta_docker_image.yml
@@ -75,3 +75,35 @@ jobs:
               shell: bash
               run: |
                 df -h .
+                
+    build_docker_volume_plugin:
+        if: github.repository == 'rclone/rclone'
+        needs: build
+        runs-on: ubuntu-latest
+        name: Build docker plugin job
+        steps:
+            - name: Free some space
+              shell: bash
+              run: |
+                df -h .
+                # Remove android SDK
+                sudo rm -rf /usr/local/lib/android || true
+                # Remove .net runtime
+                sudo rm -rf /usr/share/dotnet || true
+                df -h .
+            - name: Checkout master
+              uses: actions/checkout@v4
+              with:
+                fetch-depth: 0
+            - name: Build and publish docker plugin
+              shell: bash
+              run: |
+                PLUGIN_USER=rclone
+                docker login --username ${{ secrets.DOCKER_HUB_USER }} \
+                            --password-stdin <<< "${{ secrets.DOCKER_HUB_PASSWORD }}"
+                for PLUGIN_ARCH in amd64 arm64 arm/v7 arm/v6 ;do
+                    export PLUGIN_USER PLUGIN_ARCH
+                    make docker-plugin PLUGIN_TAG=${PLUGIN_ARCH/\//-}
+                    make docker-plugin PLUGIN_TAG=${PLUGIN_ARCH/\//-}-beta
+                done
+                make docker-plugin PLUGIN_ARCH=amd64 PLUGIN_TAG=beta

--- a/Makefile
+++ b/Makefile
@@ -279,7 +279,7 @@ winzip:
 # docker volume plugin
 PLUGIN_USER ?= rclone
 PLUGIN_TAG ?= latest
-PLUGIN_BASE_TAG ?= latest
+PLUGIN_BASE_TAG ?= $(PLUGIN_TAG)
 PLUGIN_ARCH ?= amd64
 PLUGIN_IMAGE := $(PLUGIN_USER)/docker-volume-rclone:$(PLUGIN_TAG)
 PLUGIN_BASE := $(PLUGIN_USER)/rclone:$(PLUGIN_BASE_TAG)


### PR DESCRIPTION
#### What is the purpose of this change?

Publish beta images for docker-volume-rclone when publishing main docker image.

here: https://hub.docker.com/r/rclone/docker-volume-rclone/tags

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [Y] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [NA] I have added tests for all changes in this PR if appropriate.
- [NA] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [Y] I'm done, this Pull Request is ready for review :-)

This implements https://github.com/rclone/rclone/issues/8266