### PR TITLE
fs/config: Read configuration password from EOFed stdin - fixes #8480

### DIFF
--- a/fs/config/ui.go
+++ b/fs/config/ui.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"sort"
@@ -28,7 +29,7 @@ import (
 var ReadLine = func() string {
 	buf := bufio.NewReader(os.Stdin)
 	line, err := buf.ReadString('\n')
-	if err != nil {
+	if err != nil && (line == "" || err != io.EOF) {
 		fs.Fatalf(nil, "Failed to read line: %v", err)
 	}
 	return strings.TrimSpace(line)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This change fixes #8480. When reading the configuration password from stdin, the original behavior of Rclone was to throw an error if the stream hit EOF before encountering a line break even if a password was provided. This change would ignore the EOF as long as the read string is not empty.

#### Was the change discussed in an issue or in the forum before?

The issue #8480 presents the root cause and mentions proposed change, but no discussion has occurred yet.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
