### PR TITLE
Patch ftp

### DIFF
--- a/backend/ftp/ftp.go
+++ b/backend/ftp/ftp.go
@@ -1292,7 +1292,7 @@ func (f *ftpReadCloser) Close() error {
 	// See: https://github.com/rclone/rclone/issues/3445#issuecomment-521654257
 	if errX := textprotoError(err); errX != nil {
 		switch errX.Code {
-		case ftp.StatusTransfertAborted, ftp.StatusFileUnavailable, ftp.StatusAboutToSend:
+		case ftp.StatusTransfertAborted, ftp.StatusFileUnavailable, ftp.StatusAboutToSend, ftp.StatusRequestedFileActionOK:
 			err = nil
 		}
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

When using an FTP remote as the source, some FTP servers return:

    250 Requested file action okay, completed.

at the end of a download (RETR) when the data connection is closed. In this case
`ftpReadCloser.Close()` in the FTP backend was treating this as an error and
causing the transfer to fail, even though the file was transferred successfully.

The FTP backend already special-cases `StatusRequestedFileActionOK` (250) in
other places (e.g. `Update`/`Stor`, `mkdir`). This change extends the same
treatment to the close path:

- `ftpReadCloser.Close()` now checks for `StatusRequestedFileActionOK` and
  treats it as success, alongside other already-handled codes such as
  `StatusTransfertAborted`, `StatusFileUnavailable` and `StatusAboutToSend`.

This fixes repeated failures like:

```text
ERROR : Attempt 3/3 failed with 1 errors and: 1 error occurred:
    * 250 Requested file action okay, completed.
```
when copying from an FTP remote to another backend (e.g. SMB).

#### Was the change discussed in an issue or in the forum before?

[https://forum.rclone.org/t/atem-mini-extreme-iso-ftp-reports-250-ok-but-rclone-thinks-it-was-an-error/48152](https://forum.rclone.org/t/atem-mini-extreme-iso-ftp-reports-250-ok-but-rclone-thinks-it-was-an-error/48152
)

The problem was observed when copying from an FTP remote, which returns 250 Requested file action okay, completed. at the end of a download. The transfer reached 100% but
rclone still reported a failure and removed the .partial file.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
