### PR TITLE
Bugfix: remove "Download as ZIP" icon for `rclone serve webdav`

### DIFF
--- a/cmd/serve/webdav/webdav.go
+++ b/cmd/serve/webdav/webdav.go
@@ -417,6 +417,7 @@ func (w *WebDAV) serveDir(rw http.ResponseWriter, r *http.Request, dirRemote str
 
 	// Make the entries for display
 	directory := serve.NewDirectory(dirRemote, w.server.HTMLTemplate())
+	directory.DisableZip = true
 	for _, node := range dirEntries {
 		if vfscommon.Opt.NoModTime {
 			directory.AddHTMLEntry(node.Path(), node.IsDir(), node.Size(), time.Time{})


### PR DESCRIPTION
#### What is the purpose of this change?

#8837 introduced a feature for `rclone serve http` enabling users to download directories as ZIPs, while the backend of this feature is only implemented in `cmd/serve/http/http.go`, not `cmd/serve/webdav/webdav.go` and both backends shares same template for directory listing, the issue mentioned below aroused:

1. admin serves a webdav access with `rclone serve webdav`
2. user access webdav-shared directory with a web browser, rclone handles the request with the directory listing
3. user see the download-as-zip icons on directory entries and top path bar on the directory listing page
4. user click a download-as-zip icon on the page, expecting a ZIP is downloaded
5. *rclone does not implement `?download=zip` for webdav backend, the user navigates into that directory, which is unexpected*

this patch removes the misleading icon on the directory listing page for webdav backends.

#### Was the change discussed in an issue or in the forum before?

nil

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
