### PR TITLE
listremotes should send an empty array

### DIFF
--- a/fs/config/rc.go
+++ b/fs/config/rc.go
@@ -75,6 +75,9 @@ See the [listremotes](/commands/rclone_listremotes/) command for more informatio
 // including any defined by environment variables.
 func rcListRemotes(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	remoteNames := GetRemoteNames()
+	if remoteNames == nil {
+		remoteNames = []string{}
+	}
 	out = rc.Params{
 		"remotes": remoteNames,
 	}

--- a/fs/config/rc_test.go
+++ b/fs/config/rc_test.go
@@ -138,6 +138,22 @@ func TestRc(t *testing.T) {
 	assert.Nil(t, out)
 	assert.Equal(t, "", config.GetValue(testName, "type"))
 	assert.Equal(t, "", config.GetValue(testName, "test_key"))
+
+	t.Run("ListRemotes empty not nil", func(t *testing.T) {
+		call := rc.Calls.Get("config/listremotes")
+		assert.NotNil(t, call)
+		in := rc.Params{}
+		out, err := call.Fn(context.Background(), in)
+		require.NoError(t, err)
+		require.NotNil(t, out)
+
+		var remotes []string
+		err = out.GetStruct("remotes", &remotes)
+		require.NoError(t, err)
+
+		assert.NotNil(t, remotes)
+		assert.Empty(t, remotes)
+	})
 }
 
 func TestRcProviders(t *testing.T) {


### PR DESCRIPTION
#### What is the purpose of this change?

The remote call `config/listremotes` sends nil

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
