### PR TITLE
accounting: populate transfer snapshot with "what" value

### DIFF
--- a/fs/accounting/transfer.go
+++ b/fs/accounting/transfer.go
@@ -17,6 +17,7 @@ type TransferSnapshot struct {
 	Size        int64     `json:"size"`
 	Bytes       int64     `json:"bytes"`
 	Checked     bool      `json:"checked"`
+	What        string    `json:"what"`
 	StartedAt   time.Time `json:"started_at"`
 	CompletedAt time.Time `json:"completed_at,omitempty"`
 	Error       error     `json:"-"`
@@ -186,9 +187,10 @@ func (tr *Transfer) Snapshot() TransferSnapshot {
 	}
 	snapshot := TransferSnapshot{
 		Name:        tr.remote,
-		Checked:     tr.checking,
 		Size:        s,
 		Bytes:       b,
+		Checked:     tr.checking,
+		What:        tr.what,
 		StartedAt:   tr.startedAt,
 		CompletedAt: tr.completedAt,
 		Error:       tr.err,

--- a/fs/accounting/transfer_test.go
+++ b/fs/accounting/transfer_test.go
@@ -31,6 +31,7 @@ func TestTransfer(t *testing.T) {
 		assert.Equal(t, int64(0), snap.Size)
 		assert.Equal(t, int64(0), snap.Bytes)
 		assert.Equal(t, false, snap.Checked)
+		assert.Equal(t, "", snap.What)
 		assert.Equal(t, false, snap.StartedAt.IsZero())
 		assert.Equal(t, true, snap.CompletedAt.IsZero())
 		assert.Equal(t, nil, snap.Error)
@@ -46,6 +47,7 @@ func TestTransfer(t *testing.T) {
 		assert.Equal(t, int64(0), snap.Size)
 		assert.Equal(t, int64(0), snap.Bytes)
 		assert.Equal(t, false, snap.Checked)
+		assert.Equal(t, "", snap.What)
 		assert.Equal(t, false, snap.StartedAt.IsZero())
 		assert.Equal(t, false, snap.CompletedAt.IsZero())
 		assert.Equal(t, true, errors.Is(snap.Error, io.EOF))
@@ -62,5 +64,22 @@ func TestTransfer(t *testing.T) {
 			"srcFs": "srcFs:srcFs",
 			"dstFs": "dstFs:dstFs",
 		}, out)
+	})
+
+	t.Run("Snapshot checking transfer", func(t *testing.T) {
+		ctr := newCheckingTransfer(s, o, "checking")
+		snap := ctr.Snapshot()
+
+		assert.Equal(t, "obj", snap.Name)
+		assert.Equal(t, int64(0), snap.Size)
+		assert.Equal(t, int64(0), snap.Bytes)
+		assert.Equal(t, true, snap.Checked)
+		assert.Equal(t, "checking", snap.What)
+		assert.Equal(t, false, snap.StartedAt.IsZero())
+		assert.Equal(t, true, snap.CompletedAt.IsZero())
+		assert.Equal(t, nil, snap.Error)
+		assert.Equal(t, "", snap.Group)
+		assert.Equal(t, "", snap.SrcFs)
+		assert.Equal(t, "", snap.DstFs)
 	})
 }


### PR DESCRIPTION
#### What is the purpose of this change?

The transfer snapshot contains useful information about the result of a transfer, but without knowing _what_ that transfer was doing, it makes it harder to reason about since a file can go through many different tranfers.

In my case, we're monitoring the active transfers, and want to be able to better distinguish between the type of failures.

#### Was the change discussed in an issue or in the forum before?

No
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
