### PR TITLE
b2: Fix listing root buckets with unrestricted API key

### DIFF
--- a/backend/b2/b2.go
+++ b/backend/b2/b2.go
@@ -1081,21 +1081,10 @@ type listBucketFn func(*api.Bucket) error
 func (f *Fs) listBucketsToFn(ctx context.Context, bucketName string, fn listBucketFn) error {
 	responses := make([]api.ListBucketsResponse, len(f.info.APIs.Storage.Allowed.Buckets))[:0]
 
-	for i := range f.info.APIs.Storage.Allowed.Buckets {
-		b := &f.info.APIs.Storage.Allowed.Buckets[i]
-		// Empty names indicate a bucket that no longer exists, this is non-fatal
-		// for multi-bucket API keys.
-		if b.Name == "" {
-			continue
-		}
-		// When requesting a specific bucket skip over non-matching names
-		if bucketName != "" && b.Name != bucketName {
-			continue
-		}
-
+	call := func(id string) error {
 		var account = api.ListBucketsRequest{
 			AccountID: f.info.AccountID,
-			BucketID:  b.ID,
+			BucketID:  id,
 		}
 		if bucketName != "" && account.BucketID == "" {
 			account.BucketName = f.opt.Enc.FromStandardName(bucketName)
@@ -1114,6 +1103,32 @@ func (f *Fs) listBucketsToFn(ctx context.Context, bucketName string, fn listBuck
 			return err
 		}
 		responses = append(responses, response)
+		return nil
+	}
+
+	for i := range f.info.APIs.Storage.Allowed.Buckets {
+		b := &f.info.APIs.Storage.Allowed.Buckets[i]
+		// Empty names indicate a bucket that no longer exists, this is non-fatal
+		// for multi-bucket API keys.
+		if b.Name == "" {
+			continue
+		}
+		// When requesting a specific bucket skip over non-matching names
+		if bucketName != "" && b.Name != bucketName {
+			continue
+		}
+
+		err := call(b.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	if len(f.info.APIs.Storage.Allowed.Buckets) == 0 {
+		err := call("")
+		if err != nil {
+			return err
+		}
 	}
 
 	f.bucketIDMutex.Lock()


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fixes my previous pull request #8978

A silly oversight meant that when using unrestricted API keys, the root remote couldn't be listed because the API call was never made. If the API key is unrestricted the call is now made

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

#9007 and #8978

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
