### PR TITLE
Added --files-from-strict option - Fixes #7842

### DIFF
--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -242,7 +242,9 @@ Any path/file included at that stage is processed by the rclone
 command.
 
 `--files-from` and `--files-from-raw` flags over-ride and cannot be
-combined with other filter options.
+combined with other filter options, with the exception of the flag
+`--files-from--strict`, which makes the operation fail if at least
+one of the files does not exist.
 
 To see the internal combined rule list, in regular expression form,
 for a command add the `--dump filters` flag. Running an rclone command

--- a/docs/content/flags.md
+++ b/docs/content/flags.md
@@ -187,6 +187,7 @@ Flags for filtering directory listings.
       --exclude-from stringArray            Read file exclude patterns from file (use - to read from stdin)
       --exclude-if-present stringArray      Exclude directories if filename is present
       --files-from stringArray              Read list of source-file names from file (use - to read from stdin)
+      --files-from-strict                   Makes "files-from" fail if at least one of the files does not exist
       --files-from-raw stringArray          Read list of source-file names from file without any processing of lines (use - to read from stdin)
   -f, --filter stringArray                  Add a file filtering rule
       --filter-from stringArray             Read file filtering patterns from a file (use - to read from stdin)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The purpose of this PR is to address the issue #7842 , by including a new flag that can be used when the "--files-from" filter is used.

#### Was the change discussed in an issue or in the forum before?

Yes, this PR is directly related to #7842 

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
