### PR TITLE
fix: PID not included in JSON log output

### DIFF
--- a/fs/log/slog.go
+++ b/fs/log/slog.go
@@ -310,6 +310,10 @@ func (h *OutputHandler) jsonLog(ctx context.Context, buf *bytes.Buffer, r slog.R
 	r.AddAttrs(
 		slog.String("source", getCaller(2)),
 	)
+	// Add PID if requested
+	if h.format&logFormatPid != 0 {
+		r.AddAttrs(slog.Int("pid", os.Getpid()))
+	}
 	h.mu.Lock()
 	err = h.jsonHandler.Handle(ctx, r)
 	if err == nil {

--- a/fs/log/slog_test.go
+++ b/fs/log/slog_test.go
@@ -198,6 +198,17 @@ func TestAddOutputUseJSONLog(t *testing.T) {
 	assert.Equal(t, "2020/01/02 03:04:05 INFO  : world\n", extraText)
 }
 
+// Test JSON log includes PID when logFormatPid is set.
+func TestJSONLogWithPid(t *testing.T) {
+	buf := &bytes.Buffer{}
+	h := NewOutputHandler(buf, nil, logFormatJSON|logFormatPid)
+
+	r := slog.NewRecord(t0, slog.LevelInfo, "hello", 0)
+	require.NoError(t, h.Handle(context.Background(), r))
+	output := buf.String()
+	assert.Contains(t, output, fmt.Sprintf(`"pid":%d`, os.Getpid()))
+}
+
 // Test WithAttrs and WithGroup return new handlers with same settings.
 func TestWithAttrsAndGroup(t *testing.T) {
 	buf := &bytes.Buffer{}


### PR DESCRIPTION
#### What is the purpose of this change?

When using `--log-format pid,json`, the PID was not being added to the JSON log output. This fix adds PID support to JSON logging.

The `jsonLog()` function in `fs/log/slog.go` did not check the logFormatPid flag, while `textLog()` correctly handled it via
  `formatStdLogHeader()`. This caused PID to be missing from JSON output even when explicitly requested.

#### Was the change discussed in an issue or in the forum before?

No. It's a small bugfix.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
