### PR TITLE
lib/mmap: using unsafe.Slice

### DIFF
--- a/lib/mmap/mmap_windows.go
+++ b/lib/mmap/mmap_windows.go
@@ -7,7 +7,6 @@ package mmap
 
 import (
 	"fmt"
-	"reflect"
 	"unsafe"
 
 	"golang.org/x/sys/windows"
@@ -21,21 +20,10 @@ func Alloc(size int) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("mmap: failed to allocate memory for buffer: %w", err)
 	}
-	// SliceHeader is deprecated...
-	var mem []byte
-	sh := (*reflect.SliceHeader)(unsafe.Pointer(&mem)) // nolint:staticcheck
-	sh.Data = p
-	sh.Len = size
-	sh.Cap = size
-	return mem, nil
-	// ...However the correct code gives a go vet warning
-	// "possible misuse of unsafe.Pointer"
-	//
-	// Maybe there is a different way of writing this, but none of
-	// the allowed uses of unsafe.Pointer seemed to cover it other
-	// than using SliceHeader (use 6 of unsafe.Pointer).
-	//
-	// return unsafe.Slice((*byte)(unsafe.Pointer(p)), size), nil
+
+	pp := unsafe.Pointer(&p)
+	up := *(*unsafe.Pointer)(pp)
+	return unsafe.Slice((*byte)(up), size), nil
 }
 
 // Free frees buffers allocated by Alloc.  Note it should be passed


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
refactor to use unsafe.Slice

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
