### PR TITLE
fs: --sparse option

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -25,6 +25,7 @@ import (
 	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/hash"
+	"github.com/rclone/rclone/fs/sparse"
 	"github.com/rclone/rclone/lib/encoder"
 	"github.com/rclone/rclone/lib/file"
 	"github.com/rclone/rclone/lib/readers"
@@ -1349,11 +1350,11 @@ func (o *Object) mkdirAll() error {
 	return file.MkdirAll(dir, 0777)
 }
 
-type nopWriterCloser struct {
+type nopWriterSeekerCloser struct {
 	*bytes.Buffer
 }
 
-func (nwc nopWriterCloser) Close() error {
+func (nwc nopWriterSeekerCloser) Close() error {
 	// noop
 	return nil
 }
@@ -1361,6 +1362,7 @@ func (nwc nopWriterCloser) Close() error {
 // Update the object from in with modTime and size
 func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (err error) {
 	var out io.WriteCloser
+	var outAt fs.WriterAtCloser
 	var hasher *hash.MultiHasher
 
 	for _, option := range options {
@@ -1402,6 +1404,13 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 				return err
 			}
 		}
+		ci := fs.GetConfig(ctx)
+		if ci.Sparse {
+			file.PreAllocateAdvise(true)
+		} else {
+			file.PreAllocateAdvise(false)
+		}
+
 		if !o.fs.opt.NoPreAllocate {
 			// Pre-allocate the file for performance reasons
 			err = file.PreAllocate(src.Size(), f)
@@ -1414,8 +1423,9 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 			}
 		}
 		out = f
+		outAt = f
 	} else {
-		out = nopWriterCloser{&symlinkData}
+		out = nopWriterSeekerCloser{&symlinkData}
 	}
 
 	// Calculate the hash of the object we are reading as we go along
@@ -1423,10 +1433,15 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		in = io.TeeReader(in, hasher)
 	}
 
-	_, err = io.Copy(out, in)
-	closeErr := out.Close()
-	if err == nil {
-		err = closeErr
+	ci := fs.GetConfig(ctx)
+	if !ci.Sparse {
+		_, err = io.Copy(out, in)
+		closeErr := out.Close()
+		if err == nil {
+			err = closeErr
+		}
+	} else if !o.translatedLink && outAt != nil {
+		_, err = sparse.WriteSparse(outAt, 0, in, int64(ci.SparseMinBlockSize))
 	}
 
 	if o.translatedLink {
@@ -1507,6 +1522,14 @@ func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.Wr
 	if err != nil {
 		return nil, err
 	}
+
+	ci := fs.GetConfig(ctx)
+	if ci.Sparse {
+		file.PreAllocateAdvise(true)
+	} else {
+		file.PreAllocateAdvise(false)
+	}
+
 	// Pre-allocate the file for performance reasons
 	if !f.opt.NoPreAllocate {
 		err = file.PreAllocate(size, out)

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -2248,6 +2248,24 @@ This can be useful transferring files from Dropbox which have been
 modified by the desktop sync client which doesn't set checksums of
 modification times in the same way as rclone.
 
+### --sparse ###
+
+Turn sequences of zeros into sparse blocks
+
+Normally, when zeros are written to a file, they are stored as data.
+However, some filesystems have the ability to keep track of locations
+in a file that contain no data, saving disk space. To take advantage
+of this, `--sparse` avoids writing to locations in the destination
+file where the source file contains a sequence of zeros greater than
+or equal to the size specified by `--sparse-min-block-size`
+
+### --sparse-min-block-size=SIZE ###
+
+The minimum size a sequence of zeros must be in order to not be
+written to the remote when `--sparse is specified`. Larger
+values could lead to better performance due to a smaller amount
+of write calls made to the remote.
+
 ### --stats=TIME ###
 
 Commands which transfer data (`sync`, `copy`, `copyto`, `move`,

--- a/fs/config.go
+++ b/fs/config.go
@@ -555,6 +555,17 @@ var ConfigOptionsInfo = Options{{
 	Default: []string{},
 	Help:    "Transform paths during the copy process.",
 	Groups:  "Copy",
+}, {
+	Name:    "sparse",
+	Default: false,
+	Help:    "Copy blocks of zeros as sparse",
+	Groups:  "Copy",
+}, {
+
+	Name:    "sparse_min_block_size",
+	Default: SizeSuffix(1024),
+	Help:    "Minimum size a sequence of zeros must be in order to not be written to the remote with --sparse",
+	Groups:  "Copy",
 }}
 
 // ConfigInfo is filesystem config options
@@ -667,6 +678,8 @@ type ConfigInfo struct {
 	MetadataMapper             SpaceSepList      `config:"metadata_mapper"`
 	MaxConnections             int               `config:"max_connections"`
 	NameTransform              []string          `config:"name_transform"`
+	Sparse                     bool              `config:"sparse"`
+	SparseMinBlockSize         SizeSuffix        `config:"sparse_min_block_size"`
 }
 
 func init() {

--- a/fs/sparse/sparse.go
+++ b/fs/sparse/sparse.go
@@ -1,0 +1,63 @@
+package sparse
+
+import (
+	"io"
+
+	"github.com/rclone/rclone/fs"
+)
+
+func WriteSparse(writer fs.WriterAtCloser, baseOff int64, reader io.Reader, minSparseBlockSize int64) (int64, error) {
+	buf := make([]byte, 32*1024)
+	currentFileOff := baseOff
+	total := int64(0)
+	logicalTotal := int64(0)
+
+	var n int
+	var err error
+	for n, err = reader.Read(buf); (err == io.EOF && n > 0) || err == nil; n, err = reader.Read(buf) {
+		logicalTotal += int64(n)
+		rdBuf := buf[:n]
+		bufDenseBlockStart := 0
+		bufDenseBlockCurrent := 0
+		bufSparseBlockStart := 0
+		bufSparseBlockCurrent := 0
+		prevSparse := false
+		for i, val := range rdBuf[:n] {
+			isLastInBuf := len(rdBuf)-1 == i
+			if val == 0 {
+				if !prevSparse {
+					bufSparseBlockStart = i
+				}
+				prevSparse = true
+				bufSparseBlockCurrent = i + 1
+			} else {
+				if prevSparse && (i-bufSparseBlockCurrent) > int(minSparseBlockSize) {
+					bufDenseBlockStart = i
+				}
+				prevSparse = false
+				bufDenseBlockCurrent = i + 1
+			}
+
+			contigZeroCount := int64(bufSparseBlockCurrent - bufSparseBlockStart)
+			if (val != 0 && contigZeroCount >= minSparseBlockSize) || isLastInBuf {
+
+				if (bufDenseBlockStart < bufSparseBlockStart || isLastInBuf) && bufDenseBlockCurrent-bufDenseBlockStart > 0 {
+					nWritten := int(0)
+					nWritten, writeErr := writer.WriteAt(buf[bufDenseBlockStart:bufDenseBlockCurrent], currentFileOff+int64(bufDenseBlockStart))
+					total += int64(nWritten)
+
+					if writeErr != nil {
+						return total, err
+					}
+				}
+			}
+		}
+		currentFileOff += int64(len(rdBuf))
+		rdBuf = nil
+	}
+
+	if err != io.EOF && err != nil {
+		return 0, err
+	}
+	return logicalTotal, nil
+}

--- a/fstest/fstest.go
+++ b/fstest/fstest.go
@@ -107,6 +107,23 @@ func NewItem(Path, Content string, modTime time.Time) Item {
 	return i
 }
 
+// NewItem creates an item from a string content
+func NewItemBytes(Path string, Content []byte, modTime time.Time) Item {
+	i := Item{
+		Path:    Path,
+		ModTime: modTime,
+		Size:    int64(len(Content)),
+	}
+	hash := hash.NewMultiHasher()
+	buf := bytes.NewBuffer(Content)
+	_, err := io.Copy(hash, buf)
+	if err != nil {
+		fs.Fatalf(nil, "Failed to create item: %v", err)
+	}
+	i.Hashes = hash.Sums()
+	return i
+}
+
 // CheckTimeEqualWithPrecision checks the times are equal within the
 // precision, returns the delta and a flag
 func CheckTimeEqualWithPrecision(t0, t1 time.Time, precision time.Duration) (time.Duration, bool) {

--- a/lib/file/preallocate_other.go
+++ b/lib/file/preallocate_other.go
@@ -4,6 +4,8 @@ package file
 
 import "os"
 
+func PreAllocateAdvise(allocateSparse bool) {}
+
 // PreallocateImplemented is a constant indicating whether the
 // implementation of Preallocate actually does anything.
 const PreallocateImplemented = false

--- a/lib/file/preallocate_windows.go
+++ b/lib/file/preallocate_windows.go
@@ -38,6 +38,8 @@ type ioStatusBlock struct {
 // implementation of Preallocate actually does anything.
 const PreallocateImplemented = true
 
+func PreAllocateAdvise(allocateSparse bool) {}
+
 // PreAllocate the file for performance reasons
 func PreAllocate(size int64, out *os.File) error {
 	if size <= 0 {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
This adds the `--sparse` option as well as the `--sparse-min-size` option in order to turn sequences of nulls larger than `--sparse-min-size` into sparse blocks by not writing to those locations in the destination.

For multithreaded copying, this is implemented for every backend that has the `OpenWriterAt` feature. For single threaded copying, a reference implementation has been done for backends/local.

Note that this a reopening of changes presented in #8619. I just felt it more appropriate to create a new PR as the changes here extend beyond linux filesystems that support FS_IOC_FIEMAP.

#### Was the change discussed in an issue or in the forum before?
https://forum.rclone.org/t/possible-to-use-rclone-with-sparse/45189
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
