### PR TITLE
feat(sftp-http-proxy): add proxy-authorization http header

### DIFF
--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -204,6 +204,12 @@ Example:
 			Help: `URL for HTTP CONNECT proxy
 
 Set this to a URL for an HTTP proxy which supports the HTTP CONNECT verb.
+
+Supports the format http://user:pass@host:port, http://host:port, http://host.
+
+Example:
+
+    http://myUser:myPass@proxyhostname.example.com:8000
 `,
 			Advanced: true,
 		}, {

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -519,6 +519,12 @@ Example:
 			Help: `URL for HTTP CONNECT proxy
 
 Set this to a URL for an HTTP proxy which supports the HTTP CONNECT verb.
+
+Supports the format http://user:pass@host:port, http://host:port, http://host.
+
+Example:
+
+    http://myUser:myPass@proxyhostname.example.com:8000
 `,
 			Advanced: true,
 		}, {

--- a/docs/content/ftp.md
+++ b/docs/content/ftp.md
@@ -498,6 +498,12 @@ URL for HTTP CONNECT proxy
 
 Set this to a URL for an HTTP proxy which supports the HTTP CONNECT verb.
 
+Supports the format http://user:pass@host:port, http://host:port, http://host.
+
+Example:
+
+    http://myUser:myPass@proxyhostname.example.com:8000
+
 
 Properties:
 

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -1186,6 +1186,12 @@ URL for HTTP CONNECT proxy
 
 Set this to a URL for an HTTP proxy which supports the HTTP CONNECT verb.
 
+Supports the format http://user:pass@host:port, http://host:port, http://host.
+
+Example:
+
+    http://myUser:myPass@proxyhostname.example.com:8000
+
 
 Properties:
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Add HTTP proxy authentication support to the SFTP HTTP proxy backend.
Thinking about it, this is more a bugfix rather than a feature (the username:password syntax for the proxy is already documented).

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate. --> _there is currently no tests for the http proxy._
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
