### PR TITLE
drive: map scope numbers to actual values in config

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -191,9 +191,33 @@ func driveScopes(scopesString string) (scopes []string) {
 	if scopesString == "" {
 		scopesString = defaultScope
 	}
+	
+	validScopes := map[string]string{
+		"1": "drive",
+		"2": "drive.readonly",
+		"3": "drive.file",
+		"4": "drive.appfolder",
+		"5": "drive.metadata.readonly",
+		// Also allow direct scope names
+		"drive":                   "drive",
+		"drive.readonly":          "drive.readonly",
+		"drive.file":              "drive.file",
+		"drive.appfolder":         "drive.appfolder",
+		"drive.metadata.readonly": "drive.metadata.readonly",
+	}
+	
 	for scope := range strings.SplitSeq(scopesString, ",") {
 		scope = strings.TrimSpace(scope)
-		scopes = append(scopes, scopePrefix+scope)
+		
+		// Map number or validate scope name
+		if actualScope, found := validScopes[scope]; found {
+			scopes = append(scopes, scopePrefix+actualScope)
+		} else {
+			// For unknown values, still accept them (for future-proofing)
+			// Log as info since this could be a user mistake
+			fs.Logf(nil, "Using unrecognized scope %q - valid options: 1-5 or drive, drive.readonly, drive.file, drive.appfolder, drive.metadata.readonly", scope)
+			scopes = append(scopes, scopePrefix+scope)
+		}
 	}
 	return scopes
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->
Fixes an issue where users entering scope numbers during interactive configuration (e.g., `1,4`) would have those numbers used literally in OAuth URLs instead of being mapped to the actual scope values (`drive,drive.appfolder`).

This was causing invalid OAuth scope URLs like `https://www.googleapis.com/auth/1` instead of `https://www.googleapis.com/auth/drive`.

The fix adds a lookup table in `driveScopes()` to map numeric choices (1-5) to their corresponding scope strings. It still accepts direct scope names and unknown values (with a warning) for backward compatibility and flexibility.
#### Was the change discussed in an issue or in the forum before?
No prior issue or forum discussion. Discovered during configuration when testing scope selection.
<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
