### PR TITLE
build: Update Go version to 1.24.2 to address security vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rclone/rclone
 
-go 1.23.0
+go 1.24.2
 
 require (
 	bazil.org/fuse v0.0.0-20230120002735-62a210ff1fd5


### PR DESCRIPTION
#### What is the purpose of this change?

This change updates the Go version specified in `go.mod` from `1.23.0` to `1.24.2` to address `CVE-2025-22871` in the standard library.

It also implicitly addresses several other CVEs reported by a vulnerability scanner by ensuring dependencies like `golang.org/x/net`, `golang.org/x/crypto`, and `github.com/golang-jwt/jwt/v4` / `v5` are at or above their respective fixed versions, as confirmed by running `go mod tidy`. The relevant CVEs addressed by dependency versions already present or updated transitively include:
*   `CVE-2025-30204` (`github.com/golang-jwt/jwt/v4`)
*   `CVE-2025-22869` (`golang.org/x/crypto`)
*   `CVE-2025-22870` (`golang.org/x/net`)
*   `CVE-2025-22872` (`golang.org/x/net`)

#### Was the change discussed in an issue or in the forum before?

This change was prompted by a local vulnerability scan report, not by a specific GitHub issue or forum post.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ NA] I have added tests for all changes in this PR if appropriate. (Likely not needed for a dependency update, but up to you).
- [NA ] I have added documentation for the changes if appropriate. (Likely not needed for this change).
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages). (You may want to rebase/squash your commits to fit the style if necessary).
- [X] I'm done, this Pull Request is ready for review :-)