### PR TITLE
Update rclone_mount.md

### DIFF
--- a/docs/content/commands/rclone_mount.md
+++ b/docs/content/commands/rclone_mount.md
@@ -459,6 +459,12 @@ by `-` and prepend `--` to get the command-line flags. Options containing commas
 or spaces can be wrapped in single or double quotes. Any inner quotes inside outer
 quotes of the same type should be doubled.
 
+On FreeBSD you can symlink the binary with `ln -s /usr/local/bin/rclone /usr/local/bin/rclonefs` 
+then use the following syntax for /etc/fstab:
+```
+sftp1:subdir /mnt/data none rw,noauto,args2env,mountprog=/usr/local/bin/rclonefs,vfs_cache_mode=writes,config=/usr/local/etc/rclone.conf,cache_dir=/var/cache/rclone 0 0
+```
+
 Mount option syntax includes a few extra options treated specially:
 
 - `env.NAME=VALUE` will set an environment variable for the mount process.


### PR DESCRIPTION
Added working fstab syntax to the command documentation of `rclone mount` for FreeBSD

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Since [mount(8)](https://man.freebsd.org/cgi/man.cgi?mount(8)) is a little different on FreeBSD, it requires a slightly different fstab entry. There's no need to change the code at all, it works as is.

#### Was the change discussed in an issue or in the forum before?

[#7432](https://github.com/rclone/rclone/issues/7432)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
