### PR TITLE
Change to light code block style to better match overall theme

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -32,6 +32,9 @@
       "renderer": {
         "unsafe": false
       }
+    },
+    "highlight": {
+      "style": "monokailight"
     }
   }
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Our rclone.org site is mostly a light theme - black text on white background. Markdown code blocks without any language identifier are rendered using a matching light style; dark text on light gray background. When using code blocks with language identifier specified, then Hugo enables syntax highlighting, and these have specific styling. Default Hugo style for syntax highlighting in code blocks is called "monokai", and this seem to be a dark theme oriented styling, e.g. light text on black background. This makes maybe them stand out a bit too much? Especially for large sections like the config examples, e.g. in https://rclone.org/compress/, the result is a large black "box" on the page.

A side effect is that indented code block, and fenced code block without a language, and fenced code block with a language identifier not understood by Hugo, is rendered differently from one with language identifier "text", "plain" or any other supported languages. Any supported languages will be rendered according to the styling, i.e. by default with the light text on black background, while when no language is specified there will be dark gray text on light gray background.

<img width="708" height="692" alt="image" src="https://github.com/user-attachments/assets/75e6e34e-ae25-49b9-8a22-a6b19fb3a35a" />

So this is a bit surprising. And it is in contrast to e.g. GitHub, where code blocks without language looks identical to code blocks with "text" language specified (to my eyes, at least).


Hugo supports different styles for the code blocks: https://gohugo.io/quick-reference/syntax-highlighting-styles. The default is "monokai", and seem to be a dark mode style. Our web side is more a light theme. There is a "monokailight" style which is probably a better fit:

<img width="724" height="463" alt="image" src="https://github.com/user-attachments/assets/efc415a8-6322-4fa5-850f-0df4ac6b0d75" />

There are also styles "github" and "github-dark", if we wanted colors more close to what GitHub uses, but I haven't looked too much into them, or others.

#### Was the change discussed in an issue or in the forum before?

This PR came from discussions in https://github.com/rclone/rclone/pull/8778.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
