### PR TITLE
Fix-azure-metadata

### DIFF
--- a/fs/log.go
+++ b/fs/log.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"runtime/debug"
 
 	"github.com/sirupsen/logrus"
 )
@@ -269,14 +268,6 @@ func Log(o interface{}, text string) {
 // out with the -q flag.
 func Logf(o interface{}, text string, args ...interface{}) {
 	LogLevelPrintf(LogLevelNotice, o, text, args...)
-}
-
-func LogMe(text string) {
-	LogLevelPrint(LogLevelInfo, nil, text)
-}
-
-func LogCallStack() {
-	debug.PrintStack()
 }
 
 // Infoc writes info on transfers for this Object or Fs.  Use this

--- a/fs/log.go
+++ b/fs/log.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime/debug"
 
 	"github.com/sirupsen/logrus"
 )
@@ -268,6 +269,14 @@ func Log(o interface{}, text string) {
 // out with the -q flag.
 func Logf(o interface{}, text string, args ...interface{}) {
 	LogLevelPrintf(LogLevelNotice, o, text, args...)
+}
+
+func LogMe(text string) {
+	LogLevelPrint(LogLevelInfo, nil, text)
+}
+
+func LogCallStack() {
+	debug.PrintStack()
 }
 
 // Infoc writes info on transfers for this Object or Fs.  Use this


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

- The current code is not able clone the Wasabi S3 meta data to Azure blob storage. And this pull request fixes that issue.

#### Was the change discussed in an issue or in the forum before?
no

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
