### PR TITLE
cmd serve s3: fix ListObjectsV2 response

### DIFF
--- a/cmd/serve/s3/list.go
+++ b/cmd/serve/s3/list.go
@@ -28,7 +28,8 @@ func (b *s3Backend) entryListR(_vfs *vfs.VFS, bucket, fdPath, name string, addPr
 
 		if entry.IsDir() {
 			if addPrefix {
-				response.AddPrefix(objectPath)
+				prefixWithTrailingSlash := objectPath + "/"
+				response.AddPrefix(prefixWithTrailingSlash)
 				continue
 			}
 			err := b.entryListR(_vfs, bucket, path.Join(fdPath, object), "", false, response)


### PR DESCRIPTION
#### What is the purpose of this change?
Add a trailing slash to s3 ListObjectsV2 response because some clients expect a trailing forward slash to distinguish if the returned object is a directory.

Reference: https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjectsV2.html

#### Was the change discussed in an issue or in the forum before?

Fixes #8464

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [/] I have added tests for all changes in this PR if appropriate. --> I have not enough go skills to write appropriate tests
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
