### PR TITLE
vfs-dir: the directory cache not effect

### DIFF
--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -579,7 +579,7 @@ func (d *Dir) _readDir() error {
 		return err
 	}
 
-	d.read = when
+	d.read = time.Now()
 	d.cleanupTimer.Reset(time.Duration(d.vfs.Opt.DirCacheTime * 2))
 
 	return nil


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

When querying directories with large datasets, if the query duration exceeds the directory cache expiration time, the cache becomes invalid by the time results are retrieved. Every execution of _readDir triggers _readDirFromEntries, resulting in prolonged processing times.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
