### PR TITLE
sftp: properly escape quotes in PowerShell

### DIFF
--- a/backend/sftp/sftp_internal_test.go
+++ b/backend/sftp/sftp_internal_test.go
@@ -54,6 +54,10 @@ func TestShellEscapePowerShell(t *testing.T) {
 		{"c:/test&notepad", "'c:/test&notepad'"},
 		{"c:/test\"&\"notepad", "'c:/test\"&\"notepad'"},
 		{"c:/test'&'notepad", "'c:/test''&''notepad'"},
+		{"/test/‘/2018", "'/test/'‘/2018'"},
+		{"/test/’/2019", "'/test/'’/2019'"},
+		{"/test/‚/201a", "'/test/'‚/201a'"},
+		{"/test/‛/201b", "'/test/'‛/201b'"},
 	} {
 		got, err := quoteOrEscapeShellPath("powershell", test.unescaped)
 		assert.NoError(t, err)


### PR DESCRIPTION
Fixes #9098

I'm not that experienced with Go so if this isn't done in the best way, please change it!

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
