### PR TITLE
bisync: fix error handling for renamed conflicts

### DIFF
--- a/cmd/bisync/listing.go
+++ b/cmd/bisync/listing.go
@@ -434,7 +434,6 @@ func (b *bisyncRun) listDirsOnly(listingNum int) (*fileList, error) {
 	}
 
 	fulllisting, err = b.loadListingNum(listingNum)
-
 	if err != nil {
 		b.critical = true
 		b.retryable = true
@@ -610,6 +609,11 @@ func (b *bisyncRun) modifyListing(ctx context.Context, src fs.Fs, dst fs.Fs, res
 				}
 			}
 			if srcNewName != "" { // if it was renamed and not deleted
+				if new == nil { // should not happen. log error and debug info
+					b.handleErr(b.renames, "internal error", fmt.Errorf("missing info for %q. Please report a bug at https://github.com/rclone/rclone/issues", srcNewName), true, true)
+					fs.PrettyPrint(srcList, "srcList for debugging", fs.LogLevelNotice)
+					continue
+				}
 				srcList.put(srcNewName, new.size, new.time, new.hash, new.id, new.flags)
 				dstList.put(srcNewName, new.size, new.time, new.hash, new.id, new.flags)
 			}


### PR DESCRIPTION
#### What is the purpose of this change?

Before this change, rclone could crash during `modifyListing` if a rename's `srcNewName` is known but not found in the `srcList` (`srcNewName != "" && new == nil`). This scenario should not happen, but if it does, we should print an error instead of crashing.

On #8458 there is a report of this possibly happening on `v1.68.2`. It is unknown what the underlying issue was, and whether it still exists in the latest version, but if it does, the user will now see an error and debug info instead of a crash.

#### Was the change discussed in an issue or in the forum before?

- #8458

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
