### PR TITLE
Linode - updated endpoints to use ISO 3166-1 alpha-2 standard

### DIFF
--- a/backend/s3/provider/Linode.yaml
+++ b/backend/s3/provider/Linode.yaml
@@ -1,26 +1,26 @@
 name: Linode
 description: Linode Object Storage
 endpoint:
-  nl-ams-1.linodeobjects.com: Amsterdam (Netherlands), nl-ams-1
-  us-southeast-1.linodeobjects.com: Atlanta, GA (USA), us-southeast-1
-  in-maa-1.linodeobjects.com: Chennai (India), in-maa-1
-  us-ord-1.linodeobjects.com: Chicago, IL (USA), us-ord-1
-  eu-central-1.linodeobjects.com: Frankfurt (Germany), eu-central-1
-  id-cgk-1.linodeobjects.com: Jakarta (Indonesia), id-cgk-1
-  gb-lon-1.linodeobjects.com: London 2 (Great Britain), gb-lon-1
-  us-lax-1.linodeobjects.com: Los Angeles, CA (USA), us-lax-1
-  es-mad-1.linodeobjects.com: Madrid (Spain), es-mad-1
-  au-mel-1.linodeobjects.com: Melbourne (Australia), au-mel-1
-  us-mia-1.linodeobjects.com: Miami, FL (USA), us-mia-1
-  it-mil-1.linodeobjects.com: Milan (Italy), it-mil-1
-  us-east-1.linodeobjects.com: Newark, NJ (USA), us-east-1
-  jp-osa-1.linodeobjects.com: Osaka (Japan), jp-osa-1
-  fr-par-1.linodeobjects.com: Paris (France), fr-par-1
-  br-gru-1.linodeobjects.com: São Paulo (Brazil), br-gru-1
-  us-sea-1.linodeobjects.com: Seattle, WA (USA), us-sea-1
-  ap-south-1.linodeobjects.com: Singapore, ap-south-1
-  sg-sin-1.linodeobjects.com: Singapore 2, sg-sin-1
-  se-sto-1.linodeobjects.com: Stockholm (Sweden), se-sto-1
-  us-iad-1.linodeobjects.com: Washington, DC, (USA), us-iad-1
+  nl-ams-1.linodeobjects.com: Amsterdam, NL (nl-ams-1)
+  us-southeast-1.linodeobjects.com: Atlanta, GA, US (us-southeast-1)
+  in-maa-1.linodeobjects.com: Chennai, IN (in-maa-1)
+  us-ord-1.linodeobjects.com: Chicago, IL, US (us-ord-1)
+  eu-central-1.linodeobjects.com: Frankfurt, DE (eu-central-1)
+  id-cgk-1.linodeobjects.com: Jakarta, ID (id-cgk-1)
+  gb-lon-1.linodeobjects.com: London 2, UK (gb-lon-1)
+  us-lax-1.linodeobjects.com: Los Angeles, CA, US (us-lax-1)
+  es-mad-1.linodeobjects.com: Madrid, ES (es-mad-1)
+  us-mia-1.linodeobjects.com: Miami, FL, US (us-mia-1)
+  it-mil-1.linodeobjects.com: Milan, IT (it-mil-1)
+  us-east-1.linodeobjects.com: Newark, NJ, US (us-east-1)
+  jp-osa-1.linodeobjects.com: Osaka, JP (jp-osa-1)
+  fr-par-1.linodeobjects.com: Paris, FR (fr-par-1)
+  br-gru-1.linodeobjects.com: Sao Paulo, BR (br-gru-1)
+  us-sea-1.linodeobjects.com: Seattle, WA, US (us-sea-1)
+  ap-south-1.linodeobjects.com: Singapore, SG (ap-south-1)
+  sg-sin-1.linodeobjects.com: Singapore 2, SG (sg-sin-1)
+  se-sto-1.linodeobjects.com: Stockholm, SE (se-sto-1)
+  jp-tyo-1.linodeobjects.com: Tokyo 3, JP (jp-tyo-1)
+  us-iad-10.linodeobjects.com: Washington, DC, US (us-iad-10)
 acl: {}
 bucket_acl: true


### PR DESCRIPTION
Hey, just a simple PR to standardize Linode's endpoints to the ISO 3166-1 alpha-2 standard for countries along with putting the region short name in parentheses instead of separated by another comma. :)

Let me know if you have any feedback, but personally I think this tidies things up a bit.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
