### PR TITLE
refactor: use strings.Cut to simplify code

### DIFF
--- a/backend/crypt/cipher.go
+++ b/backend/crypt/cipher.go
@@ -403,14 +403,14 @@ func (c *Cipher) deobfuscateSegment(ciphertext string) (string, error) {
 	if ciphertext == "" {
 		return "", nil
 	}
-	pos := strings.Index(ciphertext, ".")
-	if pos == -1 {
+	before, after, ok := strings.Cut(ciphertext, ".")
+	if !ok {
 		return "", ErrorNotAnEncryptedFile
 	} // No .
-	num := ciphertext[:pos]
+	num := before
 	if num == "!" {
 		// No rotation; probably original was not valid unicode
-		return ciphertext[pos+1:], nil
+		return after, nil
 	}
 	dir, err := strconv.Atoi(num)
 	if err != nil {
@@ -425,7 +425,7 @@ func (c *Cipher) deobfuscateSegment(ciphertext string) (string, error) {
 	var result bytes.Buffer
 
 	inQuote := false
-	for _, runeValue := range ciphertext[pos+1:] {
+	for _, runeValue := range after {
 		switch {
 		case inQuote:
 			_, _ = result.WriteRune(runeValue)

--- a/cmd/bisync/listing.go
+++ b/cmd/bisync/listing.go
@@ -389,8 +389,8 @@ func parseHash(str string) (string, string, error) {
 	if str == "-" {
 		return "", "", nil
 	}
-	if pos := strings.Index(str, ":"); pos > 0 {
-		name, val := str[:pos], str[pos+1:]
+	if before, after, ok := strings.Cut(str, ":"); ok {
+		name, val := before, after
 		if name != "" && val != "" {
 			return name, val, nil
 		}

--- a/cmd/serve/sftp/connection.go
+++ b/cmd/serve/sftp/connection.go
@@ -58,10 +58,10 @@ type conn struct {
 // interoperate with the rclone sftp backend
 func (c *conn) execCommand(ctx context.Context, out io.Writer, command string) (err error) {
 	binary, args := command, ""
-	space := strings.Index(command, " ")
-	if space >= 0 {
-		binary = command[:space]
-		args = strings.TrimLeft(command[space+1:], " ")
+	before, after, ok := strings.Cut(command, " ")
+	if ok {
+		binary = before
+		args = strings.TrimLeft(after, " ")
 	}
 	args = shellUnEscape(args)
 	fs.Debugf(c.what, "exec command: binary = %q, args = %q", binary, args)

--- a/fs/bwtimetable.go
+++ b/fs/bwtimetable.go
@@ -29,16 +29,16 @@ func (bp *BwPair) String() string {
 // Set the bandwidth from a string which is either
 // SizeSuffix or SizeSuffix:SizeSuffix (for tx:rx bandwidth)
 func (bp *BwPair) Set(s string) (err error) {
-	colon := strings.Index(s, ":")
+	before, after, ok := strings.Cut(s, ":")
 	stx, srx := s, ""
-	if colon >= 0 {
-		stx, srx = s[:colon], s[colon+1:]
+	if ok {
+		stx, srx = before, after
 	}
 	err = bp.Tx.Set(stx)
 	if err != nil {
 		return err
 	}
-	if colon < 0 {
+	if !ok {
 		bp.Rx = bp.Tx
 	} else {
 		err = bp.Rx.Set(srx)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The `strings.Cut` function was introduced in Go 1.18 as part of a proposal to add more efficient string manipulation functions. 

This change enhances code readability and makes it easier to understand the intent of the operation, as strings.Cut directly provides the substring before the specified delimiter, along with a boolean indicating its presence.


More info can see Go Issue https://github.com/golang/go/issues/46336




#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
