### PR TITLE
Add vendor OpenCloud

### DIFF
--- a/backend/webdav/tus-upload.go
+++ b/backend/webdav/tus-upload.go
@@ -62,14 +62,14 @@ func b64encode(s string) string {
 }
 
 // NewUpload creates a new upload from an io.Reader.
-func NewUpload(reader io.Reader, size int64, metadata Metadata, fingerprint string) *Upload {
+func NewUpload(reader io.Reader, size int64, metadata Metadata, fingerprint string) (*Upload, error) {
 	stream, ok := reader.(io.ReadSeeker)
 
 	if !ok {
 		buf := new(bytes.Buffer)
 		_, err := buf.ReadFrom(reader)
 		if err != nil {
-			return nil
+			return nil, err
 		}
 		stream = bytes.NewReader(buf.Bytes())
 	}
@@ -84,5 +84,5 @@ func NewUpload(reader io.Reader, size int64, metadata Metadata, fingerprint stri
 
 		Fingerprint: fingerprint,
 		Metadata:    metadata,
-	}
+	}, nil
 }

--- a/backend/webdav/tus.go
+++ b/backend/webdav/tus.go
@@ -2,6 +2,7 @@ package webdav
 
 /*
    Chunked upload based on the tus protocol for ownCloud Infinite Scale
+   and OpenCloud
    See https://tus.io/protocols/resumable-upload
 */
 

