### PR TITLE
Add FileLu S5 (US, EU, AP, and ME) region endpoints

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -958,26 +958,26 @@ func init() {
 				Help:  "Cubbit DS3 Object Storage endpoint",
 			}},
 		}, {
-    Name:     "endpoint",
-    Help:     "Endpoint for FileLu S5 Object Storage.\nRequired when using FileLu S5.",
-    Provider: "FileLu",
-    Examples: []fs.OptionExample{{
-        Value: "s5lu.com",
-        Help:  "Global FileLu S5 endpoint",
-    }, {
-        Value: "us.s5lu.com",
-        Help:  "North America (US-East) region endpoint",
-    }, {
-        Value: "eu.s5lu.com",
-        Help:  "Europe (EU-Central) region endpoint",
-    }, {
-        Value: "ap.s5lu.com",
-        Help:  "Asia Pacific (AP-Southeast) region endpoint",
-    }, {
-        Value: "me.s5lu.com",
-        Help:  "Middle East (ME-Central) region endpoint",
-    }},
-}, {
+			Name:     "endpoint",
+			Help:     "Endpoint for FileLu S5 Object Storage.\nRequired when using FileLu S5.",
+			Provider: "FileLu",
+			Examples: []fs.OptionExample{{
+				Value: "s5lu.com",
+				Help:  "Global FileLu S5 endpoint",
+			}, {
+				Value: "us.s5lu.com",
+				Help:  "North America (US-East) region endpoint",
+			}, {
+				Value: "eu.s5lu.com",
+				Help:  "Europe (EU-Central) region endpoint",
+			}, {
+				Value: "ap.s5lu.com",
+				Help:  "Asia Pacific (AP-Southeast) region endpoint",
+			}, {
+				Value: "me.s5lu.com",
+				Help:  "Middle East (ME-Central) region endpoint",
+			}},
+		}, {
 			Name:     "endpoint",
 			Help:     "Endpoint for Google Cloud Storage.",
 			Provider: "GCS",


### PR DESCRIPTION
Added multiple region endpoints for FileLu S5 Object Storage.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Added new region endpoints for FileLu S5 (S3-Compatible Object Storage) to improve latency and regional access for global users.

New endpoints:
- us.s5lu.com (North America - US-East)
- eu.s5lu.com (Europe - EU-Central)
- ap.s5lu.com (Asia Pacific - AP-Southeast)
- me.s5lu.com (Middle East - ME-Central)

This allows users to select the nearest FileLu S5 endpoint when configuring Rclone for optimal performance.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
