### PR TITLE
refactor: use strings.Builder to improve performance

### DIFF
--- a/backend/yandex/yandex.go
+++ b/backend/yandex/yandex.go
@@ -514,11 +514,12 @@ func (f *Fs) mkDirs(ctx context.Context, path string) (err error) {
 			if apiErr.ErrorName != "DiskPathPointsToExistentDirectoryError" {
 				// 2 if it fails then create all directories in the path from root.
 				dirs := strings.Split(dirString, "/") //path separator
-				var mkdirpath = "/"                   //path separator /
+				var mkdirpath strings.Builder
+				mkdirpath.WriteString("/") //path separator /
 				for _, element := range dirs {
 					if element != "" {
-						mkdirpath += element + "/"      //path separator /
-						_ = f.CreateDir(ctx, mkdirpath) // ignore errors while creating dirs
+						mkdirpath.WriteString(element + "/")     //path separator /
+						_ = f.CreateDir(ctx, mkdirpath.String()) // ignore errors while creating dirs
 					}
 				}
 			}

--- a/cmd/bisync/bisync_debug_test.go
+++ b/cmd/bisync/bisync_debug_test.go
@@ -98,7 +98,7 @@ func (b *bisyncTest) generateDebuggers() {
 	}
 
 	variations := []string{"LocalRemote", "RemoteLocal", "RemoteRemote"}
-	debuggers := ""
+	var debuggers strings.Builder
 
 	for _, backend := range config.Backends {
 		if backend.Remote == "" {
@@ -113,17 +113,17 @@ func (b *bisyncTest) generateDebuggers() {
 				name := fmt.Sprintf("Test %s %s %s", backend.Remote, testcase, variation)
 				switch variation {
 				case "LocalRemote":
-					debuggers += fmt.Sprintf(debugFormat, name, "local", backend.Remote, testcase)
+					debuggers.WriteString(fmt.Sprintf(debugFormat, name, "local", backend.Remote, testcase))
 				case "RemoteLocal":
-					debuggers += fmt.Sprintf(debugFormat, name, backend.Remote, "local", testcase)
+					debuggers.WriteString(fmt.Sprintf(debugFormat, name, backend.Remote, "local", testcase))
 				case "RemoteRemote":
-					debuggers += fmt.Sprintf(debugFormat, name, backend.Remote, backend.Remote, testcase)
+					debuggers.WriteString(fmt.Sprintf(debugFormat, name, backend.Remote, backend.Remote, testcase))
 				}
 			}
 		}
 	}
 
-	out := fmt.Sprintf(docFormat, debuggers)
+	out := fmt.Sprintf(docFormat, debuggers.String())
 	outpath := "./testdata/bisync_vscode_debuggers_launch.json"
 	err = os.WriteFile(outpath, []byte(out), bilib.PermSecure)
 	assert.NoError(b.t, err, "writing golden file %s", outpath)

--- a/cmd/cryptdecode/cryptdecode.go
+++ b/cmd/cryptdecode/cryptdecode.go
@@ -4,6 +4,7 @@ package cryptdecode
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/rclone/rclone/backend/crypt"
 	"github.com/rclone/rclone/cmd"
@@ -67,32 +68,32 @@ command. See the documentation on the [crypt](/crypt/) overlay for more info.`,
 
 // cryptDecode returns the unencrypted file name
 func cryptDecode(cipher *crypt.Cipher, args []string) error {
-	output := ""
+	var output strings.Builder
 
 	for _, encryptedFileName := range args {
 		fileName, err := cipher.DecryptFileName(encryptedFileName)
 		if err != nil {
-			output += fmt.Sprintln(encryptedFileName, "\t", "Failed to decrypt")
+			output.WriteString(fmt.Sprintln(encryptedFileName, "\t", "Failed to decrypt"))
 		} else {
-			output += fmt.Sprintln(encryptedFileName, "\t", fileName)
+			output.WriteString(fmt.Sprintln(encryptedFileName, "\t", fileName))
 		}
 	}
 
-	fmt.Print(output)
+	fmt.Print(output.String())
 
 	return nil
 }
 
 // cryptEncode returns the encrypted file name
 func cryptEncode(cipher *crypt.Cipher, args []string) error {
-	output := ""
+	var output strings.Builder
 
 	for _, fileName := range args {
 		encryptedFileName := cipher.EncryptFileName(fileName)
-		output += fmt.Sprintln(fileName, "\t", encryptedFileName)
+		output.WriteString(fmt.Sprintln(fileName, "\t", encryptedFileName))
 	}
 
-	fmt.Print(output)
+	fmt.Print(output.String())
 
 	return nil
 }

--- a/cmd/lsf/lsf_test.go
+++ b/cmd/lsf/lsf_test.go
@@ -3,6 +3,7 @@ package lsf
 import (
 	"bytes"
 	"context"
+	"strings"
 	"testing"
 
 	_ "github.com/rclone/rclone/backend/local"
@@ -140,12 +141,12 @@ file3
 	require.NoError(t, err)
 
 	items, _ := list.DirSorted(context.Background(), f, true, "")
-	var expectedOutput string
+	var expectedOutput strings.Builder
 	for _, item := range items {
-		expectedOutput += item.ModTime(context.Background()).Format("2006-01-02 15:04:05") + "\n"
+		expectedOutput.WriteString(item.ModTime(context.Background()).Format("2006-01-02 15:04:05") + "\n")
 	}
 
-	assert.Equal(t, expectedOutput, buf.String())
+	assert.Equal(t, expectedOutput.String(), buf.String())
 
 	buf = new(bytes.Buffer)
 	format = "sp"


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->


strings.Builder has fewer memory allocations and better performance.
More info: [golang/go#75190](https://github.com/golang/go/issues/75190)

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
