### PR TITLE
fs/operations: add support for unix and unixnano time formats

### DIFF
--- a/MANUAL.md
+++ b/MANUAL.md
@@ -1387,7 +1387,7 @@ rclone sync source:path dest:path [flags]
       --missing-on-dst string   Report all files missing from the destination to this file
       --missing-on-src string   Report all files missing from the source to this file
   -s, --separator string        Separator for the items in the format (default ";")
-  -t, --timeformat string       Specify a custom time format, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
+  -t, --timeformat string       Specify a custom time format, 'unix' / 'unixnano' for timestamp, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
 ```
 
 Options shared with other commands are described next.
@@ -5507,7 +5507,7 @@ rclone lsf remote:path [flags]
   -h, --help                 help for lsf
   -R, --recursive            Recurse into the listing
   -s, --separator string     Separator for the items in the format (default ";")
-  -t, --time-format string   Specify a custom time format, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
+  -t, --time-format string   Specify a custom time format, 'unix' / 'unixnano' for timestamp, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
 ```
 
 Options shared with other commands are described next.

--- a/MANUAL.txt
+++ b/MANUAL.txt
@@ -1335,7 +1335,7 @@ Options
           --missing-on-dst string   Report all files missing from the destination to this file
           --missing-on-src string   Report all files missing from the source to this file
       -s, --separator string        Separator for the items in the format (default ";")
-      -t, --timeformat string       Specify a custom time format, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
+      -t, --timeformat string       Specify a custom time format, 'unix' / 'unixnano' for timestamp, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
 
 Options shared with other commands are described next. See the global
 flags page for global options not listed here.
@@ -5127,7 +5127,7 @@ Options
       -h, --help                 help for lsf
       -R, --recursive            Recurse into the listing
       -s, --separator string     Separator for the items in the format (default ";")
-      -t, --time-format string   Specify a custom time format, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
+      -t, --time-format string   Specify a custom time format, 'unix' / 'unixnano' for timestamp, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
 
 Options shared with other commands are described next. See the global
 flags page for global options not listed here.

