### PR TITLE
s3: support providing `x-amz-object-lock-*` headers in `--header-upload`

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -6914,6 +6914,17 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 			ui.req.ContentType = aws.String(value)
 		case "x-amz-tagging":
 			ui.req.Tagging = aws.String(value)
+		case "x-amz-object-lock-legal-hold":
+			ui.req.ObjectLockLegalHoldStatus = types.ObjectLockLegalHoldStatus(value)
+		case "x-amz-object-lock-mode":
+			ui.req.ObjectLockMode = types.ObjectLockMode(value)
+		case "x-amz-object-lock-retain-until-date":
+			valueTime, err := time.Parse(time.RFC3339, value)
+			if err == nil {
+				ui.req.ObjectLockRetainUntilDate = aws.Time(valueTime)
+			} else {
+				fs.Errorf(o, "Cannot parse value for key %q as time on upload", key)
+			}
 		default:
 			const amzMetaPrefix = "x-amz-meta-"
 			if strings.HasPrefix(lowerKey, amzMetaPrefix) {


### PR DESCRIPTION
#### What is the purpose of this change?

This adds basic support for the features suggested by #4683. Instead of adding the CLI options, this change at least allows passing the required headers through `--header-upload`. We cannot configure lock settings globally on the bucket, so would need to rely on a tool like rclone to provide this.

I couldn't find any test for `prepareUpload()` and I don't have a lot of Go experience. Do you want any test to cover these new options and would it be possible to get some guidance on how and where to add these if necessary? :)

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/4683#issuecomment-1011109273

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)