### PR TITLE
bisync: skip TestBisyncConcurrent on non-local

### DIFF
--- a/cmd/bisync/bisync_test.go
+++ b/cmd/bisync/bisync_test.go
@@ -281,6 +281,9 @@ func TestBisyncRemoteRemote(t *testing.T) {
 
 // make sure rc can cope with running concurrent jobs
 func TestBisyncConcurrent(t *testing.T) {
+	if !isLocal(*fstest.RemoteName) {
+		t.Skip("TestBisyncConcurrent is skipped on non-local")
+	}
 	oldArgTestCase := argTestCase
 	*argTestCase = "basic"
 	*ignoreLogs = true // not useful to compare logs here because both runs will be logging at once
@@ -596,11 +599,15 @@ func (b *bisyncTest) runTestCase(ctx context.Context, t *testing.T, testCase str
 	}
 }
 
+func isLocal(remote string) bool {
+	return bilib.IsLocalPath(remote) && !strings.HasPrefix(remote, ":") && !strings.Contains(remote, ",")
+}
+
 // makeTempRemote creates temporary folder and makes a filesystem
 // if a local path is provided, it's ignored (the test will run under system temp)
 func (b *bisyncTest) makeTempRemote(ctx context.Context, remote, subdir string) (f, parent fs.Fs, path, canon string) {
 	var err error
-	if bilib.IsLocalPath(remote) && !strings.HasPrefix(remote, ":") && !strings.Contains(remote, ",") {
+	if isLocal(remote) {
 		if remote != "" && !strings.HasPrefix(remote, "local") && *fstest.RemoteName != "" {
 			b.t.Fatalf(`Missing ":" in remote %q. Use "local" to test with local filesystem.`, remote)
 		}


### PR DESCRIPTION
#### What is the purpose of this change?

skips `TestBisyncConcurrent` on non-local.

#### Was the change discussed in an issue or in the forum before?

- https://github.com/rclone/rclone/pull/8708#discussion_r2280308808

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
