### PR TITLE
docs: Clarify remote naming convention

### DIFF
--- a/docs/content/alias.md
+++ b/docs/content/alias.md
@@ -81,7 +81,7 @@ q) Quit config
 e/n/d/r/c/s/q> q
 ```
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level in `/mnt/storage/backup`
 

--- a/docs/content/box.md
+++ b/docs/content/box.md
@@ -90,7 +90,7 @@ your browser to the moment you get back the verification code.  This
 is on `http://127.0.0.1:53682/` and this may require you to unblock
 it temporarily if you are running a host firewall.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your Box
 

--- a/docs/content/fichier.md
+++ b/docs/content/fichier.md
@@ -62,7 +62,7 @@ d) Delete this remote
 y/e/d> y
 ```
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your 1Fichier account
 

--- a/docs/content/filefabric.md
+++ b/docs/content/filefabric.md
@@ -87,7 +87,7 @@ d) Delete this remote
 y/e/d> y
 ```
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your Enterprise File Fabric
 

--- a/docs/content/gofile.md
+++ b/docs/content/gofile.md
@@ -64,7 +64,7 @@ d) Delete this remote
 y/e/d> y
 ```
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories and files in the top level of your Gofile
 

--- a/docs/content/hidrive.md
+++ b/docs/content/hidrive.md
@@ -79,7 +79,7 @@ The webserver runs on `http://127.0.0.1:53682/`.
 If local port `53682` is protected by a firewall you may need to temporarily
 unblock the firewall to complete authorization.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your HiDrive root folder
 

--- a/docs/content/jottacloud.md
+++ b/docs/content/jottacloud.md
@@ -193,7 +193,7 @@ d) Delete this remote
 y/e/d> y
 ```
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your Jottacloud
 

--- a/docs/content/mega.md
+++ b/docs/content/mega.md
@@ -68,7 +68,7 @@ y/e/d> y
 **NOTE:** The encryption keys need to have been already generated after a regular login
 via the browser, otherwise attempting to use the credentials in `rclone` will fail.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your Mega
 

--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -106,7 +106,7 @@ opens your browser to the moment you get back the verification
 code.  This is on `http://127.0.0.1:53682/` and this it may require
 you to unblock it temporarily if you are running a host firewall.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your OneDrive
 

--- a/docs/content/pcloud.md
+++ b/docs/content/pcloud.md
@@ -81,7 +81,7 @@ your browser to the moment you get back the verification code.  This
 is on `http://127.0.0.1:53682/` and this it may require you to unblock
 it temporarily if you are running a host firewall.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your pCloud
 

--- a/docs/content/premiumizeme.md
+++ b/docs/content/premiumizeme.md
@@ -70,7 +70,7 @@ your browser to the moment you get back the verification code.  This
 is on `http://127.0.0.1:53682/` and this it may require you to unblock
 it temporarily if you are running a host firewall.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your premiumize.me
 

--- a/docs/content/protondrive.md
+++ b/docs/content/protondrive.md
@@ -81,7 +81,7 @@ y/e/d> y
 after a regular login via the browser, otherwise attempting to use the 
 credentials in `rclone` will fail.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your Proton Drive
 

--- a/docs/content/quatrix.md
+++ b/docs/content/quatrix.md
@@ -56,7 +56,7 @@ d) Delete this remote
 y/e/d> y
 ```
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your Quatrix
 

--- a/docs/content/sharefile.md
+++ b/docs/content/sharefile.md
@@ -89,7 +89,7 @@ your browser to the moment you get back the verification code.  This
 is on `http://127.0.0.1:53682/` and this it may require you to unblock
 it temporarily if you are running a host firewall.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your ShareFile
 

--- a/docs/content/sugarsync.md
+++ b/docs/content/sugarsync.md
@@ -76,7 +76,7 @@ y/e/d> y
 Note that the config asks for your email and password but doesn't
 store them, it only uses them to get the initial token.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories (sync folders) in top level of your SugarSync
 

--- a/docs/content/ulozto.md
+++ b/docs/content/ulozto.md
@@ -71,7 +71,7 @@ d) Delete this remote
 y/e/d> y
 ```
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List folders in root level folder:
 

--- a/docs/content/uptobox.md
+++ b/docs/content/uptobox.md
@@ -68,7 +68,7 @@ e) Edit this remote
 d) Delete this remote
 y/e/d> 
 ```
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your Uptobox
 

--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -87,7 +87,7 @@ d) Delete this remote
 y/e/d> y
 ```
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 List directories in top level of your WebDAV
 

--- a/docs/content/yandex.md
+++ b/docs/content/yandex.md
@@ -67,7 +67,7 @@ opens your browser to the moment you get back the verification code.
 This is on `http://127.0.0.1:53682/` and this it may require you to
 unblock it temporarily if you are running a host firewall.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 See top level directories
 

--- a/docs/content/zoho.md
+++ b/docs/content/zoho.md
@@ -86,7 +86,7 @@ The webserver runs on `http://127.0.0.1:53682/`.
 If local port `53682` is protected by a firewall you may need to temporarily
 unblock the firewall to complete authorization.
 
-Once configured you can then use `rclone` like this,
+Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)
 
 See top level directories
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

If this was here I would not have gotten "Failed to create file system for "remote:": Didn't find section in config file" from using the wrong name for my remote, as I didn't know that had to be the name you chose.

I replaced  
"Once configured you can then use `rclone` like this,"  
with  
"Once configured you can then use `rclone` like this, (replace `remote` with the name you gave your remote)"  

on all docs except `union.md` and `koofr.md` as they have a different format

#### Was the change discussed in an issue or in the forum before?

#290

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
