### PR TITLE
s3: add support for conditional request headers

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -4538,6 +4538,10 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 			ui.req.ContentLanguage = aws.String(value)
 		case "content-type":
 			ui.req.ContentType = aws.String(value)
+		case "if-match":
+			ui.req.IfMatch = aws.String(value)
+		case "if-none-match":
+			ui.req.IfNoneMatch = aws.String(value)
 		case "x-amz-tagging":
 			ui.req.Tagging = aws.String(value)
 		default:


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

It appears to me that the `If-None-Match` and `If-Match` conditional request headers aren’t supported by rclone with S3.

We’re leveraging these headers with an S3 Bucket Policy to prevent overwrites on certain S3 Prefixes; however, rclone prints the following error when using copy with the –header-upload ‘If-None-Match: *

`2025/11/07 15:26:02 ERROR : protected-new-new.txt: Don't know how to set key "If-None-Match" on upload`

https://docs.aws.amazon.com/AmazonS3/latest/userguide/conditional-writes.html

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/does-rclone-s3-support-if-none-match-and-if-match-upload-headers/52961/13

#### Checklist

I wasn't sure about tests. I don't see the function I'm updating being tested anywhere so I'm not sure what needs to be updated. Existing tests ran successfully.

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
