### PR TITLE
docs: explain the stringArray flag parameter descriptor

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -619,6 +619,11 @@ it to `false`.  It is also possible to specify `--boolean=false` or
 parsed as `--boolean` and the `false` is parsed as an extra command
 line argument for rclone.
 
+Options documented to take a `stringArray` parameter accept multiple 
+values. To pass more than one value, repeat the option; for example: 
+`--include value1 --include value2`.
+
+
 ### Time or duration options {#time-option}
 
 TIME or DURATION options can be specified as a duration string or a

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -9,6 +9,7 @@ description: "Rclone Global Flags"
 This describes the global flags available to every rclone command
 split into groups.
 
+Note: The parameter descriptor `stringArray` means that the flag can be used multiple times, for example: `--exclude a --exclude b`. 
 
 ## Copy
 

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -9,7 +9,8 @@ description: "Rclone Global Flags"
 This describes the global flags available to every rclone command
 split into groups.
 
-Note: The parameter descriptor `stringArray` means that the flag can be used multiple times, for example: `--exclude a --exclude b`. 
+See the [Options section](/docs/#options) for syntax and usage advice.
+
 
 ## Copy
 


### PR DESCRIPTION
This PR adds a brief description of the `stringArray` parameter descriptor to flags.md, pointing out that there is actually no such thing as a string array for flag parameters, and that the user would have to repeat the flag for each string. 

See also: https://forum.rclone.org/t/questions-about-include-and-filter-and-stringarray/1638/2