### PR TITLE
rcserver: improve content-type check

### DIFF
--- a/fs/rc/rcserver/rcserver.go
+++ b/fs/rc/rcserver/rcserver.go
@@ -209,8 +209,21 @@ func (s *Server) handlePost(w http.ResponseWriter, r *http.Request, path string)
 	ctx := r.Context()
 	contentType := r.Header.Get("Content-Type")
 
+	var (
+		contentTypeMediaType string
+		contentTypeParams    map[string]string
+	)
+	if contentType != "" {
+		var err error
+		contentTypeMediaType, contentTypeParams, err = mime.ParseMediaType(contentType)
+		if err != nil {
+			writeError(path, nil, w, fmt.Errorf("failed to parse Content-Type: %w", err), http.StatusBadRequest)
+			return
+		}
+	}
+
 	values := r.URL.Query()
-	if contentType == "application/x-www-form-urlencoded" {
+	if contentTypeMediaType == "application/x-www-form-urlencoded" {
 		// Parse the POST and URL parameters into r.Form, for others r.Form will be empty value
 		err := r.ParseForm()
 		if err != nil {
@@ -229,7 +242,13 @@ func (s *Server) handlePost(w http.ResponseWriter, r *http.Request, path string)
 	}
 
 	// Parse a JSON blob from the input
-	if contentType == "application/json" {
+	if contentTypeMediaType == "application/json" {
+		// Check the charset is utf-8 or unset
+		if charset, ok := contentTypeParams["charset"]; ok && !strings.EqualFold(charset, "utf-8") {
+			writeError(path, in, w, fmt.Errorf("unsupported charset %q for JSON input", charset), http.StatusBadRequest)
+			return
+		}
+
 		err := json.NewDecoder(r.Body).Decode(&in)
 		if err != nil {
 			writeError(path, in, w, fmt.Errorf("failed to read input JSON: %w", err), http.StatusBadRequest)

--- a/fs/rc/rcserver/rcserver_test.go
+++ b/fs/rc/rcserver/rcserver_test.go
@@ -431,6 +431,18 @@ func TestRC(t *testing.T) {
 }
 `,
 	}, {
+		Name:        "json-mixed-case-content-type",
+		URL:         "rc/noop",
+		Method:      "POST",
+		Body:        `{ "param1":"string", "param2":true }`,
+		ContentType: "ApplicAtion/JsOn",
+		Status:      http.StatusOK,
+		Expected: `{
+	"param1": "string",
+	"param2": true
+}
+`,
+	}, {
 		Name:        "json-and-url-params",
 		URL:         "rc/noop?param1=potato&param2=sausage",
 		Method:      "POST",
@@ -456,6 +468,44 @@ func TestRC(t *testing.T) {
 		"param1": "potato",
 		"param2": "sausage"
 	},
+	"path": "rc/noop",
+	"status": 400
+}
+`,
+	}, {
+		Name:        "json-charset",
+		URL:         "rc/noop",
+		Method:      "POST",
+		Body:        `{ "param1":"string", "param2":true }`,
+		ContentType: "application/json; charset=utf-8",
+		Status:      http.StatusOK,
+		Expected: `{
+	"param1": "string",
+	"param2": true
+}
+`,
+	}, {
+		Name:        "json-mixed-case-charset",
+		URL:         "rc/noop",
+		Method:      "POST",
+		Body:        `{ "param1":"string", "param2":true }`,
+		ContentType: "aPPlication/jSoN; charset=UtF-8",
+		Status:      http.StatusOK,
+		Expected: `{
+	"param1": "string",
+	"param2": true
+}
+`,
+	}, {
+		Name:        "json-bad-charset",
+		URL:         "rc/noop",
+		Method:      "POST",
+		Body:        `{ "param1":"string", "param2":true }`,
+		ContentType: "application/json; charset=latin1",
+		Status:      http.StatusBadRequest,
+		Expected: `{
+	"error": "unsupported charset \"latin1\" for JSON input",
+	"input": {},
 	"path": "rc/noop",
 	"status": 400
 }
@@ -494,6 +544,19 @@ func TestRC(t *testing.T) {
 		Status:      http.StatusBadRequest,
 		Expected: `{
 	"error": "failed to parse form/URL parameters: invalid URL escape \"%zz\"",
+	"input": null,
+	"path": "rc/noop",
+	"status": 400
+}
+`,
+	}, {
+		Name:        "malformed-content-type",
+		URL:         "rc/noop",
+		Method:      "POST",
+		ContentType: "malformed/",
+		Status:      http.StatusBadRequest,
+		Expected: `{
+	"error": "failed to parse Content-Type: mime: expected token after slash",
 	"input": null,
 	"path": "rc/noop",
 	"status": 400


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Some libraries use `application/json; charset=utf-8` as their `Content-Type`, which is valid. However we were not decoding the JSON body in that case, resulting in issues communicating parameters to the rcserver. This change improves the checks made against the provided `Content-Type`.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

Not that I'm aware of.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
