### PR TITLE
http: support custom response headers

### DIFF
--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -61,23 +61,6 @@ func AddFlags(ci *fs.ConfigInfo, flagSet *pflag.FlagSet) {
 	flags.StringVarP(flagSet, &dscp, "dscp", "", "", "Set DSCP value to connections, value or name, e.g. CS1, LE, DF, AF21", "Networking")
 }
 
-// ParseHeaders converts the strings passed in via the header flags into HTTPOptions
-func ParseHeaders(headers []string) []*fs.HTTPOption {
-	opts := []*fs.HTTPOption{}
-	for _, header := range headers {
-		parts := strings.SplitN(header, ":", 2)
-		if len(parts) == 1 {
-			fs.Fatalf(nil, "Failed to parse '%s' as an HTTP header. Expecting a string like: 'Content-Encoding: gzip'", header)
-		}
-		option := &fs.HTTPOption{
-			Key:   strings.TrimSpace(parts[0]),
-			Value: strings.TrimSpace(parts[1]),
-		}
-		opts = append(opts, option)
-	}
-	return opts
-}
-
 // SetFlags sets flags which aren't part of the config system
 func SetFlags(ci *fs.ConfigInfo) {
 	// Process obsolete --dump-headers and --dump-bodies flags
@@ -153,13 +136,13 @@ func SetFlags(ci *fs.ConfigInfo) {
 
 	// Process --headers-upload, --headers-download, --headers
 	if len(uploadHeaders) != 0 {
-		ci.UploadHeaders = ParseHeaders(uploadHeaders)
+		ci.UploadHeaders = fs.ParseHeaders(uploadHeaders)
 	}
 	if len(downloadHeaders) != 0 {
-		ci.DownloadHeaders = ParseHeaders(downloadHeaders)
+		ci.DownloadHeaders = fs.ParseHeaders(downloadHeaders)
 	}
 	if len(headers) != 0 {
-		ci.Headers = ParseHeaders(headers)
+		ci.Headers = fs.ParseHeaders(headers)
 	}
 
 	// Process --metadata-set

--- a/fs/config/configflags/configflags.go
+++ b/fs/config/configflags/configflags.go
@@ -136,13 +136,13 @@ func SetFlags(ci *fs.ConfigInfo) {
 
 	// Process --headers-upload, --headers-download, --headers
 	if len(uploadHeaders) != 0 {
-		ci.UploadHeaders = fs.ParseHeaders(uploadHeaders)
+		ci.UploadHeaders = fs.MustParseHeaders(uploadHeaders)
 	}
 	if len(downloadHeaders) != 0 {
-		ci.DownloadHeaders = fs.ParseHeaders(downloadHeaders)
+		ci.DownloadHeaders = fs.MustParseHeaders(downloadHeaders)
 	}
 	if len(headers) != 0 {
-		ci.Headers = fs.ParseHeaders(headers)
+		ci.Headers = fs.MustParseHeaders(headers)
 	}
 
 	// Process --metadata-set

--- a/fs/open_options.go
+++ b/fs/open_options.go
@@ -198,6 +198,23 @@ func (o *SeekOption) Mandatory() bool {
 	return true
 }
 
+// ParseHeaders converts the strings passed in via the header flags into HTTPOptions
+func ParseHeaders(headers []string) []*HTTPOption {
+	opts := []*HTTPOption{}
+	for _, header := range headers {
+		parts := strings.SplitN(header, ":", 2)
+		if len(parts) != 2 {
+			Fatalf(nil, "Failed to parse '%s' as an HTTP header. Expecting a string like: 'Cache-Control: no-store'", header)
+		}
+		option := &HTTPOption{
+			Key:   strings.TrimSpace(parts[0]),
+			Value: strings.TrimSpace(parts[1]),
+		}
+		opts = append(opts, option)
+	}
+	return opts
+}
+
 // HTTPOption defines a general purpose HTTP option
 type HTTPOption struct {
 	Key   string

--- a/fs/open_options.go
+++ b/fs/open_options.go
@@ -199,18 +199,27 @@ func (o *SeekOption) Mandatory() bool {
 }
 
 // ParseHeaders converts the strings passed in via the header flags into HTTPOptions
-func ParseHeaders(headers []string) []*HTTPOption {
+func ParseHeaders(headers []string) ([]*HTTPOption, error) {
 	opts := []*HTTPOption{}
 	for _, header := range headers {
 		parts := strings.SplitN(header, ":", 2)
 		if len(parts) != 2 {
-			Fatalf(nil, "Failed to parse '%s' as an HTTP header. Expecting a string like: 'Cache-Control: no-store'", header)
+			return nil, fmt.Errorf("failed to parse %q as an HTTP header. Expecting a string like: 'Cache-Control: no-store'", header)
 		}
 		option := &HTTPOption{
 			Key:   strings.TrimSpace(parts[0]),
 			Value: strings.TrimSpace(parts[1]),
 		}
 		opts = append(opts, option)
+	}
+	return opts, nil
+}
+
+// MustParseHeaders converts the strings passed in via the header flags into HTTPOptions or exits.
+func MustParseHeaders(headers []string) []*HTTPOption {
+	opts, err := ParseHeaders(headers)
+	if err != nil {
+		Fatalf(nil, "%v", err)
 	}
 	return opts
 }

--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -199,6 +199,18 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 	}
 }
 
+// MiddlewareResponseHeaders instantiates middleware that apply custom headers to every response
+func MiddlewareResponseHeaders(headers []*fs.HTTPOption) Middleware {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			for _, header := range headers {
+				w.Header().Set(header.Key, header.Value)
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
 // MiddlewareStripPrefix instantiates middleware that removes the BaseURL from the path
 func MiddlewareStripPrefix(prefix string) Middleware {
 	return func(next http.Handler) http.Handler {

--- a/lib/http/server.go
+++ b/lib/http/server.go
@@ -173,7 +173,7 @@ var ConfigInfo = fs.Options{{
 }, {
 	Name:    "response_header",
 	Default: []string{},
-	Help:    "Set HTTP header for all responses",
+	Help:    "Set HTTP header for all responses, overriding existing values",
 }}
 
 // Config contains options for the http Server
@@ -189,7 +189,7 @@ type Config struct {
 	TLSKeyBody         []byte      `config:"-"`                    // TLS PEM private key body, ignores TLSKey
 	ClientCA           string      `config:"client_ca"`            // Path to TLS PEM CA file with certificate authorities to verify clients with
 	MinTLSVersion      string      `config:"min_tls_version"`      // MinTLSVersion contains the minimum TLS version that is acceptable
-	AllowOrigin        string      `config:"allow_origin"`         // AllowOrigin sets the Access-Control-Allow-Origin header+
+	AllowOrigin        string      `config:"allow_origin"`         // AllowOrigin sets the Access-Control-Allow-Origin header
 	ResponseHeaders    []string    `config:"response_header"`      // Set HTTP header for all responses
 }
 
@@ -357,8 +357,13 @@ func NewServer(ctx context.Context, options ...Option) (*Server, error) {
 		return nil, err
 	}
 
+	responseHeaders, err := fs.ParseHeaders(s.cfg.ResponseHeaders)
+	if err != nil {
+		return nil, err
+	}
+
 	s.mux.Use(MiddlewareCORS(s.cfg.AllowOrigin))
-	s.mux.Use(MiddlewareResponseHeaders(fs.ParseHeaders(s.cfg.ResponseHeaders)))
+	s.mux.Use(MiddlewareResponseHeaders(responseHeaders))
 
 	s.initAuth()
 

--- a/lib/http/server.go
+++ b/lib/http/server.go
@@ -53,8 +53,9 @@ for a transfer.
 ` + "`--{{ .Prefix }}max-header-bytes`" + ` controls the maximum number of bytes the server will
 accept in the HTTP header.
 
-` + "`--{{ .Prefix }}response-header`" + ` can be used to set an HTTP header for all responses. The flag
-may be repeated to add multiple headers. Use the format ` + "`Header-Name: value`" + `.
+` + "`--{{ .Prefix }}response-header`" + ` can be used to set an HTTP header for all responses,
+will overriding existing values. The flag may be repeated to add multiple
+headers. Use the format ` + "`Header-Name: value`" + `.
 
 ` + "`--{{ .Prefix }}baseurl`" + ` controls the URL prefix that rclone serves from.  By default
 rclone will serve from the root.  If you used ` + "`--{{ .Prefix }}baseurl \"/rclone\"`" + ` then
@@ -190,7 +191,7 @@ type Config struct {
 	ClientCA           string      `config:"client_ca"`            // Path to TLS PEM CA file with certificate authorities to verify clients with
 	MinTLSVersion      string      `config:"min_tls_version"`      // MinTLSVersion contains the minimum TLS version that is acceptable
 	AllowOrigin        string      `config:"allow_origin"`         // AllowOrigin sets the Access-Control-Allow-Origin header
-	ResponseHeaders    []string    `config:"response_header"`      // Set HTTP header for all responses
+	ResponseHeaders    []string    `config:"response_header"`      // Set HTTP header for all responses, overriding existing values
 }
 
 // AddFlagsPrefix adds flags for the httplib
@@ -205,7 +206,7 @@ func (cfg *Config) AddFlagsPrefix(flagSet *pflag.FlagSet, prefix string) {
 	flags.StringVarP(flagSet, &cfg.BaseURL, prefix+"baseurl", "", cfg.BaseURL, "Prefix for URLs - leave blank for root", prefix)
 	flags.StringVarP(flagSet, &cfg.MinTLSVersion, prefix+"min-tls-version", "", cfg.MinTLSVersion, "Minimum TLS version that is acceptable", prefix)
 	flags.StringVarP(flagSet, &cfg.AllowOrigin, prefix+"allow-origin", "", cfg.AllowOrigin, "Origin which cross-domain request (CORS) can be executed from", prefix)
-	flags.StringArrayVarP(flagSet, &cfg.ResponseHeaders, prefix+"response-header", "", cfg.ResponseHeaders, "Set HTTP header for all responses", prefix)
+	flags.StringArrayVarP(flagSet, &cfg.ResponseHeaders, prefix+"response-header", "", cfg.ResponseHeaders, "Set HTTP header for all responses, overriding existing values", prefix)
 }
 
 // AddHTTPFlagsPrefix adds flags for the httplib

--- a/lib/http/server.go
+++ b/lib/http/server.go
@@ -53,6 +53,9 @@ for a transfer.
 ` + "`--{{ .Prefix }}max-header-bytes`" + ` controls the maximum number of bytes the server will
 accept in the HTTP header.
 
+` + "`--{{ .Prefix }}response-header`" + ` can be used to set an HTTP header for all responses. The flag
+may be repeated to add multiple headers. Use the format ` + "`Header-Name: value`" + `.
+
 ` + "`--{{ .Prefix }}baseurl`" + ` controls the URL prefix that rclone serves from.  By default
 rclone will serve from the root.  If you used ` + "`--{{ .Prefix }}baseurl \"/rclone\"`" + ` then
 rclone would serve from a URL starting with "/rclone/".  This is
@@ -167,6 +170,10 @@ var ConfigInfo = fs.Options{{
 	Name:    "allow_origin",
 	Default: "",
 	Help:    "Origin which cross-domain request (CORS) can be executed from",
+}, {
+	Name:    "response_header",
+	Default: []string{},
+	Help:    "Set HTTP header for all responses",
 }}
 
 // Config contains options for the http Server
@@ -181,8 +188,9 @@ type Config struct {
 	TLSCertBody        []byte      `config:"-"`                    // TLS PEM public key certificate body (can also include intermediate/CA certificates), ignores TLSCert
 	TLSKeyBody         []byte      `config:"-"`                    // TLS PEM private key body, ignores TLSKey
 	ClientCA           string      `config:"client_ca"`            // Path to TLS PEM CA file with certificate authorities to verify clients with
-	MinTLSVersion      string      `config:"min_tls_version"`      // MinTLSVersion contains the minimum TLS version that is acceptable.
-	AllowOrigin        string      `config:"allow_origin"`         // AllowOrigin sets the Access-Control-Allow-Origin header
+	MinTLSVersion      string      `config:"min_tls_version"`      // MinTLSVersion contains the minimum TLS version that is acceptable
+	AllowOrigin        string      `config:"allow_origin"`         // AllowOrigin sets the Access-Control-Allow-Origin header+
+	ResponseHeaders    []string    `config:"response_header"`      // Set HTTP header for all responses
 }
 
 // AddFlagsPrefix adds flags for the httplib
@@ -197,6 +205,7 @@ func (cfg *Config) AddFlagsPrefix(flagSet *pflag.FlagSet, prefix string) {
 	flags.StringVarP(flagSet, &cfg.BaseURL, prefix+"baseurl", "", cfg.BaseURL, "Prefix for URLs - leave blank for root", prefix)
 	flags.StringVarP(flagSet, &cfg.MinTLSVersion, prefix+"min-tls-version", "", cfg.MinTLSVersion, "Minimum TLS version that is acceptable", prefix)
 	flags.StringVarP(flagSet, &cfg.AllowOrigin, prefix+"allow-origin", "", cfg.AllowOrigin, "Origin which cross-domain request (CORS) can be executed from", prefix)
+	flags.StringArrayVarP(flagSet, &cfg.ResponseHeaders, prefix+"response-header", "", cfg.ResponseHeaders, "Set HTTP header for all responses", prefix)
 }
 
 // AddHTTPFlagsPrefix adds flags for the httplib
@@ -349,6 +358,7 @@ func NewServer(ctx context.Context, options ...Option) (*Server, error) {
 	}
 
 	s.mux.Use(MiddlewareCORS(s.cfg.AllowOrigin))
+	s.mux.Use(MiddlewareResponseHeaders(fs.ParseHeaders(s.cfg.ResponseHeaders)))
 
 	s.initAuth()
 


### PR DESCRIPTION
#### What is the purpose of this change?

Support custom response headers, so users can use things like `--response-header "Cache-Control: no-store"` and more. Close #7222 , Close #7225 . Thanks for previous work by @timakro (marked as `Co-authored`).

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
