### PR TITLE
Ignore duplicate author email

### DIFF
--- a/bin/.ignore-emails
+++ b/bin/.ignore-emails
@@ -13,3 +13,4 @@
 <allllaboutyou@gmail.com>
 <psycho@feltzv.fr>
 <afw5059@gmail.com>
+<piyushgarg80>

--- a/docs/content/authors.md
+++ b/docs/content/authors.md
@@ -788,7 +788,6 @@ put them back in again.` >}}
   * Adithya Kumar <akumar42@protonmail.com>
   * Tayo-pasedaRJ <138471223+Tayo-pasedaRJ@users.noreply.github.com>
   * Peter Kreuser <logo@kreuser.name>
-  * Piyush <piyushgarg80>
   * fotile96 <fotile96@users.noreply.github.com>
   * Luc Ritchie <luc.ritchie@gmail.com>
   * cynful <cynful@users.noreply.github.com>


### PR DESCRIPTION
This should merge the two (assumed) duplicates:
1. piyushgarg \<piyushgarg80@gmail.com>
2. Piyush \<piyushgarg80>

Keep 1. Remove 2 - it was introduced when adding users from Co-authored-by in cdf5a97bb617bcca764501890e57dbae732c0a92.

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
