### PR TITLE
Increase copy speed by re-enabling buffering for multithreaded copies from local filesystems

### DIFF
--- a/fs/operations/multithread.go
+++ b/fs/operations/multithread.go
@@ -141,9 +141,9 @@ func multiThreadCopy(ctx context.Context, f fs.Fs, remote string, src fs.Object,
 		noBuffering = true
 		usingOpenWriterAt = true
 	} else if src.Fs().Features().IsLocal {
-		// If the source fs is local we don't need to buffer
-		fs.Debugf(src, "multi-thread copy: disabling buffering because source is local disk")
-		noBuffering = true
+		// If the source fs is local, buffering can greatly increase performance of multithread uploads from local
+		fs.Debugf(src, "multi-thread copy: enabling buffering because source is local disk")
+		noBuffering = false
 	} else if f.Features().ChunkWriterDoesntSeek {
 		// If the destination Fs promises not to seek its chunks
 		// (except for retries) then we don't need buffering.


### PR DESCRIPTION
#### What is the purpose of this change?
Make multithreaded copies from local to S3 fast again (by re-enabling buffering)!

From v1.64.2 to v1.65+, the performance of multithreaded copies from local to S3 decreased. 
After some investigation and debugging, it seems this is a side effect of this [commit](https://github.com/rclone/rclone/commit/1f9a79ef09fe9f1720040073992f7dc06030cebf?diff=split#diff-57914b2dca5f9b6573400f20eb94657c8fcb57b692e0636af96d7a74ec228016R146) / issue https://github.com/rclone/rclone/issues/7350 - more specifically disabling buffering when copying from local filesystems.

I executed some tests in a **m6a.2xlarge** AWS EC2 instance (Network up to 12.5 Gbps and EBS up to 10 Gbps) and here are the results:

Copy of a 64 GB file from the local filesystem to S3
`time ./rclone copyto --s3-no-check-bucket --ignore-checksum --s3-disable-checksum --progress --s3-upload-cutoff=0 --multi-thread-cutoff=256M --multi-thread-streams 20 --disable=copy --no-check-dest <Local File> <S3 Bucket>`

| Buffering | Time | Avg Speed |
|:---|---|---:|
| `disabled` | 18 min 46s | ~58 MB/s |
| `enabled` | 9m 10s | ~121 MB/s |

I'm not completely sure about the memory consumption implications - but alternatively if it cannot be enabled by default - could we consider making it configurable?

What do you think? Looking forward to some input and feedback!

#### Was the change discussed in an issue or in the forum before?
No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
