### PR TITLE
operations: fix call fmt.Errorf with wrong err

### DIFF
--- a/fs/operations/multithread.go
+++ b/fs/operations/multithread.go
@@ -314,7 +314,7 @@ func (w *writerAtChunkWriter) WriteChunk(ctx context.Context, chunkNumber int, r
 	case *bufio.Writer:
 		er2 := w.Flush()
 		if er2 != nil {
-			return -1, fmt.Errorf("multi-thread copy: flush failed: %w", err)
+			return -1, fmt.Errorf("multi-thread copy: flush failed: %w", er2)
 		}
 	}
 	return n, nil

--- a/fs/operations/multithread.go
+++ b/fs/operations/multithread.go
@@ -312,9 +312,9 @@ func (w *writerAtChunkWriter) WriteChunk(ctx context.Context, chunkNumber int, r
 	// if we were buffering, flush to disk
 	switch w := writer.(type) {
 	case *bufio.Writer:
-		er2 := w.Flush()
-		if er2 != nil {
-			return -1, fmt.Errorf("multi-thread copy: flush failed: %w", er2)
+		err := w.Flush()
+		if err != nil {
+			return -1, fmt.Errorf("multi-thread copy: flush failed: %w", err)
 		}
 	}
 	return n, nil

--- a/fs/operations/multithread.go
+++ b/fs/operations/multithread.go
@@ -312,7 +312,7 @@ func (w *writerAtChunkWriter) WriteChunk(ctx context.Context, chunkNumber int, r
 	// if we were buffering, flush to disk
 	switch w := writer.(type) {
 	case *bufio.Writer:
-		err := w.Flush()
+		err = w.Flush()
 		if err != nil {
 			return -1, fmt.Errorf("multi-thread copy: flush failed: %w", err)
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

a simple bug fix, the `err` is nil, should use `er2`

#### Was the change discussed in an issue or in the forum before?


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
