### PR TITLE
swift: If storage_policy isn't set, use the root containers policy

### DIFF
--- a/backend/swift/swift.go
+++ b/backend/swift/swift.go
@@ -561,6 +561,21 @@ func (f *Fs) setRoot(root string) {
 	f.rootContainer, f.rootDirectory = bucket.Split(f.root)
 }
 
+// Fetch the base container's policy to be used if/when we need to create a
+// segments container to ensure we use the same policy.
+func (f *Fs) fetchStoragePolicy(ctx context.Context, container string) (fs.Fs, error) {
+	err := f.pacer.Call(func() (bool, error) {
+		var rxHeaders swift.Headers
+		_, rxHeaders, err := f.c.Container(ctx, container)
+
+		f.opt.StoragePolicy = rxHeaders["X-Storage-Policy"]
+		fs.Debugf(f, "Auto set StoragePolicy to %s", f.opt.StoragePolicy)
+
+		return shouldRetryHeaders(ctx, rxHeaders, err)
+	})
+	return nil, err
+}
+
 // NewFsWithConnection constructs an Fs from the path, container:path
 // and authenticated connection.
 //
@@ -590,6 +605,7 @@ func NewFsWithConnection(ctx context.Context, opt *Options, name, root string, c
 		f.opt.UseSegmentsContainer.Valid = true
 		fs.Debugf(f, "Auto set use_segments_container to %v", f.opt.UseSegmentsContainer.Value)
 	}
