### PR TITLE
cmount: add support for fuse3

### DIFF
--- a/cmd/cmount/mount.go
+++ b/cmd/cmount/mount.go
@@ -34,73 +34,6 @@ func init() {
 	buildinfo.Tags = append(buildinfo.Tags, "cmount")
 }
 
-// mountOptions configures the options from the command line flags
-func mountOptions(VFS *vfs.VFS, device string, mountpoint string, opt *mountlib.Options) (options []string) {
-	// Options
-	options = []string{
-		"-o", fmt.Sprintf("attr_timeout=%g", time.Duration(opt.AttrTimeout).Seconds()),
-	}
-	if opt.DebugFUSE {
-		options = append(options, "-o", "debug")
-	}
-
-	if runtime.GOOS == "windows" {
-		options = append(options, "-o", "uid=-1")
-		options = append(options, "-o", "gid=-1")
-		options = append(options, "--FileSystemName=rclone")
-		if opt.VolumeName != "" {
-			if opt.NetworkMode {
-				options = append(options, "--VolumePrefix="+opt.VolumeName)
-			} else {
-				options = append(options, "-o", "volname="+opt.VolumeName)
-			}
-		}
-	} else {
-		options = append(options, "-o", "fsname="+device)
-		options = append(options, "-o", "subtype=rclone")
-		options = append(options, "-o", fmt.Sprintf("max_readahead=%d", opt.MaxReadAhead))
-		// This causes FUSE to supply O_TRUNC with the Open
-		// call which is more efficient for cmount.  However
-		// it does not work with cgofuse on Windows with
-		// WinFSP so cmount must work with or without it.
-		options = append(options, "-o", "atomic_o_trunc")
-		if opt.DaemonTimeout != 0 {
-			options = append(options, "-o", fmt.Sprintf("daemon_timeout=%d", int(time.Duration(opt.DaemonTimeout).Seconds())))
-		}
-		if opt.AllowOther {
-			options = append(options, "-o", "allow_other")
-		}
-		if opt.AllowRoot {
-			options = append(options, "-o", "allow_root")
-		}
-		if opt.DefaultPermissions {
-			options = append(options, "-o", "default_permissions")
-		}
-		if VFS.Opt.ReadOnly {
-			options = append(options, "-o", "ro")
-		}
-		//if opt.WritebackCache {
-		// FIXME? options = append(options, "-o", WritebackCache())
-		//}
-		if runtime.GOOS == "darwin" {
-			if opt.VolumeName != "" {
-				options = append(options, "-o", "volname="+opt.VolumeName)
-			}
-			if opt.NoAppleDouble {
-				options = append(options, "-o", "noappledouble")
-			}
-			if opt.NoAppleXattr {
-				options = append(options, "-o", "noapplexattr")
-			}
-		}
-	}
-	for _, option := range opt.ExtraOptions {
-		options = append(options, "-o", option)
-	}
-	options = append(options, opt.ExtraFlags...)
-	return options
-}
-
 // waitFor runs fn() until it returns true or the timeout expires
 func waitFor(fn func() bool) (ok bool) {
 	const totalWait = 10 * time.Second
@@ -133,7 +66,8 @@ func mount(VFS *vfs.VFS, mountPath string, opt *mountlib.Options) (<-chan error,
 	// Create underlying FS
 	fsys := NewFS(VFS, opt)
 	host := fuse.NewFileSystemHost(fsys)
-	host.SetCapReaddirPlus(true) // only works on Windows
+	host.SetCapOpenTrunc(true) // only works on Linux
+	host.SetCapReaddirPlus(true)
 	if opt.CaseInsensitive.Valid {
 		host.SetCapCaseInsensitive(opt.CaseInsensitive.Value)
 	} else {

--- a/cmd/cmount/mount_fuse2.go
+++ b/cmd/cmount/mount_fuse2.go
@@ -1,0 +1,82 @@
+//go:build !fuse3
+
+// // Package cmount implements a FUSE mounting system for rclone remotes.
+//
+// This uses the cgo based cgofuse library
+package cmount
+
+import (
+	"fmt"
+	"runtime"
+	"time"
+
+	"github.com/rclone/rclone/cmd/mountlib"
+	"github.com/rclone/rclone/vfs"
+)
+
+// mountOptions configures the options from the command line flags
+func mountOptions(VFS *vfs.VFS, device string, mountpoint string, opt *mountlib.Options) (options []string) {
+	// Options
+	options = []string{
+		"-o", fmt.Sprintf("attr_timeout=%g", time.Duration(opt.AttrTimeout).Seconds()),
+	}
+	if opt.DebugFUSE {
+		options = append(options, "-o", "debug")
+	}
+
+	if runtime.GOOS == "windows" {
+		options = append(options, "-o", "uid=-1")
+		options = append(options, "-o", "gid=-1")
+		options = append(options, "--FileSystemName=rclone")
+		if opt.VolumeName != "" {
+			if opt.NetworkMode {
+				options = append(options, "--VolumePrefix="+opt.VolumeName)
+			} else {
+				options = append(options, "-o", "volname="+opt.VolumeName)
+			}
+		}
+	} else {
+		options = append(options, "-o", "fsname="+device)
+		options = append(options, "-o", "subtype=rclone")
+		options = append(options, "-o", fmt.Sprintf("max_readahead=%d", opt.MaxReadAhead))
+		// This causes FUSE to supply O_TRUNC with the Open
+		// call which is more efficient for cmount.  However
+		// it does not work with cgofuse on Windows with
+		// WinFSP so cmount must work with or without it.
+		options = append(options, "-o", "atomic_o_trunc")
+		if opt.DaemonTimeout != 0 {
+			options = append(options, "-o", fmt.Sprintf("daemon_timeout=%d", int(time.Duration(opt.DaemonTimeout).Seconds())))
+		}
+		if opt.AllowOther {
+			options = append(options, "-o", "allow_other")
+		}
+		if opt.AllowRoot {
+			options = append(options, "-o", "allow_root")
+		}
+		if opt.DefaultPermissions {
+			options = append(options, "-o", "default_permissions")
+		}
+		if VFS.Opt.ReadOnly {
+			options = append(options, "-o", "ro")
+		}
+		//if opt.WritebackCache {
+		// FIXME? options = append(options, "-o", WritebackCache())
+		//}
+		if runtime.GOOS == "darwin" {
+			if opt.VolumeName != "" {
+				options = append(options, "-o", "volname="+opt.VolumeName)
+			}
+			if opt.NoAppleDouble {
+				options = append(options, "-o", "noappledouble")
+			}
+			if opt.NoAppleXattr {
+				options = append(options, "-o", "noapplexattr")
+			}
+		}
+	}
+	for _, option := range opt.ExtraOptions {
+		options = append(options, "-o", option)
+	}
+	options = append(options, opt.ExtraFlags...)
+	return options
+}

--- a/cmd/cmount/mount_fuse3.go
+++ b/cmd/cmount/mount_fuse3.go
@@ -1,0 +1,49 @@
+//go:build fuse3 && (linux || freebsd)
+
+// // Package cmount implements a FUSE mounting system for rclone remotes.
+//
+// This uses the cgo based cgofuse library
+package cmount
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/rclone/rclone/cmd/mountlib"
+	"github.com/rclone/rclone/vfs"
+)
+
+// mountOptions configures the options from the command line flags
+func mountOptions(VFS *vfs.VFS, device string, mountpoint string, opt *mountlib.Options) (options []string) {
+	// Options
+	options = []string{
+		"-o", fmt.Sprintf("attr_timeout=%g", time.Duration(opt.AttrTimeout).Seconds()),
+	}
+	if opt.DebugFUSE {
+		options = append(options, "-o", "debug")
+	}
+
+	options = append(options, "-o", "fsname="+device)
+	options = append(options, "-o", "subtype=rclone")
+	if opt.AllowOther {
+		options = append(options, "-o", "allow_other")
+	}
+	if opt.AllowRoot {
+		options = append(options, "-o", "allow_root")
+	}
+	if opt.DefaultPermissions {
+		options = append(options, "-o", "default_permissions")
+	}
+	if VFS.Opt.ReadOnly {
+		options = append(options, "-o", "ro")
+	}
+	//if opt.WritebackCache {
+	// FIXME? options = append(options, "-o", WritebackCache())
+	//}
+
+	for _, option := range opt.ExtraOptions {
+		options = append(options, "-o", option)
+	}
+	options = append(options, opt.ExtraFlags...)
+	return options
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Adds support for fuse3 to the cmount command on Linux and NetBSD based on the recent release from cgofuse https://github.com/winfsp/cgofuse/releases/tag/v1.6.0. This is done by using the `fuse3` build tag which cgofuse uses to link to libfuse3. To build rclone with fuse3 you now can do `go build -tags=cmount,fuse3`

#### Was the change discussed in an issue or in the forum before?

(https://github.com/rclone/rclone/issues/6632)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
