### PR TITLE
filen: fix potential panic in case of error during upload

### DIFF
--- a/backend/filen/filen.go
+++ b/backend/filen/filen.go
@@ -415,12 +415,12 @@ func (cw *chunkWriter) WriteChunk(ctx context.Context, chunkNumber int, reader i
 			return totalWritten, err
 		}
 		resp, err := cw.filen.UploadChunk(ctx, &cw.FileUpload, realChunkNumber, chunkReadSlice)
+		if err != nil {
+			return totalWritten, err
+		}
 		select { // only care about getting this once
 		case cw.bucketAndRegion <- *resp:
 		default:
-		}
-		if err != nil {
-			return totalWritten, err
 		}
 		totalWritten += int64(len(chunkReadSlice))
 		realChunkNumber++


### PR DESCRIPTION


#### What is the purpose of this change?
Fixes a panic that could occur if the chunk writer errored during the upload, instead of returning an error, the function would first try to dereference the returned value causing a null pointer exception.
#### Was the change discussed in an issue or in the forum before?
No, it was reported on our fork [here](https://github.com/FilenCloudDienste/filen-rclone/issues/5)
#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
