### PR TITLE
s3: add transfer and check objects acls logic

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -68,6 +68,46 @@ import (
 	"github.com/rclone/rclone/lib/version"
 )
 
+// rwChoices type for fs.Bits
+type rwChoices struct{}
+
+func (rwChoices) Choices() []fs.BitsChoicesInfo {
+	return []fs.BitsChoicesInfo{
+		{Bit: uint64(rwOff), Name: "off"},
+		{Bit: uint64(rwRead), Name: "read"},
+		{Bit: uint64(rwWrite), Name: "write"},
+		{Bit: uint64(rwFailOK), Name: "failok"},
+	}
+}
+
+// rwChoice type alias
+type rwChoice = fs.Bits[rwChoices]
+
+const (
+	rwRead rwChoice = 1 << iota
+	rwWrite
+	rwFailOK
+	rwOff rwChoice = 0
+)
+
+// Examples for the options
+var rwExamples = fs.OptionExamples{{
+	Value: rwOff.String(),
+	Help:  "Do not read or write the value",
+}, {
+	Value: rwRead.String(),
+	Help:  "Read the value only",
+}, {
+	Value: rwWrite.String(),
+	Help:  "Write the value only",
+}, {
+	Value: rwFailOK.String(),
+	Help:  "If writing fails log errors only, don't fail the transfer",
+}, {
+	Value: (rwRead | rwWrite).String(),
+	Help:  "Read and Write the value.",
+}}
+
 // Register with Fs
 func init() {
 	fs.Register(addProvidersToInfo(&fs.RegInfo{
@@ -704,6 +744,21 @@ In this case, you might want to try disabling this option.
 			Advanced: true,
 			Default:  false,
 		}, {
+			Name: "metadata_acl",
+			Help: `Control whether object ACLs should be transferred or checked.
+
+Object access can be controlled through various methods, including ACLs.
+
+This flag transfers object ACLs during copy operations and check ACLs during check operations.
+Note that when bucket owners differ, the ACL owner is updated to the new bucket owner.
+Other grantees in the ACL that are not the source bucket owner remain unchanged.
+
+Also note that this flag is relevant if the metadata flag is enabled.
+`,
+			Advanced: true,
+			Default:  rwOff,
+			Examples: rwExamples,
+		}, {
 			Name:     "sts_endpoint",
 			Help:     "Endpoint for STS (deprecated).\n\nLeave blank if using AWS to use the default endpoint for the region.",
 			Advanced: true,
@@ -1085,6 +1140,7 @@ type Options struct {
 	UseDualStack                bool                 `config:"use_dual_stack"`
 	LocationConstraint          string               `config:"location_constraint"`
 	ACL                         string               `config:"acl"`
+	MetadataACL                 rwChoice             `config:"metadata_acl"`
 	BucketACL                   string               `config:"bucket_acl"`
 	RequesterPays               bool                 `config:"requester_pays"`
 	ServerSideEncryption        string               `config:"server_side_encryption"`
@@ -1187,6 +1243,8 @@ type Object struct {
 	meta         map[string]string // The object metadata if known - may be nil - with lower case keys
 	mimeType     string            // MimeType of object - may be ""
 	versionID    *string           // If present this points to an object version
+	acl          *string           // Object ACL
+	bucketOwner  *string           // Bucket owner
 
 	// Metadata as pointers to strings as they often won't be present
 	storageClass       *string // e.g. GLACIER
@@ -4370,7 +4428,63 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 		})
 	}
 
+	if o.fs.opt.MetadataACL.IsSet(rwRead) {
+		aclString, err := o.getACLString(ctx)
+		if err != nil {
+			fs.Logf(o, "Failed to get acl: %v", err)
+			return resp.Body, nil
+		}
+		o.acl = &aclString
+
+		bucketOwner, err := o.getBucketOwner(ctx)
+		if err != nil {
+			fs.Logf(o, "Failed to get bucket owner: %v", err)
+			return resp.Body, nil
+		}
+		o.bucketOwner = &bucketOwner
+	}
+
 	return resp.Body, nil
+}
+
+func (o *Object) getACLString(ctx context.Context) (string, error) {
+	bucket, bucketPath := o.split()
+
+	resp, err := o.fs.c.GetObjectAcl(ctx, &s3.GetObjectAclInput{
+		Bucket: &bucket,
+		Key:    &bucketPath,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	objectACLBytes, err := json.Marshal(types.AccessControlPolicy{
+		Grants: resp.Grants,
+		Owner:  resp.Owner,
+	})
+	if err != nil {
+		return "", nil
+	}
+
+	return string(objectACLBytes), nil
+}
+
+func (o *Object) getBucketOwner(ctx context.Context) (string, error) {
+	bucket, _ := o.split()
+
+	resp, err := o.fs.c.GetBucketAcl(ctx, &s3.GetBucketAclInput{
+		Bucket: &bucket,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	ownerBytes, err := json.Marshal(resp.Owner)
+	if err != nil {
+		return "", err
+	}
+
+	return string(ownerBytes), nil
 }
 
 var warnStreamUpload sync.Once
@@ -4771,8 +4885,10 @@ func (o *Object) uploadSinglepartPresignedRequest(ctx context.Context, req *s3.P
 
 // Info needed for an upload
 type uploadInfo struct {
-	req       *s3.PutObjectInput
-	md5sumHex string
+	req         *s3.PutObjectInput
+	aclReq      *s3.PutObjectAclInput
+	bucketOwner *types.Owner
+	md5sumHex   string
 }
 
 // Prepare object for being uploaded
@@ -4800,6 +4916,14 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 			ui.req.StorageClass = types.StorageClass(strings.ToUpper(tier))
 		}
 	}
+
+	if o.fs.opt.MetadataACL.IsSet(rwWrite) {
+		ui.aclReq = &s3.PutObjectAclInput{
+			Bucket: &bucket,
+			Key:    &bucketPath,
+		}
+	}
+
 	// Fetch metadata if --metadata is in use
 	meta, err := fs.GetMetadataOptions(ctx, o.fs, src, options)
 	if err != nil {
@@ -4827,6 +4951,24 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 			ui.req.ContentType = pv
 		case "x-amz-tagging":
 			ui.req.Tagging = pv
+		case "x-amz-acl":
+			if !o.fs.opt.MetadataACL.IsSet(rwWrite) {
+				continue
+			}
+			var acl types.AccessControlPolicy
+			if err := json.Unmarshal([]byte(v), &acl); err != nil {
+				fs.Debugf(o, "failed to parse metadata %s: %q: %v", k, v, err)
+			}
+			ui.aclReq.AccessControlPolicy = &acl
+		case "bucket-owner":
+			if !o.fs.opt.MetadataACL.IsSet(rwWrite) {
+				continue
+			}
+			var owner types.Owner
+			if err := json.Unmarshal([]byte(v), &owner); err != nil {
+				fs.Debugf(o, "failed to parse metadata %s: %q: %v", k, v, err)
+			}
+			ui.bucketOwner = &owner
 		case "tier":
 			// ignore
 		case "mtime":
@@ -4862,6 +5004,19 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 			}
 		default:
 			ui.req.Metadata[k] = v
+		}
+	}
+
+	if o.fs.opt.MetadataACL.IsSet(rwWrite) {
+		resp, err := o.fs.c.GetBucketAcl(ctx, &s3.GetBucketAclInput{
+			Bucket: &bucket,
+		})
+		if err != nil {
+			fs.Logf(o, "failed to get bucket acl: %v", err)
+		}
+		ui.aclReq.AccessControlPolicy, err = o.mapACL(ui.aclReq.AccessControlPolicy, ui.bucketOwner, resp.Owner)
+		if err != nil {
+			fs.Logf(o, "failed to map acl: %v", err)
 		}
 	}
 
@@ -4992,6 +5147,57 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 	return ui, nil
 }
 
+// We need to transfer ownership of objects to the owner of the dst bucket
+// if the objects were owned by the owner of the src bucket
+func (o *Object) mapACL(srcACL *types.AccessControlPolicy, srcBucketOwner, dstBucketOwner *types.Owner) (*types.AccessControlPolicy, error) {
+	if srcACL == nil {
+		return nil, fmt.Errorf("src acl is nil")
+	}
+	srcObjectOwner := srcACL.Owner
+
+	dstGrants := make([]types.Grant, len(srcACL.Grants))
+	for i, grant := range srcACL.Grants {
+		if grant.Grantee == nil {
+			return nil, fmt.Errorf("grantee is nil")
+		}
+
+		newOwner := o.mapOwner(&types.Owner{
+			DisplayName: grant.Grantee.DisplayName,
+			ID:          grant.Grantee.ID,
+		}, srcBucketOwner, dstBucketOwner)
+
+		dstGrants[i] = types.Grant{
+			Grantee: &types.Grantee{
+				Type:         grant.Grantee.Type,
+				DisplayName:  newOwner.DisplayName,
+				EmailAddress: grant.Grantee.EmailAddress,
+				ID:           newOwner.ID,
+				URI:          grant.Grantee.URI,
+			},
+			Permission: grant.Permission,
+		}
+	}
+
+	newOwner := o.mapOwner(srcObjectOwner, srcBucketOwner, dstBucketOwner)
+
+	return &types.AccessControlPolicy{
+		Grants: dstGrants,
+		Owner: &types.Owner{
+			ID:          newOwner.ID,
+			DisplayName: newOwner.DisplayName,
+		},
+	}, nil
+}
+
+func (o *Object) mapOwner(srcObjectOwner, srcBucketOwner, dstBucketOwner *types.Owner) *types.Owner {
+	if (srcObjectOwner != nil && srcObjectOwner.ID != nil) &&
+		(srcBucketOwner != nil && srcBucketOwner.ID != nil) &&
+		*srcObjectOwner.ID == *srcBucketOwner.ID {
+		return dstBucketOwner
+	}
+	return srcObjectOwner
+}
+
 // Update the Object from in with modTime and size
 func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
 	if o.fs.opt.VersionAt.IsSet() {
@@ -5023,6 +5229,17 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	if err != nil {
 		return err
 	}
+
+	if o.fs.opt.MetadataACL.IsSet(rwWrite) && ui.aclReq != nil {
+		err = o.fs.pacer.CallNoRetry(func() (bool, error) {
+			_, err = o.fs.c.PutObjectAcl(ctx, ui.aclReq)
+			return o.fs.shouldRetry(ctx, err)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
 	// Only record versionID if we are using --s3-versions or --s3-version-at
 	if o.fs.opt.Versions || o.fs.opt.VersionAt.IsSet() {
 		o.versionID = versionID
@@ -5278,6 +5495,14 @@ func (o *Object) Metadata(ctx context.Context) (metadata fs.Metadata, err error)
 	// metadata["x-amz-tagging"] = ""
 	if !o.lastModified.IsZero() {
 		metadata["btime"] = o.lastModified.Format(time.RFC3339Nano)
+	}
+
+	if o.acl != nil {
+		metadata["x-amz-acl"] = *o.acl
+	}
+
+	if o.bucketOwner != nil {
+		metadata["bucket-owner"] = *o.bucketOwner
 	}
 
 	// Set system metadata

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -745,15 +745,14 @@ In this case, you might want to try disabling this option.
 			Default:  false,
 		}, {
 			Name: "metadata_acl",
-			Help: `Control whether object ACLs should be transferred or checked.
+			Help: `Control whether object ACLs should be read or written to the metadata.
 
-Object access can be controlled through various methods, including ACLs.
+In conjunction with the --metadata flag this can be used to read or
+write ACLs or preserve ACLs during a copy operation with "read,write"
 
-This flag transfers object ACLs during copy operations and check ACLs during check operations.
-Note that when bucket owners differ, the ACL owner is updated to the new bucket owner.
-Other grantees in the ACL that are not the source bucket owner remain unchanged.
-
-Also note that this flag is relevant if the metadata flag is enabled.
+Note that when writing ACLs if bucket owners differ, the ACL owner
+is updated to the new bucket owner. Other grantees in the ACL that
+are not the source bucket owner remain unchanged.
 `,
 			Advanced: true,
 			Default:  rwOff,
@@ -1125,6 +1124,18 @@ var systemMetadataInfo = map[string]fs.MetadataHelp{
 		Help:    "Object Lock legal hold status: ON or OFF",
 		Type:    "string",
 		Example: "OFF",
+	},
+	"x-amz-acl": {
+		Help: "Object ACl",
+		Type: "string",
+		Example: `{"Owner":{"DisplayName":"my-username","ID":"7009a8971cd538e11f6b6606438875e7c86c5b672f46db45460ddcd087d36c32"},
+		"Grants":[{"Grantee":{"DisplayName":"my-username","ID":"7009a8971cd538e11f6b6606438875e7c86c5b672f46db45460ddcd087d36c32"},
+		"Permission":"FULL_CONTROL"}]}`,
+	},
+	"bucket-owner": {
+		Help:    "Bucket owner ID",
+		Type:    "string",
+		Example: "7009a8971cd538e11f6b6606438875e7c86c5b672f46db45460ddcd087d36c32",
 	},
 }
 
@@ -4431,15 +4442,13 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	if o.fs.opt.MetadataACL.IsSet(rwRead) {
 		aclString, err := o.getACLString(ctx)
 		if err != nil {
-			fs.Logf(o, "Failed to get acl: %v", err)
-			return resp.Body, nil
+			return nil, fmt.Errorf("failed to read ACL: %w", err)
 		}
 		o.acl = &aclString
 
 		bucketOwner, err := o.getBucketOwner(ctx)
 		if err != nil {
-			fs.Logf(o, "Failed to get bucket owner: %v", err)
-			return resp.Body, nil
+			return nil, fmt.Errorf("failed to get bucket owner: %w", err)
 		}
 		o.bucketOwner = &bucketOwner
 	}
@@ -4455,7 +4464,7 @@ func (o *Object) getACLString(ctx context.Context) (string, error) {
 		Key:    &bucketPath,
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("get ACL failed: %w", err)
 	}
 
 	objectACLBytes, err := json.Marshal(types.AccessControlPolicy{
@@ -4463,7 +4472,7 @@ func (o *Object) getACLString(ctx context.Context) (string, error) {
 		Owner:  resp.Owner,
 	})
 	if err != nil {
-		return "", nil
+		return "", fmt.Errorf("marshal ACL failed: %w", err)
 	}
 
 	return string(objectACLBytes), nil
@@ -4476,12 +4485,12 @@ func (o *Object) getBucketOwner(ctx context.Context) (string, error) {
 		Bucket: &bucket,
 	})
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("get bucket ACL failed: %w", err)
 	}
 
 	ownerBytes, err := json.Marshal(resp.Owner)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("marshal bucket ACL failed: %w", err)
 	}
 
 	return string(ownerBytes), nil
@@ -4957,7 +4966,7 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 			}
 			var acl types.AccessControlPolicy
 			if err := json.Unmarshal([]byte(v), &acl); err != nil {
-				fs.Debugf(o, "failed to parse metadata %s: %q: %v", k, v, err)
+				return ui, fmt.Errorf("failed to parse metadata %s: %q: %v", k, v, err)
 			}
 			ui.aclReq.AccessControlPolicy = &acl
 		case "bucket-owner":
@@ -4966,7 +4975,7 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 			}
 			var owner types.Owner
 			if err := json.Unmarshal([]byte(v), &owner); err != nil {
-				fs.Debugf(o, "failed to parse metadata %s: %q: %v", k, v, err)
+				return ui, fmt.Errorf("failed to parse metadata %s: %q: %v", k, v, err)
 			}
 			ui.bucketOwner = &owner
 		case "tier":
@@ -5012,11 +5021,11 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 			Bucket: &bucket,
 		})
 		if err != nil {
-			fs.Logf(o, "failed to get bucket acl: %v", err)
+			return ui, fmt.Errorf("failed to get bucket ACL: %v", err)
 		}
 		ui.aclReq.AccessControlPolicy, err = o.mapACL(ui.aclReq.AccessControlPolicy, ui.bucketOwner, resp.Owner)
 		if err != nil {
-			fs.Logf(o, "failed to map acl: %v", err)
+			return ui, fmt.Errorf("failed to map ACL: %v", err)
 		}
 	}
 
@@ -5151,7 +5160,7 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 // if the objects were owned by the owner of the src bucket
 func (o *Object) mapACL(srcACL *types.AccessControlPolicy, srcBucketOwner, dstBucketOwner *types.Owner) (*types.AccessControlPolicy, error) {
 	if srcACL == nil {
-		return nil, fmt.Errorf("src acl is nil")
+		return nil, fmt.Errorf("src ACL is nil")
 	}
 	srcObjectOwner := srcACL.Owner
 


### PR DESCRIPTION
#### What is the purpose of this change?

Added the ability to transfer ACL objects using rclone copy and verify ACL objects using rclone check.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/8905

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
