### PR TITLE
fuse version query

### DIFF
--- a/docs/content/docker.md
+++ b/docs/content/docker.md
@@ -45,7 +45,7 @@ on the host.
 The _FUSE_ driver is a prerequisite for rclone mounting and should be
 installed on host:
 ```
-sudo apt-get -y install fuse
+sudo apt-get -y install fuse3
 ```
 
 Create two directories required by rclone docker plugin:


### PR DESCRIPTION
I think it would be nice if the readme clarifies that fuse3 vs fuse is required, or fuse is required and not fuse3.

I can't think why fuse would be chosen over fuse3 ? 

It would be good to explicitly state if fuse3 is not the correct version.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [*] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [*] I'm done, this Pull Request is ready for review :-)
