### PR TITLE
googlecloudstorage: improve endpoint parameter docs

### DIFF
--- a/backend/googlecloudstorage/googlecloudstorage.go
+++ b/backend/googlecloudstorage/googlecloudstorage.go
@@ -346,9 +346,26 @@ can't check the size and hash but the file contents will be decompressed.
 			Advanced: true,
 			Default:  false,
 		}, {
-			Name:     "endpoint",
-			Help:     "Endpoint for the service.\n\nLeave blank normally.",
+			Name: "endpoint",
+			Help: `Custom endpoint for the storage API. Leave blank to use the provider default.
+
+When using a custom endpoint that includes a subpath (e.g. example.org/custom/endpoint),
+the subpath will be ignored during upload operations due to a limitation in the
+underlying Google API Go client library.
+Download and listing operations will work correctly with the full endpoint path.
+If you require subpath support for uploads, avoid using subpaths in your custom
+endpoint configuration.`,
 			Advanced: true,
+			Examples: []fs.OptionExample{{
+				Value: "storage.example.org",
+				Help:  "Specify a custom endpoint",
+			}, {
+				Value: "storage.example.org:4443",
+				Help:  "Specifying a custom endpoint with port",
+			}, {
+				Value: "storage.example.org:4443/gcs/api",
+				Help:  "Specifying a subpath, see the note, uploads won't use the custom path!",
+			}},
 		}, {
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,


### PR DESCRIPTION
When specifying a custom endpoint with a subpath, there is a limitation in the Google cloud storage integration that the subpath is ignored during upload operations. For example with the custom endpoint "example.org/custom/endpoint" on upload the /custom/endpoint is not reflected.

As this is most likely an issue with the underlying API client, there is no way to fix this in rclone. By extending the documentation at least rclone users are made aware of this limitation.

Related forum thread: https://forum.rclone.org/t/googlecloudstorage-custom-endpoint-subpath-removed-for-upload/53059

This is the rendered documentation
<img width="1364" height="615" alt="image" src="https://github.com/user-attachments/assets/e8ca2551-b231-4f27-ac27-0d5354984a6f" />


- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
