### PR TITLE
build: bump Go version to 1.24.11 to fix CVE-2025-61729

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/rclone/rclone
 
-go 1.24.4
+go 1.24.11
 
 godebug x509negativeserial=1
 


### PR DESCRIPTION
This update addresses CVE-2025-61729 by upgrading the Go version to 1.24.11.
See https://pkg.go.dev/vuln/GO-2025-4155 and https://go.dev/doc/devel/release#go1.24.minor