### PR TITLE
sync: fix testLoggerVsLsf when dst is local

### DIFF
--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -56,7 +56,7 @@ func TestCopyWithDryRun(t *testing.T) {
 	ci.DryRun = true
 	ctx = predictDstFromLogger(ctx)
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t) // error expected here because dry-run
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t) // error expected here because dry-run
 	require.NoError(t, err)
 
 	r.CheckLocalItems(t, file1)
@@ -77,7 +77,7 @@ func TestCopy(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file1)
@@ -144,7 +144,7 @@ func testCopyMetadata(t *testing.T, createEmptySrcDirs bool) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, r.Fremote, r.Flocal, createEmptySrcDirs)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file1)
@@ -194,7 +194,7 @@ func TestCopyMissingDirectory(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, r.Fremote, nonExistingFs, false)
 	require.Error(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 }
 
 // Now with --no-traverse
@@ -210,7 +210,7 @@ func TestCopyNoTraverse(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file1)
@@ -229,7 +229,7 @@ func TestCopyCheckFirst(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file1)
@@ -249,7 +249,7 @@ func TestSyncNoTraverse(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file1)
@@ -269,7 +269,7 @@ func TestCopyWithDepth(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1, file2)
 	r.CheckRemoteItems(t, file2)
@@ -297,7 +297,7 @@ func testCopyWithFilesFrom(t *testing.T, noTraverse bool) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1, file2)
 	r.CheckRemoteItems(t, file1)
