### PR TITLE
rc: fix name of `queue` JSON key in docs for `vfs/cache`

### DIFF
--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -450,7 +450,7 @@ This is only useful if |--vfs-cache-mode| > off. If you call it when
 the |--vfs-cache-mode| is off, it will return an empty result.
 
     {
-        "queued": // an array of files queued for upload
+        "queue": // an array of files queued for upload
         [
             {
                 "name":      "file",   // string: name (full path) of the file,


### PR DESCRIPTION
#### What is the purpose of this change?

Fixing a small typo in the `vfs/queue` docs: the `queued` key is actually named `queue`:

https://github.com/rclone/rclone/blob/eaab3f5271f8222ebdbee237f841801725ec1aa4/vfs/vfscache/cache.go#L176

#### Was the change discussed in an issue or in the forum before?

Nope

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
  - Not applicable
- [x] I have added documentation for the changes if appropriate.
  - Not applicable
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
