### PR TITLE
filen: swap to blake3 hashes

### DIFF
--- a/backend/filen/filen.go
+++ b/backend/filen/filen.go
@@ -226,7 +226,7 @@ func (f *Fs) Precision() time.Duration {
 
 // Hashes returns the supported hash sets.
 func (f *Fs) Hashes() hash.Set {
-	return hash.Set(hash.SHA512)
+	return hash.Set(hash.BLAKE3)
 }
 
 // Features returns the optional features of this Fs
@@ -659,7 +659,7 @@ func (o *Object) Size() int64 {
 // Hash returns the selected checksum of the file
 // If no checksum is available it returns ""
 func (o *Object) Hash(ctx context.Context, ty hash.Type) (string, error) {
-	if ty != hash.SHA512 {
+	if ty != hash.BLAKE3 {
 		return "", hash.ErrUnsupported
 	}
 	if o.file.Hash == "" {

--- a/docs/content/filen.md
+++ b/docs/content/filen.md
@@ -83,7 +83,7 @@ y/e/d> y
 ### Modification times and hashes
 Modification times are fully supported for files, for directories, only the creation time matters.
 
-Filen supports SHA512 hashes.
+Filen supports Blake3 hashes.
 
 ### Restricted filename characters
 Invalid UTF-8 bytes will be [replaced](/overview/#invalid-utf8)

--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -27,7 +27,7 @@ Here is an overview of the major features of each cloud storage system.
 | Dropbox                      | DBHASH ¹          | R       | Yes              | No              | -         | -        |
 | Enterprise File Fabric       | -                 | R/W     | Yes              | No              | R/W       | -        |
 | FileLu Cloud Storage         | MD5               | R/W     | No               | Yes             | R         | -        |
-| Filen                        | SHA512            | R/W     | Yes              | No              | R/W       | -        |
+| Filen                        | Blake3            | R/W     | Yes              | No              | R/W       | -        |
 | Files.com                    | MD5, CRC32        | DR/W    | Yes              | No              | R         | -        |
 | FTP                          | -                 | R/W ¹⁰  | No               | No              | -         | -        |
 | Gofile                       | MD5               | DR/W    | No               | Yes             | R         | -        |

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azfile v1.5.3
 	github.com/Azure/go-ntlmssp v0.0.2-0.20251110135918-10b7b7e7cd26
-	github.com/FilenCloudDienste/filen-sdk-go v0.0.34
+	github.com/FilenCloudDienste/filen-sdk-go v0.0.35
 	github.com/Files-com/files-sdk-go/v3 v3.2.264
 	github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd
 	github.com/a1ex3/zstd-seekable-format-go/pkg v0.10.0
@@ -155,8 +155,8 @@ require (
 	github.com/creasty/defaults v1.8.0 // indirect
 	github.com/cronokirby/saferith v0.33.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
-	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/dromara/dongle v1.0.1 // indirect
+	github.com/dsnet/compress v0.0.2-0.20230904184137-39efe44ab707 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/ebitengine/purego v0.9.1 // indirect
 	github.com/emersion/go-message v0.18.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgv
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/FilenCloudDienste/filen-sdk-go v0.0.34 h1:Fd/wagh/Qn35p3PkCUYubmaELATQlYGC9pxpJ9TkHUE=
-github.com/FilenCloudDienste/filen-sdk-go v0.0.34/go.mod h1:XkI1Iq30/tU8vk4Zd1cKr2cCTiFqBEf0ZfG4+KKUBrY=
+github.com/FilenCloudDienste/filen-sdk-go v0.0.35 h1:geuYpD/1ZXSp1H3kdW7si+KRUIrHHqM1kk8lqoA8Y9M=
+github.com/FilenCloudDienste/filen-sdk-go v0.0.35/go.mod h1:0cBhKXQg49XbKZZfk5TCDa3sVLP+xMxZTWL+7KY0XR0=
 github.com/Files-com/files-sdk-go/v3 v3.2.264 h1:lMHTplAYI9FtmCo/QOcpRxmPA5REVAct1r2riQmDQKw=
 github.com/Files-com/files-sdk-go/v3 v3.2.264/go.mod h1:wGqkOzRu/ClJibvDgcfuJNAqI2nLhe8g91tPlDKRCdE=
 github.com/IBM/go-sdk-core/v5 v5.21.0 h1:DUnYhvC4SoC8T84rx5omnhY3+xcQg/Whyoa3mDPIMkk=


### PR DESCRIPTION
#### What is the purpose of this change?

After adding the filen backend to rclone in #8537, and with people testing our fork finding odd hash mismatches, yesterday we identified an issue causing hash generation using our TypeScript SDK to have a potential race condition meaning that (since we don't add any client fingerprinting to uploads) all old hashes are potentially wrong, and therefore useless.

This change updates the Go SDK version to a version that uses blake3 for hashing (since it seems to be better for this use-case anyway), I will be doing the same work for our Rust SDK which all our clients will soon be migrating to.

We only identified this now because the TypeScript SDK never actually validated file hashes on download, whereas the newer SDKs do. File integrity hasn't been compromised here, the issue is just that we can't trust the hash mismatches.

Tests run on the latest version: [2026-01-15-163419.zip](https://github.com/user-attachments/files/24667146/2026-01-15-163419.zip)


#### Was the change discussed in an issue or in the forum before?
No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
