### PR TITLE
Go-1.26 vet fix

### DIFF
--- a/fs/bwtimetable.go
+++ b/fs/bwtimetable.go
@@ -97,7 +97,7 @@ func validateHour(HHMM string) error {
 		return fmt.Errorf("invalid minute in time specification: %q: %v", HHMM, err)
 	}
 	if mm < 0 || mm > 59 {
-		return fmt.Errorf("invalid minute (must be between 00 and 59): %d", hh)
+		return fmt.Errorf("invalid minute (must be between 00 and 59): %d", mm)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

With Go-1.26 vet checks are more strict.

    ./bwtimetable.go:93:64: fmt.Errorf format %q has arg hh of wrong type int
    ./bwtimetable.go:100:66: fmt.Errorf format %q has arg hh of wrong type int

Detected building in Fedora Rawhide.

Also made minor change to correctly report minutes instead of hours in `validateHour`.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
