### PR TITLE
cli: don't crash if rclone is invoked without any arguments

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -430,7 +430,7 @@ func initConfig() {
 	}
 
 	// Start the metrics server if configured and not running the "rc" command
-	if os.Args[1] != "rc" {
+	if len(os.Args) >= 2 && os.Args[1] != "rc" {
 		_, err = rcserver.MetricsStart(ctx, &rc.Opt)
 		if err != nil {
 			fs.Fatalf(nil, "Failed to start metrics server: %v", err)


### PR DESCRIPTION
for #8378

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix https://github.com/rclone/rclone/issues/8378

#### Was the change discussed in an issue or in the forum before?

Yes: https://github.com/rclone/rclone/issues/8378

#### Checklist

Well, I guess there could be a test that runs rclone with an empty argv.  Hopefully this PR is ok without one.

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
