### PR TITLE
iclouddrive: fix so created files are writable

### DIFF
--- a/backend/iclouddrive/api/drive.go
+++ b/backend/iclouddrive/api/drive.go
@@ -631,7 +631,7 @@ func NewUpdateFileInfo() UpdateFileInfo {
 		FileFlags: FileFlags{
 			IsExecutable: true,
 			IsHidden:     false,
-			IsWritable:   false,
+			IsWritable:   true,
 		},
 	}
 }


### PR DESCRIPTION
#### What is the purpose of this change?

At present any created file (eg through the touch command, copy, mount etc) is read-only in iCloud. This means it cannot be edited other devices as one would reasonably expect by default.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/icloud-and-file-editing-permissions/50659

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
