### PR TITLE
build: use os.UserHomeDir() instead of github.com/mitchellh/go-homedir

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -14,8 +14,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/mitchellh/go-homedir"
-
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/cache"
 	"github.com/rclone/rclone/fs/config/configmap"
@@ -144,7 +142,7 @@ func findFile(dir string, name string) string {
 
 // Find current user's home directory
 func findHomeDir() (string, error) {
-	path, err := homedir.Dir()
+	path, err := os.UserHomeDir()
 	if err != nil {
 		fs.Debugf(nil, "Home directory lookup failed and cannot be used as configuration location: %v", err)
 	} else if path == "" {

--- a/go.mod
+++ b/go.mod
@@ -51,7 +51,6 @@ require (
 	github.com/mattn/go-colorable v0.1.14
 	github.com/mattn/go-runewidth v0.0.16
 	github.com/minio/minio-go/v7 v7.0.92
-	github.com/mitchellh/go-homedir v1.1.0
 	github.com/moby/sys/mountinfo v0.7.2
 	github.com/ncw/swift/v2 v2.0.4
 	github.com/oracle/oci-go-sdk/v65 v65.93.0

--- a/go.sum
+++ b/go.sum
@@ -470,7 +470,6 @@ github.com/minio/minio-go/v7 v7.0.92/go.mod h1:vTIc8DNcnAZIhyFsk8EB90AbPjj3j68aW
 github.com/minio/sha256-simd v0.1.1/go.mod h1:B5e1o+1/KgNmWrSQK08Y6Z1Vb5pwIktudl0J58iy0KM=
 github.com/minio/xxml v0.0.3 h1:ZIpPQpfyG5uZQnqqC0LZuWtPk/WT8G/qkxvO6jb7zMU=
 github.com/minio/xxml v0.0.3/go.mod h1:wcXErosl6IezQIMEWSK/LYC2VS7LJ1dAkgvuyIN3aH4=
-github.com/mitchellh/go-homedir v1.1.0 h1:lukF9ziXFxDFPkA1vsr5zpc1XuPDn/wFntq5mG+4E0Y=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=

--- a/lib/env/env.go
+++ b/lib/env/env.go
@@ -4,8 +4,6 @@ package env
 import (
 	"os"
 	"os/user"
-
-	homedir "github.com/mitchellh/go-homedir"
 )
 
 // ShellExpandHelp describes what ShellExpand does for inclusion into help
@@ -16,7 +14,7 @@ const ShellExpandHelp = "\n\nLeading `~` will be expanded in the file name as wi
 func ShellExpand(s string) string {
 	if s != "" {
 		if s[0] == '~' {
-			newS, err := homedir.Expand(s)
+			newS, err := expandHomeDir(s)
 			if err == nil {
 				s = newS
 			}

--- a/lib/env/env_test.go
+++ b/lib/env/env_test.go
@@ -5,13 +5,12 @@ import (
 	"path/filepath"
 	"testing"
 
-	homedir "github.com/mitchellh/go-homedir"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
 func TestShellExpand(t *testing.T) {
-	home, err := homedir.Dir()
+	home, err := os.UserHomeDir()
 	require.NoError(t, err)
 	require.NoError(t, os.Setenv("EXPAND_TEST", "potato"))
 	defer func() {

--- a/lib/env/homedir_expand.go
+++ b/lib/env/homedir_expand.go
@@ -1,0 +1,62 @@
+// The expandHomeDir function has been copied from github.com/mitchellh/go-homedir@v1.1.0.
+// https://github.com/mitchellh/go-homedir/blob/af06845cf3004701891bf4fdb884bfe4920b3727/homedir.go#L58
+// https://proxy.golang.org/github.com/mitchellh/go-homedir/@v/v1.1.0.zip
+//
+// So this file is distributed under the license below.
+// The original code has been adapted to use os.UserHomeDir().
+//
+// -------------------------------------------------------------------------------
+//
+// The MIT License (MIT)
+//
+// Copyright (c) 2013 Mitchell Hashimoto
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package env
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+// expandHomeDir expands the path to include the home directory if the path
+// is prefixed with `~`. If it isn't prefixed with `~`, the path is
+// returned as-is.
+func expandHomeDir(path string) (string, error) {
+	if len(path) == 0 {
+		return path, nil
+	}
+
+	if path[0] != '~' {
+		return path, nil
+	}
+
+	if len(path) > 1 && path[1] != '/' && path[1] != '\\' {
+		return "", errors.New("cannot expand user-specific home dir")
+	}
+
+	dir, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Join(dir, path[1:]), nil
+}


### PR DESCRIPTION
#### What is the purpose of this change?

Use [`os.UserHomeDir()`](https://pkg.go.dev/os#UserHomeDir) instead of [`Dir()` from `github.com/mitchellh/go-homedir`](https://pkg.go.dev/github.com/mitchellh/go-homedir#Dir).


Why?
- os.UserHomeDir() now has all the fixes (and even more) than what go-homedir was designed for. See https://github.com/mitchellh/go-homedir/issues/34#issuecomment-2011915588
- The github.com/mitchellh/go-homedir has been unmaintained for years and has been finally archived in July 2024. See https://gist.github.com/mitchellh/90029601268e59a29e64e55bab1c5bdc

How?
- func homedir.Dir replaced by `os.UserHomeDir()`
- func homedir.Expand copied as `func expandHomeDir` in `lib/env/homedir_expand.go`, and adapted to use `os.UserHomeDir(). `go-homedir` license is MIT https://github.com/mitchellh/go-homedir/blob/v1.1.0/LICENSE

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
