### PR TITLE
vfs: fix free space calculation with --vfs-disk-space-total-size

### DIFF
--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -694,6 +694,10 @@ func (vfs *VFS) Statfs() (total, used, free int64) {
 
 	if int64(vfs.Opt.DiskSpaceTotalSize) >= 0 {
 		total = int64(vfs.Opt.DiskSpaceTotalSize)
+		if used > total {
+			used = total
+		}
+		free = -1
 	}
 
 	total, used, free = fillInMissingSizes(total, used, free, unknownFreeBytes)


### PR DESCRIPTION
#### What is the purpose of this change?

Statfs currently reports negative free space when used space is greater than the value set by --vfs-disk-space-total-size. While writing the tests, I also noticed that free space isn't recalculated when using this flag.
```
$ tree
.
├── data
│   └── 4MiB.bin
└── mnt

3 directories, 1 file
$ rclone mount -v --vfs-used-is-size --vfs-disk-space-total-size 2M local:data mnt/

--------

$ df -h mnt/
Filesystem                        Size  Used Avail Use% Mounted on
/home/elliot/tmp/data             2.0M  -16E   16E    - /home/elliot/tmp/mnt
```

After changes:
```
$ df -h mnt/
Filesystem                        Size  Used Avail Use% Mounted on
/home/elliot/tmp/data             2.0M  2.0M     0 100% /home/elliot/tmp/mnt
```

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