+
 	if f.rootContainer != "" && f.rootDirectory != "" {
 		// Check to see if the object exists - ignoring directory markers
 		var info swift.Object
@@ -1132,6 +1148,13 @@ func (f *Fs) newSegmentedUpload(ctx context.Context, dstContainer string, dstPat
 		container:    dstContainer,
 	}
 	if f.opt.UseSegmentsContainer.Value {
+		if f.opt.StoragePolicy == "" {
+			_, err = f.fetchStoragePolicy(ctx, dstContainer)
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		su.container += segmentsContainerSuffix
 		err = f.makeContainer(ctx, su.container)
 		if err != nil {

--- a/backend/swift/swift_test.go
+++ b/backend/swift/swift_test.go
@@ -76,6 +76,7 @@ func (f *Fs) testNoChunk(t *testing.T) {
 
 // Additional tests that aren't in the framework
 func (f *Fs) InternalTest(t *testing.T) {
+	t.Run("PolicyDiscovery", f.testPolicyDiscovery)
 	t.Run("NoChunk", f.testNoChunk)
 	t.Run("WithChunk", f.testWithChunk)
 	t.Run("WithChunkFail", f.testWithChunkFail)
@@ -193,6 +194,52 @@ func (f *Fs) testCopyLargeObject(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, objTarget)
 	require.Equal(t, obj.Size(), objTarget.Size())
+}
+
+func (f *Fs) testPolicyDiscovery(t *testing.T) {
+	ctx := context.TODO()
+	container := "testPolicyDiscovery-1"
+	// Reset the policy so we can test if it is populated.
+	f.opt.StoragePolicy = ""
+	err := f.makeContainer(ctx, container)
+	require.NoError(t, err)
+	_, err = f.fetchStoragePolicy(ctx, container)
+	require.NoError(t, err)
+
+	// Default policy for Swift is Policy-0.
+	assert.Equal(t, "Policy-0", f.opt.StoragePolicy)
+
+	// Create a container using a non-default policy, and check to ensure
+	// that the created segments container uses the same non-default policy.
+	policy := "Policy-1"
+	container = "testPolicyDiscovery-2"
+
+	f.opt.StoragePolicy = policy
+	err = f.makeContainer(ctx, container)
+	require.NoError(t, err)
+
+	// Reset the policy so we can test if it is populated, and set to the
+	// non-default policy.
+	f.opt.StoragePolicy = ""
+	_, err = f.fetchStoragePolicy(ctx, container)
+	require.NoError(t, err)
+	assert.Equal(t, policy, f.opt.StoragePolicy)
+
+	// Test that when a segmented upload container is made, the newly
+	// created container inherits the non-default policy of the base
+	// container.
+	f.opt.StoragePolicy = ""
+	f.opt.UseSegmentsContainer.Value = true
+	su, err := f.newSegmentedUpload(ctx, container, "")
+	require.NoError(t, err)
+	// The container name we expected?
+	segmentsContainer := container + segmentsContainerSuffix
+	assert.Equal(t, segmentsContainer, su.container)
+	// The policy we expected?
+	f.opt.StoragePolicy = ""
+	_, err = f.fetchStoragePolicy(ctx, su.container)
+	require.NoError(t, err)
+	assert.Equal(t, policy, f.opt.StoragePolicy)
 }
 
 var _ fstests.InternalTester = (*Fs)(nil)

--- a/backend/swift/swift_test.go
+++ b/backend/swift/swift_test.go
@@ -206,8 +206,8 @@ func (f *Fs) testPolicyDiscovery(t *testing.T) {
 	_, err = f.fetchStoragePolicy(ctx, container)
 	require.NoError(t, err)
 
-	// Default policy for Swift is Policy-0.
-	assert.Equal(t, "Policy-0", f.opt.StoragePolicy)
+	// Default policy for SAIO image is 1replica.
+	assert.Equal(t, "1replica", f.opt.StoragePolicy)
 
 	// Create a container using a non-default policy, and check to ensure
 	// that the created segments container uses the same non-default policy.

--- a/fstest/testserver/init.d/TestSwiftAIO
+++ b/fstest/testserver/init.d/TestSwiftAIO
@@ -11,8 +11,8 @@ start() {
     # We need to replace the remakerings in the container to create Policy-1.
     docker run --rm -d --name ${NAME} \
            -p 127.0.0.1:${PORT}:8080 \
-	   -v $(dirname "$0")/TestSwiftAIO.d/remakerings:/swift/bin/remakerings:ro \
-           bouncestorage/swift-aio
+	   -v $(dirname "$0")/TestSwiftAIO.d/remakerings:/etc/swift/remakerings:ro \
+           openstackswift/saio
 
     echo type=swift
     echo env_auth=false

--- a/fstest/testserver/init.d/TestSwiftAIO
+++ b/fstest/testserver/init.d/TestSwiftAIO
@@ -8,10 +8,12 @@ PORT=28628
 . $(dirname "$0")/docker.bash
 
 start() {
+    # We need to replace the remakerings in the container to create Policy-1.
     docker run --rm -d --name ${NAME} \
            -p 127.0.0.1:${PORT}:8080 \
+	   -v $(dirname "$0")/TestSwiftAIO.d/remakerings:/swift/bin/remakerings:ro \
            bouncestorage/swift-aio
-    
+
     echo type=swift
     echo env_auth=false
     echo user=test:tester

--- a/fstest/testserver/init.d/TestSwiftAIO.d/remakerings
+++ b/fstest/testserver/init.d/TestSwiftAIO.d/remakerings
@@ -1,14 +1,7 @@
-#!/bin/bash
+#!/bin/sh
 
-cd /etc/swift
-
-if ! grep storage-policy swift.conf; then
+if ! grep -q "^\[storage-policy:1\]" swift.conf; then
     cat <<EOF >> swift.conf
-
-# Policy-0 is the default, we need two policies to test policy inheritance.
-[storage-policy:0]
-name = Policy-0
-default = true
 
 [storage-policy:1]
 name = Policy-1
@@ -18,16 +11,36 @@ fi
 rm -f *.builder *.ring.gz backups/*.builder backups/*.ring.gz
 
 swift-ring-builder object.builder create 10 1 1
-swift-ring-builder object.builder add r1z1-127.0.0.1:6010/sdb1 1
+swift-ring-builder object.builder add r1z1-127.0.0.1:6200/swift-d0 1
+swift-ring-builder object.builder add r1z1-127.0.0.1:6200/swift-d1 1
+swift-ring-builder object.builder add r1z1-127.0.0.1:6200/swift-d2 1
+swift-ring-builder object.builder add r1z1-127.0.0.1:6200/swift-d3 1
+swift-ring-builder object.builder add r1z1-127.0.0.1:6200/swift-d4 1
+swift-ring-builder object.builder add r1z1-127.0.0.1:6200/swift-d5 1
 swift-ring-builder object.builder rebalance
 swift-ring-builder container.builder create 10 1 1
-swift-ring-builder container.builder add r1z1-127.0.0.1:6011/sdb1 1
+swift-ring-builder container.builder add r1z1-127.0.0.1:6201/swift-d0 1
+swift-ring-builder container.builder add r1z1-127.0.0.1:6201/swift-d1 1
+swift-ring-builder container.builder add r1z1-127.0.0.1:6201/swift-d2 1
+swift-ring-builder container.builder add r1z1-127.0.0.1:6201/swift-d3 1
+swift-ring-builder container.builder add r1z1-127.0.0.1:6201/swift-d4 1
+swift-ring-builder container.builder add r1z1-127.0.0.1:6201/swift-d5 1
 swift-ring-builder container.builder rebalance
 swift-ring-builder account.builder create 10 1 1
-swift-ring-builder account.builder add r1z1-127.0.0.1:6012/sdb1 1
+swift-ring-builder account.builder add r1z1-127.0.0.1:6202/swift-d0 1
+swift-ring-builder account.builder add r1z1-127.0.0.1:6202/swift-d1 1
+swift-ring-builder account.builder add r1z1-127.0.0.1:6202/swift-d2 1
+swift-ring-builder account.builder add r1z1-127.0.0.1:6202/swift-d3 1
+swift-ring-builder account.builder add r1z1-127.0.0.1:6202/swift-d4 1
+swift-ring-builder account.builder add r1z1-127.0.0.1:6202/swift-d5 1
 swift-ring-builder account.builder rebalance
 
 # For Policy-1:
 swift-ring-builder object-1.builder create 10 1 1
-swift-ring-builder object-1.builder add r1z1-127.0.0.1:6010/sdb1 1
+swift-ring-builder object-1.builder add r1z1-127.0.0.1:6200/swift-d0 1
+swift-ring-builder object-1.builder add r1z1-127.0.0.1:6200/swift-d1 1
+swift-ring-builder object-1.builder add r1z1-127.0.0.1:6200/swift-d2 1
+swift-ring-builder object-1.builder add r1z1-127.0.0.1:6200/swift-d3 1
+swift-ring-builder object-1.builder add r1z1-127.0.0.1:6200/swift-d4 1
+swift-ring-builder object-1.builder add r1z1-127.0.0.1:6200/swift-d5 1
 swift-ring-builder object-1.builder rebalance

--- a/fstest/testserver/init.d/TestSwiftAIO.d/remakerings
+++ b/fstest/testserver/init.d/TestSwiftAIO.d/remakerings
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+cd /etc/swift
+
+if ! grep storage-policy swift.conf; then
+    cat <<EOF >> swift.conf
+
+# Policy-0 is the default, we need two policies to test policy inheritance.
+[storage-policy:0]
+name = Policy-0
+default = true
+
+[storage-policy:1]
+name = Policy-1
+EOF
+fi
+
+rm -f *.builder *.ring.gz backups/*.builder backups/*.ring.gz
+
+swift-ring-builder object.builder create 10 1 1
+swift-ring-builder object.builder add r1z1-127.0.0.1:6010/sdb1 1
+swift-ring-builder object.builder rebalance
+swift-ring-builder container.builder create 10 1 1
+swift-ring-builder container.builder add r1z1-127.0.0.1:6011/sdb1 1
+swift-ring-builder container.builder rebalance
+swift-ring-builder account.builder create 10 1 1
+swift-ring-builder account.builder add r1z1-127.0.0.1:6012/sdb1 1
+swift-ring-builder account.builder rebalance
+
+# For Policy-1:
+swift-ring-builder object-1.builder create 10 1 1
+swift-ring-builder object-1.builder add r1z1-127.0.0.1:6010/sdb1 1
+swift-ring-builder object-1.builder rebalance

--- a/fstest/testserver/init.d/TestSwiftAIOsegments
+++ b/fstest/testserver/init.d/TestSwiftAIOsegments
@@ -8,9 +8,11 @@ PORT=28632
 . $(dirname "$0")/docker.bash
 
 start() {
+    # We need to replace the remakerings in the container to create Policy-1.
     docker run --rm -d --name ${NAME} \
            -p 127.0.0.1:${PORT}:8080 \
-           bouncestorage/swift-aio
+	   -v $(dirname "$0")/TestSwiftAIO.d/remakerings:/etc/swift/remakerings:ro \
+           openstackswift/saio
     
     echo type=swift
     echo env_auth=false

--- a/fstest/testserver/testserver.go
+++ b/fstest/testserver/testserver.go
@@ -175,7 +175,16 @@ func Start(remoteName string) (fn func(), err error) {
 	if running[name] <= 0 {
 		// if server isn't running check to see if this server has
 		// been started already but not by us and stop it if so
-		if os.Getenv(envKey(name, "type")) == "" && isRunning(name) {
+		const maxTries = 10
+		for i := 1; i <= maxTries; i++ {
+			if os.Getenv(envKey(name, "type")) == "" && !isRunning(name) {
+				fs.Logf(name, "Stopped server")
+				break
+			}
+			if i != 1 {
+				time.Sleep(time.Second)
+				fs.Logf(name, "Attempting to stop %s try %d/%d", name, i, maxTries)
+			}
 			stop(name)
 		}
 		if !isRunning(name) {
@@ -211,6 +220,6 @@ func stop(name string) {
 			fs.Errorf(name, "Failed to stop server: %v", err)
 		}
 		running[name] = 0
-		fs.Logf(name, "Stopped server")
+		fs.Logf(name, "Stopping server")
 	}
 }

--- a/fstest/testserver/testserver.go
+++ b/fstest/testserver/testserver.go
@@ -110,7 +110,7 @@ func start(name string) error {
 		return nil
 	}
 	// If we got a _connect value then try to connect to it
-	const maxTries = 30
+	const maxTries = 100
 	var rdBuf = make([]byte, 1)
 	for i := 1; i <= maxTries; i++ {
 		if i != 0 {


### PR DESCRIPTION
Ensure that if we need to create a segments container it uses the same storage policy as the root container.

Fixes #8858

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
