### PR TITLE
drive: fixed the issue where Google Docs file name was truncated, causing panic or unparseable characters

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1698,7 +1698,7 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 		return nil, err
 	}
 
-	remote = remote[:len(remote)-len(extension)]
+	remote = strings.TrimSuffix(remote, extension)
 	obj, err := f.newObjectWithExportInfo(ctx, remote, info, extension, exportName, exportMimeType, isDocument)
 	switch {
 	case err != nil:


### PR DESCRIPTION
#### What is the purpose of this change?
When downloading Google documents, the remote does not contain the suffix, and the extension is '.docx'. The code here will cause panic or the file name will be truncated (if the file name is Chinese or Japanese, there will be unparseable characters)

![9f7df015cbd14d1f07ae0f6b60ea02bf](https://github.com/user-attachments/assets/6404c109-5bef-4f7f-9508-7d11aa843c1d)
![86a48ca000ff88e2d611e171d2f1efe5](https://github.com/user-attachments/assets/1282a64a-7f26-4857-aba3-a56c3043ede0)


#### Was the change discussed in an issue or in the forum before?


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
