### PR TITLE
sync: fix two testLoggerVsLsf bugs

### DIFF
--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -658,7 +658,7 @@ func TestServerSideCopyOverSelf(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, FremoteCopy, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, FremoteCopy, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
 	fstest.CheckItems(t, FremoteCopy, file1)
 
 	file2 := r.WriteObject(ctx, "sub dir/hello world", "hello world again", t2)
@@ -667,7 +667,7 @@ func TestServerSideCopyOverSelf(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, FremoteCopy, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, FremoteCopy, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
 	fstest.CheckItems(t, FremoteCopy, file2)
 }
 
@@ -703,7 +703,7 @@ func TestServerSideMoveOverSelf(t *testing.T) {
 	ctx = predictDstFromLogger(ctx)
 	err = CopyDir(ctx, FremoteCopy, r.Fremote, false)
 	require.NoError(t, err)
-	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
+	testLoggerVsLsf(ctx, FremoteCopy, r.Fremote, operations.GetLoggerOpt(ctx).JSON, t)
 	fstest.CheckItems(t, FremoteCopy, file1)
 
 	file2 := r.WriteObject(ctx, "sub dir/hello world", "hello world again", t2)

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -3031,6 +3031,9 @@ func DstLsf(ctx context.Context, Fremote fs.Fs) *bytes.Buffer {
 
 	list.SetSeparator(";")
 	timeFormat := operations.FormatForLSFPrecision(Fremote.Precision())
+	if Fremote.Precision() == fs.ModTimeNotSupported {
+		timeFormat = "none"
+	}
 	list.AddModTime(timeFormat)
 	list.AddHash(hash.MD5)
 	list.AddSize()
@@ -3082,7 +3085,7 @@ func testLoggerVsLsf(ctx context.Context, fdst, fsrc fs.Fs, logger *bytes.Buffer
 			elements := bytes.Split(line, []byte(";"))
 			if len(elements) >= 2 {
 				if !canTestModtime {
-					elements[0] = []byte("")
+					elements[0] = []byte("none")
 				}
 				if !canTestHash {
 					elements[1] = []byte("")


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes two bugs in the `testLoggerVsLsf` function of the sync tests.

#### Was the change discussed in an issue or in the forum before?

- https://github.com/rclone/rclone/issues/8629#issuecomment-3098646317

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
