### PR TITLE
oauthutil: improve OAuth client ID/secret help text

### DIFF
--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -133,11 +133,11 @@ func (conf *Config) MakeClientCredentialsConfig() *clientcredentials.Config {
 // SharedOptions are shared between backends the utilize an OAuth flow
 var SharedOptions = []fs.Option{{
 	Name:      config.ConfigClientID,
-	Help:      "OAuth Client Id.\n\nLeave blank normally.",
+	Help:      "OAuth Client Id.\n\nLeave blank to use rclone's.",
 	Sensitive: true,
 }, {
 	Name:      config.ConfigClientSecret,
-	Help:      "OAuth Client Secret.\n\nLeave blank normally.",
+	Help:      "OAuth Client Secret.\n\nLeave blank to use rclone's.",
 	Sensitive: true,
 }, {
 	Name:      config.ConfigToken,


### PR DESCRIPTION
## Summary
This PR fixes #8731

## Changes
- Updated the help text for `OAuth Client ID` from "Leave blank normally." to "Leave blank to use rclone's."
- Updated the help text for `OAuth Client Secret` from "Leave blank normally." to "Leave blank to use rclone's."

## Rationale
The previous text "Leave blank normally" was confusing because:
1. It doesn't explain *why* users should leave it blank
2. It's particularly confusing when users provide their own client ID - the subsequent secret field still says "normally left blank" which contradicts their action

The new text "Leave blank to use rclone's." clearly explains that leaving these fields blank means rclone will use its built-in credentials, making the onboarding experience less confusing.

## Testing
- `go build ./lib/oauthutil/...` - passes
- `go vet ./lib/oauthutil/...` - passes
- `gofmt` - file is properly formatted