### PR TITLE
log: Avoid side effects by using own logger instance - fixes #8907

### DIFF
--- a/fs/log.go
+++ b/fs/log.go
@@ -9,6 +9,10 @@ import (
 	"slices"
 )
 
+// logger represents the slog logging facility and should be overriden by
+// the fs/log handling code.
+var logger *slog.Logger = slog.Default()
+
 // LogLevel describes rclone's logs.  These are a subset of the syslog log levels.
 type LogLevel = Enum[logLevelChoices]
 
@@ -134,7 +138,7 @@ func LogLevelToSlog(level LogLevel) slog.Level {
 }
 
 func logSlog(level LogLevel, text string, attrs []any) {
-	slog.Log(context.Background(), LogLevelToSlog(level), text, attrs...)
+	logger.Log(context.Background(), LogLevelToSlog(level), text, attrs...)
 }
 
 func logSlogWithObject(level LogLevel, o any, text string, attrs []any) {
@@ -302,4 +306,9 @@ func PrettyPrint(in any, label string, level LogLevel) {
 		return
 	}
 	LogPrintf(level, label, "\n%s\n", string(inBytes))
+}
+
+// SetLogger overrides the slog logger using the specified handler
+func SetLogger(h slog.Handler) {
+	logger = slog.New(h)
 }

--- a/fs/log.go
+++ b/fs/log.go
@@ -9,9 +9,22 @@ import (
 	"slices"
 )
 
-// logger represents the slog logging facility and should be overriden by
+// logger represents the slog logging facility and should be overridden by
 // the fs/log handling code.
 var logger *slog.Logger = slog.Default()
+
+// InitialiseDefaultLogger controls whether rclone sets the process-wide
+// default slog logger (via slog.SetDefault) during initialisation.
+//
+// When rclone is used as a library, the host application can set this
+// to false before any rclone logging is initialised to prevent rclone
+// from overriding the process-wide default logger. Rclone's own
+// internal logging will still work correctly through its private
+// logger instance.
+//
+// This should be set before importing packages that trigger init()
+// (e.g. backend/all) or before calling fs/log.InitLogging().
+var InitialiseDefaultLogger = true
 
 // LogLevel describes rclone's logs.  These are a subset of the syslog log levels.
 type LogLevel = Enum[logLevelChoices]

--- a/fs/log.go
+++ b/fs/log.go
@@ -13,19 +13,6 @@ import (
 // the fs/log handling code.
 var logger *slog.Logger = slog.Default()
 
-// InitialiseDefaultLogger controls whether rclone sets the process-wide
-// default slog logger (via slog.SetDefault) during initialisation.
-//
-// When rclone is used as a library, the host application can set this
-// to false before any rclone logging is initialised to prevent rclone
-// from overriding the process-wide default logger. Rclone's own
-// internal logging will still work correctly through its private
-// logger instance.
-//
-// This should be set before importing packages that trigger init()
-// (e.g. backend/all) or before calling fs/log.InitLogging().
-var InitialiseDefaultLogger = true
-
 // LogLevel describes rclone's logs.  These are a subset of the syslog log levels.
 type LogLevel = Enum[logLevelChoices]
 

--- a/fs/log/log.go
+++ b/fs/log/log.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"reflect"
 	"runtime"
@@ -201,7 +202,21 @@ func init() {
 }
 
 // InitLogging start the logging as per the command line flags
+//
+// This is called explicitly from the CLI, the librclone wrapper and
+// the test framework, but not from package init, so that importing
+// rclone as a library has no side effects on the process-wide default
+// slog logger.
 func InitLogging() {
+	// Redirect the process-wide default logger through rclone's
+	// handler so that log.Print/log.Fatal and slog.Default() (used by
+	// some standard library and third party code) end up in rclone's
+	// log output.
+	slog.SetDefault(slog.New(Handler))
+
+	// Make log.Printf logs at level Notice
+	slog.SetLogLoggerLevel(fs.SlogLevelNotice)
+
 	// Note that ci only has the defaults in at this point
 	// We set real values in logReload
 	ci := fs.GetConfig(context.Background())

--- a/fs/log/slog.go
+++ b/fs/log/slog.go
@@ -36,11 +36,8 @@ func defaultHandler() *OutputHandler {
 	// Create our handler
 	h := NewOutputHandler(os.Stderr, opts, logFormatDate|logFormatTime)
 
-	// Set the slog default handler
-	slog.SetDefault(slog.New(h))
-
-	// Make log.Printf logs at level Notice
-	slog.SetLogLoggerLevel(fs.SlogLevelNotice)
+	// Setup the logger
+	fs.SetLogger(h)
 
 	return h
 }

--- a/fs/log/slog.go
+++ b/fs/log/slog.go
@@ -36,8 +36,17 @@ func defaultHandler() *OutputHandler {
 	// Create our handler
 	h := NewOutputHandler(os.Stderr, opts, logFormatDate|logFormatTime)
 
-	// Setup the logger
+	// Always set rclone's internal logger so rclone logging works
 	fs.SetLogger(h)
+
+	// Optionally set the process-wide default logger so that
+	// log.Print/log.Fatal and slog.Default() also use rclone's handler.
+	// Library consumers can set fs.InitialiseDefaultLogger = false to
+	// prevent this.
+	if fs.InitialiseDefaultLogger {
+		slog.SetDefault(slog.New(h))
+		slog.SetLogLoggerLevel(fs.SlogLevelNotice)
+	}
 
 	return h
 }

--- a/fs/log/slog.go
+++ b/fs/log/slog.go
@@ -27,6 +27,12 @@ var Handler = defaultHandler()
 // This will be adjusted by InitLogging to be the configured levels
 // but it is important we have a logger running regardless of whether
 // InitLogging has been called yet or not.
+//
+// Note that this only sets rclone's private logger via fs.SetLogger
+// so that importing this package has no side effects on the
+// process-wide default slog logger. The CLI and other rclone-as-a-
+// program entry points pick up the default logger redirection in
+// InitLogging instead.
 func defaultHandler() *OutputHandler {
 	// Default options for default handler
 	opts := &slog.HandlerOptions{
@@ -36,17 +42,8 @@ func defaultHandler() *OutputHandler {
 	// Create our handler
 	h := NewOutputHandler(os.Stderr, opts, logFormatDate|logFormatTime)
 
-	// Always set rclone's internal logger so rclone logging works
+	// Set rclone's internal logger so rclone logging works
 	fs.SetLogger(h)
-
-	// Optionally set the process-wide default logger so that
-	// log.Print/log.Fatal and slog.Default() also use rclone's handler.
-	// Library consumers can set fs.InitialiseDefaultLogger = false to
-	// prevent this.
-	if fs.InitialiseDefaultLogger {
-		slog.SetDefault(slog.New(h))
-		slog.SetLogLoggerLevel(fs.SlogLevelNotice)
-	}
 
 	return h
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Commit dfa4d94 replaced the old logging with the more modern `slog` package. However, this change is intrusive for applications using `slog` as their default logging facility, causing side effects and a fragile construct when using `slog` logging with custom output functions.

This PR sets up a custom logger, avoiding side effects from overriding the `slog` default logger.

#### Was the change discussed in an issue or in the forum before?

resolves #8907 

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
