### PR TITLE
gendocs: ignore missing rclone_mount.md, rclone_nfsmount.md, rclone_serve_nfs.md on windows

### DIFF
--- a/cmd/gendocs/gendocs.go
+++ b/cmd/gendocs/gendocs.go
@@ -170,17 +170,18 @@ rclone.org website.`,
 				name := filepath.Base(path)
 				cmd, ok := commands[name]
 				if !ok {
-					switch runtime.GOOS {
-					case "darwin":
-						if name == "rclone_mount.md" {
-							return nil // won't exist without -tags cmount
+					switch name {
+					case "rclone_mount.md":
+						switch runtime.GOOS {
+						case "darwin", "windows":
+							fs.Logf(nil, "Skipping docs for command not available without the cmount build tag: %v", name)
+							return nil
 						}
-					case "windows":
-						switch name {
-						case "rclone_mount.md":
-							return nil // won't exist without -tags cmount
-						case "rclone_nfsmount.md", "rclone_serve_nfs.md":
-							return nil // not supported
+					case "rclone_nfsmount.md", "rclone_serve_nfs.md":
+						switch runtime.GOOS {
+						case "windows":
+							fs.Logf(nil, "Skipping docs for command not supported on %v: %v", runtime.GOOS, name)
+							return nil
 						}
 					}
 					return fmt.Errorf("didn't find command for %q", name)


### PR DESCRIPTION

#### What is the purpose of this change?

Following in the steps of recent https://github.com/rclone/rclone/commit/7f5a44435028851315bdde7e03eb0726c010bb82; ignore errors when running gendocs on Windows as a result of missing .md files due to missing build flag or unsupported os.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
