### PR TITLE
Fix authentication error when using --baseurl

### DIFF
--- a/cmd/serve/s3/server.go
+++ b/cmd/serve/s3/server.go
@@ -79,6 +79,7 @@ func newServer(ctx context.Context, f fs.Fs, opt *Options, vfsOpt *vfscommon.Opt
 		gofakes3.WithoutVersioning(),
 		gofakes3.WithV4Auth(authlistResolver(opt.AuthKey)),
 		gofakes3.WithIntegrityCheck(true), // Check Content-MD5 if supplied
+		gofakes3.WithBaseURL(opt.HTTP.BaseURL),
 	)
 
 	w.handler = w.faker.Server()


### PR DESCRIPTION
#### What is the purpose of this change?

Fix the authentication error that happens when you use the **--baseurl** flag (with **rclone serve s3**)

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/serve-s3-signaturedoesnotmatch-error-when-using-baseurl/52325

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
