### PR TITLE
vfs: retry cache operations with backoff when disk quota/space exceeded

### DIFF
--- a/fs/fserrors/enospc_error.go
+++ b/fs/fserrors/enospc_error.go
@@ -9,15 +9,20 @@ import (
 )
 
 // IsErrNoSpace checks a possibly wrapped error to
-// see if it contains a ENOSPC error
+// see if it contains a ENOSPC or EDQUOT error
 func IsErrNoSpace(cause error) (isNoSpc bool) {
 	liberrors.Walk(cause, func(c error) bool {
-		if c == syscall.ENOSPC {
+		switch c {
+		case syscall.ENOSPC:
 			isNoSpc = true
 			return true
+		case syscall.EDQUOT:
+			isNoSpc = true
+			return true
+		default:
+			isNoSpc = false
+			return false
 		}
-		isNoSpc = false
-		return false
 	})
 	return
 }


### PR DESCRIPTION
#### What is the purpose of this change?

This change introduces backpressure when the VFS cache reaches a hard space limit by retrying cache operations with exponential backoff while kicking the cache cleaner, instead of failing immediately. That lets bulk uploads continue even when local writes outpace remote upload speeds, because writes pause until cached data is uploaded and space is reclaimed.

#### Was the change discussed in an issue or in the forum before?

- https://github.com/rclone/rclone/issues/6005
- https://forum.rclone.org/t/backpressure-when-cache-is-full/53367

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
