### PR TITLE
adds logging during failure condition for low-level-retry

### DIFF
--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -400,7 +400,18 @@ func (f *Fs) shouldRetry(ctx context.Context, resp *http.Response, err error) (b
 		}
 		return true, err
 	}
-	return f.shouldRetryNoReauth(ctx, resp, err)
+	shouldRetry, err := f.shouldRetryNoReauth(ctx, resp, err)
+	if !shouldRetry && resp != nil {
+		// Log details when not retrying to help with debugging
+		var peek []byte
+		if resp.Body != nil {
+			peek, _ = io.ReadAll(io.LimitReader(resp.Body, 50))
+			_ = resp.Body.Close()
+		}
+		fs.Debugf(f, "Not retrying HTTP response: status=%d headers=%v body=%q",
+			resp.StatusCode, resp.Header, string(peek))
+	}
+	return shouldRetry, err
 }
 
 // errorHandler parses a non 2xx error response into an error


### PR DESCRIPTION
This is extra logging to inspect the low level retry failure on the b2 backend when using `-v`

See also:
https://github.com/rclone/rclone/issues/8383