### PR TITLE
pikpak: improve error handling for missing links and unrecoverable 500s

### DIFF
--- a/backend/pikpak/helper.go
+++ b/backend/pikpak/helper.go
@@ -155,6 +155,7 @@ func (f *Fs) getFile(ctx context.Context, ID string) (info *api.File, err error)
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.rst.CallJSON(ctx, &opts, nil, &info)
 		if err == nil && !info.Links.ApplicationOctetStream.Valid() {
+			time.Sleep(5 * time.Second)
 			return true, errors.New("no link")
 		}
 		return f.shouldRetry(ctx, resp, err)

--- a/backend/pikpak/pikpak.go
+++ b/backend/pikpak/pikpak.go
@@ -479,6 +479,11 @@ func (f *Fs) shouldRetry(ctx context.Context, resp *http.Response, err error) (b
 			// when a zero-byte file was uploaded with an invalid captcha token
 			f.rst.captcha.Invalidate()
 			return true, err
+		} else if strings.Contains(apiErr.Reason, "idx.shub.mypikpak.com") && apiErr.Code == 500 {
+			// internal server error: Post "http://idx.shub.mypikpak.com": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+			// This typically happens when trying to retrieve a gcid for which no record exists.
+			// No retry is needed in this case.
+			return false, err
 		}
 	}
 


### PR DESCRIPTION
#### What is the purpose of this change?

This commit improves error handling on two specific scenarios:

* Missing Download Links: Introduces a 5-second delay when a download link is missing, as low-level retries are insufficient to cover this delay. Empirically, it requires about 30s-1m for the link to become available. This resolves failed integration tests: backend: `TestIntegration/FsMkdir/FsPutFiles/ObjectUpdate`, vfs: `TestFileReadAtNonZeroLength`
* Unrecoverable 500 Errors: Updates the `shouldRetry` method to skip retries for 500 errors originating from "idx.shub.mypikpak.com" that indicate "no record for gcid." These errors are non-recoverable, and retrying them is futile.

#### Was the change discussed in an issue or in the forum before?

N/A

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)