### PR TITLE
Report disk usage in segment containers

### DIFF
--- a/backend/swift/swift.go
+++ b/backend/swift/swift.go
@@ -927,6 +927,20 @@ func (f *Fs) About(ctx context.Context) (usage *fs.Usage, err error) {
 		used = container.Bytes
 		objects = container.Count
 		total = container.QuotaBytes
+
+		if f.opt.UseSegmentsContainer.Value {
+			err = f.pacer.Call(func() (bool, error) {
+				segmentsContainer := f.rootContainer + segmentsContainerSuffix
+				container, _, err = f.c.Container(ctx, segmentsContainer)
+				return shouldRetry(ctx, err)
+			})
+			if err != nil && err != swift.ContainerNotFound {
+				return nil, fmt.Errorf("container info failed: %w", err)
+			}
+			if err == nil {
+				used += container.Bytes
+			}
+		}
 	} else {
 		var containers []swift.Container
 		err = f.pacer.Call(func() (bool, error) {

--- a/backend/swift/swift_test.go
+++ b/backend/swift/swift_test.go
@@ -56,6 +56,11 @@ func (f *Fs) testNoChunk(t *testing.T) {
 	uploadHash := hash.NewMultiHasher()
 	in := io.TeeReader(buf, uploadHash)
 
+	// Track how much space is used before we put our object.
+	usage, err := f.About(ctx)
+	require.NoError(t, err)
+	usedBeforePut := *usage.Used
+
 	file.Size = -1
 	obji := object.NewStaticObjectInfo(file.Path, file.ModTime, file.Size, true, nil, nil)
 	obj, err := f.Features().PutStream(ctx, in, obji)
@@ -69,6 +74,13 @@ func (f *Fs) testNoChunk(t *testing.T) {
 	obj, err = f.NewObject(ctx, file.Path)
 	require.NoError(t, err)
 	file.Check(t, obj, f.Precision())
+
+	// Check how much space is used after the upload, should match the amount we
+	// uploaded..
+	usage, err = f.About(ctx)
+	require.NoError(t, err)
+	expectedUsed := usedBeforePut + obj.Size()
+	require.EqualValues(t, expectedUsed, *usage.Used)
 
 	// Delete the object
 	assert.NoError(t, obj.Remove(ctx))
@@ -104,12 +116,24 @@ func (f *Fs) testWithChunk(t *testing.T) {
 	uploadHash := hash.NewMultiHasher()
 	in := io.TeeReader(buf, uploadHash)
 
+	// Track how much space is used before we put our object.
+	ctx := context.TODO()
+	usage, err := f.About(ctx)
+	require.NoError(t, err)
+	usedBeforePut := *usage.Used
+
 	file.Size = -1
 	obji := object.NewStaticObjectInfo(file.Path, file.ModTime, file.Size, true, nil, nil)
-	ctx := context.TODO()
 	obj, err := f.Features().PutStream(ctx, in, obji)
 	require.NoError(t, err)
 	require.NotEmpty(t, obj)
+
+	// Check how much space is used after the upload, should match the amount we
+	// uploaded..
+	usage, err = f.About(ctx)
+	require.NoError(t, err)
+	expectedUsed := usedBeforePut + obj.Size()
+	require.EqualValues(t, expectedUsed, *usage.Used)
 }
 
 func (f *Fs) testWithChunkFail(t *testing.T) {
@@ -182,9 +206,14 @@ func (f *Fs) testCopyLargeObject(t *testing.T) {
 	uploadHash := hash.NewMultiHasher()
 	in := io.TeeReader(buf, uploadHash)
 
+	// Track how much space is used before we put our object.
+	ctx := context.TODO()
+	usage, err := f.About(ctx)
+	require.NoError(t, err)
+	usedBeforePut := *usage.Used
+
 	file.Size = -1
 	obji := object.NewStaticObjectInfo(file.Path, file.ModTime, file.Size, true, nil, nil)
-	ctx := context.TODO()
 	obj, err := f.Features().PutStream(ctx, in, obji)
 	require.NoError(t, err)
 	require.NotEmpty(t, obj)
@@ -193,6 +222,13 @@ func (f *Fs) testCopyLargeObject(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, objTarget)
 	require.Equal(t, obj.Size(), objTarget.Size())
+
+	// Check how much space is used after the upload, should match the amount we
+	// uploaded *and* the copy.
+	usage, err = f.About(ctx)
+	require.NoError(t, err)
+	expectedUsed := usedBeforePut + obj.Size() + objTarget.Size()
+	require.EqualValues(t, expectedUsed, *usage.Used)
 }
 
 var _ fstests.InternalTester = (*Fs)(nil)


### PR DESCRIPTION
Large objects are split and stored in a _segments container in Swift. These should be included when reporting on the space used.

Fixes: #8857 

I've tried to run the tests that use SwiftAIO, but rclone just tells me it can't find the remotes in the config, and I can't see how to fix...

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
