### PR TITLE
union: make {ep}lno policy universal across all remote types

### DIFF
--- a/backend/union/policy/lno.go
+++ b/backend/union/policy/lno.go
@@ -28,6 +28,6 @@ func (p *Lno) Create(ctx context.Context, upstreams []*upstream.Fs, path string)
 	if len(upstreams) == 0 {
 		return nil, fs.ErrorPermissionDenied
 	}
-	u, err := p.lno(upstreams)
+	u, err := p.lno(ctx, upstreams)
 	return []*upstream.Fs{u}, err
 }


### PR DESCRIPTION
#### What is the purpose of this change?

The `{ep}lno` policy of rclone was unsupported by [a lot of backends](https://github.com/rclone/rclone/issues/8492#issuecomment-2791987004). This PR adds support to all of them by falling back to normal listing instead of object counting (informing the user that the operation will be slower).

The log listed in the issue below becomes:

<details>

```
2025/04/10 17:04:59 DEBUG : Setting --user-agent "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.0.0" from environment variable RCLONE_USER_AGENT="Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36 Edg/134.0.0.0"
2025/04/10 17:04:59 DEBUG : rclone: Version "v1.70.0-beta.8712.7a09de9f2.better-lno-policy" starting with parameters ["./rclone" "copy" "-vv" "rclone.conf" "Union:"]
2025/04/10 17:04:59 DEBUG : Creating backend with remote "rclone.conf"
2025/04/10 17:04:59 DEBUG : Using config file from "/home/ferferga/.config/rclone/rclone.conf"
2025/04/10 17:04:59 DEBUG : fs cache: renaming child cache item "rclone.conf" to be canonical for parent "/home/ferferga/.config/rclone"
2025/04/10 17:04:59 DEBUG : Creating backend with remote "Union:"
2025/04/10 17:04:59 DEBUG : Creating backend with remote "Crypt:Backups/1"
2025/04/10 17:04:59 DEBUG : Creating backend with remote "Crypt:Backups/3"
2025/04/10 17:04:59 DEBUG : Creating backend with remote "Crypt:Backups/2"
2025/04/10 17:04:59 DEBUG : Creating backend with remote "OpenDrive:[REDACTED]"
2025/04/10 17:04:59 DEBUG : Creating backend with remote "OpenDrive:[REDACTED]"
2025/04/10 17:04:59 DEBUG : Creating backend with remote "OpenDrive:[REDACTED]"
2025/04/10 17:05:00 DEBUG : Starting OpenDrive session with ID: [REDACTED]
2025/04/10 17:05:00 DEBUG : Starting OpenDrive session with ID: [REDACTED]
2025/04/10 17:05:00 DEBUG : Starting OpenDrive session with ID: [REDACTED]
2025/04/10 17:05:01 DEBUG : union root '': actionPolicy = *policy.Lno, createPolicy = *policy.Lno, searchPolicy = *policy.FF
2025/04/10 17:05:02 DEBUG : rclone.conf: Need to transfer - File not found at Destination
2025/04/10 17:05:02 NOTICE: Number of Objects is not supported for upstream Crypt, falling back to listing (this may be slower)...
2025/04/10 17:05:06 DEBUG : Counted 9233 objects for upstream Crypt by listing
2025/04/10 17:05:06 NOTICE: Number of Objects is not supported for upstream Crypt, falling back to listing (this may be slower)...
2025/04/10 17:05:06 DEBUG : Counted 27 objects for upstream Crypt by listing
2025/04/10 17:05:07 DEBUG : [REDACTED]: Uploading chunk 0, size=2542536, remain=0
2025/04/10 17:05:09 DEBUG : rclone.conf: md5 = 400d21863fca7f183fc80b95a5dd0a14 OK
2025/04/10 17:05:09 INFO  : rclone.conf: Copied (new)
```

</details>

#### Was the change discussed in an issue or in the forum before?

Fixes #8492 

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate — *(this didn't have any tests and I don't have experience with Go to feel safe to do good ones, but I will happily take feedback)*
- [ ] I have added documentation for the changes if appropriate — *(will do once code review is over)*
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
