### PR TITLE
sftp: add --sftp-disable-concurrent-opens option 

### DIFF
--- a/backend/sftp/sftp_internal_test.go
+++ b/backend/sftp/sftp_internal_test.go
@@ -3,11 +3,42 @@
 package sftp
 
 import (
+	"context"
 	"fmt"
+	"io"
+	"strings"
+	"sync"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fstest/fstests"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+// mockSSHClient implements sshClient interface for testing
+type mockSSHClient struct{}
+
+func (m *mockSSHClient) Wait() error                     { return nil }
+func (m *mockSSHClient) SendKeepAlive()                  {}
+func (m *mockSSHClient) Close() error                    { return nil }
+func (m *mockSSHClient) NewSession() (sshSession, error) { return nil, nil }
+func (m *mockSSHClient) CanReuse() bool                  { return true }
+
+type settings map[string]any
+
+func deriveFs(ctx context.Context, t *testing.T, f fs.Fs, opts settings) fs.Fs {
+	fsName := strings.Split(f.Name(), "{")[0] // strip off hash
+	configMap := configmap.Simple{}
+	for key, val := range opts {
+		configMap[key] = fmt.Sprintf("%v", val)
+	}
+	remote := fmt.Sprintf("%s,%s:%s", fsName, configMap.String(), f.Root())
+	newFs, err := fs.NewFs(ctx, remote)
+	require.NoError(t, err)
+	return newFs
+}
 
 func TestShellEscapeUnix(t *testing.T) {
 	for i, test := range []struct {
@@ -86,3 +117,121 @@ func TestParseUsage(t *testing.T) {
 		assert.Equal(t, test.usage, [3]int64{gotSpaceTotal, gotSpaceUsed, gotSpaceAvail}, fmt.Sprintf("Test %d sshOutput = %q", i, test.sshOutput))
 	}
 }
+
+func TestDisableConcurrentOpensOption(t *testing.T) {
+	// Test that DisableConcurrentOpens option is correctly defined
+	t.Run("OptionDefault", func(t *testing.T) {
+		opt := Options{}
+		assert.False(t, opt.DisableConcurrentOpens, "DisableConcurrentOpens should default to false")
+	})
+
+	t.Run("OptionEnabled", func(t *testing.T) {
+		opt := Options{DisableConcurrentOpens: true}
+		assert.True(t, opt.DisableConcurrentOpens, "DisableConcurrentOpens should be settable to true")
+	})
+}
+
+func TestPutSftpConnectionReturnsToPool(t *testing.T) {
+	// Test that putSftpConnection correctly returns connection to pool
+	f := &Fs{
+		poolMu: sync.Mutex{},
+		pool:   []*conn{},
+	}
+
+	mockConn := &conn{
+		sshClient: &mockSSHClient{},
+	}
+
+	t.Run("ConnectionReturnedToPool", func(t *testing.T) {
+		f.pool = []*conn{}
+		c := mockConn
+
+		// Verify pool is empty before
+		assert.Equal(t, 0, len(f.pool))
+
+		// Call putSftpConnection
+		f.putSftpConnection(&c, nil)
+
+		// Verify connection is in pool
+		assert.Equal(t, 1, len(f.pool))
+		assert.Equal(t, mockConn, f.pool[0])
+	})
+
+	t.Run("PointerNilledAfterReturn", func(t *testing.T) {
+		f.pool = []*conn{}
+		c := mockConn
+
+		f.putSftpConnection(&c, nil)
+
+		// Verify pointer is nilled (prevents reuse)
+		assert.Nil(t, c)
+	})
+}
+
+// testDisableConcurrentOpens tests that DisableConcurrentOpens option works correctly
+func (f *Fs) testDisableConcurrentOpens(t *testing.T) {
+	ctx := context.Background()
+
+	// Skip if no test files available
+	if len(fstests.InternalTestFiles) == 0 {
+		t.Skip("no test files available")
+	}
+
+	// Create a new Fs with DisableConcurrentOpens enabled
+	testFs := deriveFs(ctx, t, f, settings{
+		"disable_concurrent_opens": true,
+	})
+	sftpFs := testFs.(*Fs)
+
+	// Verify option is enabled
+	assert.True(t, sftpFs.opt.DisableConcurrentOpens, "DisableConcurrentOpens should be enabled")
+
+	// Get a test file
+	testFile := fstests.InternalTestFiles[0]
+	obj, err := testFs.NewObject(ctx, testFile.Path)
+	require.NoError(t, err)
+
+	// Record pool size before Open
+	sftpFs.poolMu.Lock()
+	poolSizeBefore := len(sftpFs.pool)
+	sftpFs.poolMu.Unlock()
+
+	// Open the file for reading
+	reader, err := obj.Open(ctx)
+	require.NoError(t, err)
+
+	// While file is open, pool should not have grown
+	// (connection is held by the reader, not returned to pool)
+	sftpFs.poolMu.Lock()
+	poolSizeDuringRead := len(sftpFs.pool)
+	sftpFs.poolMu.Unlock()
+
+	// Read some data to ensure the transfer is active
+	buf := make([]byte, 1024)
+	_, _ = reader.Read(buf)
+
+	// Close the reader
+	err = reader.Close()
+	require.NoError(t, err)
+
+	// After Close, pool should have the connection back
+	sftpFs.poolMu.Lock()
+	poolSizeAfter := len(sftpFs.pool)
+	sftpFs.poolMu.Unlock()
+
+	// The pool should have grown after Close (connection returned)
+	assert.GreaterOrEqual(t, poolSizeAfter, poolSizeDuringRead,
+		"Pool should have connection after Close (before: %d, during: %d, after: %d)",
+		poolSizeBefore, poolSizeDuringRead, poolSizeAfter)
+}
+
+// InternalTest dispatches all internal tests
+func (f *Fs) InternalTest(t *testing.T) {
+	t.Run("DisableConcurrentOpens", f.testDisableConcurrentOpens)
+}
+
+var _ fstests.InternalTester = (*Fs)(nil)
+
+// Ensure sync and io packages are used
+var _ = sync.Mutex{}
+var _ io.Reader


### PR DESCRIPTION
#### What is the purpose of this change?

Some SFTP servers limit the number of files that can be opened simultaneously on a single connection, even though they allow multiple SFTP connections to be established at the same time to enable parallel downloads of multiple files.

At present, even if `--sftp-connections` and `--transfer` are set to the same value, it still cannot guarantee that each connection transfers only one file. As a result, the server may returns a permission denied error when a second file is opened. Therefore, I added a `--sftp-disable-concurrent-opens` option to prevent multiple open operations from being performed on the same connection.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
