### PR TITLE
Update docs to specify HTTP for SeaweedFS

### DIFF
--- a/backend/s3/provider/SeaweedFS.yaml
+++ b/backend/s3/provider/SeaweedFS.yaml
@@ -2,7 +2,7 @@ name: SeaweedFS
 description: SeaweedFS S3
 region: {}
 endpoint:
-  localhost:8333: SeaweedFS S3 localhost
+  http://localhost:8333: SeaweedFS S3 localhost
 location_constraint: {}
 acl: {}
 bucket_acl: true


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The SeaweedFS endpoint currently recommended by the docs will cause rclone to hang with no apparent cause. This change explicitly shows the use of HTTP to match the standard SeaweedFS deplopyment.

#### Was the change discussed in an issue or in the forum before?

#8572

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
Solidly into yak shaving territory putting in this PR; gonna go figure out the SeaweedFS issue I started on 30 minutes ago and fix the commit title later. In the meantime, discussion on whether we want to encourage use of HTTP for an entirely local S3 provider is welcome.