### PR TITLE
docs/s3: fix typo in Lyve Cloud setup instructions

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -3975,7 +3975,7 @@ Required when using an S3 clone.
 Please type in your LyveCloud endpoint.
 Examples:
 - s3.us-west-1.{account_name}.lyve.seagate.com (US West 1 - California)
-- s3.eu-west-1.{account_name}.lyve.seagate.com (US West 1 - Ireland)
+- s3.eu-west-1.{account_name}.lyve.seagate.com (EU West 1 - Ireland)
 Enter a value.
 endpoint> s3.us-west-1.global.lyve.seagate.com
 ```


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Fixes a minor typo in the Lyve Cloud setup instructions in the `docs/content/s3.md` file. This improves clarity and ensures accurate guidance for users configuring Seagate Lyve Cloud with Rclone.

#### Was the change discussed in an issue or in the forum before?
No — this is a minor documentation typo and was fixed directly without prior discussion.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