--- a/backend/webdav/tus.go
+++ b/backend/webdav/tus.go
@@ -20,7 +20,7 @@ import (
 
 func (o *Object) updateViaTus(ctx context.Context, in io.Reader, contentType string, src fs.ObjectInfo, options ...fs.OpenOption) (err error) {
 
-	fn := filepath.Base(src.Remote())
+	fn := filepath.Base(o.Remote())
 	metadata := map[string]string{
 		"filename": fn,
 		"mtime":    strconv.FormatInt(src.ModTime(ctx).Unix(), 10),

--- a/backend/webdav/tus.go
+++ b/backend/webdav/tus.go
@@ -31,7 +31,10 @@ func (o *Object) updateViaTus(ctx context.Context, in io.Reader, contentType str
 	fingerprint := ""
 
 	// create an upload from a file.
-	upload := NewUpload(in, src.Size(), metadata, fingerprint)
+	upload, err := NewUpload(in, src.Size(), metadata, fingerprint)
+	if err != nil {
+		return err
+	}
 
 	// create the uploader.
 	uploader, err := o.CreateUploader(ctx, upload, options...)

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -649,7 +649,7 @@ func (f *Fs) setQuirks(ctx context.Context, vendor string) error {
 	case "opencloud", "infinitescale":
 		f.precision = time.Second
 		f.useOCMtime = true
-		f.propsetMtime = true
+		f.propsetMtime = false
 		f.hasOCMD5 = false
 		f.hasOCSHA1 = true
 		f.canChunk = false

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -91,6 +91,9 @@ func init() {
 				Value: "infinitescale",
 				Help:  "ownCloud Infinite Scale",
 			}, {
+				Value: "opencloud",
+				Help:  "OpenCloud",
+			}, {
 				Value: "sharepoint",
 				Help:  "Sharepoint Online, authenticated by Microsoft account",
 			}, {
@@ -643,7 +646,7 @@ func (f *Fs) setQuirks(ctx context.Context, vendor string) error {
 		f.propsetMtime = true
 		f.hasOCMD5 = true
 		f.hasOCSHA1 = true
-	case "infinitescale":
+	case "opencloud", "infinitescale":
 		f.precision = time.Second
 		f.useOCMtime = true
 		f.propsetMtime = true

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -1559,7 +1559,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		return fmt.Errorf("Update mkParentDir failed: %w", err)
 	}
 
-	if o.fs.canTus { // supports the tus upload protocol, ie. InfiniteScale
+	if o.fs.canTus && src.Size() != 0 { // supports the tus upload protocol, ie. OpenCloud and InfiniteScale
 		fs.Debugf(src, "Update will use the tus protocol to upload")
 		contentType := fs.MimeType(ctx, src)
 		err = o.updateViaTus(ctx, in, contentType, src, options...)

--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -862,7 +862,7 @@ func (f *Fs) listAll(ctx context.Context, dir string, directoriesOnly bool, file
 		}
 
 		// Check OK
-		if !item.Props.StatusOK() {
+		if !(item.Props.StatusOK() || item.Props.Code() == 425) {
 			fs.Debugf(remote, "Ignoring item with bad status %q", item.Props.Status)
 			continue
 		}

--- a/backend/webdav/webdav_test.go
+++ b/backend/webdav/webdav_test.go
@@ -22,20 +22,34 @@ func TestIntegration(t *testing.T) {
 
 // TestIntegration runs integration tests against the remote
 func TestIntegration2(t *testing.T) {
-	if *fstest.RemoteName != "" {
-		t.Skip("skipping as -remote is set")
-	}
-	fstests.Run(t, &fstests.Opt{
-		RemoteName: "TestWebdavOwncloud:",
-		NilObject:  (*Object)(nil),
-		ChunkedUpload: fstests.ChunkedUploadConfig{
-			Skip: true,
-		},
-	})
+        if *fstest.RemoteName != "" {
+                t.Skip("skipping as -remote is set")
+        }
+        fstests.Run(t, &fstests.Opt{
+                RemoteName: "TestWebdavOwncloud:",
+                NilObject:  (*Object)(nil),
+                ChunkedUpload: fstests.ChunkedUploadConfig{
+                        Skip: true,
+                },
+        })
 }
 
-// TestIntegration runs integration tests against the remote
 func TestIntegration3(t *testing.T) {
+        if *fstest.RemoteName != "" {
+                t.Skip("skipping as -remote is set")
+        }
+        fstests.Run(t, &fstests.Opt{
+                RemoteName: "TestWebdavOpenCloud:",
+                NilObject:  (*Object)(nil),
+                ChunkedUpload: fstests.ChunkedUploadConfig{
+                        Skip: true,
+                },
+        })
+}
+
+
+// TestIntegration runs integration tests against the remote
+func TestIntegration4(t *testing.T) {
 	if *fstest.RemoteName != "" {
 		t.Skip("skipping as -remote is set")
 	}
@@ -49,7 +63,7 @@ func TestIntegration3(t *testing.T) {
 }
 
 // TestIntegration runs integration tests against the remote
-func TestIntegration4(t *testing.T) {
+func TestIntegration5(t *testing.T) {
 	if *fstest.RemoteName != "" {
 		t.Skip("skipping as -remote is set")
 	}

--- a/backend/webdav/webdav_test.go
+++ b/backend/webdav/webdav_test.go
@@ -22,31 +22,30 @@ func TestIntegration(t *testing.T) {
 
 // TestIntegration runs integration tests against the remote
 func TestIntegration2(t *testing.T) {
-        if *fstest.RemoteName != "" {
-                t.Skip("skipping as -remote is set")
-        }
-        fstests.Run(t, &fstests.Opt{
-                RemoteName: "TestWebdavOwncloud:",
-                NilObject:  (*Object)(nil),
-                ChunkedUpload: fstests.ChunkedUploadConfig{
-                        Skip: true,
-                },
-        })
+	if *fstest.RemoteName != "" {
+		t.Skip("skipping as -remote is set")
+	}
+	fstests.Run(t, &fstests.Opt{
+		RemoteName: "TestWebdavOwncloud:",
+		NilObject:  (*Object)(nil),
+		ChunkedUpload: fstests.ChunkedUploadConfig{
+			Skip: true,
+		},
+	})
 }
 
 func TestIntegration3(t *testing.T) {
-        if *fstest.RemoteName != "" {
-                t.Skip("skipping as -remote is set")
-        }
-        fstests.Run(t, &fstests.Opt{
-                RemoteName: "TestWebdavOpenCloud:",
-                NilObject:  (*Object)(nil),
-                ChunkedUpload: fstests.ChunkedUploadConfig{
-                        Skip: true,
-                },
-        })
+	if *fstest.RemoteName != "" {
+		t.Skip("skipping as -remote is set")
+	}
+	fstests.Run(t, &fstests.Opt{
+		RemoteName: "TestWebdavOpenCloud:",
+		NilObject:  (*Object)(nil),
+		ChunkedUpload: fstests.ChunkedUploadConfig{
+			Skip: true,
+		},
+	})
 }
-
 
 // TestIntegration runs integration tests against the remote
 func TestIntegration4(t *testing.T) {

--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -391,6 +391,16 @@ settings of the user through a checkbox there.
 Infinite Scale works with the chunking [tus](https://tus.io) upload protocol.
 The chunk size is currently fixed 10 MB.
 
+### OpenCloud
+
+The WebDAV URL for OpenCloud can be found in the details panel of
+any space in OpenCloud if the display was enabled in the personal
+settings of the user through a checkbox there.
+
+OpenCloud works with the chunking [tus](https://tus.io) upload protocol.
+The chunk size is currently fixed 10 MB. With that, files of any size
+can be uploaded to the cloud.
+
 ### Sharepoint Online
 
 Rclone can be used with Sharepoint provided by OneDrive for Business

--- a/fstest/fstests/fstests.go
+++ b/fstest/fstests/fstests.go
@@ -459,11 +459,11 @@ func Run(t *testing.T, opt *Opt) {
 		t.Logf("Didn't find %q in config file - skipping tests", remoteName)
 		return
 	}
-	require.NoError(t, err, fmt.Sprintf("unexpected error: %v", err))
+	require.NoError(t, err, fmt.Sprintf(" 1 unexpected error: %v", err))
 
 	// Get fsInfo which contains type, etc. of the fs
 	fsInfo, _, _, _, err := fs.ConfigFs(subRemoteName)
-	require.NoError(t, err, fmt.Sprintf("unexpected error: %v", err))
+	require.NoError(t, err, fmt.Sprintf(" 2 unexpected error: %v", err))
 
 	// Skip the rest if it failed
 	skipIfNotOk(t)

--- a/fstest/test_all/config.yaml
+++ b/fstest/test_all/config.yaml
@@ -502,6 +502,17 @@ backends:
  #     - cmd/bisync
  #     - cmd/gitannex
  - backend:  "webdav"
+   remote:   "TestWebdavOpenCloud:"
+   ignore:
+     - TestIntegration/FsMkdir/FsEncoding/punctuation
+     - TestIntegration/FsMkdir/FsEncoding/invalid_UTF-8
+   env:
+      - RCLONE_NO_CHECK_CERTIFICATE=true
+   fastlist: false
+   ignoretests:
+     - cmd/bisync
+     - cmd/gitannex
+ - backend:  "webdav"
    remote:   "TestWebdavRclone:"
    ignore:
      - TestFileReadAtZeroLength

--- a/fstest/testserver/init.d/TestWebdavOpenCloud
+++ b/fstest/testserver/init.d/TestWebdavOpenCloud
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -e
+
+NAME=opencloud
+USER=admin
+PASS=admin
+PORT=9200
+
+CONF_DIR=/tmp/opencloud-config
+install -d -m 0777 ${CONF_DIR}
+
+. $(dirname "$0")/docker.bash
+
+start() {
+    echo "*************************** init"
+    docker run --rm --name $NAME \
+           -v ${CONF_DIR}:/etc/opencloud \
+           -e "OC_INSECURE=true" \
+           -e "IDM_ADMIN_PASSWORD=$PASS" \
+           -e "OC_FORCE_CONFIG_OVERWRITE=true" \
+           -e "OC_URL=https://127.0.0.1:$PORT" \
+           opencloudeu/opencloud-rolling \
+           init
+
+    docker run --rm -d --name $NAME \
+           -e "OC_LOG_LEVEL=debug" \
+           -e "OC_LOG_PRETTY=true" \
+           -e "OC_URL=https://127.0.0.1:$PORT" \
+           -e "IDM_ADMIN_PASSWORD=$PASS" \
+           -e "OC_INSECURE=true" \
+           -e "PROXY_ENABLE_BASIC_AUTH=true" \
+           -v ${CONF_DIR}:/etc/opencloud \
+           -p 127.0.0.1:${PORT}:9200 \
+           opencloudeu/opencloud-rolling 
+    
+    echo type=webdav
+    echo url=https://127.0.0.1:${PORT}/dav/spaces/some-admin-user-id-0000-100000000000
+    echo user=$USER
+    echo pass=$(rclone obscure $PASS)
+    echo vendor=opencloud
+    echo _connect=127.0.0.1:${PORT}
+    echo _connect_delay=5s
+}
+
+stop() {
+    # Clean up the mess
+    docker stop opencloud 
+    rm -r ${CONF_DIR}
+}
+
+. $(dirname "$0")/run.bash

--- a/fstest/testserver/init.d/TestWebdavOpenCloud
+++ b/fstest/testserver/init.d/TestWebdavOpenCloud
@@ -20,24 +20,32 @@ start() {
            -e "IDM_ADMIN_PASSWORD=$PASS" \
            -e "OC_FORCE_CONFIG_OVERWRITE=true" \
            -e "OC_URL=https://127.0.0.1:$PORT" \
+	   -e "OC_ADMIN_USER_ID=some-admin-user-id-0000-100000000000" \
+	   -e "GATEWAY_STORAGE_USERS_MOUNT_ID=storage-users-1" \
+           -e "STORAGE_USERS_MOUNT_ID=storage-users-1" \
            opencloudeu/opencloud-rolling \
            init
 
-    docker run --rm -d --name $NAME \
+    docker run -d --name $NAME \
            -e "OC_LOG_LEVEL=debug" \
            -e "OC_LOG_PRETTY=true" \
            -e "OC_URL=https://127.0.0.1:$PORT" \
            -e "IDM_ADMIN_PASSWORD=$PASS" \
+           -e "OC_ADMIN_USER_ID=some-admin-user-id-0000-100000000000" \
+           -e "GATEWAY_STORAGE_USERS_MOUNT_ID=storage-users-1" \
+           -e "STORAGE_USERS_MOUNT_ID=storage-users-1" \
            -e "OC_INSECURE=true" \
            -e "PROXY_ENABLE_BASIC_AUTH=true" \
            -v ${CONF_DIR}:/etc/opencloud \
            -p 127.0.0.1:${PORT}:9200 \
            opencloudeu/opencloud-rolling 
-    
+
+    sleep 10
     echo type=webdav
-    echo url=https://127.0.0.1:${PORT}/dav/spaces/some-admin-user-id-0000-100000000000
+    url=$(curl -f -s -k -u admin:${PASS} "https://127.0.0.1:${PORT}/graph/v1.0/me/drive"   -H 'accept: application/json' | jq -r '.root.webDavUrl' - )
+    echo url=${url}
     echo user=$USER
-    echo pass=$(rclone obscure $PASS)
+    echo pass=$(/home/kf/git/rclone/rclone obscure $PASS)
     echo vendor=opencloud
     echo _connect=127.0.0.1:${PORT}
     echo _connect_delay=5s

--- a/fstest/testserver/init.d/TestWebdavOpenCloud
+++ b/fstest/testserver/init.d/TestWebdavOpenCloud
@@ -20,20 +20,14 @@ start() {
            -e "IDM_ADMIN_PASSWORD=$PASS" \
            -e "OC_FORCE_CONFIG_OVERWRITE=true" \
            -e "OC_URL=https://127.0.0.1:$PORT" \
-	   -e "OC_ADMIN_USER_ID=some-admin-user-id-0000-100000000000" \
-	   -e "GATEWAY_STORAGE_USERS_MOUNT_ID=storage-users-1" \
-           -e "STORAGE_USERS_MOUNT_ID=storage-users-1" \
            opencloudeu/opencloud-rolling \
            init
 
-    docker run -d --name $NAME \
+    docker run --rm -d --name $NAME \
            -e "OC_LOG_LEVEL=debug" \
            -e "OC_LOG_PRETTY=true" \
            -e "OC_URL=https://127.0.0.1:$PORT" \
            -e "IDM_ADMIN_PASSWORD=$PASS" \
-           -e "OC_ADMIN_USER_ID=some-admin-user-id-0000-100000000000" \
-           -e "GATEWAY_STORAGE_USERS_MOUNT_ID=storage-users-1" \
-           -e "STORAGE_USERS_MOUNT_ID=storage-users-1" \
            -e "OC_INSECURE=true" \
            -e "PROXY_ENABLE_BASIC_AUTH=true" \
            -v ${CONF_DIR}:/etc/opencloud \
@@ -45,7 +39,7 @@ start() {
     url=$(curl -f -s -k -u admin:${PASS} "https://127.0.0.1:${PORT}/graph/v1.0/me/drive"   -H 'accept: application/json' | jq -r '.root.webDavUrl' - )
     echo url=${url}
     echo user=$USER
-    echo pass=$(/home/kf/git/rclone/rclone obscure $PASS)
+    echo pass=$(rclone obscure $PASS)
     echo vendor=opencloud
     echo _connect=127.0.0.1:${PORT}
     echo _connect_delay=5s


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

It adds a new WebDAV vendor OpenCloud to the webdav backend of rclone.

OpenCloud is a fork of ownCloud InfiniteScale which is actively maintained by some former InfiniteScale developers. It's living on Github under https://github.com/opencloud-eu

#### Was the change discussed in an issue or in the forum before?

Not that I know

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

This PR still does not fix the problems as discussed in https://github.com/rclone/rclone/pull/8172#issuecomment-3015157471 but still suffers from the same problem.