### PR TITLE
obscure: avoid shell variable replacement

### DIFF
--- a/cmd/obscure/obscure.go
+++ b/cmd/obscure/obscure.go
@@ -34,7 +34,7 @@ argument by passing a hyphen as an argument. This will use the first
 line of STDIN as the password not including the trailing newline.
 
 ` + "```console" + `
-echo "secretpassword" | rclone obscure -
+echo 'secretpassword' | rclone obscure -
 ` + "```" + `
 
 If there is no data on STDIN to read, rclone obscure will default to


### PR DESCRIPTION
I had a $ in my password. To avoid variable replacement, single quotes might be the better choice.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

I could not connect to a Hetzner Storage Box with sftp and it took me a while to realize what went wrong - the $ in my password, which fooled the obscuring. 

#### Was the change discussed in an issue or in the forum before?

I searched in the issues and discussions and did not find anything.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
