### PR TITLE
pool: fix flaky unreliability test

### DIFF
--- a/lib/pool/pool_test.go
+++ b/lib/pool/pool_test.go
@@ -16,23 +16,21 @@ import (
 
 // makes the allocations be unreliable
 func makeUnreliable(bp *Pool) {
-	const maxFailsInARow = 10
-	var allocFails int
+	var allocCount int
+	tests := rand.Intn(4) + 1
 	bp.alloc = func(size int) ([]byte, error) {
-		if rand.Intn(3) != 0 && allocFails < maxFailsInARow {
-			allocFails++
+		allocCount++
+		if allocCount%tests != 0 {
 			return nil, errors.New("failed to allocate memory")
 		}
-		allocFails = 0
 		return make([]byte, size), nil
 	}
-	var freeFails int
+	var freeCount int
 	bp.free = func(b []byte) error {
-		if rand.Intn(3) != 0 && freeFails < maxFailsInARow {
-			freeFails++
+		freeCount++
+		if freeCount%tests != 0 {
 			return errors.New("failed to free memory")
 		}
-		freeFails = 0
 		return nil
 	}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Sometimes the pool integration tests would fail due to how it used random numbers. 

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
