### PR TITLE
smb: refresh Kerberos credentials when ccache file changes

### DIFF
--- a/backend/smb/connpool.go
+++ b/backend/smb/connpool.go
@@ -38,7 +38,7 @@ func (f *Fs) dial(ctx context.Context, network, addr string) (*conn, error) {
 
 	d := &smb2.Dialer{}
 	if f.opt.UseKerberos {
-		cl, err := createKerberosClient(f.opt.KerberosCCache)
+		cl, err := NewKerberosFactory().GetClient(f.opt.KerberosCCache)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Depends on https://github.com/rclone/rclone/pull/8559
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This PR enhances the **SMB** backend in Rclone to automatically refresh Kerberos credentials when the associated `ccache` file is updated. Previously, credentials were only loaded once per path and cached indefinitely, which caused issues when service tickets expired or the cache was renewed on the server.

**Changes**
- Track the `mtime` (modification time) of each Kerberos ccache file.
- Reload the credentials and Kerberos client only if the file's `mtime` has changed.
- Avoid redundant reloads by caching both client and load errors.
- Refactor function calls to allow test injection.
- Add a unit test to validate reload behavior when the ccache file is modified.


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
