### PR TITLE
Make rclone sync directory mtimes 

### DIFF
--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -1109,23 +1109,17 @@ func (s *syncCopyMove) copyDirMetadata(ctx context.Context, f fs.Fs, dst fs.Dire
 	if !s.setDirModTimeAfter && equal {
 		return nil
 	}
-	if s.setDirModTimeAfter && equal {
-		newDst = dst
-	} else if s.copyEmptySrcDirs {
-		if s.setDirMetadata {
+	newDst = dst
+	if !equal {
+		if s.setDirMetadata && s.copyEmptySrcDirs {
 			newDst, err = operations.CopyDirMetadata(ctx, f, dst, dir, src)
-		} else if s.setDirModTime {
-			if dst == nil {
-				newDst, err = operations.MkdirModTime(ctx, f, dir, src.ModTime(ctx))
-			} else {
-				newDst, err = operations.SetDirModTime(ctx, f, dst, dir, src.ModTime(ctx))
-			}
-		} else if dst == nil {
-			// Create the directory if it doesn't exist
+		} else if dst == nil && s.setDirModTime && s.copyEmptySrcDirs {
+			newDst, err = operations.MkdirModTime(ctx, f, dir, src.ModTime(ctx))
+		} else if dst == nil && s.copyEmptySrcDirs {
 			err = operations.Mkdir(ctx, f, dir)
+		} else if dst != nil && s.setDirModTime {
+			newDst, err = operations.SetDirModTime(ctx, f, dst, dir, src.ModTime(ctx))
 		}
-	} else {
-		newDst = dst
 	}
 	// If we need to set modtime after and we created a dir, then save it for later
 	if s.setDirModTime && s.setDirModTimeAfter && err == nil {

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -2762,6 +2762,81 @@ func TestSyncConcurrentTruncate(t *testing.T) {
 	testSyncConcurrent(t, "truncate")
 }
 
+// Test that sync replaces dir modtimes in dst if they've changed
+func testSyncReplaceDirModTime(t *testing.T, copyEmptySrcDirs bool) {
+	accounting.GlobalStats().ResetCounters()
+	ctx, _ := fs.AddConfig(context.Background())
+	r := fstest.NewRun(t)
+
+	file1 := r.WriteFile("file1", "file1", t2)
+	file2 := r.WriteFile("test_dir1/file2", "file2", t2)
+	file3 := r.WriteFile("test_dir2/sub_dir/file3", "file3", t2)
+	r.CheckLocalItems(t, file1, file2, file3)
+
+	_, err := operations.MkdirModTime(ctx, r.Flocal, "empty_dir", t2)
+	require.NoError(t, err)
+
+	// A directory that's empty on both src and dst
+	_, err = operations.MkdirModTime(ctx, r.Flocal, "empty_on_remote", t2)
+	require.NoError(t, err)
+	_, err = operations.MkdirModTime(ctx, r.Fremote, "empty_on_remote", t2)
+	require.NoError(t, err)
+
+	// set logging
+	// (this checks log output as DirModtime operations do not yet have stats, and r.CheckDirectoryModTimes also does not tell us what actions were taken)
+	oldLogLevel := fs.GetConfig(context.Background()).LogLevel
+	defer func() { fs.GetConfig(context.Background()).LogLevel = oldLogLevel }() // reset to old val after test
+	// need to do this as fs.Infof only respects the globalConfig
+	fs.GetConfig(context.Background()).LogLevel = fs.LogLevelInfo
+
+	// First run
+	accounting.GlobalStats().ResetCounters()
+	ctx = predictDstFromLogger(ctx)
+	output := bilib.CaptureOutput(func() {
+		err := CopyDir(ctx, r.Fremote, r.Flocal, copyEmptySrcDirs)
+		require.NoError(t, err)
+	})
+	require.NotNil(t, output)
+	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+
+	// Save all dirs
+	dirs := []string{"test_dir1", "test_dir2", "test_dir2/sub_dir", "empty_on_remote"}
+	if copyEmptySrcDirs {
+		dirs = append(dirs, "empty_dir")
+	}
+
+	// Change dir modtimes
+	for _, dir := range dirs {
+		_, err := operations.SetDirModTime(ctx, r.Flocal, nil, dir, t1)
+		if err != nil && !errors.Is(err, fs.ErrorNotImplemented) {
+			require.NoError(t, err)
+		}
+	}
+
+	// Run again
+	accounting.GlobalStats().ResetCounters()
+	ctx = predictDstFromLogger(ctx)
+	output = bilib.CaptureOutput(func() {
+		err := CopyDir(ctx, r.Fremote, r.Flocal, copyEmptySrcDirs)
+		require.NoError(t, err)
+	})
+	require.NotNil(t, output)
+	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	r.CheckLocalItems(t, file1, file2, file3)
+	r.CheckRemoteItems(t, file1, file2, file3)
+
+	// Check that the modtimes of the directories are as expected
+	r.CheckDirectoryModTimes(t, dirs...)
+}
+
+func TestSyncReplaceDirModTime(t *testing.T) {
+	testSyncReplaceDirModTime(t, false)
+}
+
+func TestSyncReplaceDirModTimeWithEmptyDirs(t *testing.T) {
+	testSyncReplaceDirModTime(t, true)
+}
+
 // Tests that nothing is transferred when src and dst already match
 // Run the same sync twice, ensure no action is taken the second time
 func testNothingToTransfer(t *testing.T, copyEmptySrcDirs bool) {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
This will make rclone sync directory mtimes by default if they've changed on the src, just like it is for files. 
This works both with and without empty directories and does _not_ change any default. 

#### Was the change discussed in an issue or in the forum before?

Fixes #8317

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
