### PR TITLE
add rc call to unlock config

### DIFF
--- a/fs/config/rc.go
+++ b/fs/config/rc.go
@@ -11,6 +11,37 @@ import (
 
 func init() {
 	rc.Add(rc.Call{
+		Path:         "config/unlock",
+		Fn:           rcConfigPassword,
+		Title:        "Unlock the config file.",
+		AuthRequired: true,
+		Help: `
+Unlocks the config file if it is locked.
+
+Parameters:
+
+- 'config_password' - password to unlock the config file
+
+A good idea is to disable AskPassword before making this call
+`,
+	})
+}
+
+// Unlock the config file
+// A good idea is to disable AskPassword before making this call
+func rcConfigPassword(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+	configPass, err := in.GetString("config_password")
+	if err != nil {
+		return nil, err
+	}
+	if SetConfigPassword(configPass) != nil {
+		return nil, errors.New("failed to set config password")
+	}
+	return DumpRcBlob(), nil
+}
+
+func init() {
+	rc.Add(rc.Call{
 		Path:         "config/dump",
 		Fn:           rcDump,
 		Title:        "Dumps the config file.",

--- a/fs/config/rc.go
+++ b/fs/config/rc.go
@@ -37,7 +37,7 @@ func rcConfigPassword(ctx context.Context, in rc.Params) (out rc.Params, err err
 	if SetConfigPassword(configPass) != nil {
 		return nil, errors.New("failed to set config password")
 	}
-	return true, nil
+	return nil, nil
 }
 
 func init() {

--- a/fs/config/rc.go
+++ b/fs/config/rc.go
@@ -37,7 +37,7 @@ func rcConfigPassword(ctx context.Context, in rc.Params) (out rc.Params, err err
 	if SetConfigPassword(configPass) != nil {
 		return nil, errors.New("failed to set config password")
 	}
-	return DumpRcBlob(), nil
+	return true, nil
 }
 
 func init() {

--- a/fs/config/rc_test.go
+++ b/fs/config/rc_test.go
@@ -188,3 +188,17 @@ func TestRcPaths(t *testing.T) {
 	assert.Equal(t, config.GetCacheDir(), out["cache"])
 	assert.Equal(t, os.TempDir(), out["temp"])
 }
+
+func TestRcConfigUnlock(t *testing.T) {
+	call := rc.Calls.Get("config/unlock")
+	assert.NotNil(t, call)
+	in := rc.Params{
+		"config_password": "test",
+	}
+	out, err := call.Fn(context.Background(), in)
+	require.NoError(t, err)
+
+	assert.Nil(t, err)
+	assert.Nil(t, out)
+
+}


### PR DESCRIPTION
#### What is the purpose of this change?

Add a call to unlock the configuration file

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/librclone-rpc-encryption-configuration/50761
https://forum.rclone.org/t/askpassword-in-remote-control/50768/2

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
