### PR TITLE
build: introducing .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,16 @@
+.*
+!.git
+**/*_test.go
+**/testdata
+**/*.txt
+bin
+backend/alias/test
+backend/http/test
+contrib
+docs
+graphics
+*.md
+COPYING
+MANUAL.html
+Dockerfile
+rclone.1


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

Thank you for maintaining such wonderful software!

#### What is the purpose of this change?

We reduced the size of the docker image(the stage `builder`) by introducing a `.dockerignore` file.

```diff
$ docker build --target builder -t rclone-builder-(before|after) . && docker image ls
- rclone-builder-before            latest    e755bd13a361   27 seconds ago   3.15GB
+ rclone-builder-after             latest    abf311bda5d1   4 seconds ago    3.09GB
```

<!--
Describe the changes here
-->

Upon investigating the details using [dive](https://github.com/wagoodman/dive), I found that the .git directory used in the Makefile was huge. It seems that improving the Makefile is necessary for more effective improvements.

<img width="800" height="1052" alt="image" src="https://github.com/user-attachments/assets/333a12fa-f905-48c3-a1db-849deb679238" />


#### Was the change discussed in an issue or in the forum before?

No

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
