### PR TITLE
Fix WinFsp link in rclone_mount documentation

### DIFF
--- a/cmd/mountlib/mount.md
+++ b/cmd/mountlib/mount.md
@@ -66,7 +66,7 @@ at all, then 1 PiB is set as both the total and the free size.
 ### Installing on Windows
 
 To run `rclone @ on Windows`, you will need to
-download and install [WinFsp](http://www.secfs.net/winfsp/).
+download and install [WinFsp](https://winfsp.dev).
 
 [WinFsp](https://github.com/winfsp/winfsp) is an open-source
 Windows File System Proxy which makes it easy to write user space file

--- a/librclone/README.md
+++ b/librclone/README.md
@@ -44,7 +44,7 @@ omit symbol table and debug information, reducing size by about 25% on Linux and
 
 Note that on macOS and Windows the mount functions will not be available unless
 you add additional argument `-tags cmount`. On Windows this also requires you to
-first install the third party utility [WinFsp](http://www.secfs.net/winfsp/),
+first install the third party utility [WinFsp](https://winfsp.dev),
 with the "Developer" feature selected, and to set environment variable CPATH
 pointing to the fuse include directory within the WinFsp installation
 (typically `C:\Program Files (x86)\WinFsp\inc\fuse`). See also the


### PR DESCRIPTION
Updated the WinFsp link. The current URL's DNS is not resolving. This new URL is the one linked to on the Github project.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
