### PR TITLE
check: improved reporting of differences in sizes and contents

### DIFF
--- a/cmd/bisync/checkfn.go
+++ b/cmd/bisync/checkfn.go
@@ -125,12 +125,12 @@ func (b *bisyncRun) ReverseCryptCheckFn(ctx context.Context, dst, src fs.Object)
 }
 
 // DownloadCheckFn is a slightly modified version of Check with --download
-func DownloadCheckFn(ctx context.Context, a, b fs.Object) (differ bool, noHash bool, err error) {
-	differ, err = operations.CheckIdenticalDownload(ctx, a, b)
+func DownloadCheckFn(ctx context.Context, dst, src fs.Object) (equal bool, noHash bool, err error) {
+	equal, err = operations.CheckIdenticalDownload(ctx, src, dst)
 	if err != nil {
 		return true, true, fmt.Errorf("failed to download: %w", err)
 	}
-	return differ, false, nil
+	return equal, false, nil
 }
 
 // check potential conflicts (to avoid renaming if already identical)

--- a/fs/operations/check_test.go
+++ b/fs/operations/check_test.go
@@ -218,21 +218,21 @@ func TestCheckEqualReaders(t *testing.T) {
 	b65b[len(b65b)-1] = 1
 	b66 := make([]byte, 66*1024)
 
-	differ, err := operations.CheckEqualReaders(bytes.NewBuffer(b65a), bytes.NewBuffer(b65a))
+	equal, err := operations.CheckEqualReaders(bytes.NewBuffer(b65a), bytes.NewBuffer(b65a))
 	assert.NoError(t, err)
-	assert.Equal(t, differ, false)
+	assert.Equal(t, equal, true)
 
-	differ, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), bytes.NewBuffer(b65b))
+	equal, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), bytes.NewBuffer(b65b))
 	assert.NoError(t, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
-	differ, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), bytes.NewBuffer(b66))
+	equal, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), bytes.NewBuffer(b66))
 	assert.NoError(t, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
-	differ, err = operations.CheckEqualReaders(bytes.NewBuffer(b66), bytes.NewBuffer(b65a))
+	equal, err = operations.CheckEqualReaders(bytes.NewBuffer(b66), bytes.NewBuffer(b65a))
 	assert.NoError(t, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
 	myErr := errors.New("sentinel")
 	wrap := func(b []byte) io.Reader {
@@ -241,37 +241,37 @@ func TestCheckEqualReaders(t *testing.T) {
 		return io.MultiReader(r, e)
 	}
 
-	differ, err = operations.CheckEqualReaders(wrap(b65a), bytes.NewBuffer(b65a))
+	equal, err = operations.CheckEqualReaders(wrap(b65a), bytes.NewBuffer(b65a))
 	assert.Equal(t, myErr, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
-	differ, err = operations.CheckEqualReaders(wrap(b65a), bytes.NewBuffer(b65b))
+	equal, err = operations.CheckEqualReaders(wrap(b65a), bytes.NewBuffer(b65b))
 	assert.Equal(t, myErr, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
-	differ, err = operations.CheckEqualReaders(wrap(b65a), bytes.NewBuffer(b66))
+	equal, err = operations.CheckEqualReaders(wrap(b65a), bytes.NewBuffer(b66))
 	assert.Equal(t, myErr, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
-	differ, err = operations.CheckEqualReaders(wrap(b66), bytes.NewBuffer(b65a))
+	equal, err = operations.CheckEqualReaders(wrap(b66), bytes.NewBuffer(b65a))
 	assert.Equal(t, myErr, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
-	differ, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), wrap(b65a))
+	equal, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), wrap(b65a))
 	assert.Equal(t, myErr, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
-	differ, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), wrap(b65b))
+	equal, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), wrap(b65b))
 	assert.Equal(t, myErr, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
-	differ, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), wrap(b66))
+	equal, err = operations.CheckEqualReaders(bytes.NewBuffer(b65a), wrap(b66))
 	assert.Equal(t, myErr, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 
-	differ, err = operations.CheckEqualReaders(bytes.NewBuffer(b66), wrap(b65a))
+	equal, err = operations.CheckEqualReaders(bytes.NewBuffer(b66), wrap(b65a))
 	assert.Equal(t, myErr, err)
-	assert.Equal(t, differ, true)
+	assert.Equal(t, equal, false)
 }
 
 func TestParseSumFile(t *testing.T) {


### PR DESCRIPTION
#### What is the purpose of this change?

As was reported in the linked forum thread, when running check with `--download`, then rclone does not actually report which files differ, only the overall number of differences! See case 1b below, where it does not mention anything about the different file `x.txt`, only `y.txt` because it has a size difference as well. So the main thing in this PR is to add an error message for this, the same way as is done when running without --download and hash differs. For even more consistency, I chose to also make the reporting of size differences same as md5/content differences.

While implementing this, I found a couple of things in code which I found a bit confusing: CheckEqualReaders returned "opposite" result, i.e. true if different, which I found counter intuitive. Also, a few of the "top-level" check-with-download functions had argument `dst` before `src`, and sometimes only named `a` and `b`. This does not match what the corresponding check-with-hash functions does. However, it does end up in `CheckOpt.Check` function, which takes arguments `a` and `b` and returns `differ bool`, and it is called with `dst` before `src`, so I don't know what is the original strategy here. In any case I found it confusing that the two check call stacks did it opposite. I chose to follow the existing check-with-hash from the check command entry point and mimic the same with the check-with-download so at least these two paths are consistent.

Example setup, two folders `C:\Temp\a` and `C:\Temp\b`, with 3 files each:
- a.xml ➡️ Identical
- x.txt ➡️ Same size (1 byte), different md5/content
- y.txt ➡️ Different size (1 vs 2 bytes)/md5/content

Base command:

```
rclone check C:\Temp\a C:\Temp\b -vv
```

Final check results in all cases:
```
NOTICE: Local file system at //?/C:/Temp/b: 2 differences found
NOTICE: Local file system at //?/C:/Temp/b: 2 errors while checking
NOTICE: Local file system at //?/C:/Temp/b: 1 matching files
```

Case 1a: Existing version base command:

```
ERROR : y.txt: sizes differ
DEBUG : x.txt: md5 = 9dd4e461268c8034f5c8564e155c67a6 (Local file system at //?/C:/Temp/a)
DEBUG : x.txt: md5 = 415290769594460e2e485922904f345d (Local file system at //?/C:/Temp/b)
ERROR : x.txt: md5 differ
DEBUG : a.xml: md5 = 7bacc18299a8ab9a57e26602f8973575 OK
DEBUG : a.xml: OK
```

Case 1b: Existing version with added option `--download`:

```
ERROR : y.txt: sizes differ
DEBUG : a.xml: OK
```

Case 2a: New version (this PR) base command:

```
DEBUG : a.xml: size = 199982 OK
DEBUG : x.txt: size = 1 OK
DEBUG : y.txt: size = 1 (Local file system at //?/C:/Temp/a)
DEBUG : y.txt: size = 2 (Local file system at //?/C:/Temp/b)
ERROR : y.txt: sizes differ
DEBUG : a.xml: md5 = 7bacc18299a8ab9a57e26602f8973575 OK
DEBUG : a.xml: OK
DEBUG : x.txt: md5 = 9dd4e461268c8034f5c8564e155c67a6 (Local file system at //?/C:/Temp/a)
DEBUG : x.txt: md5 = 415290769594460e2e485922904f345d (Local file system at //?/C:/Temp/b)
ERROR : x.txt: md5 differ
```

Case 2b: New version (this PR) with added option `--download`:

```
DEBUG : a.xml: size = 199982 OK
DEBUG : x.txt: size = 1 OK
DEBUG : y.txt: size = 1 (Local file system at //?/C:/Temp/a)
DEBUG : y.txt: size = 2 (Local file system at //?/C:/Temp/b)
ERROR : y.txt: sizes differ
DEBUG : a.xml: OK
ERROR : x.txt: contents differ
```


#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/displaying-errors-with-rclone-check/52934

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
