### PR TITLE
Remote setup doc improvements

### DIFF
--- a/cmd/authorize/authorize.go
+++ b/cmd/authorize/authorize.go
@@ -23,7 +23,7 @@ func init() {
 }
 
 var commandDefinition = &cobra.Command{
-	Use:   "authorize <fs name> [base64_json_blob | client_id client_secret]",
+	Use:   "authorize <backendname> [base64_json_blob | client_id client_secret]",
 	Short: `Remote authorization.`,
 	Long: `Remote authorization. Used to authorize a remote or headless
 rclone from a machine with a browser - use as instructed by
@@ -31,7 +31,7 @@ rclone config.
 
 The command requires 1-3 arguments:
 
-- fs name (e.g., "drive", "s3", etc.)
+- Name of a backend (e.g. "drive", "s3")
 - Either a base64 encoded JSON blob obtained from a previous rclone config session
 - Or a client_id and client_secret pair obtained from the remote service
 

--- a/cmd/authorize/authorize.go
+++ b/cmd/authorize/authorize.go
@@ -26,8 +26,8 @@ var commandDefinition = &cobra.Command{
 	Use:   "authorize <backendname> [base64_json_blob | client_id client_secret]",
 	Short: `Remote authorization.`,
 	Long: `Remote authorization. Used to authorize a remote or headless
-rclone from a machine with a browser - use as instructed by
-rclone config.
+rclone from a machine with a browser. Use as instructed by rclone config.
+See also the [remote setup documentation](/remote_setup).
 
 The command requires 1-3 arguments:
 

--- a/cmd/authorize/authorize_test.go
+++ b/cmd/authorize/authorize_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestAuthorizeCommand(t *testing.T) {
 	// Test that the Use string is correctly formatted
-	if commandDefinition.Use != "authorize <fs name> [base64_json_blob | client_id client_secret]" {
+	if commandDefinition.Use != "authorize <backendname> [base64_json_blob | client_id client_secret]" {
 		t.Errorf("Command Use string doesn't match expected format: %s", commandDefinition.Use)
 	}
 
@@ -26,7 +26,7 @@ func TestAuthorizeCommand(t *testing.T) {
 	}
 
 	helpOutput := buf.String()
-	if !strings.Contains(helpOutput, "authorize <fs name>") {
+	if !strings.Contains(helpOutput, "authorize <backendname>") {
 		t.Errorf("Help output doesn't contain correct usage information")
 	}
 }

--- a/docs/content/box.md
+++ b/docs/content/box.md
@@ -84,7 +84,7 @@ y/e/d> y
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from Box. This only runs from the moment it opens

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -96,7 +96,7 @@ y/e/d> y
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from Google if using web browser to automatically

--- a/docs/content/dropbox.md
+++ b/docs/content/dropbox.md
@@ -60,7 +60,7 @@ y/e/d> y
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from Dropbox. This only

--- a/docs/content/googlecloudstorage.md
+++ b/docs/content/googlecloudstorage.md
@@ -147,7 +147,7 @@ y/e/d> y
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from Google if using web browser to automatically

--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -97,7 +97,7 @@ y/e/d> y
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from Google if using web browser to automatically

--- a/docs/content/hidrive.md
+++ b/docs/content/hidrive.md
@@ -72,7 +72,7 @@ and hence should not be shared with other persons.**
 See the [below section](#keeping-your-tokens-safe) for more information.
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from HiDrive. This only runs from the moment it opens

--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -100,7 +100,7 @@ y/e/d> y
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from Microsoft. This only runs from the moment it

--- a/docs/content/pcloud.md
+++ b/docs/content/pcloud.md
@@ -71,7 +71,7 @@ y/e/d> y
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note if you are using remote config with rclone authorize while your pcloud
 server is the EU region, you will need to set the hostname in 'Edit advanced

--- a/docs/content/premiumizeme.md
+++ b/docs/content/premiumizeme.md
@@ -65,7 +65,7 @@ y/e/d>
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from premiumize.me. This only runs from the moment it opens

--- a/docs/content/putio.md
+++ b/docs/content/putio.md
@@ -80,7 +80,7 @@ e/n/d/r/c/s/q> q
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from put.io  if using web browser to automatically

--- a/docs/content/remote_setup.md
+++ b/docs/content/remote_setup.md
@@ -6,7 +6,7 @@ description: "Configuring rclone up on a remote / headless machine"
 # Configuring rclone on a remote / headless machine
 
 Some of the configurations (those involving oauth2) require an
-Internet connected web browser.
+internet-connected web browser.
 
 If you are trying to set rclone up on a remote or headless box with no
 browser available on it (e.g. a NAS or a server in a datacenter) then

--- a/docs/content/remote_setup.md
+++ b/docs/content/remote_setup.md
@@ -8,20 +8,21 @@ description: "Configuring rclone up on a remote / headless machine"
 Some of the configurations (those involving oauth2) require an
 internet-connected web browser.
 
-If you are trying to set rclone up on a remote or headless box with no
-browser available on it (e.g. a NAS or a server in a datacenter) then
-you will need to use an alternative means of configuration.  There are
-two ways of doing it, described below.
+If you are trying to set rclone up on a remote or headless machine with no
+browser available on it (e.g. a NAS or a server in a datacenter), then
+you will need to use an alternative means of configuration. There are
+three ways of doing it, described below.
 
 ## Configuring using rclone authorize
 
-On the headless box run `rclone` config but answer `N` to the `Use auto config?`
-question.
+On the headless machine run [rclone config](/commands/rclone_config), but
+answer `N` to the question `Use web browser to automatically authenticate rclone with remote?`.
 
 ```text
-Use auto config?
- * Say Y if not sure
- * Say N if you are working on a remote or headless machine
+Use web browser to automatically authenticate rclone with remote?
+ * Say Y if the machine running rclone has a web browser you can use
+ * Say N if running rclone on a (remote) machine without web browser access
+If not sure try Y. If Y failed, try N.
 
 y) Yes (default)
 n) No
@@ -33,33 +34,35 @@ a web browser available.
 For more help and alternate methods see: https://rclone.org/remote_setup/
 Execute the following on the machine with the web browser (same rclone
 version recommended):
-rclone authorize "onedrive"
+        rclone authorize "onedrive"
 Then paste the result.
 Enter a value.
 config_token>
 ```
 
-Then on your main desktop machine
+Then on your main desktop machine, run [rclone authorize](/commands/rclone_authorize/).
 
 ```text
 rclone authorize "onedrive"
-If your browser doesn't open automatically go to the following link: http://127.0.0.1:53682/auth
-Log in and authorize rclone for access
-Waiting for code...
+NOTICE: Make sure your Redirect URL is set to "http://localhost:53682/" in your custom config.
+NOTICE: If your browser doesn't open automatically go to the following link: http://127.0.0.1:53682/auth?state=xxxxxxxxxxxxxxxxxxxxxx
+NOTICE: Log in and authorize rclone for access
+NOTICE: Waiting for code...
+
 Got code
 Paste the following into your remote machine --->
 SECRET_TOKEN
 <---End paste
 ```
 
-Then back to the headless box, paste in the code
+Then back to the headless machine, paste in the code.
 
 ```text
 config_token> SECRET_TOKEN
 --------------------
 [acd12]
-client_id = 
-client_secret = 
+client_id =
+client_secret =
 token = SECRET_TOKEN
 --------------------
 y) Yes this is OK
@@ -70,18 +73,19 @@ y/e/d>
 
 ## Configuring by copying the config file
 
-Rclone stores all of its config in a single configuration file.  This
-can easily be copied to configure a remote rclone.
+Rclone stores all of its configuration in a single file. This can easily be
+copied to configure a remote rclone (although some backends does not support
+reusing the same configuration, consult your backend documentation to be
+sure).
 
-So first configure rclone on your desktop machine with
+Start by running [rclone config](/commands/rclone_config) to create the
+configuration file on your desktop machine.
 
 ```sh
 rclone config
 ```
 
-to set up the config file.
-
-Find the config file by running `rclone config file`, for example
+Then locate the file by running [rclone config file](/commands/rclone_config_file).
 
 ```sh
 $ rclone config file
@@ -89,31 +93,37 @@ Configuration file is stored at:
 /home/user/.rclone.conf
 ```
 
-Now transfer it to the remote box (scp, cut paste, ftp, sftp, etc.) and
-place it in the correct place (use `rclone config file` on the remote
-box to find out where).
+Finally, transfer the file to the remote machine (scp, cut paste, ftp, sftp, etc.)
+and place it in the correct location (use [rclone config file](/commands/rclone_config_file)
+on the remote machine to find out where).
 
 ## Configuring using SSH Tunnel
 
-Linux and MacOS users can utilize SSH Tunnel to redirect the headless box
-port 53682 to local machine by using the following command:
+If you have an SSH client installed on your local machine, you can set up an
+SSH tunnel to redirect the port 53682 into the headless machine by using the
+following command:
 
 ```sh
 ssh -L localhost:53682:localhost:53682 username@remote_server
 ```
 
-Then on the headless box run `rclone config` and answer `Y` to the
-`Use auto config?` question.
+Then on the headless machine run [rclone config](/commands/rclone_config) and
+answer `Y` to the question `Use web browser to automatically authenticate rclone with remote?`.
 
 ```text
-Use auto config?
- * Say Y if not sure
- * Say N if you are working on a remote or headless machine
+Use web browser to automatically authenticate rclone with remote?
+ * Say Y if the machine running rclone has a web browser you can use
+ * Say N if running rclone on a (remote) machine without web browser access
+If not sure try Y. If Y failed, try N.
 
 y) Yes (default)
 n) No
 y/n> y
+NOTICE: Make sure your Redirect URL is set to "http://localhost:53682/" in your custom config.
+NOTICE: If your browser doesn't open automatically go to the following link: http://127.0.0.1:53682/auth?state=xxxxxxxxxxxxxxxxxxxxxx
+NOTICE: Log in and authorize rclone for access
+NOTICE: Waiting for code...
 ```
 
-Then copy and paste the auth url `http://127.0.0.1:53682/auth?state=xxxxxxxxxxxx`
-to the browser on your local machine, complete the auth and it is done.
+Finally, copy and paste the presented URL `http://127.0.0.1:53682/auth?state=xxxxxxxxxxxxxxxxxxxxxx`
+to the browser on your local machine, complete the auth and you are done.

--- a/docs/content/sharefile.md
+++ b/docs/content/sharefile.md
@@ -84,7 +84,7 @@ y/e/d> y
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from Citrix ShareFile. This only runs from the moment it opens

--- a/docs/content/yandex.md
+++ b/docs/content/yandex.md
@@ -61,7 +61,7 @@ y/e/d> y
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Note that rclone runs a webserver on your local machine to collect the
 token as returned from Yandex Disk. This only runs from the moment it

--- a/docs/content/zoho.md
+++ b/docs/content/zoho.md
@@ -80,7 +80,7 @@ y/e/d>
 ```
 
 See the [remote setup docs](/remote_setup/) for how to set it up on a
-machine with no Internet browser available.
+machine without an internet-connected web browser available.
 
 Rclone runs a webserver on your local computer to collect the
 authorization token from Zoho Workdrive. This is only from the moment

--- a/docs/layouts/chrome/navbar.html
+++ b/docs/layouts/chrome/navbar.html
@@ -19,6 +19,7 @@
           <a class="dropdown-item" href="/filtering/"><i class="fa fa-book fa-fw"></i> Filtering</a>
           <a class="dropdown-item" href="/gui/"><i class="fa fa-book fa-fw"></i> GUI</a>
           <a class="dropdown-item" href="/rc/"><i class="fa fa-book fa-fw"></i> Remote Control</a>
+          <a class="dropdown-item" href="/remote_setup/"><i class="fa fa-book fa-fw"></i> Remote Setup</a>
           <a class="dropdown-item" href="/changelog/"><i class="fa fa-book fa-fw"></i> Changelog</a>
           <a class="dropdown-item" href="/bugs/"><i class="fa fa-book fa-fw"></i> Bugs</a>
           <a class="dropdown-item" href="/faq/"><i class="fa fa-book fa-fw"></i> FAQ</a>

--- a/fs/config/authorize.go
+++ b/fs/config/authorize.go
@@ -12,9 +12,9 @@ import (
 //
 // It expects 1, 2 or 3 arguments
 //
-//	rclone authorize "fs name"
-//	rclone authorize "fs name" "base64 encoded JSON blob"
-//	rclone authorize "fs name" "client id" "client secret"
+//	rclone authorize "backend name"
+//	rclone authorize "backend name" "base64 encoded JSON blob"
+//	rclone authorize "backend name" "client id" "client secret"
 func Authorize(ctx context.Context, args []string, noAutoBrowser bool, templateFile string) error {
 	ctx = suppressConfirm(ctx)
 	ctx = fs.ConfigOAuthOnly(ctx)


### PR DESCRIPTION
#### What is the purpose of this change?

I found the https://rclone.org/remote_setup page a bit outdated, so I updated it, as well as some small updates to the related https://rclone.org/commands/rclone_authorize/ page and others.

PS: The https://rclone.org/remote_setup page is not listed in the "Docs" drop down menu, it is only linked to from the FAQ page and some backend docs pages. Should we list it?

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
