### PR TITLE
docs: update OneDrive client ID instructions to current Azure AD portal - fixes #8027

### DIFF
--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -132,7 +132,8 @@ For example, you might see throttling.
 
 To create your own Client ID, please follow these steps:
 
-1. Open https://portal.azure.com/#blade/Microsoft_AAD_RegisteredApps/ApplicationsListBlade and then click `New registration`.
+1. Open https://portal.azure.com/?quickstart=true#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/Overview and then under the `Add` menu click `App registration`.
+    * If you have not created an Azure account, you will be prompted to. This is free, but you need to provide a phone number, address, and credit card for identity verification.
 2. Enter a name for your app, choose account type `Accounts in any organizational directory (Any Azure AD directory - Multitenant) and personal Microsoft accounts (e.g. Skype, Xbox)`, select `Web` in `Redirect URI`, then type (do not copy and paste) `http://localhost:53682/` and click Register. Copy and keep the `Application (client) ID` under the app name for later use.
 3. Under `manage` select `Certificates & secrets`, click `New client secret`. Enter a description (can be anything) and set `Expires` to 24 months. Copy and keep that secret _Value_ for later use (you _won't_ be able to see this value afterwards).
 4. Under `manage` select `API permissions`, click `Add a permission` and select `Microsoft Graph` then select `delegated permissions`.


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Microsoft has moved AAD (and technically deprecated it), and now requires a free, but verified, Azure account to create your own client id. The docs are currently pointing to an older interface that has completely deprecated creating new apps.

#### Was the change discussed in an issue or in the forum before?

Briefly: https://github.com/rclone/rclone/issues/8027

I found corrected instructions were posted to the rclone forums here: https://forum.rclone.org/t/ondrive-personal-client-id-and-key-creation-changed-help-needed/47383/21

I was able to make a client ID sync to my personal OneDrive account this evening via the link from the forum.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
