### PR TITLE
accounting: Add deletedDirs stat to core/stats help output

### DIFF
--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -89,6 +89,7 @@ Returns the following values:
 {
 	"bytes": total transferred bytes since the start of the group,
 	"checks": number of files checked,
+	"deletedDirs": number of directories deleted,
 	"deletes" : number of files deleted,
 	"elapsedTime": time in floating point seconds since rclone was started,
 	"errors": number of errors,


### PR DESCRIPTION
#### What is the purpose of this change?

This change adds the missing `deletedDirs` stat to the help output of `core/stats`.

#### Was the change discussed in an issue or in the forum before?

This change was not discussed, I noticed the inconsistency when comparing the output of `core/stats` to the documentation on `https://rclone.org/rc/#core-stats`.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
