### PR TITLE
Fix Proton Drive upload issues

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -280,6 +280,6 @@ require (
 )
 
 replace (
-	github.com/henrybear327/Proton-API-Bridge v1.0.0 => github.com/coderFrankenstain/Proton-API-Bridge v1.1.0
+	github.com/henrybear327/Proton-API-Bridge v1.0.0 => github.com/coderFrankenstain/Proton-API-Bridge v1.1.1
 	github.com/henrybear327/go-proton-api v1.0.0 => github.com/coderFrankenstain/go-proton-api v1.1.0
 )

--- a/go.sum
+++ b/go.sum
@@ -207,8 +207,8 @@ github.com/cloudsoda/sddl v0.0.0-20250224235906-926454e91efc/go.mod h1:uvR42Hb/t
 github.com/cloudwego/base64x v0.1.5 h1:XPciSp1xaq2VCSt6lF0phncD4koWyULpl5bUxbfCyP4=
 github.com/cloudwego/base64x v0.1.5/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/coderFrankenstain/Proton-API-Bridge v1.1.0 h1:G51zblki27qXmVYZoktnOVuLEcjKaH6O1+zDiHjGOz0=
-github.com/coderFrankenstain/Proton-API-Bridge v1.1.0/go.mod h1:gunH16hf6U74W2b9CGDaWRadiLICsoJ6KRkSt53zLts=
+github.com/coderFrankenstain/Proton-API-Bridge v1.1.1 h1:ILtK91Iw5JG9C7dYdDPQh0xnPWBOr1l08us5yZ4zRdg=
+github.com/coderFrankenstain/Proton-API-Bridge v1.1.1/go.mod h1:gunH16hf6U74W2b9CGDaWRadiLICsoJ6KRkSt53zLts=
 github.com/coderFrankenstain/go-proton-api v1.1.0 h1:Ld+jhTLBVIlaCu3NuqAR3CuCGpWxOfvp5iix47nwMU8=
 github.com/coderFrankenstain/go-proton-api v1.1.0/go.mod h1:w63MZuzufKcIZ93pwRgiOtxMXYafI8H74D77AxytOBc=
 github.com/colinmarc/hdfs/v2 v2.4.0 h1:v6R8oBx/Wu9fHpdPoJJjpGSUxo8NhHIwrwsfhFvU9W0=


### PR DESCRIPTION
#### What is the purpose of this change?

This change fixes Proton Drive uploads by implementing the missing block
verification step required by the official Proton Drive web client.

The implementation is based on the block verification flow used by Proton’s
official open-source web client. In particular, for each encrypted block we:
- request VerificationCode and ContentKeyPacket from the Verification endpoint
- decrypt the verifier session key via the file’s node key
- perform a decrypt-check of the encrypted block
- generate the per-block verification token (XOR-based, with 0-padding)
- include the token in the block metadata submitted during upload

Previously, rclone did not generate/submit the per-block verifier token, so the
server could accept encrypted block uploads initially but later reject the block
or the revision, leading to stalled or failed uploads.

#### Was the change discussed in an issue or in the forum before?

Not prior to this PR. This was investigated after users reported recent Proton
Drive upload failures, and the fix was derived by aligning rclone’s behavior
with the official web client.

#### Checklist

- [x] I have read the contribution guidelines.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in house style.
- [x] I'm done, this Pull Request is ready for review :-)
