### PR TITLE
Update rclone_serve_nfs.md

### DIFF
--- a/docs/content/commands/rclone_serve_nfs.md
+++ b/docs/content/commands/rclone_serve_nfs.md
@@ -7,6 +7,8 @@ versionIntroduced: v1.65
 ---
 # rclone serve nfs
 
+*Not available in Windows.*
+
 Serve the remote as an NFS mount
 
 ## Synopsis


### PR DESCRIPTION
NFS serve is not available for Windows, but there is no mention of this in the docs. Infact, the use of Windows in the text suggests that it is available.

This change adds a small message to let the user know that nsf serve is not available for Windows.