### PR TITLE
serve s3: Properly format log arguments

### DIFF
--- a/cmd/serve/s3/logger.go
+++ b/cmd/serve/s3/logger.go
@@ -2,6 +2,7 @@ package s3
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/rclone/gofakes3"
 	"github.com/rclone/rclone/fs"
@@ -12,25 +13,23 @@ type logger struct{}
 
 // print log message
 func (l logger) Print(level gofakes3.LogLevel, v ...any) {
-	var s string
-	if len(v) == 0 {
-		s = ""
-	} else {
-		var ok bool
-		s, ok = v[0].(string)
-		if !ok {
-			s = fmt.Sprint(v[0])
+	var b strings.Builder
+	for i := range v {
+		if i > 0 {
+			fmt.Fprintf(&b, " ")
 		}
-		v = v[1:]
+		fmt.Fprint(&b, v[i])
 	}
+	s := b.String()
+
 	switch level {
 	default:
 		fallthrough
 	case gofakes3.LogErr:
-		fs.Errorf("serve s3", s, v...)
+		fs.Errorf("serve s3", s)
 	case gofakes3.LogWarn:
-		fs.Infof("serve s3", s, v...)
+		fs.Infof("serve s3", s)
 	case gofakes3.LogInfo:
-		fs.Debugf("serve s3", s, v...)
+		fs.Debugf("serve s3", s)
 	}
 }


### PR DESCRIPTION
As shown in https://github.com/rclone/gofakes3/blob/81e56a30c86f942861f105439339812439b53415/log.go#L74, it seems like the wanted behaviour for merging arguments is the one of PrintLn, which is "put a space between each arg"

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
To change how the s3 serve feature logs messages, to avoid the `%!(EXTRA` golang output

Before:
```
serve s3: GET OBJECT%!(EXTRA string=Bucket:, string=fakebucket, string=Object:, string=ls)
```

After (same as https://github.com/johannesboyne/gofakes3/blob/master/example/main.go):
```
2025/10/03 22:23:25 DEBUG : serve s3: GET OBJECT Bucket: fakebucket Object: ls
```

#### Was the change discussed in an issue or in the forum before?
No

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
