### PR TITLE
Add support for MediaMarkt Cloud as a Jottacloud whitelabel service

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -89,6 +89,7 @@ func getWhitelabelServices() map[string]struct {
 		"elgiganten_dk": {"Elgiganten Cloud (Denmark)", "cloud.elgiganten.dk", "elgiganten", "desktop", []string{"openid", "jotta-default", "offline_access"}},
 		"gigantti":      {"Gigantti Cloud (Finland)", "cloud.gigantti.fi", "gigantti", "desktop", []string{"openid", "jotta-default", "offline_access"}},
 		"elko":          {"ELKO Cloud (Iceland)", "cloud.elko.is", "elko", "desktop", []string{"openid", "jotta-default", "offline_access"}},
+		"mediamarkt":    {"MediaMarkt Cloud", "mediamarkt.jottacloud.com", "mediamarkt", "desktop", []string{"openid", "jotta-default", "offline_access"}},
 		"letsgo":        {"Let's Go Cloud (Germany)", "letsgo.jotta.cloud", "letsgo", "desktop-win", []string{"openid", "offline_access"}},
 	}
 }

--- a/docs/content/jottacloud.md
+++ b/docs/content/jottacloud.md
@@ -28,6 +28,7 @@ as described [below](#whitelabel-authentication):
 - Onlime
   - Onlime (onlime.dk)
 - MediaMarkt
+  - MediaMarkt Cloud (mediamarkt.jottacloud.com)
   - Let's Go Cloud (letsgo.jotta.cloud)
 
 Paths are specified as `remote:path`


### PR DESCRIPTION
#### What is the purpose of this change?

Some background - if my investigations are correct:
- "MediaMarkt" is a German company that (according to wikipedia) operates in Germany, Austria, Belgium, Hungary, Italy, Luxembourg, Netherlands, Poland, Portugal (2004 - October 1st 2025 - turned into Darty (Fnac)), Spain, Switzerland, Turkey.
- In Germany, they offer a cloud service through the name "Let's Go Cloud" ("LET'S GO CLOUD powered by Jottacloud bei MediaMarkt").
  - I already added support for this in #8855, and it was discussed in #8852.
- "MediaMarkt Cloud" is a service they offer in Spain, Poland, Netherlands, Belgium and Luxembourg.
  - They seem to basically share the same service; all use domain mediamarkt.jottacloud.com and realm "mediamarkt". They can also use the same client_id and scopes as other whitelabels.
  - There are domains cloud.mediamarkt.nl/.be/.lu/.es/.pl but they all just redirect to mediamarkt.jottacloud.com.
- I could not find that the cloud service is offered in Austria, Hungary, Italy, Switzerland and Turkey. I just tried to ping cloud.mediamarkt.X, so I could be wrong, as they could use other domains.

Note that domain cloud.mediamarkt.de also works. Not sure if this overlaps with "Let's Go Cloud", or if "MediaMarkt Cloud" is also a thing in Germany and it is separate from "Let's Go Cloud"? Domain cloud.mediamarkt.de redirects to mediamarkt.jottacloud.com like the others. Let's Go Cloud uses a different domain letsgo.jotta.cloud and realm "letsgo", and even though the domain name resolves to same IP as mediamarkt.jottacloud.com, the realm "letsgo" only works with domain letsgo.jotta.cloud. Also it needs a bit different client_id and scopes for the oauth to work.

My conclusion is that I can create a single whitelabel entry for domain mediamarkt.jottacloud.com and realm mediamarkt, which should cover all of the "MediaMarkt Cloud". I've already created Let's Go Cloud, and since it is a bit different than the others, I'll keep that, even though I'm not sure if it overlaps with this new and more generic "MediaMarkt Cloud" entry.

#### Was the change discussed in an issue or in the forum before?

This was requested in https://github.com/rclone/rclone/issues/8852#issuecomment-3368319606, after authentication was already fixed for existing whitelabels and the issue was closed. I also implemented it temporarily in another pull request which I created a beta build for, which was tested successfully (https://github.com/rclone/rclone/issues/8852#issuecomment-3368540870).

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