@@ -324,7 +324,7 @@ func TestCopyEmptyDirectories(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, r.Fremote, r.Flocal, true)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteListing(
 		t,
@@ -381,7 +381,7 @@ func TestMoveEmptyDirectories(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = MoveDir(ctx, r.Fremote, r.Flocal, false, true)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteListing(
 		t,
@@ -426,7 +426,7 @@ func TestSyncNoUpdateDirModtime(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteListing(
 		t,
@@ -482,7 +482,7 @@ func TestSyncEmptyDirectories(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteListing(
 		t,
@@ -547,7 +547,7 @@ func TestSyncSetDelayedModTimes(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, true)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteListing(t, []fstest.Item{}, dirs)
 
@@ -593,7 +593,7 @@ func TestServerSideCopy(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, FremoteCopy, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	fstest.CheckItems(t, FremoteCopy, file1)
 }
@@ -610,7 +610,7 @@ func TestCopyOverSelf(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckRemoteItems(t, file2)
 }
 
@@ -629,7 +629,7 @@ func TestServerSideCopyOverSelf(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, FremoteCopy, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	fstest.CheckItems(t, FremoteCopy, file1)
 
 	file2 := r.WriteObject(ctx, "sub dir/hello world", "hello world again", t2)
@@ -638,7 +638,7 @@ func TestServerSideCopyOverSelf(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, FremoteCopy, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	fstest.CheckItems(t, FremoteCopy, file2)
 }
 
@@ -654,7 +654,7 @@ func TestMoveOverSelf(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := MoveDir(ctx, r.Fremote, r.Flocal, false, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t)
 	r.CheckRemoteItems(t, file2)
 }
@@ -674,7 +674,7 @@ func TestServerSideMoveOverSelf(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, FremoteCopy, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	fstest.CheckItems(t, FremoteCopy, file1)
 
 	file2 := r.WriteObject(ctx, "sub dir/hello world", "hello world again", t2)
@@ -683,7 +683,7 @@ func TestServerSideMoveOverSelf(t *testing.T) {
 	// ctx = predictDstFromLogger(ctx)
 	err = MoveDir(ctx, FremoteCopy, r.Fremote, false, false)
 	require.NoError(t, err)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t) // not currently supported
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t) // not currently supported
 	r.CheckRemoteItems(t)
 	fstest.CheckItems(t, FremoteCopy, file2)
 
@@ -695,7 +695,7 @@ func TestServerSideMoveOverSelf(t *testing.T) {
 	fs.Debugf(nil, "testing file moves")
 	err = moveDir(ctx, FremoteCopy, r.Fremote, false, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, FremoteCopy, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, FremoteCopy, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckRemoteItems(t)
 	fstest.CheckItems(t, FremoteCopy, file3)
 }
@@ -715,7 +715,7 @@ func TestCopyAfterDelete(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t)
 	r.CheckRemoteItems(t, file1)
@@ -731,7 +731,7 @@ func TestCopyRedownload(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := CopyDir(ctx, r.Flocal, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// Test with combined precision of local and remote as we copied it there and back
 	r.CheckLocalListing(t, []fstest.Item{file1}, nil)
@@ -753,7 +753,7 @@ func TestSyncBasedOnCheckSum(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// We should have transferred exactly one file.
 	assert.Equal(t, toyFileTransfers(r), accounting.GlobalStats().GetTransfers())
@@ -767,7 +767,7 @@ func TestSyncBasedOnCheckSum(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// We should have transferred no files
 	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
@@ -791,7 +791,7 @@ func TestSyncSizeOnly(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// We should have transferred exactly one file.
 	assert.Equal(t, toyFileTransfers(r), accounting.GlobalStats().GetTransfers())
@@ -805,7 +805,7 @@ func TestSyncSizeOnly(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// We should have transferred no files
 	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
@@ -829,7 +829,7 @@ func TestSyncIgnoreSize(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// We should have transferred exactly one file.
 	assert.Equal(t, toyFileTransfers(r), accounting.GlobalStats().GetTransfers())
@@ -843,7 +843,7 @@ func TestSyncIgnoreSize(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// We should have transferred no files
 	assert.Equal(t, int64(0), accounting.GlobalStats().GetTransfers())
@@ -862,7 +862,7 @@ func TestSyncIgnoreTimes(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// We should have transferred exactly 0 files because the
 	// files were identical.
@@ -874,7 +874,7 @@ func TestSyncIgnoreTimes(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// We should have transferred exactly one file even though the
 	// files were identical.
@@ -898,7 +898,7 @@ func TestSyncIgnoreExisting(t *testing.T) {
 	require.NoError(t, err)
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file1)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// Change everything
 	r.WriteFile("existing", "newpotatoes", t2)
@@ -908,7 +908,7 @@ func TestSyncIgnoreExisting(t *testing.T) {
 	require.NoError(t, err)
 	// Items should not change
 	r.CheckRemoteItems(t, file1)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 }
 
 func TestSyncIgnoreErrors(t *testing.T) {
@@ -949,7 +949,7 @@ func TestSyncIgnoreErrors(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	_ = fs.CountError(ctx, errors.New("boom"))
 	assert.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalListing(
 		t,
@@ -991,7 +991,7 @@ func TestSyncAfterChangingModtimeOnly(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file2)
@@ -1002,7 +1002,7 @@ func TestSyncAfterChangingModtimeOnly(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file1)
@@ -1030,7 +1030,7 @@ func TestSyncAfterChangingModtimeOnlyWithNoUpdateModTime(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file2)
@@ -1053,7 +1053,7 @@ func TestSyncDoesntUpdateModtime(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file1)
@@ -1075,7 +1075,7 @@ func TestSyncAfterAddingAFile(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file1, file2)
 	r.CheckRemoteItems(t, file1, file2)
 }
@@ -1092,7 +1092,7 @@ func TestSyncAfterChangingFilesSizeOnly(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file2)
 	r.CheckRemoteItems(t, file2)
 }
@@ -1117,7 +1117,7 @@ func TestSyncAfterChangingContentsOnly(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file2)
 	r.CheckRemoteItems(t, file2)
 }
@@ -1137,7 +1137,7 @@ func TestSyncAfterRemovingAFileAndAddingAFileDryRun(t *testing.T) {
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	ci.DryRun = false
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalItems(t, file3, file1)
 	r.CheckRemoteItems(t, file3, file2)
@@ -1156,7 +1156,7 @@ func testSyncAfterRemovingAFileAndAddingAFile(ctx context.Context, t *testing.T)
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file1, file3)
 	r.CheckRemoteItems(t, file1, file3)
 }
@@ -1203,7 +1203,7 @@ func testSyncAfterRemovingAFileAndAddingAFileSubDir(ctx context.Context, t *test
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalListing(
 		t,
@@ -1271,7 +1271,7 @@ func TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors(t *testing.T) {
 	_ = fs.CountError(ctx, errors.New("boom"))
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	assert.Equal(t, fs.ErrorNotDeleting, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalListing(
 		t,
@@ -1344,7 +1344,7 @@ func TestCopyDeleteBefore(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteItems(t, file1, file2)
 	r.CheckLocalItems(t, file2)
@@ -1369,7 +1369,7 @@ func TestSyncWithExclude(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckRemoteItems(t, file2, file1)
 
 	// Now sync the other way round and check enormous doesn't get
@@ -1378,7 +1378,7 @@ func TestSyncWithExclude(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Flocal, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file2, file1, file3)
 }
 
@@ -1402,7 +1402,7 @@ func TestSyncWithExcludeAndDeleteExcluded(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckRemoteItems(t, file2)
 
 	// Check sync the other way round to make sure enormous gets
@@ -1411,7 +1411,7 @@ func TestSyncWithExcludeAndDeleteExcluded(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Flocal, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file2)
 }
 
@@ -1444,7 +1444,7 @@ func TestSyncWithUpdateOlder(t *testing.T) {
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
 	require.NoError(t, err)
 	r.CheckRemoteItems(t, oneO, twoF, threeO, fourF, fiveF)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t) // no modtime
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t) // no modtime
 
 	if r.Fremote.Hashes().Count() == 0 {
 		t.Logf("Skip test with --checksum as no hashes supported")
@@ -1495,7 +1495,7 @@ func testSyncWithMaxDuration(t *testing.T, cutoffMode fs.CutoffMode) {
 	// ctx = predictDstFromLogger(ctx) // not currently supported (but tests do pass for CutoffModeSoft)
 	startTime := time.Now()
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.True(t, errors.Is(err, ErrorMaxDurationReached))
 
 	if cutoffMode == fs.CutoffModeHard {
@@ -1544,7 +1544,7 @@ func TestSyncWithTrackRenames(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	ctx = predictDstFromLogger(ctx)
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteItems(t, f1, f2)
 	r.CheckLocalItems(t, f1, f2)
@@ -1555,7 +1555,7 @@ func TestSyncWithTrackRenames(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	ctx = predictDstFromLogger(ctx)
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteItems(t, f1, f2)
 
@@ -1616,7 +1616,7 @@ func TestSyncWithTrackRenamesStrategyModtime(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	ctx = predictDstFromLogger(ctx)
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteItems(t, f1, f2)
 	r.CheckLocalItems(t, f1, f2)
@@ -1627,7 +1627,7 @@ func TestSyncWithTrackRenamesStrategyModtime(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	ctx = predictDstFromLogger(ctx)
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteItems(t, f1, f2)
 
@@ -1655,7 +1655,7 @@ func TestSyncWithTrackRenamesStrategyLeaf(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	ctx = predictDstFromLogger(ctx)
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteItems(t, f1, f2)
 	r.CheckLocalItems(t, f1, f2)
@@ -1666,7 +1666,7 @@ func TestSyncWithTrackRenamesStrategyLeaf(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	ctx = predictDstFromLogger(ctx)
 	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckRemoteItems(t, f1, f2)
 
@@ -1715,7 +1715,7 @@ func testServerSideMove(ctx context.Context, t *testing.T, r *fstest.Run, withFi
 	// ctx = predictDstFromLogger(ctx) // not currently supported -- doesn't list all contents of dir.
 	err = MoveDir(ctx, FremoteMove, r.Fremote, testDeleteEmptyDirs, false)
 	require.NoError(t, err)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	if withFilter {
 		r.CheckRemoteItems(t, file2)
@@ -1744,7 +1744,7 @@ func testServerSideMove(ctx context.Context, t *testing.T, r *fstest.Run, withFi
 	// ctx = predictDstFromLogger(ctx)
 	err = MoveDir(ctx, FremoteMove2, FremoteMove, testDeleteEmptyDirs, false)
 	require.NoError(t, err)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	if withFilter {
 		fstest.CheckItems(t, FremoteMove2, file1, file3u)
@@ -1787,7 +1787,7 @@ func TestMoveWithDeleteEmptySrcDirs(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := MoveDir(ctx, r.Fremote, r.Flocal, true, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalListing(
 		t,
@@ -1807,7 +1807,7 @@ func TestMoveWithoutDeleteEmptySrcDirs(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err := MoveDir(ctx, r.Fremote, r.Flocal, false, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	r.CheckLocalListing(
 		t,
@@ -1834,7 +1834,7 @@ func TestMoveWithIgnoreExisting(t *testing.T) {
 	// ctx = predictDstFromLogger(ctx)
 	err := MoveDir(ctx, r.Fremote, r.Flocal, false, false)
 	require.NoError(t, err)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalListing(
 		t,
 		[]fstest.Item{},
@@ -1855,7 +1855,7 @@ func TestMoveWithIgnoreExisting(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = MoveDir(ctx, r.Fremote, r.Flocal, false, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	// Source items should still exist in modified state
 	r.CheckLocalListing(
 		t,
@@ -1922,7 +1922,7 @@ func TestServerSideMoveOverlap(t *testing.T) {
 	// ctx = predictDstFromLogger(ctx)
 	err = MoveDir(ctx, FremoteMove, r.Fremote, false, false)
 	assert.EqualError(t, err, fs.ErrorOverlapping.Error())
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// Now try with a filter which should also fail with ErrorCantMoveOverlapping
 	fi, err := filter.NewFilter(nil)
@@ -1933,7 +1933,7 @@ func TestServerSideMoveOverlap(t *testing.T) {
 	// ctx = predictDstFromLogger(ctx)
 	err = MoveDir(ctx, FremoteMove, r.Fremote, false, false)
 	assert.EqualError(t, err, fs.ErrorOverlapping.Error())
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 }
 
 // Test a sync with overlap
@@ -1953,16 +1953,16 @@ func TestSyncOverlap(t *testing.T) {
 
 	ctx = predictDstFromLogger(ctx)
 	checkErr(Sync(ctx, FremoteSync, r.Fremote, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	ctx = predictDstFromLogger(ctx)
 	checkErr(Sync(ctx, r.Fremote, FremoteSync, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	ctx = predictDstFromLogger(ctx)
 	checkErr(Sync(ctx, r.Fremote, r.Fremote, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	ctx = predictDstFromLogger(ctx)
 	checkErr(Sync(ctx, FremoteSync, FremoteSync, false))
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 }
 
 // Test a sync with filtered overlap
@@ -2009,59 +2009,59 @@ func TestSyncOverlapWithFilter(t *testing.T) {
 	checkNoErr(Sync(filterCtx, FremoteSync, r.Fremote, false))
 	checkErr(Sync(ctx, FremoteSync, r.Fremote, false))
 	checkNoErr(Sync(filterCtx, r.Fremote, FremoteSync, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(ctx, r.Fremote, FremoteSync, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(filterCtx, r.Fremote, r.Fremote, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(ctx, r.Fremote, r.Fremote, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(filterCtx, FremoteSync, FremoteSync, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(ctx, FremoteSync, FremoteSync, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 
 	checkNoErr(Sync(filterCtx, FremoteSync2, r.Fremote, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(ctx, FremoteSync2, r.Fremote, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkNoErr(Sync(filterCtx, r.Fremote, FremoteSync2, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(ctx, r.Fremote, FremoteSync2, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(filterCtx, FremoteSync2, FremoteSync2, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(ctx, FremoteSync2, FremoteSync2, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 
 	checkNoErr(Sync(filterCtx, FremoteSync3, r.Fremote, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(ctx, FremoteSync3, r.Fremote, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	// Destination is excluded so this test makes no sense
 	// checkNoErr(Sync(filterCtx, r.Fremote, FremoteSync3, false))
 	checkErr(Sync(ctx, r.Fremote, FremoteSync3, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(filterCtx, FremoteSync3, FremoteSync3, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 	filterCtx = predictDstFromLogger(filterCtx)
 	checkErr(Sync(ctx, FremoteSync3, FremoteSync3, false))
-	testLoggerVsLsf(filterCtx, r.Fremote, operations.GetLoggerOpt(filterCtx).JSON, t)
+	testLoggerVsLsf(filterCtx, r.Fremote, r.Flocal, operations.GetLoggerOpt(filterCtx).JSON, t)
 }
 
 // Test with CompareDest set
@@ -2168,7 +2168,7 @@ func TestSyncCompareDest(t *testing.T) {
 		accounting.GlobalStats().ResetCounters()
 		// ctx = predictDstFromLogger(ctx)
 		err = Sync(ctx, fdst, r.Flocal, false)
-		// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+		// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 		require.NoError(t, err)
 
 		r.CheckRemoteItems(t, file2, file3, file4)
@@ -2184,7 +2184,7 @@ func TestSyncCompareDest(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	// ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, fdst, r.Flocal, false)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	file5cdst := file5c
@@ -2248,7 +2248,7 @@ func TestSyncCopyDest(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	// ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, fdst, r.Flocal, false)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t) // not currently supported
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t) // not currently supported
 	require.NoError(t, err)
 
 	file1dst := file1
@@ -2264,7 +2264,7 @@ func TestSyncCopyDest(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	// ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, fdst, r.Flocal, false)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	file1bdst := file1b
@@ -2285,7 +2285,7 @@ func TestSyncCopyDest(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	// ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, fdst, r.Flocal, false)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	file2dst := file2
@@ -2303,7 +2303,7 @@ func TestSyncCopyDest(t *testing.T) {
 
 	accounting.GlobalStats().ResetCounters()
 	// ctx = predictDstFromLogger(ctx)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	err = Sync(ctx, fdst, r.Flocal, false)
 	require.NoError(t, err)
 
@@ -2316,7 +2316,7 @@ func TestSyncCopyDest(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	// ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, fdst, r.Flocal, false)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckRemoteItems(t, file2, file2dst, file3, file4, file4dst)
@@ -2330,7 +2330,7 @@ func TestSyncCopyDest(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	// ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, fdst, r.Flocal, false)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	file7dst := file7
@@ -2548,7 +2548,7 @@ func TestSyncUTFNorm(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	// ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t) // can't test this on macOS
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t) // can't test this on macOS
 	require.NoError(t, err)
 
 	// We should have transferred exactly one file, but kept the
@@ -2576,7 +2576,7 @@ func TestSyncImmutable(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file1)
@@ -2590,7 +2590,7 @@ func TestSyncImmutable(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, false)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	assert.EqualError(t, err, fs.ErrorImmutableModified.Error())
 	r.CheckLocalItems(t, file2)
 	r.CheckRemoteItems(t, file1)
@@ -2619,7 +2619,7 @@ func TestSyncIgnoreCase(t *testing.T) {
 	accounting.GlobalStats().ResetCounters()
 	// ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t) // can't test this on macOS
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t) // can't test this on macOS
 	require.NoError(t, err)
 	r.CheckLocalItems(t, file1)
 	r.CheckRemoteItems(t, file2)
@@ -2694,7 +2694,7 @@ func TestMaxTransfer(t *testing.T) {
 
 		// ctx = predictDstFromLogger(ctx) // not currently supported
 		err := Sync(ctx, r.Fremote, r.Flocal, false)
-		// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+		// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 		expectedErr := fserrors.FsError(accounting.ErrorMaxTransferLimitReachedFatal)
 		if cutoff != fs.CutoffModeHard {
 			expectedErr = accounting.ErrorMaxTransferLimitReachedGraceful
@@ -2746,7 +2746,7 @@ func testSyncConcurrent(t *testing.T, subtest string) {
 	stats.ResetErrors()
 	ctx = predictDstFromLogger(ctx)
 	err := Sync(ctx, r.Fremote, r.Flocal, false)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	if errors.Is(err, fs.ErrorCantUploadEmptyFiles) {
 		t.Skipf("Skip test because remote cannot upload empty files")
 	}
@@ -2798,7 +2798,7 @@ func testSyncReplaceDirModTime(t *testing.T, copyEmptySrcDirs bool) {
 		require.NoError(t, err)
 	})
 	require.NotNil(t, output)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 
 	// Save all dirs
 	dirs := []string{"test_dir1", "test_dir2", "test_dir2/sub_dir", "empty_on_remote"}
@@ -2822,7 +2822,7 @@ func testSyncReplaceDirModTime(t *testing.T, copyEmptySrcDirs bool) {
 		require.NoError(t, err)
 	})
 	require.NotNil(t, output)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file1, file2, file3)
 	r.CheckRemoteItems(t, file1, file2, file3)
 
@@ -2869,7 +2869,7 @@ func testNothingToTransfer(t *testing.T, copyEmptySrcDirs bool) {
 		require.NoError(t, err)
 	})
 	require.NotNil(t, output)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file1, file2)
 	r.CheckRemoteItems(t, file1, file2)
 	// Check that the modtimes of the directories are as expected
@@ -2891,7 +2891,7 @@ func testNothingToTransfer(t *testing.T, copyEmptySrcDirs bool) {
 		require.NoError(t, err)
 	})
 	require.NotNil(t, output)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file1, file2)
 	r.CheckRemoteItems(t, file1, file2)
 	// Check that the modtimes of the directories are as expected
@@ -2928,7 +2928,7 @@ func testNothingToTransfer(t *testing.T, copyEmptySrcDirs bool) {
 		require.NoError(t, err)
 	})
 	require.NotNil(t, output)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	r.CheckLocalItems(t, file1, file2, file3)
 	r.CheckRemoteItems(t, file1, file2, file3)
 	// Check that the modtimes of the directories are as expected
@@ -3043,10 +3043,10 @@ func Diff(rev1, rev2 string) {
 	_, _ = os.Stdout.Write(out)
 }
 
-func testLoggerVsLsf(ctx context.Context, Fremote fs.Fs, logger *bytes.Buffer, t *testing.T) {
+func testLoggerVsLsf(ctx context.Context, fdst, fsrc fs.Fs, logger *bytes.Buffer, t *testing.T) {
 	var newlogger bytes.Buffer
-	canTestModtime := fs.GetModifyWindow(ctx, Fremote) != fs.ModTimeNotSupported
-	canTestHash := Fremote.Hashes().Contains(hash.MD5)
+	canTestModtime := fs.GetModifyWindow(ctx, fdst) != fs.ModTimeNotSupported
+	canTestHash := fdst.Hashes().Contains(hash.MD5)
 	if !canTestHash || !canTestModtime {
 		loggerSplit := bytes.Split(logger.Bytes(), []byte("\n"))
 		for i, line := range loggerSplit {
@@ -3066,9 +3066,8 @@ func testLoggerVsLsf(ctx context.Context, Fremote fs.Fs, logger *bytes.Buffer, t
 		newlogger.Write(logger.Bytes())
 	}
 
-	r := fstest.NewRun(t)
-	if r.Flocal.Precision() == Fremote.Precision() && r.Flocal.Hashes().Contains(hash.MD5) && canTestHash {
-		lsf := DstLsf(ctx, Fremote)
+	if fsrc.Precision() == fdst.Precision() && fsrc.Hashes().Contains(hash.MD5) && canTestHash {
+		lsf := DstLsf(ctx, fdst)
 		err := LoggerMatchesLsf(&newlogger, lsf)
 		require.NoError(t, err)
 	}

--- a/fs/sync/sync_transform_test.go
+++ b/fs/sync/sync_transform_test.go
@@ -235,7 +235,7 @@ func TestTransformCopy(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalItems(t, file1)
@@ -252,7 +252,7 @@ func TestDoubleTransform(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalItems(t, file1)
@@ -269,7 +269,7 @@ func TestFileTag(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalItems(t, file1)
@@ -286,7 +286,7 @@ func TestNoTag(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalItems(t, file1)
@@ -305,7 +305,7 @@ func TestDirTag(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalListing(t, []fstest.Item{fstest.NewItem("toe/toe/toe.txt", "hello world", t1)}, []string{"empty_dir", "toe", "toe/toe"})
@@ -324,7 +324,7 @@ func TestAllTag(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalListing(t, []fstest.Item{fstest.NewItem("toe/toe/toe.txt", "hello world", t1)}, []string{"empty_dir", "toe", "toe/toe"})
@@ -343,7 +343,7 @@ func TestRunTwice(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalItems(t, file1)
@@ -352,7 +352,7 @@ func TestRunTwice(t *testing.T) {
 	// result should not change second time, since src is unchanged
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalItems(t, file1)
@@ -384,7 +384,7 @@ func TestConflicting(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	// should result in no change as prefix and trimprefix cancel out
@@ -404,7 +404,7 @@ func TestMove(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = MoveDir(ctx, r.Fremote, r.Flocal, true, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalListing(t, []fstest.Item{}, []string{})
@@ -423,7 +423,7 @@ func TestTransformFile(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = MoveDir(ctx, r.Fremote, r.Flocal, true, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalListing(t, []fstest.Item{}, []string{})
@@ -447,7 +447,7 @@ func TestBase64(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalItems(t, file1)
@@ -458,7 +458,7 @@ func TestBase64(t *testing.T) {
 	require.NoError(t, err)
 	ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Flocal, r.Fremote, true)
-	testLoggerVsLsf(ctx, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, r.Flocal, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
 	require.NoError(t, err)
 
 	r.CheckLocalItems(t, file1)
@@ -475,7 +475,7 @@ func TestError(t *testing.T) {
 	r.Mkdir(ctx, r.Fremote)
 	// ctx = predictDstFromLogger(ctx)
 	err = Sync(ctx, r.Fremote, r.Flocal, true)
-	// testLoggerVsLsf(ctx, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
+	// testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
 	assert.Error(t, err)
 
 	r.CheckLocalListing(t, []fstest.Item{file1}, []string{"toe", "toe/toe"})


### PR DESCRIPTION
#### What is the purpose of this change?

Before this change, the `testLoggerVsLsf` function would get confused if given `r.Flocal` when expecting `r.Fremote`. This change makes it agnostic.

#### Was the change discussed in an issue or in the forum before?

No (but `TestBase64` integration tests were failing).

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
