### PR TITLE
docs: fix googlephotos custom client_id instructions

### DIFF
--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -659,8 +659,14 @@ second that each client_id can do set by Google.
 If there is a problem with this client_id (eg quota too low or the
 client_id stops working) then you can make your own.
 
-Please follow the steps in [the google drive docs](https://rclone.org/drive/#making-your-own-client-id).
-You will need these scopes instead of the drive ones detailed:
+Please follow the steps in [the google drive docs](https://rclone.org/drive/#making-your-own-client-id)
+with the following differences:
+
+- At step 3, instead of enabling the "Google Drive API", search for and
+  enable the "Photos Library API".
+
+- At step 5, you will need to add different scopes. Use these scopes
+  instead of the drive ones:
 
 ```text
 https://www.googleapis.com/auth/photoslibrary.appendonly


### PR DESCRIPTION
#### What is the purpose of this change?
 
The Google Photos "Making your own client_id" documentation was incomplete. It referenced the Google Drive guide but only mentioned changing the OAuth scopes, without noting that users must also enable a different API.
 
This change clarifies the two key differences from the Google Drive setup:
1. At step 3, enable the "Photos Library API" instead of the "Google Drive API"
2. At step 5, use the Google Photos specific scopes instead of the Drive scopes
 
Before this fix, users following the documentation would get errors because the Photos Library API was not enabled in their Google Cloud Console project.
 
#### Was the change discussed in an issue or in the forum before?
 
No prior discussion - this was a documentation gap discovered while following the setup instructions.
 
#### Checklist
 
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)