### PR TITLE
Improved token refresh handling in Jottacloud

### DIFF
--- a/backend/jottacloud/jottacloud.go
+++ b/backend/jottacloud/jottacloud.go
@@ -993,6 +993,13 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		f.features.ListR = nil
 	}
 
+	cust, err := getCustomerInfo(ctx, f.apiSrv)
+	if err != nil {
+		return nil, err
+	}
+	f.user = cust.Username
+	f.setEndpoints()
+
 	// Renew the token in the background
 	f.tokenRenewer = oauthutil.NewRenew(f.String(), ts, func() error {
 		_, err := f.readMetaDataForPath(ctx, "")
@@ -1001,13 +1008,6 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		}
 		return err
 	})
-
-	cust, err := getCustomerInfo(ctx, f.apiSrv)
-	if err != nil {
-		return nil, err
-	}
-	f.user = cust.Username
-	f.setEndpoints()
 
 	if root != "" && !rootIsDir {
 		// Check to see if the root actually an existing file


### PR DESCRIPTION
The oauthutil.Renew was initialized early in NewFs, before the first request to the service where a token is needed. When token is already expired at the time NewFs is called, the Renew operation would be triggered immediately, only to abort before actually performing a token refresh, for reason described in debug message:

    Token expired but no uploads in progress - doing nothing

Then later in NewFs, a request to the customer endpoint was made, and since it requires a valid token it would perform a token refresh after all.

This was not a big problem, but a bit unnecessary, and the debug log messages made it confusing to understand what rclone was actually doing regarding token refreshing.

If, from debugger, we were forcing the Renew operation to perform actual token refresh, even if no uploads in process, then it would fail because it actually needs the username which is retrieved from the customer endpoint

    jottacloud root '': Token refresh failed: read metadata failed: error 400: org.springframework.security.core.userdetails.UsernameNotFoundException: Username not found in url! (Bad Request)

Don't think this can happen in any real situations, but better to make sure it never can.

Typical log messages which made me look into this:

```
DEBUG : xxweb: Loaded invalid token from config file - ignoring
DEBUG : jottacloud root '': Token expired but no uploads in progress - doing nothing
DEBUG : Saving config "token" in section "xxweb" of the config file
DEBUG : Keeping previous permissions for config file: -rw-rw-rw-
DEBUG : xxweb: Saved new token in config file
```

It says "invalid token" but "Ignoring", then "expired" but "doing nothing", but then "saving config token" seem to have a new token after all... 😵 

PS: I'm working on a suggestion to adjust the debug log messages during token refresh in general, to make it more clear what is going on. E.g. in the above example, it does not explicitly say that it ends up performing a token refresh operation! It was while working on this I realized that there was this above issue specific to the Jottacloud backend. But when that is now fixed, I need to rethink the log messages a bit. But there may come a small pull request for it soon... EDIT: Here  it is:
  - #8890

#### What is the purpose of this change?

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
