### PR TITLE
Update GPhotos scopes to at least allow uploading new photos/albums

### DIFF
--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -52,8 +52,8 @@ const (
 	listChunks                  = 100 // chunk size to read directory listings
 	albumChunks                 = 50  // chunk size to read album listings
 	minSleep                    = 10 * time.Millisecond
-	scopeReadOnly               = "https://www.googleapis.com/auth/photoslibrary.readonly"
-	scopeReadWrite              = "https://www.googleapis.com/auth/photoslibrary"
+	scopeReadOnly               = "https://www.googleapis.com/auth/photoslibrary.appendonly"
+	scopeReadWrite              = "https://www.googleapis.com/auth/photoslibrary.appendonly"
 	scopeAccess                 = 2 // position of access scope in list
 )
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Google Photos has updated their allowed scopes and now the only capability that RClone can offer is to upload new photos. It will also be able to download photos, but only those that Rclone uploaded.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/8434

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
