### PR TITLE
webdav: Add Access-Control-Max-Age header for CORS preflight caching 

### DIFF
--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -191,6 +191,7 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
 				w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
 				w.Header().Add("Access-Control-Allow-Methods", "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK")
+				w.Header().Add("Access-Control-Max-Age", "86400")
 			}
 
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
#### What is the purpose of this change?

Currently, the CORS implementation does not include the `Access-Control-Max-Age` header. This forces web browsers to send a preflight `OPTIONS` request before almost every actual request (e.g., `PROPFIND`, `GET`, `PUT`), which adds significant network latency and overhead.

This PR adds the `Access-Control-Max-Age: 86400` header to the CORS response. This instructs the browser to cache the preflight response for 24 hours, dramatically reducing the number of `OPTIONS` requests. This results in a much more responsive experience for users of web applications interacting with the rclone WebDAV server.

#### Was the change discussed in an issue or in the forum before?

https://[github.com/rclone/rclone/issues/5078](https://github.com/rclone/rclone/issues/5078)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)


