### PR TITLE
cmd/authorize: show required arguments in help text

### DIFF
--- a/cmd/authorize/authorize.go
+++ b/cmd/authorize/authorize.go
@@ -23,11 +23,16 @@ func init() {
 }
 
 var commandDefinition = &cobra.Command{
-	Use:   "authorize",
+	Use:   "authorize <fs name> [base64_json_blob | client_id client_secret]",
 	Short: `Remote authorization.`,
 	Long: `Remote authorization. Used to authorize a remote or headless
 rclone from a machine with a browser - use as instructed by
 rclone config.
+
+The command requires 1-3 arguments:
+  - fs name (e.g., "drive", "s3", etc.)
+  - Either a base64 encoded JSON blob obtained from a previous rclone config session
+  - Or a client_id and client_secret pair obtained from the remote service
 
 Use --auth-no-open-browser to prevent rclone to open auth
 link in default browser automatically.
@@ -35,7 +40,6 @@ link in default browser automatically.
 Use --template to generate HTML output via a custom Go template. If a blank string is provided as an argument to this flag, the default template is used.`,
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.27",
-		// "groups":            "",
 	},
 	RunE: func(command *cobra.Command, args []string) error {
 		cmd.CheckArgs(1, 3, command, args)

--- a/cmd/authorize/authorize_test.go
+++ b/cmd/authorize/authorize_test.go
@@ -1,0 +1,32 @@
+package authorize
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestAuthorizeCommand(t *testing.T) {
+	// Test that the Use string is correctly formatted
+	if commandDefinition.Use != "authorize <fs name> [base64_json_blob | client_id client_secret]" {
+		t.Errorf("Command Use string doesn't match expected format: %s", commandDefinition.Use)
+	}
+
+	// Test that help output contains the argument information
+	buf := &bytes.Buffer{}
+	cmd := &cobra.Command{}
+	cmd.AddCommand(commandDefinition)
+	cmd.SetOut(buf)
+	cmd.SetArgs([]string{"authorize", "--help"})
+	err := cmd.Execute()
+	if err != nil {
+		t.Fatalf("Failed to execute help command: %v", err)
+	}
+
+	helpOutput := buf.String()
+	if !strings.Contains(helpOutput, "authorize <fs name>") {
+		t.Errorf("Help output doesn't contain correct usage information")
+	}
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Before this change, the help text for 'authorize' didn't show that
the command requires at least one argument, with two optional arguments.
This made it impossible for users to know how to use the command
correctly from the help output alone.

Updated to clearly show '<fs name> [base64_json_blob | client_id client_secret]'
in the usage text.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

No, this was a direct fix for an issue I encountered while using the command.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
