### PR TITLE
fs: refactor password obscure tests

### DIFF
--- a/fs/config/obscure/obscure_test.go
+++ b/fs/config/obscure/obscure_test.go
@@ -2,7 +2,6 @@ package obscure
 
 import (
 	"bytes"
-	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,6 @@ func TestObscure(t *testing.T) {
 	} {
 		cryptRand = bytes.NewBufferString(test.iv)
 		got, err := Obscure(test.in)
-		cryptRand = rand.Reader
 		assert.NoError(t, err)
 		assert.Equal(t, test.want, got)
 		recoveredIn, err := Reveal(got)
@@ -29,7 +27,6 @@ func TestObscure(t *testing.T) {
 		// Now the Must variants
 		cryptRand = bytes.NewBufferString(test.iv)
 		got = MustObscure(test.in)
-		cryptRand = rand.Reader
 		assert.Equal(t, test.want, got)
 		recoveredIn = MustReveal(got)
 		assert.Equal(t, test.in, recoveredIn, "not bidirectional")
@@ -41,18 +38,15 @@ func TestReveal(t *testing.T) {
 	for _, test := range []struct {
 		in   string
 		want string
-		iv   string
 	}{
-		{"YWFhYWFhYWFhYWFhYWFhYQ", "", "aaaaaaaaaaaaaaaa"},
-		{"YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "potato", "aaaaaaaaaaaaaaaa"},
-		{"YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "potato", "bbbbbbbbbbbbbbbb"},
+		{"YWFhYWFhYWFhYWFhYWFhYQ", ""},
+		{"YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "potato"},
+		{"YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "potato"},
 	} {
-		cryptRand = bytes.NewBufferString(test.iv)
 		got, err := Reveal(test.in)
 		assert.NoError(t, err)
 		assert.Equal(t, test.want, got)
 		// Now the Must variants
-		cryptRand = bytes.NewBufferString(test.iv)
 		got = MustReveal(test.in)
 		assert.Equal(t, test.want, got)
 


### PR DESCRIPTION
#### What is the purpose of this change?

Refactoring of obscure tests: deleting reduntant code.
These tests actually do not use any randomness: TestObscure() is using static IVs, defined explictly, and TestReveal() is testing deterministic function.
After the changes, all tests are still passed.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
