### PR TITLE
serve/s3: add --cors flag to enable permissive CORS headers

### DIFF
--- a/cmd/serve/s3/s3.go
+++ b/cmd/serve/s3/s3.go
@@ -37,6 +37,10 @@ var OptionsInfo = fs.Options{{
 	Name:    "no_cleanup",
 	Default: false,
 	Help:    "Not to cleanup empty folder after object is deleted",
+}, {
+	Name:    "cors",
+	Default: false,
+	Help:    "Add permissive CORS headers (Access-Control-Allow-*) to all responses",
 }}.
 	Add(httplib.ConfigInfo).
 	Add(httplib.AuthConfigInfo)
@@ -48,6 +52,7 @@ type Options struct {
 	EtagHash       string   `config:"etag_hash"`
 	AuthKey        []string `config:"auth_key"`
 	NoCleanup      bool     `config:"no_cleanup"`
+	CORS           bool     `config:"cors"`
 	Auth           httplib.AuthConfig
 	HTTP           httplib.Config
 }

--- a/cmd/serve/s3/serve_s3.md
+++ b/cmd/serve/s3/serve_s3.md
@@ -28,6 +28,11 @@ Use `--etag-hash` if you want to change the hash uses for the `ETag`.
 Note that using anything other than `MD5` (the default) is likely to
 cause problems for S3 clients which rely on the Etag being the MD5.
 
+Use `--cors` to enable permissive Cross-Origin Resource Sharing (CORS)
+headers on all responses. This allows browser-based applications
+running on different origins to access the S3 server without being
+blocked by the same-origin policy.
+
 ### Quickstart
 
 For a simple set up, to serve `remote:path` over s3, run the server


### PR DESCRIPTION
#### What is the purpose of this change?

Adds a new --cors flag to `rclone serve s3` which enables permissive Access-Control-Allow-* headers on all responses. This makes it easier to use browser-based S3 clients or test local apps without proxying.

Includes documentation in serve_s3.md and a TestCORS integration test verifying the response headers.

#### Was the change discussed in an issue or in the forum before?

I couldn't find any issues or posts that discussed this specific issue.
 
#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
