### PR TITLE
install.sh: ensure curl follows redirects in installation script

### DIFF
--- a/docs/content/install.sh
+++ b/docs/content/install.sh
@@ -53,9 +53,9 @@ export XDG_CONFIG_HOME=config
 #check installed version of rclone to determine if update is necessary
 version=$(rclone --version 2>>errors | head -n 1)
 if [ -z "$install_beta" ]; then
-    current_version=$(curl -fsS https://downloads.rclone.org/version.txt)
+    current_version=$(curl -fsSL https://downloads.rclone.org/version.txt)
 else
-    current_version=$(curl -fsS https://beta.rclone.org/version.txt)
+    current_version=$(curl -fsSL https://beta.rclone.org/version.txt)
 fi
 
 if [ "$version" = "$current_version" ]; then
@@ -131,7 +131,7 @@ else
     rclone_zip="rclone-beta-latest-${OS}-${OS_type}.zip"
 fi
 
-curl -OfsS "$download_link"
+curl -OfsSL "$download_link"
 unzip_dir="tmp_unzip_dir_for_rclone"
 # there should be an entry in this switch for each element of unzip_tools_list
 case "$unzip_tool" in


### PR DESCRIPTION
#### What is the purpose of this change?

Added the `-L` option to curl commands in the installation script to handle HTTP redirects properly. 
This resolves issues where the install script fails when some proxy server is used.

#### Was the change discussed in an issue or in the forum before?

Not discussed yet.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
