### PR TITLE
fs: remove unnecessary Seek call on log file

### DIFF
--- a/fs/log/log.go
+++ b/fs/log/log.go
@@ -216,10 +216,6 @@ func InitLogging() {
 			if err != nil {
 				fs.Fatalf(nil, "Failed to open log file: %v", err)
 			}
-			_, err = f.Seek(0, io.SeekEnd)
-			if err != nil {
-				fs.Errorf(nil, "Failed to seek log file to end: %v", err)
-			}
 			redirectStderr(f)
 			w = f
 		} else {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

We were seeing a (non-fatal) error in our logs:
```
Failed to seek log file to end: seek /proc/1/fd/1: illegal seek
```

Because we open the log file with O_APPEND,
we don't need to manually seek to the end.
As https://pkg.go.dev/os#File.Seek also confirms
that the behavior of `Seek` is not specified
if the file has been opened with O_APPEND,
remove the `Seek` call.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

I manually tested this by building a new rclone binary and confirm the spurious error goes away (but logging output is emitted to the log-file as normal).