### PR TITLE
vfs: fix SIGHUP killing serve instead of flushing directory caches

### DIFF
--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -403,27 +403,7 @@ func (m *MountPoint) Wait() error {
 	fnHandle := atexit.Register(finalise)
 	defer atexit.Unregister(fnHandle)
 
-	// Reload VFS cache on SIGHUP
-	sigHup := make(chan os.Signal, 1)
-	NotifyOnSigHup(sigHup)
-	var err error
-
-	waiting := true
-	for waiting {
-		select {
-		// umount triggered outside the app
-		case err = <-m.ErrChan:
-			waiting = false
-		// user sent SIGHUP to clear the cache
-		case <-sigHup:
-			root, err := m.VFS.Root()
-			if err != nil {
-				fs.Errorf(m.VFS.Fs(), "Error reading root: %v", err)
-			} else {
-				root.ForgetAll()
-			}
-		}
-	}
+	err := <-m.ErrChan
 
 	finalise()
 

--- a/cmd/serve/docker/driver.go
+++ b/cmd/serve/docker/driver.go
@@ -76,7 +76,6 @@ func NewDriver(ctx context.Context, root string, mntOpt *mountlib.Options, vfsOp
 	// start mount monitoring
 	drv.hupChan = make(chan os.Signal, 1)
 	drv.monChan = make(chan bool, 1)
-	mountlib.NotifyOnSigHup(drv.hupChan)
 	go drv.monitor()
 
 	// unmount all volumes on exit

--- a/vfs/sighup.go
+++ b/vfs/sighup.go
@@ -1,6 +1,6 @@
 //go:build !plan9 && !js
 
-package mountlib
+package vfs
 
 import (
 	"os"

--- a/vfs/sighup_unsupported.go
+++ b/vfs/sighup_unsupported.go
@@ -1,6 +1,6 @@
 //go:build plan9 || js
 
-package mountlib
+package vfs
 
 import (
 	"os"

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -179,6 +179,7 @@ type VFS struct {
 	root        *Dir
 	Opt         vfscommon.Options
 	cache       *vfscache.Cache
+	cancel      context.CancelFunc
 	cancelCache context.CancelFunc
 	usageMu     sync.Mutex
 	usageTime   time.Time
@@ -197,8 +198,10 @@ var (
 // DefaultOpt will be used
 func New(f fs.Fs, opt *vfscommon.Options) *VFS {
 	fsDir := fs.NewDir("", time.Now())
+	ctx, cancel := context.WithCancel(context.Background())
 	vfs := &VFS{
-		f: f,
+		f:      f,
+		cancel: cancel,
 	}
 	vfs.inUse.Store(1)
 
@@ -259,6 +262,9 @@ func New(f fs.Fs, opt *vfscommon.Options) *VFS {
 		go vfs.refresh()
 	}
 
+	// Handle supported signals
+	go vfs.signalHandler(ctx)
+
 	// This can take some time so do it after the Pin
 	vfs.SetCacheMode(vfs.Opt.CacheMode)
 
@@ -271,6 +277,27 @@ func (vfs *VFS) refresh() {
 	err := vfs.root.readDirTree()
 	if err != nil {
 		fs.Errorf(vfs.f, "Error refreshing VFS directory cache: %v", err)
+	}
+}
+
+// Reload VFS cache on SIGHUP
+func (vfs *VFS) signalHandler(ctx context.Context) {
+	sigHup := make(chan os.Signal, 1)
+	NotifyOnSigHup(sigHup)
+
+	waiting := true
+	for waiting {
+		select {
+		case <-ctx.Done():
+			waiting = false
+		case <-sigHup:
+			root, err := vfs.Root()
+			if err != nil {
+				fs.Errorf(vfs.Fs(), "Error reading root: %v", err)
+			} else {
+				root.ForgetAll()
+			}
+		}
 	}
 }
 
@@ -372,6 +399,9 @@ func (vfs *VFS) Shutdown() {
 		close(vfs.pollChan)
 		vfs.pollChan = nil
 	}
+
+	// Cancel any background go routines
+	vfs.cancel()
 }
 
 // CleanUp deletes the contents of the on disk cache


### PR DESCRIPTION
Before, rclone serve would crash when sent a SIGHUP which contradicts the documentation - saying it should flush the directory caches.

Moved signal handling from the mount into the vfs layer, which now handles SIGHUP on all uses of the VFS including mount and serve.

Fixes #8607


#### Checklist

- [ x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ x] I'm done, this Pull Request is ready for review :-)
