### PR TITLE
Docs: Clarify subcommand description in rclone docs

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -103,7 +103,7 @@ Its syntax is like this
 rclone subcommand [options] <parameters> <parameters...>
 ```
 
-A `subcommand` is a the rclone operation required, (e.g. `sync`,
+A `subcommand` is an rclone operation required (e.g. `sync`,
 `copy`, `ls`).
 
 An `option` is a single letter flag (e.g. `-v`) or a group of single


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This PR fixes a minor grammar issue in the rclone subcommand documentation.  
The original sentence used a double article:

"A subcommand is a the rclone operation required (e.g. sync, copy, ls)."

I found the "a the" combination a bit jarring while reading, so it has been corrected to:

"A subcommand is an rclone operation required (e.g. sync, copy, ls)."

This improves clarity and readability for users without changing the meaning.

#### Was the change discussed in an issue or in the forum before?

No, this is a small documentation correction.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
