### PR TITLE
Add FAQ for getting rid of the 'Config file not found' message

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -22,6 +22,20 @@ See the [remote setup docs](/remote_setup/) for more info.
 
 This has now been documented in its own [remote setup page](/remote_setup/).
 
+### How can I get rid of the "Config file not found" notice?
+
+If you see a notice like 'NOTICE: Config file "rclone.conf" not found', this
+means you have not configured any remotes.
+
+If you need to configure a remote, see the [config help docs](/docs/#configure).
+
+If you are using rclone entirely with [on the fly remotes](/docs/#backend-path-to-dir),
+you can create an empty config file to get rid of this notice, for example:
+
+```
+rclone config touch
+```
+
 ### Can rclone sync directly from drive to s3 ###
 
 Rclone can sync between two remote cloud storage systems just fine.


### PR DESCRIPTION
#### What is the purpose of this change?

To make it more obvious to users who don't need to configure remotes that they can create an empty `rclone.conf` file to get rid of the annoying notices after every command like:

```
2025/05/06 17:42:15 NOTICE: Config file "/Users/jgeerling/.config/rclone/rclone.conf" not found - using defaults
```

#### Was the change discussed in an issue or in the forum before?

Yes, see https://forum.rclone.org/t/notice-about-missing-rclone-conf-is-annoying/51116

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
