### PR TITLE
opendrive: adding access flag to handle permissions

### DIFF
--- a/docs/content/commands/rclone.md
+++ b/docs/content/commands/rclone.md
@@ -627,6 +627,7 @@ rclone [flags]
       --oos-upload-concurrency int                          Concurrency for multipart uploads (default 10)
       --oos-upload-cutoff SizeSuffix                        Cutoff for switching to chunked upload (default 200Mi)
       --opendrive-chunk-size SizeSuffix                     Files will be uploaded in chunks this size (default 10Mi)
+      --opendrive-access string                             Files and folders will be uploaded with this access permission (default private)
       --opendrive-description string                        Description of the remote
       --opendrive-encoding Encoding                         The encoding for the backend (default Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,LeftSpace,LeftCrLfHtVt,RightSpace,RightCrLfHtVt,InvalidUtf8,Dot)
       --opendrive-password string                           Password (obscured)

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -810,6 +810,7 @@ Backend-only flags (these can be set in the config file also).
       --oos-upload-concurrency int                          Concurrency for multipart uploads (default 10)
       --oos-upload-cutoff SizeSuffix                        Cutoff for switching to chunked upload (default 200Mi)
       --opendrive-chunk-size SizeSuffix                     Files will be uploaded in chunks this size (default 10Mi)
+      --opendrive-access string                             Files and folders will be uploaded with this access permission (default private)
       --opendrive-description string                        Description of the remote
       --opendrive-encoding Encoding                         The encoding for the backend (default Slash,LtGt,DoubleQuote,Colon,Question,Asterisk,Pipe,BackSlash,LeftSpace,LeftCrLfHtVt,RightSpace,RightCrLfHtVt,InvalidUtf8,Dot)
       --opendrive-password string                           Password (obscured)

--- a/docs/content/opendrive.md
+++ b/docs/content/opendrive.md
@@ -163,6 +163,17 @@ Properties:
 - Type:        SizeSuffix
 - Default:     10Mi
 
+#### --opendrive-access
+
+Files and folders will be uploaded with this access permission.
+
+Properties:
+
+- Config:      access
+- Env Var:     RCLONE_OPENDRIVE_ACCESS
+- Type:        string
+- Default:     private
+
 #### --opendrive-description
 
 Description of the remote.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Hello folks, I wanted to add a config to handle opendrive file/folder upload access instead of providing only default private option. I saw that this was already raised as an issue here . I have referred  the issue and attached discussions to add this config. I did a set of local testing from my end as well, seems to be working as expected. I am pretty new to this codebase, please let me know if anything else needs to be done. Thanks

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
