### PR TITLE
refactor: simplify code by fixing govet issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,6 +19,11 @@ linters:
     - unconvert
   # Configure checks. Mostly using defaults but with some commented exceptions.
   settings:
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+        - shadow
     staticcheck:
       # With staticcheck there is only one setting, so to extend the implicit
       # default value it must be explicitly included.

--- a/backend/linkbox/linkbox.go
+++ b/backend/linkbox/linkbox.go
@@ -497,9 +497,6 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 	}
 
 	f.dirCache.FlushDir(dir)
-	if err != nil {
-		return err
-	}
 	return nil
 }
 

--- a/cmd/serve/docker/driver.go
+++ b/cmd/serve/docker/driver.go
@@ -44,11 +44,6 @@ func NewDriver(ctx context.Context, root string, mntOpt *mountlib.Options, vfsOp
 		return nil, fmt.Errorf("failed to create cache directory: %s: %w", cacheDir, err)
 	}
 
-	//err = file.MkdirAll(root, 0755)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create mount root: %s: %w", root, err)
-	}
-
 	// setup driver state
 	if mntOpt == nil {
 		mntOpt = &mountlib.Opt

--- a/cmd/test/info/info.go
+++ b/cmd/test/info/info.go
@@ -233,7 +233,6 @@ func (r *results) checkStringPositions(k, s string) {
 	fs.Infof(r.f, "Writing position file 0x%0X", s)
 	positionError := internal.PositionNone
 	res := internal.ControlResult{
-		Text:       s,
 		WriteError: make(map[internal.Position]string, 3),
 		GetError:   make(map[internal.Position]string, 3),
 		InList:     make(map[internal.Position]internal.Presence, 3),

--- a/cmd/test/info/internal/build_csv/main.go
+++ b/cmd/test/info/internal/build_csv/main.go
@@ -46,8 +46,7 @@ func main() {
 	var remoteNames []string
 	for _, r := range remotes {
 		remoteNames = append(remoteNames, r.Remote)
-		for k, v := range *r.ControlCharacters {
-			v.Text = k
+		for k := range *r.ControlCharacters {
 			quoted := strconv.Quote(k)
 			charsMap[k] = quoted[1 : len(quoted)-1]
 		}

--- a/cmd/test/info/internal/internal.go
+++ b/cmd/test/info/internal/internal.go
@@ -36,7 +36,6 @@ var PositionList = []Position{PositionMiddle, PositionLeft, PositionRight}
 
 // ControlResult contains the result of a single character test
 type ControlResult struct {
-	Text       string `json:"-"`
 	WriteError map[Position]string
 	GetError   map[Position]string
 	InList     map[Position]Presence

--- a/fs/operations/multithread_test.go
+++ b/fs/operations/multithread_test.go
@@ -105,9 +105,7 @@ func TestMultithreadCalculateNumChunks(t *testing.T) {
 		{size: (1 << 20) - 1, chunkSize: 2, wantNumChunks: 1 << 19},
 	} {
 		t.Run(fmt.Sprintf("%+v", test), func(t *testing.T) {
-			mc := &multiThreadCopyState{
-				size: test.size,
-			}
+			mc := &multiThreadCopyState{}
 			mc.numChunks = calculateNumChunks(test.size, test.chunkSize)
 			assert.Equal(t, test.wantNumChunks, mc.numChunks)
 		})

--- a/lib/errors/errors.go
+++ b/lib/errors/errors.go
@@ -57,7 +57,7 @@ func Walk(err error, f WalkFunc) {
 				}
 			}
 		}
-		if reflect.DeepEqual(err, prev) {
+		if reflect.DeepEqual(err, prev) { //nolint:govet // deepequalerrors
 			break
 		}
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

This PR enables all [`govet`](https://golangci-lint.run/docs/linters/configuration/#govet) checks (except `fieldalignment` and `shadow`), and fixes appeared lint issues.

```console
$ golangci-lint run
backend/linkbox/linkbox.go:500:9: nilness: impossible condition: nil != nil (govet)
        if err != nil {
               ^
cmd/serve/docker/driver.go:48:9: nilness: impossible condition: nil != nil (govet)
        if err != nil {
               ^
cmd/test/info/internal/build_csv/main.go:50:6: unusedwrite: unused write to field Text (govet)
                        v.Text = k
                          ^
fs/operations/multithread_test.go:109:9: unusedwrite: unused write to field size (govet)
                                size: test.size,
                                    ^
lib/errors/errors.go:60:6: deepequalerrors: avoid using reflect.DeepEqual with errors (govet)
                if reflect.DeepEqual(err, prev) {
                   ^
5 issues:
* govet: 5
```

#### Was the change discussed in an issue or in the forum before?

Nope. It's a small change that doesn't affect behaviour.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
