### PR TITLE
Allows B2 Retry on Recoverable error

### DIFF
--- a/fs/fserrors/error.go
+++ b/fs/fserrors/error.go
@@ -378,14 +378,15 @@ func Cause(cause error) (retriable bool, err error) {
 // This is incredibly ugly - if only errors.Cause worked for all
 // errors and all errors were exported from the stdlib.
 var retriableErrorStrings = []string{
-	"use of closed network connection", // internal/poll/fd.go
-	"unexpected EOF reading trailer",   // net/http/transfer.go
-	"transport connection broken",      // net/http/transport.go
-	"http: ContentLength=",             // net/http/transfer.go
-	"server closed idle connection",    // net/http/transport.go
-	"bad record MAC",                   // crypto/tls/alert.go
-	"stream error:",                    // net/http/h2_bundle.go
-	"tls: use of closed connection",    // crypto/tls/conn.go
+	"use of closed network connection",                     // internal/poll/fd.go
+	"unexpected EOF reading trailer",                       // net/http/transfer.go
+	"transport connection broken",                          // net/http/transport.go
+	"http: ContentLength=",                                 // net/http/transfer.go
+	"server closed idle connection",                        // net/http/transport.go
+	"bad record MAC",                                       // crypto/tls/alert.go
+	"stream error:",                                        // net/http/h2_bundle.go
+	"tls: use of closed connection",                        // crypto/tls/conn.go
+	"invalid character '<' looking for beginning of value", // From Zach Vorhies
 }
 
 // Errors which indicate networking errors which should be retried


### PR DESCRIPTION
Fixes https://github.com/rclone/rclone/issues/8383

Tested on `Ubuntu 24.10`

This turns out to be a very major bug on the B2 backend.

This patch definitely fixes it as I see that retry=True is now set for the error when it comes. 

The next (recoverable) error that jumps out is this:

`no tomes available`

Which led me to this:

https://forum.duplicati.com/t/upload-to-backblaze-b2-no-tomes-available-connection-reset-by-peer/16621

Which led me to this:

https://www.backblaze.com/blog/b2-503-500-server-error/

## In a nutshell

B2 API is supposed to occasionally give 500 internal error codes. It will resolve with additional retries. Since Rclone doesn't do a retry for this specific type of error, it fails.

This error is the *probably* the reason my datalakes has been failing the src->dst file audits in every one of the data repos. I'll know more next week.

