### PR TITLE
fix: add configurable bar for name truncation for partial files

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -2116,6 +2116,12 @@ Suffix length limit is 16 characters.
 
 The default is `.partial`.
 
+### --partial-pathmax PATHMAX
+
+Rclone truncates the names of partial files by the length of the partial suffix (formatted as `.hash.partial`) if the base path exceeds `--partial-pathmax` characters in attempt to respect remote path maximums. If `--partial-pathmax` is set to 0, truncation to fit the suffix is disabled entirely.
+
+The default is 100 characters
+
 ### --password-command SpaceSepList {#password-command}
 
 This flag supplies a program which should supply the config password

--- a/fs/config.go
+++ b/fs/config.go
@@ -545,6 +545,11 @@ var ConfigOptionsInfo = Options{{
 	Help:    "Add partial-suffix to temporary file name when --inplace is not used",
 	Groups:  "Copy",
 }, {
+	Name:    "partial_pathmax",
+	Default: 100,
+	Help:    "Maximum length a path can be before the path is truncated to this length to fit the partial suffix. 0 to disable",
+	Groups:  "Copy",
+}, {
 	Name:     "max_connections",
 	Help:     "Maximum number of simultaneous backend API connections, 0 for unlimited.",
 	Default:  0,
@@ -664,6 +669,7 @@ type ConfigInfo struct {
 	DefaultTime                Time              `config:"default_time"` // time that directories with no time should display
 	Inplace                    bool              `config:"inplace"`      // Download directly to destination file instead of atomic download to temp/rename
 	PartialSuffix              string            `config:"partial_suffix"`
+	PartialPathmax             int               `config:"partial_pathmax"`
 	MetadataMapper             SpaceSepList      `config:"metadata_mapper"`
 	MaxConnections             int               `config:"max_connections"`
 	NameTransform              []string          `config:"name_transform"`

--- a/fs/operations/copy.go
+++ b/fs/operations/copy.go
@@ -104,7 +104,8 @@ func (c *copy) checkPartial(ctx context.Context) (remoteForCopy string, inplace 
 
 	suffix := fmt.Sprintf(".%x%s", hash, c.ci.PartialSuffix)
 	base := path.Base(remoteForCopy)
-	if len(base) > 100 {
+	// ci.PartialPathmax == 0 implies pathmax checks for partial names is disabled
+	if c.ci.PartialPathmax != 0 && len(base) > c.ci.PartialPathmax {
 		remoteForCopy = TruncateString(remoteForCopy, len(remoteForCopy)-len(suffix)) + suffix
 	} else {
 		remoteForCopy += suffix


### PR DESCRIPTION
#### What is the purpose of this change?

Currently, rclone truncates paths over a hundred characters to fit a partial suffix. Sometimes, this comes around and bites you when it turns out the ending, say 10 characters, are the only thing distinguishing one file being transferred from another. Thus, I have added this flag to make this limit not hardcoded.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