--- a/cmd/lsf/lsf.go
+++ b/cmd/lsf/lsf.go
@@ -33,7 +33,7 @@ func init() {
 	cmd.Root.AddCommand(commandDefinition)
 	cmdFlags := commandDefinition.Flags()
 	flags.StringVarP(cmdFlags, &format, "format", "F", "p", "Output format - see  help for details", "")
-	flags.StringVarP(cmdFlags, &timeFormat, "time-format", "t", "", "Specify a custom time format, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)", "")
+	flags.StringVarP(cmdFlags, &timeFormat, "time-format", "t", "", "Specify a custom time format, 'unix' / 'unixnano' for timestamp, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)", "")
 	flags.StringVarP(cmdFlags, &separator, "separator", "s", ";", "Separator for the items in the format", "")
 	flags.BoolVarP(cmdFlags, &dirSlash, "dir-slash", "d", true, "Append a slash to directory names", "")
 	flags.FVarP(cmdFlags, &hashType, "hash", "", "Use this hash when `h` is used in the format MD5|SHA-1|DropboxHash", "")

--- a/cmd/lsf/lsf_test.go
+++ b/cmd/lsf/lsf_test.go
@@ -3,6 +3,7 @@ package lsf
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"testing"
 
 	_ "github.com/rclone/rclone/backend/local"
@@ -247,6 +248,84 @@ func TestTimeFormat(t *testing.T) {
 	}
 	for _, item := range itemsInSubdir {
 		expectedOutput = append(expectedOutput, item.ModTime(context.Background()).Format(timeFormat))
+	}
+
+	assert.Equal(t, `file1_+_0_+_`+expectedOutput[0]+`
+file2_+_321_+_`+expectedOutput[1]+`
+file3_+_1234_+_`+expectedOutput[2]+`
+subdir/_+_-1_+_`+expectedOutput[3]+`
+subdir/file1_+_0_+_`+expectedOutput[4]+`
+subdir/file2_+_1_+_`+expectedOutput[5]+`
+subdir/file3_+_111_+_`+expectedOutput[6]+`
+`, buf.String())
+
+	format = ""
+	separator = ""
+	recurse = false
+	dirSlash = false
+}
+
+func TestTimeFormatUnix(t *testing.T) {
+	fstest.Initialise()
+	f, err := fs.NewFs(context.Background(), "testfiles")
+	require.NoError(t, err)
+	format = "pst"
+	separator = "_+_"
+	recurse = true
+	dirSlash = true
+	timeFormat = "unix"
+
+	buf := new(bytes.Buffer)
+	err = Lsf(context.Background(), f, buf)
+	require.NoError(t, err)
+
+	items, _ := list.DirSorted(context.Background(), f, true, "")
+	itemsInSubdir, _ := list.DirSorted(context.Background(), f, true, "subdir")
+	var expectedOutput []string
+	for _, item := range items {
+		expectedOutput = append(expectedOutput, fmt.Sprint(item.ModTime(context.Background()).Unix()))
+	}
+	for _, item := range itemsInSubdir {
+		expectedOutput = append(expectedOutput, fmt.Sprint(item.ModTime(context.Background()).Unix()))
+	}
+
+	assert.Equal(t, `file1_+_0_+_`+expectedOutput[0]+`
+file2_+_321_+_`+expectedOutput[1]+`
+file3_+_1234_+_`+expectedOutput[2]+`
+subdir/_+_-1_+_`+expectedOutput[3]+`
+subdir/file1_+_0_+_`+expectedOutput[4]+`
+subdir/file2_+_1_+_`+expectedOutput[5]+`
+subdir/file3_+_111_+_`+expectedOutput[6]+`
+`, buf.String())
+
+	format = ""
+	separator = ""
+	recurse = false
+	dirSlash = false
+}
+
+func TestTimeFormatUnixNano(t *testing.T) {
+	fstest.Initialise()
+	f, err := fs.NewFs(context.Background(), "testfiles")
+	require.NoError(t, err)
+	format = "pst"
+	separator = "_+_"
+	recurse = true
+	dirSlash = true
+	timeFormat = "unixnano"
+
+	buf := new(bytes.Buffer)
+	err = Lsf(context.Background(), f, buf)
+	require.NoError(t, err)
+
+	items, _ := list.DirSorted(context.Background(), f, true, "")
+	itemsInSubdir, _ := list.DirSorted(context.Background(), f, true, "subdir")
+	var expectedOutput []string
+	for _, item := range items {
+		expectedOutput = append(expectedOutput, fmt.Sprint(item.ModTime(context.Background()).UnixNano()))
+	}
+	for _, item := range itemsInSubdir {
+		expectedOutput = append(expectedOutput, fmt.Sprint(item.ModTime(context.Background()).UnixNano()))
 	}
 
 	assert.Equal(t, `file1_+_0_+_`+expectedOutput[0]+`

--- a/docs/content/commands/rclone_lsf.md
+++ b/docs/content/commands/rclone_lsf.md
@@ -159,7 +159,7 @@ rclone lsf remote:path [flags]
   -h, --help                 help for lsf
   -R, --recursive            Recurse into the listing
   -s, --separator string     Separator for the items in the format (default ";")
-  -t, --time-format string   Specify a custom time format, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
+  -t, --time-format string   Specify a custom time format, 'unix' / 'unixnano' for timestamp, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
 ```
 
 Options shared with other commands are described next.

--- a/docs/content/commands/rclone_sync.md
+++ b/docs/content/commands/rclone_sync.md
@@ -114,7 +114,7 @@ rclone sync source:path dest:path [flags]
       --missing-on-dst string   Report all files missing from the destination to this file
       --missing-on-src string   Report all files missing from the source to this file
   -s, --separator string        Separator for the items in the format (default ";")
-  -t, --timeformat string       Specify a custom time format, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
+  -t, --timeformat string       Specify a custom time format, 'unix' / 'unixnano' for timestamp, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)
 ```
 
 Options shared with other commands are described next.

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -2219,14 +2219,25 @@ func (l *ListFormat) SetOutput(output []func(entry *ListJSONItem) string) {
 
 // AddModTime adds file's Mod Time to output
 func (l *ListFormat) AddModTime(timeFormat string) {
-	if timeFormat == "" {
-		timeFormat = "2006-01-02 15:04:05"
-	} else {
+	switch timeFormat {
+	case "":
+		l.AppendOutput(func(entry *ListJSONItem) string {
+			return entry.ModTime.When.Local().Format("2006-01-02 15:04:05")
+		})
+	case "unix":
+		l.AppendOutput(func(entry *ListJSONItem) string {
+			return fmt.Sprint(entry.ModTime.When.Unix())
+		})
+	case "unixnano":
+		l.AppendOutput(func(entry *ListJSONItem) string {
+			return fmt.Sprint(entry.ModTime.When.UnixNano())
+		})
+	default:
 		timeFormat = transform.TimeFormat(timeFormat)
+		l.AppendOutput(func(entry *ListJSONItem) string {
+			return entry.ModTime.When.Local().Format(timeFormat)
+		})
 	}
-	l.AppendOutput(func(entry *ListJSONItem) string {
-		return entry.ModTime.When.Local().Format(timeFormat)
-	})
 }
 
 // AddSize adds file's size to output

--- a/fs/operations/operationsflags/operationsflags.go
+++ b/fs/operations/operationsflags/operationsflags.go
@@ -62,7 +62,7 @@ func AddLoggerFlags(cmdFlags *pflag.FlagSet, opt *operations.LoggerOpt, flagsOpt
 
 	// lsf flags for destAfter
 	flags.StringVarP(cmdFlags, &opt.Format, "format", "F", "p", "Output format - see lsf help for details", "Sync")
-	flags.StringVarP(cmdFlags, &opt.TimeFormat, "timeformat", "t", "", "Specify a custom time format, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)", "")
+	flags.StringVarP(cmdFlags, &opt.TimeFormat, "timeformat", "t", "", "Specify a custom time format, 'unix' / 'unixnano' for timestamp, or 'max' for max precision supported by remote (default: 2006-01-02 15:04:05)", "")
 	flags.StringVarP(cmdFlags, &opt.Separator, "separator", "s", ";", "Separator for the items in the format", "Sync")
 	flags.BoolVarP(cmdFlags, &opt.DirSlash, "dir-slash", "d", true, "Append a slash to directory names", "Sync")
 	opt.HashType = hash.MD5


### PR DESCRIPTION
#### What is the purpose of this change?

First of all, **thank you** so much for this amazing project! 🙂 I found Rclone extremely useful and very well done.

In this very simple PR I'm adding support for two new **time formats**: `unix` and `unixnano`. The reason behind this is that sometimes I use the `rclone lsf` command like this:

```
$ rclone lsf -R --format=pst --time-format=RFC3339 myremote:/
myfiles/;-1;2025-08-04T13:00:00+02:00
myfiles/file01.txt;123;2025-08-04T13:10:00+02:00
myfiles/file02.txt;456;2025-08-04T13:20:00+02:00
myfiles/file03.txt;789;2025-08-04T13:30:00+02:00
```

to generate a sort of **CSV-based "tree" of a directory** (either local or remote) with file sizes and last modification times. But the output of such command is **timezone-dependent** (note the `+02:00`s). So, if I run the same command on one of my servers, which has a copy of the same folder but the system time zone set to UTC, I get this:

```
$ rclone lsf -R --format=pst --time-format=RFC3339 myremote:/
myfiles/;-1;2025-08-04T11:00:00Z
myfiles/file01.txt;123;2025-08-04T11:10:00Z
myfiles/file02.txt;456;2025-08-04T11:20:00Z
myfiles/file03.txt;789;2025-08-04T11:30:00Z
```

So, even if the content of the directory is exactly the same, I'm unable to programmatically compare the two outputs, e.g. using the `diff` command.

Since Unix timestamps are **timezone-agnostic**, with this PR I'm introducing the possibility to do this:

```
$ rclone lsf -R --format=pst --time-format=unix myremote:/
myfiles/;-1;1754305200
myfiles/file01.txt;123;1754305800
myfiles/file02.txt;456;1754306400
myfiles/file03.txt;789;1754307000
```

And:

```
$ rclone lsf -R --format=pst --time-format=unixnano myremote:/
myfiles/;-1;1754305200123456789
myfiles/file01.txt;123;1754305800123456789
myfiles/file02.txt;456;1754306400123456789
myfiles/file03.txt;789;1754307000123456789
```

I hope this is useful :) let me know what you think. Thanks in advance!

#### Was the change discussed in an issue or in the forum before?

I don't think so. I tried to search but couldn't find anything related :)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
