### PR TITLE
Documentation - Add note for using `rclone cat` for slicing out a byte range from a file, embedded in the copy-to documentation.

### DIFF
--- a/cmd/copyto/copyto.go
+++ b/cmd/copyto/copyto.go
@@ -43,6 +43,8 @@ This doesn't transfer files that are identical on src and dst, testing
 by size and modification time or MD5SUM.  It doesn't delete files from
 the destination.
 
+*If you are looking to copy just a byte range of a file, please see 'rclone cat --offset X --count Y'*
+
 **Note**: Use the ` + "`-P`" + `/` + "`--progress`" + ` flag to view real-time transfer statistics
 `,
 	Annotations: map[string]string{


### PR DESCRIPTION
Knowing that cat is the tool for byte slicing would have saved me a lot of time from emulating this via mount with caching minimum and direct-io.

Updating the docs with this bread-crumb so that users in the future can easily discover that `cat --offset X --count Y` is the proper sub command to get a byte slice out of large remote file.