### PR TITLE
filen: fix 32 bit targets not being able to list directories Fixes #9142

### DIFF
--- a/backend/filen/filen.go
+++ b/backend/filen/filen.go
@@ -355,19 +355,19 @@ type chunkWriter struct {
 	chunkSize       int64
 
 	chunksLock      sync.Mutex
-	knownChunks     map[int][]byte // known chunks to be hashed
-	nextChunkToHash int
+	knownChunks     map[int64][]byte // known chunks to be hashed
+	nextChunkToHash int64
 
 	sizeLock sync.Mutex
 	size     int64
 }
 
 func (cw *chunkWriter) WriteChunk(ctx context.Context, chunkNumber int, reader io.ReadSeeker) (bytesWritten int64, err error) {
-	realChunkNumber := int(int64(chunkNumber) * (cw.chunkSize) / sdk.ChunkSize)
+	realChunkNumber := int64(chunkNumber) * (cw.chunkSize) / sdk.ChunkSize
 	chunk := make([]byte, sdk.ChunkSize, sdk.ChunkSize+cw.EncryptionKey.Cipher.Overhead())
 
 	totalWritten := int64(0)
-	for sliceStart := 0; sliceStart < int(cw.chunkSize); sliceStart += sdk.ChunkSize {
+	for sliceStart := int64(0); sliceStart < cw.chunkSize; sliceStart += sdk.ChunkSize {
 		chunk = chunk[:sdk.ChunkSize]
 		chunkRead := 0
 		for {
@@ -496,7 +496,7 @@ func (f *Fs) OpenChunkWriter(ctx context.Context, remote string, src fs.ObjectIn
 		filen:           f.filen,
 		chunkSize:       chunkSize,
 		bucketAndRegion: make(chan client.V3UploadResponse, 1),
-		knownChunks:     make(map[int][]byte),
+		knownChunks:     make(map[int64][]byte),
 		nextChunkToHash: 0,
 		size:            0,
 	}, nil
@@ -1122,8 +1122,8 @@ func (f *Fs) About(ctx context.Context) (*fs.Usage, error) {
 		return nil, err
 	}
 
-	total := int64(userInfo.MaxStorage)
-	used := int64(userInfo.UsedStorage)
+	total := userInfo.MaxStorage
+	used := userInfo.UsedStorage
 	free := total - used
 	return &fs.Usage{
 		Total:   &total,

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.6.3
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azfile v1.5.3
 	github.com/Azure/go-ntlmssp v0.0.2-0.20251110135918-10b7b7e7cd26
-	github.com/FilenCloudDienste/filen-sdk-go v0.0.35
+	github.com/FilenCloudDienste/filen-sdk-go v0.0.37
 	github.com/Files-com/files-sdk-go/v3 v3.2.264
 	github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd
 	github.com/a1ex3/zstd-seekable-format-go/pkg v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0 h1:XRzhVemXdgv
 github.com/AzureAD/microsoft-authentication-library-for-go v1.6.0/go.mod h1:HKpQxkWaGLJ+D/5H8QRpyQXA1eKjxkFlOMwck5+33Jk=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/FilenCloudDienste/filen-sdk-go v0.0.35 h1:geuYpD/1ZXSp1H3kdW7si+KRUIrHHqM1kk8lqoA8Y9M=
-github.com/FilenCloudDienste/filen-sdk-go v0.0.35/go.mod h1:0cBhKXQg49XbKZZfk5TCDa3sVLP+xMxZTWL+7KY0XR0=
+github.com/FilenCloudDienste/filen-sdk-go v0.0.37 h1:W8S9TrAyZ4//3PXsU6+Bi+fe/6uIL986GyS7PVzIDL4=
+github.com/FilenCloudDienste/filen-sdk-go v0.0.37/go.mod h1:0cBhKXQg49XbKZZfk5TCDa3sVLP+xMxZTWL+7KY0XR0=
 github.com/Files-com/files-sdk-go/v3 v3.2.264 h1:lMHTplAYI9FtmCo/QOcpRxmPA5REVAct1r2riQmDQKw=
 github.com/Files-com/files-sdk-go/v3 v3.2.264/go.mod h1:wGqkOzRu/ClJibvDgcfuJNAqI2nLhe8g91tPlDKRCdE=
 github.com/IBM/go-sdk-core/v5 v5.18.5 h1:g0JRl3sYXJczB/yuDlrN6x22LJ6jIxhp0Sa4ARNW60c=


### PR DESCRIPTION
or do pretty much anything,
this was caused by timestamps not being read to 64 bit integers

#### What is the purpose of this change?
The Filen backend in 1.73 does not support 32 bit targets due to usage of ints instead of int64s, this fixes that issue in both the backend code and the filen-sdk-go

#### Was the change discussed in an issue or in the forum before?

#9142

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
