### PR TITLE
sftp: respect --no-check-dest parameter

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -2214,6 +2214,15 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 
 	// Stat the file after the upload to read its stats back if o.fs.opt.SetModTime == false
 	if !o.fs.opt.SetModTime {
+		ci := fs.GetConfig(ctx)
+		if ci.NoCheckDest {
+			fs.Debugf(o, "--no-check-dest is set, so returning best guess")
+			o.modTime = uint32(src.ModTime(ctx).Unix())
+			o.size = src.Size()
+			o.mode = os.FileMode(0666) // regular file
+			return nil
+		}
+
 		err = o.stat(ctx)
 		if err == fs.ErrorObjectNotFound {
 			// In the specific case of o.fs.opt.SetModTime == false


### PR DESCRIPTION



#### What is the purpose of this change?

I need to upload files to sftp folder that does not allow list, read, only upload.
SFTP backend attempts to get object stats after upload. This will fail in case when uploading to folder that has only write permissions (no read, list, etc.) with "permission denied" error.
Change makes Update method to return "best guess" stats when --no-check-dest flag is used.

#### Was the change discussed in an issue or in the forum before?
Did not find previous referrences

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
