### PR TITLE
backend: add region option in iCloud Drive to fix #8257

### DIFF
--- a/backend/iclouddrive/api/client.go
+++ b/backend/iclouddrive/api/client.go
@@ -15,12 +15,20 @@ import (
 	"github.com/rclone/rclone/lib/rest"
 )
 
-const (
+var (
 	baseEndpoint  = "https://www.icloud.com"
 	homeEndpoint  = "https://www.icloud.com"
 	setupEndpoint = "https://setup.icloud.com/setup/ws/1"
 	authEndpoint  = "https://idmsa.apple.com/appleauth/auth"
 )
+
+// UseChinaMainlandEndpoints switches API endpoints to China Mainland (GCBD) domains.
+func UseChinaMainlandEndpoints() {
+	baseEndpoint = "https://www.icloud.com.cn"
+	homeEndpoint = "https://www.icloud.com.cn"
+	setupEndpoint = "https://setup.icloud.com.cn/setup/ws/1"
+	authEndpoint = "https://idmsa.apple.com.cn/appleauth/auth"
+}
 
 type sessionSave func(*Session)
 

--- a/docs/content/iclouddrive.md
+++ b/docs/content/iclouddrive.md
@@ -43,6 +43,15 @@ XX / iCloud Drive
    \ (iclouddrive)
 [snip]
 Storage> iclouddrive
+Option region.
+Region for iCloud endpoints.
+Choose a number from below, or type in an existing value of type string.
+Press Enter for the default (global).
+ 1 / Global (default)
+   \ (global)
+ 2 / China Mainland
+   \ (chinamainland)
+region> 1
 Option apple_id.
 Apple ID.
 Enter a value.
@@ -69,6 +78,7 @@ Remote config
 --------------------
 [iclouddrive]
 - type: iclouddrive
+- region: global
 - apple_id: APPLEID
 - password: *** ENCRYPTED ***
 - cookies: ****************************
@@ -109,6 +119,19 @@ functions properly.
 ### Standard options
 
 Here are the Standard options specific to iclouddrive (iCloud Drive).
+
+#### --iclouddrive-region
+
+Region for iCloud endpoints.
+
+If your Apple ID is based in mainland China, set region to "China Mainland" during configuration. This switches iCloud endpoints to `.com.cn` (GCBD) domains and avoids redirects error.
+
+Properties:
+
+- Config:      region
+- Env Var:     RCLONE_ICLOUDDRIVE_REGION
+- Type:        string
+- Required:    true
 
 #### --iclouddrive-apple-id
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The purpose of this change is to officially add support for iCloud Drive accounts in Mainland China (GCBD) to rclone’s iCloud Drive backend.

Previously, rclone’s iCloud Drive integration only hardcoded URLs for global iCloud servers (e.g., https://www.icloud.com), which caused fatal HTTP 302 errors when users with Mainland China Apple IDs attempted to connect—since Mainland China iCloud relies on independent .cn-suffixed servers (e.g., https://www.icloud.com.cn).

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

Fixes #8257 

As discussed in Issue, given the maintainer’s limited environment, I followed the instruction to add a new region option for iCloud Drive and test it. This option now works for users in Mainland China, and the relevant logs are attached below.

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
