### PR TITLE
cmd/gitannex: Tweak remote parsing to accept any backend

### DIFF
--- a/cmd/gitannex/gitannex_test.go
+++ b/cmd/gitannex/gitannex_test.go
@@ -535,6 +535,127 @@ var fstestTestCases = []testCase{
 		expectedError: "remote does not exist:",
 	},
 	{
+		label: "HandlesPrepareWithNonexistentBackendAsRemote",
+		testProtocolFunc: func(t *testing.T, h *testState) {
+			h.requireReadLineExact("VERSION 1")
+			h.requireWriteLine("PREPARE")
+			h.requireReadLineExact("GETCONFIG rcloneremotename")
+			h.requireWriteLine("VALUE :nonexistentBackend:")
+			h.requireReadLineExact("GETCONFIG rcloneprefix")
+			h.requireWriteLine("VALUE /foo")
+			h.requireReadLineExact("GETCONFIG rclonelayout")
+			h.requireWriteLine("VALUE foo")
+			h.requireReadLineExact("PREPARE-SUCCESS")
+
+			require.Equal(t, ":nonexistentBackend:", h.server.configRcloneRemoteName)
+			require.Equal(t, "/foo", h.server.configPrefix)
+			require.True(t, h.server.configsDone)
+
+			h.requireWriteLine("INITREMOTE")
+			h.requireReadLineExact("INITREMOTE-FAILURE backend does not exist: nonexistentBackend")
+
+			require.NoError(t, h.mockStdinW.Close())
+		},
+		expectedError: "backend does not exist:",
+	},
+	{
+		label: "HandlesPrepareWithBackendAsRemote",
+		testProtocolFunc: func(t *testing.T, h *testState) {
+			h.requireReadLineExact("VERSION 1")
+			h.requireWriteLine("PREPARE")
+			h.requireReadLineExact("GETCONFIG rcloneremotename")
+			h.requireWriteLine("VALUE :local:")
+			h.requireReadLineExact("GETCONFIG rcloneprefix")
+			h.requireWriteLine("VALUE /foo")
+			h.requireReadLineExact("GETCONFIG rclonelayout")
+			h.requireWriteLine("VALUE foo")
+			h.requireReadLineExact("PREPARE-SUCCESS")
+
+			require.Equal(t, ":local:", h.server.configRcloneRemoteName)
+			require.Equal(t, "/foo", h.server.configPrefix)
+			require.True(t, h.server.configsDone)
+
+			h.requireWriteLine("INITREMOTE")
+			h.requireReadLineExact("INITREMOTE-SUCCESS")
+
+			require.NoError(t, h.mockStdinW.Close())
+		},
+	},
+	{
+		label: "HandlesPrepareWithBackendMissingTrailingColonAsRemote",
+		testProtocolFunc: func(t *testing.T, h *testState) {
+			h.requireReadLineExact("VERSION 1")
+			h.requireWriteLine("PREPARE")
+			h.requireReadLineExact("GETCONFIG rcloneremotename")
+			h.requireWriteLine("VALUE :local")
+			h.requireReadLineExact("GETCONFIG rcloneprefix")
+			h.requireWriteLine("VALUE /foo")
+			h.requireReadLineExact("GETCONFIG rclonelayout")
+			h.requireWriteLine("VALUE foo")
+			h.requireReadLineExact("PREPARE-SUCCESS")
+
+			require.Equal(t, ":local", h.server.configRcloneRemoteName)
+			require.Equal(t, "/foo", h.server.configPrefix)
+			require.True(t, h.server.configsDone)
+
+			h.requireWriteLine("INITREMOTE")
+			h.requireReadLineExact("INITREMOTE-FAILURE remote could not be parsed as a backend: :local")
+
+			require.NoError(t, h.mockStdinW.Close())
+		},
+		expectedError: "remote could not be parsed as a backend:",
+	},
+	{
+		label: "HandlesPrepareWithBackendContainingOptionsAsRemote",
+		testProtocolFunc: func(t *testing.T, h *testState) {
+			h.requireReadLineExact("VERSION 1")
+			h.requireWriteLine("PREPARE")
+			h.requireReadLineExact("GETCONFIG rcloneremotename")
+			h.requireWriteLine("VALUE :local,description=banana:")
+			h.requireReadLineExact("GETCONFIG rcloneprefix")
+			h.requireWriteLine("VALUE /foo")
+			h.requireReadLineExact("GETCONFIG rclonelayout")
+			h.requireWriteLine("VALUE foo")
+			h.requireReadLineExact("PREPARE-SUCCESS")
+
+			require.Equal(t, ":local,description=banana:", h.server.configRcloneRemoteName)
+			require.Equal(t, "/foo", h.server.configPrefix)
+			require.True(t, h.server.configsDone)
+
+			h.requireWriteLine("INITREMOTE")
+			h.requireReadLineExact("INITREMOTE-SUCCESS")
+
+			require.NoError(t, h.mockStdinW.Close())
+		},
+	},
+	{
+		label: "HandlesPrepareWithBackendContainingOptionsAndIllegalPathAsRemote",
+		testProtocolFunc: func(t *testing.T, h *testState) {
+			h.requireReadLineExact("VERSION 1")
+			h.requireWriteLine("PREPARE")
+			h.requireReadLineExact("GETCONFIG rcloneremotename")
+			h.requireWriteLine("VALUE :local,description=banana:/bad/path")
+			h.requireReadLineExact("GETCONFIG rcloneprefix")
+			h.requireWriteLine("VALUE /foo")
+			h.requireReadLineExact("GETCONFIG rclonelayout")
+			h.requireWriteLine("VALUE foo")
+			h.requireReadLineExact("PREPARE-SUCCESS")
+
+			require.Equal(t, ":local,description=banana:/bad/path", h.server.configRcloneRemoteName)
+			require.Equal(t, "/foo", h.server.configPrefix)
+			require.True(t, h.server.configsDone)
+
+			h.requireWriteLine("INITREMOTE")
+			require.Regexp(t,
+				regexp.MustCompile("^INITREMOTE-FAILURE backend must not have a path: "),
+				h.requireReadLine(),
+			)
+
+			require.NoError(t, h.mockStdinW.Close())
+		},
+		expectedError: "backend must not have a path:",
+	},
+	{
 		label: "HandlesPrepareWithSynonyms",
 		testProtocolFunc: func(t *testing.T, h *testState) {
 			h.requireReadLineExact("VERSION 1")
@@ -1178,11 +1299,11 @@ func TestGitAnnexFstestBackendCases(t *testing.T) {
 			require.NoError(t, err)
 
 			// The gitannex command requires the `rcloneremotename` is the name
-			// of a remote or exactly ":local", so the empty string will not
-			// suffice.
+			// of a remote or a colon-prefixed backend name like ":local:", so
+			// the empty string will not suffice.
 			if remoteName == "" {
 				require.True(t, r.Fremote.Features().IsLocal)
-				remoteName = ":local"
+				remoteName = ":local:"
 			}
 
 			handle := makeTestState(t)

--- a/cmd/gitannex/gitannex_test.go
+++ b/cmd/gitannex/gitannex_test.go
@@ -140,7 +140,6 @@ var messageParserTestCases = []messageParserTestCase{
 		"OneLongFinalParameter",
 		func(t *testing.T) {
 			for _, lineEnding := range []string{"", "\n", "\r", "\r\n", "\n\r"} {
-				lineEnding := lineEnding
 				testName := fmt.Sprintf("lineEnding%x", lineEnding)
 
 				t.Run(testName, func(t *testing.T) {
@@ -184,7 +183,6 @@ var messageParserTestCases = []messageParserTestCase{
 
 func TestMessageParser(t *testing.T) {
 	for _, testCase := range messageParserTestCases {
-		testCase := testCase
 		t.Run(testCase.label, func(t *testing.T) {
 			t.Parallel()
 			testCase.testFunc(t)
@@ -1171,11 +1169,6 @@ func TestMain(m *testing.M) {
 func TestGitAnnexFstestBackendCases(t *testing.T) {
 
 	for _, testCase := range fstestTestCases {
-		// TODO: Remove this when rclone requires a Go version >= 1.22. Future
-		// versions of Go fix the semantics of capturing a range variable.
-		// https://go.dev/blog/loopvar-preview
-		testCase := testCase
-
 		t.Run(testCase.label, func(t *testing.T) {
 			r := fstest.NewRun(t)
 			t.Cleanup(func() { r.Finalise() })


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

The "rcloneremotename" (aka "target") config parameter is now permitted
to contain (1) remote names that are defined by environment variables,
but not in an rclone config file, and (2) backend strings such as
":memory:".

This should fix some of the failing integration tests. For context:
https://github.com/rclone/rclone/pull/7987#issuecomment-2688580667

Issue https://github.com/rclone/rclone/issues/7984

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
