### PR TITLE
backend/s3: require custom endpoint for Lyve Cloud v2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Rclone *("rsync for cloud storage")* is a command-line program to sync files and
   * rsync.net [:page_facing_up:](https://rclone.org/sftp/#rsync-net)
   * Scaleway [:page_facing_up:](https://rclone.org/s3/#scaleway)
   * Seafile [:page_facing_up:](https://rclone.org/seafile/)
+  * Seagate Lyve Cloud ["page_facing_up:](https://rclone.org/s3/#lyve)
   * SeaweedFS [:page_facing_up:](https://rclone.org/s3/#seaweedfs)
   * Selectel Object Storage [:page_facing_up:](https://rclone.org/s3/#selectel)
   * SFTP [:page_facing_up:](https://rclone.org/sftp/)

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1007,6 +1007,12 @@ func init() {
 				Help:  "Washington, DC, (USA), us-iad-1",
 			}},
 		}, {
+			// Lyve Cloud endpoints
+			Name:     "endpoint",
+			Help:     "Endpoint for Lyve Cloud S3 API.\nRequired when using an S3 clone. Please type in your LyveCloud endpoint.\nExamples:\n- s3.us-west-1.{account_name}.lyve.seagate.com (US West 1 - California)\n- s3.eu-west-1.{account_name}.lyve.seagate.com (EU West 1 - Ireland)",
+			Provider: "LyveCloud",
+			Required: true,
+		}, {
 			// Magalu endpoints: https://docs.magalu.cloud/docs/object-storage/how-to/copy-url
 			Name:     "endpoint",
 			Help:     "Endpoint for Magalu Object Storage API.",
@@ -1380,7 +1386,7 @@ func init() {
 		}, {
 			Name:     "endpoint",
 			Help:     "Endpoint for S3 API.\n\nRequired when using an S3 clone.",
-			Provider: "!AWS,ArvanCloud,IBMCOS,IDrive,IONOS,TencentCOS,HuaweiOBS,Alibaba,ChinaMobile,GCS,Liara,Linode,Magalu,Scaleway,Selectel,StackPath,Storj,Synology,RackCorp,Qiniu,Petabox",
+			Provider: "!AWS,ArvanCloud,IBMCOS,IDrive,IONOS,TencentCOS,HuaweiOBS,Alibaba,ChinaMobile,GCS,Liara,Linode,LyveCloud,Magalu,Scaleway,Selectel,StackPath,Storj,Synology,RackCorp,Qiniu,Petabox",
 			Examples: []fs.OptionExample{{
 				Value:    "objects-us-east-1.dream.io",
 				Help:     "Dream Objects endpoint",
@@ -1429,18 +1435,6 @@ func init() {
 				Value:    "localhost:8333",
 				Help:     "SeaweedFS S3 localhost",
 				Provider: "SeaweedFS",
-			}, {
-				Value:    "s3.us-east-1.lyvecloud.seagate.com",
-				Help:     "Seagate Lyve Cloud US East 1 (Virginia)",
-				Provider: "LyveCloud",
-			}, {
-				Value:    "s3.us-west-1.lyvecloud.seagate.com",
-				Help:     "Seagate Lyve Cloud US West 1 (California)",
-				Provider: "LyveCloud",
-			}, {
-				Value:    "s3.ap-southeast-1.lyvecloud.seagate.com",
-				Help:     "Seagate Lyve Cloud AP Southeast 1 (Singapore)",
-				Provider: "LyveCloud",
 			}, {
 				Value:    "oos.eu-west-2.outscale.com",
 				Help:     "Outscale EU West 2 (Paris)",

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -3895,20 +3895,17 @@ Press Enter to leave empty.
 region>
 ```
 
-Choose an endpoint from the list
+Enter your Lyve Cloud endpoint. This field cannot be kept empty.
 
 ```
-Endpoint for S3 API.
+Endpoint for Lyve Cloud S3 API.
 Required when using an S3 clone.
-Choose a number from below, or type in your own value.
-Press Enter to leave empty.
- 1 / Seagate Lyve Cloud US East 1 (Virginia)
-   \ (s3.us-east-1.lyvecloud.seagate.com)
- 2 / Seagate Lyve Cloud US West 1 (California)
-   \ (s3.us-west-1.lyvecloud.seagate.com)
- 3 / Seagate Lyve Cloud AP Southeast 1 (Singapore)
-   \ (s3.ap-southeast-1.lyvecloud.seagate.com)
-endpoint> 1
+Please type in your LyveCloud endpoint.
+Examples:
+- s3.us-west-1.{account_name}.lyve.seagate.com (US West 1 - California)
+- s3.eu-west-1.{account_name}.lyve.seagate.com (US West 1 - Ireland)
+Enter a value.
+endpoint> s3.us-west-1.global.lyve.seagate.com
 ```
 
 Leave location constraint blank


### PR DESCRIPTION
Lyve Cloud v2 no longer provides a shared S3 endpoint like v1 did. Instead, each customer receives a unique, reseller-specific endpoint. To reflect this change, the S3 backend now requires users to manually enter their endpoint when selecting Lyve Cloud as a provider. Previously, users selected from a list of hardcoded Lyve Cloud v1 endpoints. This was not compatible with Lyve Cloud v2 accounts and could cause confusion or misconfiguration.

This change:
- Removes outdated pre-defined endpoint selection for Lyve Cloud
- Requires users to provide their own endpoint
- Adds a format example to guide correct usage

Before: Users selected a fixed endpoint from a list (v1 only)
After:  Users must input their own endpoint (v2-compatible)

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

To support Lyve Cloud v2 in the S3 backend.

Lyve Cloud v2 requires users to use a unique endpoint (per reseller or tenant), unlike v1 which used a shared set of predefined endpoints. This change removes the v1-style selection and makes endpoint input mandatory for Lyve Cloud users. It improves compatibility and avoids misconfiguration issues.

#### Was the change discussed in an issue or in the forum before?

Not discussed in an issue. This was implemented based on observed compatibility issues with Lyve Cloud v2 accounts during internal testing.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
