### PR TITLE
s3: fix single file copying behavior with low permission

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1648,10 +1648,13 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		newRoot, leaf := path.Split(oldRoot)
 		f.setRoot(newRoot)
 		_, err := f.NewObject(ctx, leaf)
-		if err != nil {
+		if errors.Is(err, fs.ErrorObjectNotFound) {
 			// File doesn't exist or is a directory so return old f
 			f.setRoot(oldRoot)
 			return f, nil
+		}
+		if err != nil {
+			return nil, err
 		}
 		// return an error with an fs which points to the parent
 		return f, fs.ErrorIsFile


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fixes https://github.com/rclone/rclone/issues/8975

the error check should only setRoot when there is a NotFound error

##### compare
1. before
no file to transfer
2. after
```
CRITICAL: Failed to create file system for "s3://path/to/a/file": operation error S3: HeadObject, https response error StatusCode: 403, RequestID: , HostID: , api error Forbidden: Forbidden
```

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
