### PR TITLE
fs: fix operations/check api endpoint ignoring "oneWay" parameter.

### DIFF
--- a/fs/operations/rc.go
+++ b/fs/operations/rc.go
@@ -820,7 +820,7 @@ func rcCheck(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 		return nil, rc.NewErrParamInvalid(errors.New("need srcFs parameter when not using checkFileHash"))
 	}
 
-	oneway, _ := in.GetBool("oneway")
+	oneway, _ := in.GetBool("oneWay")
 	download, _ := in.GetBool("download")
 
 	opt := &CheckOpt{


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
when posting to rclone remote control api endpoinit "operations/check", "oneWay" key in json payload always got ignored, and rclone always perform a bi-direction check. it turn out to be rcCheck function in rclone/fs/operations/rc.go getting the wrong key("oneway") in json payload, which should be "oneWay".
change
`oneway, _ := in.GetBool("oneway")`
to
`oneway, _ := in.GetBool("oneWay")`
fix the problem

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/rclone-rcd-operations-check-api-ignore-oneway-true/51939

#### Checklist

- [✔] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [✔ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [✔ ] I'm done, this Pull Request is ready for review :-)
