### PR TITLE
http: correct root if definitely pointing to a file - fixes #8428

### DIFF
--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -180,7 +180,6 @@ func getFsEndpoint(ctx context.Context, client *http.Client, url string, opt *Op
 	}
 	addHeaders(req, opt)
 	res, err := noRedir.Do(req)
-
 	if err != nil {
 		fs.Debugf(nil, "Assuming path is a file as HEAD request could not be sent: %v", err)
 		return createFileResult()
@@ -249,6 +248,14 @@ func (f *Fs) httpConnection(ctx context.Context, opt *Options) (isFile bool, err
 	f.httpClient = client
 	f.endpoint = u
 	f.endpointURL = u.String()
+
+	if isFile {
+		// Correct root if definitely pointing to a file
+		f.root = path.Dir(f.root)
+		if f.root == "." || f.root == "/" {
+			f.root = ""
+		}
+	}
 	return isFile, nil
 }
 


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes #8428 by ensuring that `http` returns the correct root when pointing to a file (as opposed to a dir).

This was formalized in https://github.com/rclone/rclone/commit/c69eb84573c85206ab028eda2987180e049ef2e4 But it appears that we forgot to update `http`, and the `FsRoot` test didn't catch it because we don't currently have an `http` integration test.

#### Was the change discussed in an issue or in the forum before?

- #8428

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
