### PR TITLE
fs/sync: add high level retries to rc sync/copy/move

### DIFF
--- a/fs/sync/rc.go
+++ b/fs/sync/rc.go
@@ -2,7 +2,10 @@ package sync
 
 import (
 	"context"
+	"time"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/rc"
 )
 
@@ -45,17 +48,59 @@ func rcSyncCopyMove(ctx context.Context, in rc.Params, name string) (out rc.Para
 	if rc.NotErrParamNotFound(err) {
 		return nil, err
 	}
-	switch name {
-	case "sync":
-		return nil, Sync(ctx, dstFs, srcFs, createEmptySrcDirs)
-	case "copy":
-		return nil, CopyDir(ctx, dstFs, srcFs, createEmptySrcDirs)
-	case "move":
-		deleteEmptySrcDirs, err := in.GetBool("deleteEmptySrcDirs")
-		if rc.NotErrParamNotFound(err) {
-			return nil, err
+
+	ci := fs.GetConfig(ctx)
+
+	for try := 1; try <= ci.Retries; try++ {
+		switch name {
+		case "sync":
+			err = Sync(ctx, dstFs, srcFs, createEmptySrcDirs)
+		case "copy":
+			err = CopyDir(ctx, dstFs, srcFs, createEmptySrcDirs)
+		case "move":
+			deleteEmptySrcDirs, err := in.GetBool("deleteEmptySrcDirs")
+			if rc.NotErrParamNotFound(err) {
+				return nil, err
+			}
+			return nil, MoveDir(ctx, dstFs, srcFs, deleteEmptySrcDirs, createEmptySrcDirs)
+		default:
+			panic("unknown rcSyncCopyMove type")
 		}
-		return nil, MoveDir(ctx, dstFs, srcFs, deleteEmptySrcDirs, createEmptySrcDirs)
+
+		if err == nil {
+			if try > 1 {
+				fs.Logf(nil, "rc %s: Attempt %d/%d succeeded", name, try, ci.Retries)
+			}
+			break
+		}
+
+		if fserrors.IsFatalError(err) {
+			fs.Errorf(nil, "rc %s: Fatal error received - not attempting retries: %v", name, err)
+			break
+		}
+
+		if fserrors.IsNoRetryError(err) {
+			fs.Errorf(nil, "rc %s: Non-retryable error - not attempting retries: %v", name, err)
+			break
+		}
+
+		fs.Errorf(nil, "rc %s: Attempt %d/%d failed: %v", name, try, ci.Retries, err)
+
+		if fserrors.IsRetryAfterError(err) {
+			retryAfter := fserrors.RetryAfterErrorTime(err)
+			d := time.Until(retryAfter)
+			if d > 0 {
+				fs.Logf(nil, "rc %s: Retry-after error - sleeping until %s (%v)", name, retryAfter.Format(time.RFC3339Nano), d)
+				time.Sleep(d)
+				continue
+			}
+		}
+
+		if ci.RetriesInterval > 0 {
+			fs.Logf(nil, "rc %s: Sleeping %v before retry %d/%d", name, ci.RetriesInterval, try+1, ci.Retries)
+			time.Sleep(time.Duration(ci.RetriesInterval))
+		}
 	}
-	panic("unknown rcSyncCopyMove type")
+
+	return nil, err
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Adds previously missing high level retries for `rc` calls. Fixes [issue 8957](https://github.com/rclone/rclone/issues/8957)

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/retry-logic-for-cmd-based-copy-vs-remote-api-sync-copy/48905
https://github.com/rclone/rclone/issues/8957

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
