### PR TITLE
accounting: add per ctx token bucket

### DIFF
--- a/fs/accounting/accounting.go
+++ b/fs/accounting/accounting.go
@@ -344,6 +344,16 @@ func (acc *Account) limitPerFileBandwidth(n int) {
 	}
 }
 
+// Account for n bytes from the current context bandwidth limit (if any)
+func (acc *Account) limitPerContextBandwidth(n int) {
+	value := acc.ctx.Value(TokenBucketWrapperPerContextKey)
+	if value != nil {
+		if tbw, ok := value.(*TokenBucketWrapper); ok {
+			tbw.LimitBandwidth(TokenBucketSlotAccounting, n)
+		}
+	}
+}
+
 // Account the read and limit bandwidth
 func (acc *Account) accountRead(n int) {
 	// Update Stats
@@ -356,6 +366,7 @@ func (acc *Account) accountRead(n int) {
 
 	TokenBucket.LimitBandwidth(TokenBucketSlotAccounting, n)
 	acc.limitPerFileBandwidth(n)
+	acc.limitPerContextBandwidth(n)
 }
 
 // read bytes from the io.Reader passed in and account them

--- a/fs/accounting/token_bucket.go
+++ b/fs/accounting/token_bucket.go
@@ -15,6 +15,11 @@ import (
 // TokenBucket holds the global token bucket limiter
 var TokenBucket tokenBucket
 
+type TokenBucketWrapperPerContextKeyType struct{}
+
+// Context key for per context token bucket
+var TokenBucketWrapperPerContextKey = TokenBucketWrapperPerContextKeyType{}
+
 // TokenBucketSlot is the type to select which token bucket to use
 type TokenBucketSlot int
 
@@ -35,6 +40,16 @@ type tokenBucket struct {
 	prev       buckets
 	toggledOff bool
 	currLimit  fs.BwTimeSlot
+}
+
+type TokenBucketWrapper struct {
+	tokenBucket
+}
+
+func NewTokenBucketWrapper() *TokenBucketWrapper {
+	return &TokenBucketWrapper{
+		tokenBucket: tokenBucket{},
+	}
 }
 
 // Return true if limit is disabled


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The motivation of this change is, we use rclone as imported library in our go project, and there could be simultaneously operations such as multiple sync.CopyDir() calls in a single process, and each of them need have different bandwidth limit. We can not achive that by setting ConfigInfo.BwLimit b/c the TokenBucket in token_bucket.go is a global variable. Since each sync.CopyDir() have different context, we can use the context to pass different bwlimit to transfer.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

expose a token bucket wrapper type, so that client code can set a limiter in context to limit the transfer bandwidth in context scope. this is useful when rclone is used as imported library.

The client code can be written as:
```golang
var bwp fs.BwPair
bwp.Set(fmt.Sprintf("%dB", bwlimit))

var tbw accounting.TokenBucketWrapper
tbw.SetBwLimit(bwp)

ctx = context.WithValue(ctx, accounting.TokenBucketWrapperPerContextKey, &tbw)

sync.CopyDir(ctx1, dstFS, srcFs, false)
```

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
