### PR TITLE
Clarify usage of SSE-C options

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -1271,13 +1271,13 @@ Properties:
 
 #### --s3-sse-customer-algorithm
 
-If using SSE-C, the server-side encryption algorithm used when storing this object in S3.
+If using SSE-C, the server-side encryption algorithm used when storing this object in S3.  As per AWS S3 standard, this must be "AES256" if SSE-C is used.
 
 Properties:
 
 - Config:      sse_customer_algorithm
 - Env Var:     RCLONE_S3_SSE_CUSTOMER_ALGORITHM
-- Provider:    AWS,Ceph,ChinaMobile,Minio
+- Provider:    AWS,Ceph,ChinaMobile,Minio, IDrive (if enabled via dashboard)
 - Type:        string
 - Required:    false
 - Examples:
@@ -1288,15 +1288,13 @@ Properties:
 
 #### --s3-sse-customer-key
 
-To use SSE-C you may provide the secret encryption key used to encrypt/decrypt your data.
-
-Alternatively you can provide --sse-customer-key-base64.
+To use SSE-C you must provide a 32 byte secret encryption key to encrypt/decrypt your data either using this option or --sse-customer-key-base64.
 
 Properties:
 
 - Config:      sse_customer_key
 - Env Var:     RCLONE_S3_SSE_CUSTOMER_KEY
-- Provider:    AWS,Ceph,ChinaMobile,Minio
+- Provider:    AWS,Ceph,ChinaMobile,Minio, IDrive (if enabled via dashboard)
 - Type:        string
 - Required:    false
 - Examples:
@@ -1305,9 +1303,7 @@ Properties:
 
 #### --s3-sse-customer-key-base64
 
-If using SSE-C you must provide the secret encryption key encoded in base64 format to encrypt/decrypt your data.
-
-Alternatively you can provide --sse-customer-key.
+If using SSE-C you must provide the 32 byte secret encryption key encoded in base64 format to encrypt/decrypt your data.  Alternatively you can provide --sse-customer-key.
 
 Properties:
 


### PR DESCRIPTION
explain a bit more AWS requirements on the key/options

Added IDrive as supported backend only if enabled on their side.

#### What is the purpose of this change?

Rclone currently accepts incorrect parameters to these options and the error messages are not helpful.

Added documentation so folks know what is expected.

#### Was the change discussed in an issue or in the forum before?

Yes, I mentioned it here

https://forum.rclone.org/t/doucmentation-suggestion-s3-sse-c-key-requirement/49562

and was pointed here to create PR.

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)

Above not applicalbe.  Just look at the diff; this is a small change that obviously helps improve docs