### PR TITLE
copyurl: Extend copyurl docs with an example of CSV FILENAMEs starting with a path

### DIFF
--- a/cmd/copyurl/copyurl.go
+++ b/cmd/copyurl/copyurl.go
@@ -70,6 +70,15 @@ Note that |--stdout| and |--print-filename| are incompatible with |--urls|.
 This will do |--transfers| copies in parallel. Note that if |--auto-filename|
 is desired for all URLs then a file with only URLs and no filename can be used.
 
+Each FILENAME in the CSV file can start with a relative path which will be appended
+to the destination path provided at the command line. For example, running the command
+shown above with the following CSV file will write two files to the destination: 
+|remote:dir/local/path/bar.json| and |remote:dir/another/local/directory/qux.json|
+|||csv
+https://example.org/foo/bar.json,local/path/bar.json
+https://example.org/qux/baz.json,another/local/directory/qux.json
+|||
+
 ### Troubleshooting
 
 If you can't get |rclone copyurl| to work then here are some things you can try:


### PR DESCRIPTION
This is a tiny PR which just adds an example to the `copyurl` docs!

#### What is the purpose of this change?

To make it clear that `copyurl` has a super-power: It's the only `rclone` command I'm aware of that can map from arbitrary source URLs to arbitrary destination paths.


#### Was the change discussed in an issue or in the forum before?

It's such a small change that I haven't discussed it in an issue first.


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)