### PR TITLE
serve: fix sort order of dir entries when using `name`, `namedirfirst` modes

### DIFF
--- a/lib/http/serve/dir_test.go
+++ b/lib/http/serve/dir_test.go
@@ -124,3 +124,102 @@ func TestServe(t *testing.T) {
 </html>
 `, string(body))
 }
+
+func TestDirectory_ProcessQueryParams(t *testing.T) {
+	newDate := func(day int) time.Time {
+		return time.Date(2025, time.September, day, 0, 0, 0, 0, time.UTC)
+	}
+
+	dir := Directory{
+		Entries: []DirEntry{
+			{Leaf: "a/", IsDir: true, ModTime: newDate(1), Size: 0},
+			{Leaf: "test/", IsDir: true, ModTime: newDate(2), Size: 0},
+			{Leaf: "test 1/", IsDir: true, ModTime: newDate(3), Size: 0},
+			{Leaf: "hello.jpg", ModTime: newDate(1), Size: 1253028},
+			{Leaf: "report 1.txt", ModTime: newDate(3), Size: 1000},
+			{Leaf: "report 2.txt", ModTime: newDate(2), Size: 2000},
+			{Leaf: "report 12.txt", ModTime: newDate(3), Size: 1500},
+			{Leaf: "x.png", ModTime: newDate(3), Size: 1363148},
+			{Leaf: "X.jpeg", ModTime: newDate(10), Size: 454382},
+		},
+	}
+
+	assertEntriesOrder := func(wantLeafs ...string) {
+		leafs := make([]string, 0, len(dir.Entries))
+		for _, e := range dir.Entries {
+			leafs = append(leafs, e.Leaf)
+		}
+		assert.Equal(t, wantLeafs, leafs)
+	}
+
+	// Sort by name
+	dir.ProcessQueryParams(sortByName, "asc")
+	assertEntriesOrder(
+		"a/",
+		"hello.jpg",
+		"report 1.txt",
+		"report 12.txt",
+		"report 2.txt",
+		"test/",
+		"test 1/",
+		"X.jpeg",
+		"x.png",
+	)
+
+	// Sort by name, dirs first (should be the default order)
+	for _, order := range []string{"", sortByNameDirFirst, "qwerty"} {
+		dir.ProcessQueryParams(order, "asc")
+		assertEntriesOrder(
+			"a/",
+			"test/",
+			"test 1/",
+			"hello.jpg",
+			"report 1.txt",
+			"report 12.txt",
+			"report 2.txt",
+			"X.jpeg",
+			"x.png",
+		)
+	}
+	//
+	dir.ProcessQueryParams(sortByNameDirFirst, "desc")
+	assertEntriesOrder(
+		"x.png",
+		"X.jpeg",
+		"report 2.txt",
+		"report 12.txt",
+		"report 1.txt",
+		"hello.jpg",
+		"test 1/",
+		"test/",
+		"a/",
+	)
+
+	// Sort by size
+	dir.ProcessQueryParams(sortBySize, "desc")
+	assertEntriesOrder(
+		"x.png",
+		"hello.jpg",
+		"X.jpeg",
+		"report 2.txt",
+		"report 12.txt",
+		"report 1.txt",
+		"test 1/",
+		"test/",
+		"a/",
+	)
+
+	// Sort by mod time
+	dir.ProcessQueryParams(sortByTime, "asc")
+	assertEntriesOrder(
+		"a/",            // 2025-09-01
+		"hello.jpg",     // 2025-09-01
+		"test/",         // 2025-09-02
+		"report 2.txt",  // 2025-09-02
+		"test 1/",       // 2025-09-03
+		"report 1.txt",  // 2025-09-03
+		"report 12.txt", // 2025-09-03
+		"x.png",         // 2025-09-03
+		"X.jpeg",        // 2025-09-10
+	)
+}


### PR DESCRIPTION
Ignore trailing `/` when sorting dir entries by name. This change
fixes order of directories with names like `Test/` `Test 1/`:

- current order: `Test 1/`, `Test/` (`' '` < `'/'`)
- new order: `Test/`, `Test 1/` (`/` is ignored)

Also migrate from `sort.Sort` to more performant and modern `slices.SortFunc`.
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
