### PR TITLE
better error message on missing winfsp

### DIFF
--- a/cmd/cmount/mount.go
+++ b/cmd/cmount/mount.go
@@ -8,6 +8,7 @@ package cmount
 import (
 	"errors"
 	"fmt"
+	"strings"
 	"os"
 	"runtime"
 	"time"
@@ -149,7 +150,11 @@ func mount(VFS *vfs.VFS, mountPath string, opt *mountlib.Options) (<-chan error,
 	go func() {
 		defer func() {
 			if r := recover(); r != nil {
-				errChan <- fmt.Errorf("mount failed: %v", r)
+				err := fmt.Errorf("mount failed: %v", r)
+				if strings.Contains(strings.ToLower(err.Error()), "cannot find winfsp") {
+					err = fmt.Errorf("%w\nHint: Install WinFsp from https://winfsp.dev/rel/", err)
+				}
+				errChan <- err
 			}
 		}()
 		var err error


### PR DESCRIPTION
change the error
```
2025/10/26 07:59:37 CRITICAL: Fatal error: failed to mount FUSE fs: mount stopped before calling Init: mount failed: cgofuse: cannot find winfsp
```
to
```
2025/10/26 07:59:37 CRITICAL: Fatal error: failed to mount FUSE fs: mount stopped before calling Init: mount failed: cgofuse: cannot find winfsp
Hint: Install WinFsp from https://winfsp.dev/rel/
```
related threads showcasing why I think this is a good idea:

https://github.com/rclone/rclone/issues/2254

https://github.com/rclone/rclone/issues/6927

https://forum.rclone.org/t/rclone-mount-in-windows-impossible/13037

https://forum.rclone.org/t/cannot-mount-remote-as-local-drive/21637

https://forum.rclone.org/t/noob-need-to-mount/41632

https://forum.rclone.org/t/error-with-rclone-mount/48684

https://forum.rclone.org/t/need-to-mount-the-drive-with-the-example-of-command-script-to-run-it/23487

(and there are more examples)

I believe the majority of these threads would never have been created if the error message had pointed them to winfsp.dev

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

point users requiring winfsp to winfsp.dev
<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

no
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [ ] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
