### PR TITLE
docs: replace option `--auto-filename-header` with `--header-filename`

### DIFF
--- a/cmd/copyurl/copyurl.go
+++ b/cmd/copyurl/copyurl.go
@@ -43,7 +43,7 @@ Setting |--auto-filename| will attempt to automatically determine the
 filename from the URL (after any redirections) and used in the
 destination path.
 
-With |--auto-filename-header| in addition, if a specific filename is
+With |--header-filename| in addition, if a specific filename is
 set in HTTP headers, it will be used instead of the name from the URL.
 With |--print-filename| in addition, the resulting file name will be
 printed.

--- a/docs/content/commands/rclone_copyurl.md
+++ b/docs/content/commands/rclone_copyurl.md
@@ -17,7 +17,7 @@ Setting `--auto-filename` will attempt to automatically determine the
 filename from the URL (after any redirections) and used in the
 destination path.
 
-With `--auto-filename-header` in addition, if a specific filename is
+With `--header-filename` in addition, if a specific filename is
 set in HTTP headers, it will be used instead of the name from the URL.
 With `--print-filename` in addition, the resulting file name will be
 printed.
@@ -28,7 +28,7 @@ destination if there is one with the same name.
 Setting `--stdout` or making the output file name `-`
 will cause the output to be written to standard output.
 
-## Troublshooting
+## Troubleshooting
 
 If you can't get `rclone copyurl` to work then here are some things you can try:
 

--- a/docs/content/commands/rclone_copyurl.md
+++ b/docs/content/commands/rclone_copyurl.md
@@ -17,7 +17,7 @@ Setting `--auto-filename` will attempt to automatically determine the
 filename from the URL (after any redirections) and used in the
 destination path.
 
-With `--header-filename` in addition, if a specific filename is
+With `--auto-filename-header` in addition, if a specific filename is
 set in HTTP headers, it will be used instead of the name from the URL.
 With `--print-filename` in addition, the resulting file name will be
 printed.
@@ -28,7 +28,7 @@ destination if there is one with the same name.
 Setting `--stdout` or making the output file name `-`
 will cause the output to be written to standard output.
 
-## Troubleshooting
+## Troublshooting
 
 If you can't get `rclone copyurl` to work then here are some things you can try:
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Running the `rclone copyurl` command with the `--auto-filename-header` option will produce the following error:

 `Fatal error: unknown flag: --auto-filename-header`

Considering the updated option `--header-filename` is also listed in the document, I assume this is a mistake. If I've misunderstood, my apologies.

Also changed 'Troublshooting' to 'Troubleshooting'.

Thank you!

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

A search on the `rclone` GitHub repository for `is:issue state:open "--auto-filename-header"` & `is:pr is:open "--auto-filename-header"` returns nothing, and a Google search for `"rclone" "--auto-filename-header" "error"|"fatal error"|"unknown flag"` doesn't return anything relevant. I don't believe the issue has previously been discussed.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)