### PR TITLE
FAQ: specify the availability of SSL_CERT_* env vars

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -185,7 +185,7 @@ ntpclient -s -h pool.ntp.org
 
 The two environment variables `SSL_CERT_FILE` and `SSL_CERT_DIR`, mentioned in
 the [x509 package](https://godoc.org/crypto/x509), provide an additional way to
-provide the SSL root certificates.
+provide the SSL root certificates on Unix systems other than macOS.
 
 Note that you may need to add the `--insecure` option to the `curl` command line
 if it doesn't work without.


### PR DESCRIPTION
#### What is the purpose of this change?

Make the FAQ entry about `SSL_CERT_FILE` and `SSL_CERT_DIR` env vars more clear.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/pull/1977#issuecomment-3201961570

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
