### PR TITLE
http: metadata, content-disposition

### DIFF
--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -125,7 +125,11 @@ type Object struct {
 	remote      string
 	size        int64
 	modTime     time.Time
+	meta        map[string]string // The object metadata if known - may be nil - with lower case keys
 	contentType string
+
+	// Metadata as pointers to strings as they often won't be present
+	contentDisposition *string // Content-Disposition: header
 }
 
 // statusError returns an error if the res contained an error
@@ -628,6 +632,13 @@ func (o *Object) decodeMetadata(ctx context.Context, res *http.Response) error {
 	o.contentType = res.Header.Get("Content-Type")
 	o.size = rest.ParseSizeFromHeaders(res.Header)
 
+	// Parse Content-Disposition header
+	contentDisposition := res.Header.Get("Content-Disposition")
+	if contentDisposition != "" {
+		o.contentDisposition = &contentDisposition
+		o.meta["content-disposition"] = contentDisposition
+	}
+
 	// If NoSlash is set then check ContentType to see if it is a directory
 	if o.fs.opt.NoSlash {
 		mediaType, _, err := mime.ParseMediaType(o.contentType)
@@ -764,6 +775,14 @@ func (f *Fs) Command(ctx context.Context, name string, arg []string, opt map[str
 	}
 }
 
+// Metadata returns metadata for an object
+//
+// It should return nil if there is no Metadata
+func (o *Object) Metadata(ctx context.Context) (metadata fs.Metadata, err error) {
+	metadata = o.meta
+	return metadata, nil
+}
+
 // Check the interfaces are satisfied
 var (
 	_ fs.Fs          = &Fs{}
@@ -771,4 +790,5 @@ var (
 	_ fs.Object      = &Object{}
 	_ fs.MimeTyper   = &Object{}
 	_ fs.Commander   = &Fs{}
+	_ fs.Metadataer  = &Object{}
 )

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -635,9 +635,7 @@ func (o *Object) decodeMetadata(ctx context.Context, res *http.Response) error {
 	// Parse Content-Disposition header
 	contentDisposition := res.Header.Get("Content-Disposition")
 	if contentDisposition != "" {
-		o.meta = make(map[string]string)
 		o.contentDisposition = &contentDisposition
-		o.meta["content-disposition"] = contentDisposition
 	}
 
 	// If NoSlash is set then check ContentType to see if it is a directory
@@ -780,7 +778,14 @@ func (f *Fs) Command(ctx context.Context, name string, arg []string, opt map[str
 //
 // It should return nil if there is no Metadata
 func (o *Object) Metadata(ctx context.Context) (metadata fs.Metadata, err error) {
-	metadata = o.meta
+	metadata = make(fs.Metadata, 1)
+	setMetadata := func(k string, v *string) {
+		if v == nil || *v == "" {
+			return
+		}
+		metadata[k] = *v
+	}
+	setMetadata("content-disposition", o.contentDisposition)
 	return metadata, nil
 }
 

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -635,6 +635,7 @@ func (o *Object) decodeMetadata(ctx context.Context, res *http.Response) error {
 	// Parse Content-Disposition header
 	contentDisposition := res.Header.Get("Content-Disposition")
 	if contentDisposition != "" {
+		o.meta = make(map[string]string)
 		o.contentDisposition = &contentDisposition
 		o.meta["content-disposition"] = contentDisposition
 	}

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -125,7 +125,6 @@ type Object struct {
 	remote      string
 	size        int64
 	modTime     time.Time
-	meta        map[string]string // The object metadata if known - may be nil - with lower case keys
 	contentType string
 
 	// Metadata as pointers to strings as they often won't be present

--- a/docs/content/commands/rclone_lsjson.md
+++ b/docs/content/commands/rclone_lsjson.md
@@ -56,7 +56,8 @@ Different options may also affect which properties are included:
   properties will be omitted - even for encrypted remotes.
 - If `--metadata` is set then an additional Metadata property will be
   returned. This will have [metadata](/docs/#metadata) in rclone standard format
-  as a JSON object.
+  as a JSON object. Also, if `--metadata` is set then name of the file can be
+  taken from the metadata field "content-disposition" if the remote supports it.
 
 The default is to list directories and files/objects, but this can be changed
 with the following options:

--- a/docs/content/http.md
+++ b/docs/content/http.md
@@ -235,6 +235,16 @@ Properties:
 - Type:        string
 - Required:    false
 
+### Metadata
+
+Here are the possible system metadata items for the http backend.
+
+| Name | Help | Type | Example | Read Only |
+|------|------|------|---------|-----------|
+| content-disposition | Content-Disposition header | string | inline | N |
+
+See the [metadata](/docs/#metadata) docs for more info.
+
 ## Backend commands
 
 Here are the commands specific to the http backend.

--- a/fs/operations/lsjson.go
+++ b/fs/operations/lsjson.go
@@ -207,6 +207,9 @@ func (lj *listJSON) entry(ctx context.Context, entry fs.DirEntry) (*ListJSONItem
 		var parsedName string
 		if metadata != nil && metadata["content-disposition"] != "" {
 			parsedName, err = parseFilenameFromContentDisposition(metadata["content-disposition"])
+			if err != nil {
+				fs.Errorf(entry, "Failed to parse filename from content-disposition: %v", err)
+			}
 		}
 		if parsedName != "" {
 			name = parsedName

--- a/fs/operations/lsjson.go
+++ b/fs/operations/lsjson.go
@@ -195,13 +195,9 @@ func (lj *listJSON) entry(ctx context.Context, entry fs.DirEntry) (*ListJSONItem
 	}
 
 	// Read the metadata if required
-	var meta fs.Metadata
-	var err error
-	if entryMetadataer, ok := entry.(fs.Metadataer); ok {
-		meta, err = entryMetadataer.Metadata(ctx)
-		if err != nil {
-			fs.Errorf(entry, "Failed to read metadata: %v", err)
-		}
+	meta, err := fs.GetMetadata(ctx, entry)
+	if err != nil {
+		fs.Errorf(entry, "Failed to read metadata: %v", err)
 	}
 
 	// Extract the name from the metadata if possible

--- a/fs/operations/lsjson.go
+++ b/fs/operations/lsjson.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"mime"
+	"net/textproto"
 	"path"
 	"strings"
 	"time"
@@ -152,6 +154,29 @@ func newListJSON(ctx context.Context, fsrc fs.Fs, remote string, opt *ListJSONOp
 	return lj, nil
 }
 
+// parseFilenameFromContentDisposition extracts the filename from a Content-Disposition header
+func parseFilenameFromContentDisposition(header string) (string, error) {
+	// Normalize the header to canonical MIME format
+	mediaType, params, err := mime.ParseMediaType(header)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse Content-Disposition header: %v", err)
+	}
+
+	// Check if the header is an attachment
+	if strings.ToLower(mediaType) != "attachment" {
+		return "", fmt.Errorf("not an attachment: %s", mediaType)
+	}
+
+	// Extract the filename from the parameters
+	filename, ok := params["filename"]
+	if !ok {
+		return "", fmt.Errorf("filename not found in Content-Disposition header")
+	}
+
+	// Decode filename if it contains special encoding
+	return textproto.TrimString(filename), nil
+}
+
 // Convert a single entry to JSON
 //
 // It may return nil if there is no entry to return
@@ -169,9 +194,27 @@ func (lj *listJSON) entry(ctx context.Context, entry fs.DirEntry) (*ListJSONItem
 		fs.Errorf(nil, "Unknown type %T in listing", entry)
 	}
 
+	// Read the metadata if required
+	entryMetadataer := entry.(fs.Metadataer)
+	meta, err := entryMetadataer.Metadata(ctx)
+	if err != nil {
+		fs.Errorf(entry, "Failed to read metadata: %v", err)
+	}
+
+	var name string
+	if meta != nil && meta["content-disposition"] != "" {
+		name, err = parseFilenameFromContentDisposition(meta["content-disposition"])
+		if err != nil {
+			fs.Errorf(entry, "Failed to parse filename from Content-Disposition: %v", err)
+			name = path.Base(entry.Remote())
+		}
+	} else {
+		name = path.Base(entry.Remote())
+	}
+
 	item := &ListJSONItem{
 		Path: entry.Remote(),
-		Name: path.Base(entry.Remote()),
+		Name: name,
 		Size: entry.Size(),
 	}
 	if entry.Remote() == "" {

--- a/fs/operations/lsjson.go
+++ b/fs/operations/lsjson.go
@@ -84,7 +84,6 @@ type ListJSONOpt struct {
 	DirsOnly      bool     `json:"dirsOnly"`
 	FilesOnly     bool     `json:"filesOnly"`
 	Metadata      bool     `json:"metadata"`
-	AutoFilename  bool     `json:"autoFilename"`
 	HashTypes     []string `json:"hashTypes"` // hash types to show if ShowHash is set, e.g. "MD5", "SHA-1"
 }
 
@@ -195,9 +194,11 @@ func (lj *listJSON) entry(ctx context.Context, entry fs.DirEntry) (*ListJSONItem
 		fs.Errorf(nil, "Unknown type %T in listing", entry)
 	}
 
-	// Extract the name from the metadata if requested
+	// Get default name
 	name := path.Base(entry.Remote())
-	if lj.opt.AutoFilename {
+
+	// Extract the name from the metadata if requested
+	if lj.opt.Metadata {
 		// Get metadata
 		metadata, err := fs.GetMetadata(ctx, entry)
 		if err != nil {

--- a/fs/operations/lsjson.go
+++ b/fs/operations/lsjson.go
@@ -204,6 +204,7 @@ func (lj *listJSON) entry(ctx context.Context, entry fs.DirEntry) (*ListJSONItem
 		}
 	}
 
+	// Extract the name from the metadata if possible
 	var name string
 	if meta != nil && meta["content-disposition"] != "" {
 		name, err = parseFilenameFromContentDisposition(meta["content-disposition"])

--- a/fs/operations/lsjson.go
+++ b/fs/operations/lsjson.go
@@ -84,6 +84,7 @@ type ListJSONOpt struct {
 	DirsOnly      bool     `json:"dirsOnly"`
 	FilesOnly     bool     `json:"filesOnly"`
 	Metadata      bool     `json:"metadata"`
+	AutoFilename  bool     `json:"autoFilename"`
 	HashTypes     []string `json:"hashTypes"` // hash types to show if ShowHash is set, e.g. "MD5", "SHA-1"
 }
 
@@ -194,22 +195,22 @@ func (lj *listJSON) entry(ctx context.Context, entry fs.DirEntry) (*ListJSONItem
 		fs.Errorf(nil, "Unknown type %T in listing", entry)
 	}
 
-	// Read the metadata if required
-	meta, err := fs.GetMetadata(ctx, entry)
-	if err != nil {
-		fs.Errorf(entry, "Failed to read metadata: %v", err)
-	}
-
-	// Extract the name from the metadata if possible
-	var name string
-	if meta != nil && meta["content-disposition"] != "" {
-		name, err = parseFilenameFromContentDisposition(meta["content-disposition"])
+	// Extract the name from the metadata if requested
+	name := path.Base(entry.Remote())
+	if lj.opt.AutoFilename {
+		// Get metadata
+		metadata, err := fs.GetMetadata(ctx, entry)
 		if err != nil {
-			fs.Errorf(entry, "Failed to parse filename from Content-Disposition: %v", err)
-			name = path.Base(entry.Remote())
+			fs.Errorf(entry, "Failed to read metadata: %v", err)
 		}
-	} else {
-		name = path.Base(entry.Remote())
+		// Parse the filename from the metadata
+		var parsedName string
+		if metadata != nil && metadata["content-disposition"] != "" {
+			parsedName, err = parseFilenameFromContentDisposition(metadata["content-disposition"])
+		}
+		if parsedName != "" {
+			name = parsedName
+		}
 	}
 
 	item := &ListJSONItem{

--- a/fs/operations/lsjson.go
+++ b/fs/operations/lsjson.go
@@ -195,10 +195,13 @@ func (lj *listJSON) entry(ctx context.Context, entry fs.DirEntry) (*ListJSONItem
 	}
 
 	// Read the metadata if required
-	entryMetadataer := entry.(fs.Metadataer)
-	meta, err := entryMetadataer.Metadata(ctx)
-	if err != nil {
-		fs.Errorf(entry, "Failed to read metadata: %v", err)
+	var meta fs.Metadata
+	var err error
+	if entryMetadataer, ok := entry.(fs.Metadataer); ok {
+		meta, err = entryMetadataer.Metadata(ctx)
+		if err != nil {
+			fs.Errorf(entry, "Failed to read metadata: %v", err)
+		}
 	}
 
 	var name string

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -404,23 +404,3 @@ func TestStatJSON(t *testing.T) {
 		assert.True(t, err != nil || f.Features().BucketBased, "Need an error for non bucket based backends")
 	})
 }
-
-//func TestAutoFilename(t *testing.T) {
-//	ctx := context.Background()
-//	r := fstest.NewRun(t)
-//	file1 := r.WriteBoth(ctx, "file1", "file1", t1)
-//	r.CheckRemoteItems(t, file1)
-//
-//	// Metadata update for "AutoFilename" test case
-//	if item.Metadata == nil {
-//		item.Metadata = fs.Metadata{}
-//	}
-//	item.Metadata["Content-Disposition"] = "attachment; filename=\"file_name_from_metadata\""
-//
-//	got, err := operations.StatJSON(ctx, r.Fremote, "file1", &operations.ListJSONOpt{
-//		AutoFilename: true,
-//	})
-//	require.NoError(t, err)
-//	require.NotNil(t, got)
-//	assert.Equal(t, "file_name_from_metadata", got.Name)
-//}

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -409,7 +409,7 @@ func TestStatJSON(t *testing.T) {
 
 func TestStatJsonMetadataContentDisposition(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("Custom metadata not supported on Windows")
+		t.Skip("Custom metadata is not supported on Windows")
 	}
 	ctx := context.Background()
 	r := fstest.NewRun(t)

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -412,6 +412,12 @@ func TestStatJsonMetadataContentDisposition(t *testing.T) {
 	file1 := fstest.Item{Path: "file1", ModTime: t1, Size: 5}
 	metadata := fs.Metadata{"content-disposition": "Attachment; filename=file1.txt"}
 	fstests.PutTestContentsMetadata(ctx, t, r.Fremote, &file1, false, "file1", true, "", metadata)
+	// Skip the test if the remote doesn't support SetMetadata
+	obj := fstest.NewObject(ctx, t, r.Fremote, file1.Path)
+	_, objectHasSetMetadata := obj.(fs.SetMetadataer)
+	if !objectHasSetMetadata {
+		t.Skip("SetMetadata method not supported")
+	}
 	got, err := operations.StatJSON(ctx, r.Fremote, "file1", &operations.ListJSONOpt{Metadata: true})
 	require.NoError(t, err)
 	require.NotNil(t, got)

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -193,7 +193,6 @@ func TestListJSON(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var got []*operations.ListJSONItem
 			require.NoError(t, operations.ListJSON(ctx, r.Fremote, test.remote, &test.opt, func(item *operations.ListJSONItem) error {
-				got = append(got, item)
 				return nil
 			}))
 			sort.Slice(got, func(i, j int) bool {
@@ -385,6 +384,7 @@ func TestStatJSON(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
+			// Metadata update for "AutoFilename" test case
 			got, err := operations.StatJSON(ctx, r.Fremote, test.remote, &test.opt)
 			require.NoError(t, err)
 			if test.want == nil {
@@ -404,3 +404,23 @@ func TestStatJSON(t *testing.T) {
 		assert.True(t, err != nil || f.Features().BucketBased, "Need an error for non bucket based backends")
 	})
 }
+
+//func TestAutoFilename(t *testing.T) {
+//	ctx := context.Background()
+//	r := fstest.NewRun(t)
+//	file1 := r.WriteBoth(ctx, "file1", "file1", t1)
+//	r.CheckRemoteItems(t, file1)
+//
+//	// Metadata update for "AutoFilename" test case
+//	if item.Metadata == nil {
+//		item.Metadata = fs.Metadata{}
+//	}
+//	item.Metadata["Content-Disposition"] = "attachment; filename=\"file_name_from_metadata\""
+//
+//	got, err := operations.StatJSON(ctx, r.Fremote, "file1", &operations.ListJSONOpt{
+//		AutoFilename: true,
+//	})
+//	require.NoError(t, err)
+//	require.NotNil(t, got)
+//	assert.Equal(t, "file_name_from_metadata", got.Name)
+//}

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -193,6 +193,7 @@ func TestListJSON(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var got []*operations.ListJSONItem
 			require.NoError(t, operations.ListJSON(ctx, r.Fremote, test.remote, &test.opt, func(item *operations.ListJSONItem) error {
+				got = append(got, item)
 				return nil
 			}))
 			sort.Slice(got, func(i, j int) bool {
@@ -384,7 +385,6 @@ func TestStatJSON(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			// Metadata update for "AutoFilename" test case
 			got, err := operations.StatJSON(ctx, r.Fremote, test.remote, &test.opt)
 			require.NoError(t, err)
 			if test.want == nil {

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -2,6 +2,7 @@ package operations_test
 
 import (
 	"context"
+	"github.com/rclone/rclone/fstest/fstests"
 	"sort"
 	"testing"
 	"time"
@@ -403,4 +404,16 @@ func TestStatJSON(t *testing.T) {
 		// This should return an error except for bucket based remotes
 		assert.True(t, err != nil || f.Features().BucketBased, "Need an error for non bucket based backends")
 	})
+}
+
+func TestStatJsonAutoFilename(t *testing.T) {
+	ctx := context.Background()
+	r := fstest.NewRun(t)
+	file1 := fstest.Item{Path: "file1", ModTime: t1, Size: 5}
+	metadata := fs.Metadata{"content-disposition": "Attachment; filename=file1.txt"}
+	fstests.PutTestContentsMetadata(ctx, t, r.Fremote, &file1, false, "file1", true, "", metadata)
+	got, err := operations.StatJSON(ctx, r.Fremote, "file1", &operations.ListJSONOpt{AutoFilename: true})
+	require.NoError(t, err)
+	require.NotNil(t, got)
+	assert.Equal(t, "file1.txt", got.Name)
 }

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -406,13 +406,13 @@ func TestStatJSON(t *testing.T) {
 	})
 }
 
-func TestStatJsonAutoFilename(t *testing.T) {
+func TestStatJsonMetadataContentDisposition(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
 	file1 := fstest.Item{Path: "file1", ModTime: t1, Size: 5}
 	metadata := fs.Metadata{"content-disposition": "Attachment; filename=file1.txt"}
 	fstests.PutTestContentsMetadata(ctx, t, r.Fremote, &file1, false, "file1", true, "", metadata)
-	got, err := operations.StatJSON(ctx, r.Fremote, "file1", &operations.ListJSONOpt{AutoFilename: true})
+	got, err := operations.StatJSON(ctx, r.Fremote, "file1", &operations.ListJSONOpt{Metadata: true})
 	require.NoError(t, err)
 	require.NotNil(t, got)
 	assert.Equal(t, "file1.txt", got.Name)

--- a/fs/operations/lsjson_test.go
+++ b/fs/operations/lsjson_test.go
@@ -2,7 +2,6 @@ package operations_test
 
 import (
 	"context"
-	"github.com/rclone/rclone/fstest/fstests"
 	"sort"
 	"testing"
 	"time"
@@ -10,6 +9,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fstest"
+	"github.com/rclone/rclone/fstest/fstests"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/lib/http/serve/serve.go
+++ b/lib/http/serve/serve.go
@@ -39,6 +39,15 @@ func Object(w http.ResponseWriter, r *http.Request, o fs.Object) {
 	modTime := o.ModTime(r.Context())
 	w.Header().Set("Last-Modified", modTime.UTC().Format(http.TimeFormat))
 
+	// Set content disposition if available
+	metadata, err := fs.GetMetadata(r.Context(), o)
+	if err != nil {
+		fs.Debugf(o, "Request get metadata error: %v", err)
+	}
+	if metadata != nil && metadata["content-disposition"] != "" {
+		w.Header().Set("Content-Disposition", metadata["content-disposition"])
+	}
+
 	if r.Method == "HEAD" {
 		return
 	}

--- a/lib/http/serve/serve_test.go
+++ b/lib/http/serve/serve_test.go
@@ -2,6 +2,8 @@ package serve
 
 import (
 	"context"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/object"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -81,4 +83,14 @@ func TestObjectBadRange(t *testing.T) {
 	}
 	body, _ := io.ReadAll(resp.Body)
 	assert.Equal(t, "Bad Request\n", string(body))
+}
+
+func TestObjectHEADContentDisposition(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("HEAD", "http://example.com/aFile", nil)
+	m := fs.Metadata{"content-disposition": "inline"}
+	o := object.NewMemoryObject("aFile", time.Now(), []byte("")).WithMetadata(m)
+	Object(w, r, o)
+	resp := w.Result()
+	assert.Equal(t, "inline", resp.Header.Get("Content-Disposition"))
 }

--- a/lib/http/serve/serve_test.go
+++ b/lib/http/serve/serve_test.go
@@ -2,14 +2,14 @@ package serve
 
 import (
 	"context"
-	"github.com/rclone/rclone/fs"
-	"github.com/rclone/rclone/fs/object"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/object"
 	"github.com/rclone/rclone/fstest/mockobject"
 	"github.com/stretchr/testify/assert"
 )


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The objective is to extract the file name from the content-disposition header. This name should replace the one in stat, and a content-disposition handler should be provided via serve.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/8298

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
