### PR TITLE
WebDAV: Permit redirects on PROPFIND for metadata

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -348,7 +348,7 @@ func (f *Fs) readMetaDataForPath(ctx context.Context, path string, depth string)
 		ExtraHeaders: map[string]string{
 			"Depth": depth,
 		},
-		NoRedirect: true,
+		CheckRedirect: rest.PreserveMethodRedirectFn,
 	}
 	if f.hasOCMD5 || f.hasOCSHA1 {
 		opts.Body = bytes.NewBuffer(owncloudProps)

--- a/lib/rest/rest.go
+++ b/lib/rest/rest.go
@@ -216,6 +216,22 @@ func ClientWithNoRedirects(c *http.Client) *http.Client {
 	return &clientCopy
 }
 
+// PreserveMethodRedirectFn is a CheckRedirect function that
+// preserves the original HTTP method on redirects.
+//
+// By default Go's http.Client changes the method to GET on 301, 302,
+// and 303 redirects. This function overrides that behaviour so the
+// original method (e.g. PROPFIND being preserved across a 307) is kept.
+func PreserveMethodRedirectFn(req *http.Request, via []*http.Request) error {
+	if len(via) >= 10 {
+		return errors.New("stopped after 10 redirects")
+	}
+	if len(via) > 0 {
+		req.Method = via[0].Method
+	}
+	return nil
+}
+
 // Do calls the internal http.Client.Do method
 func (api *Client) Do(req *http.Request) (*http.Response, error) {
 	return api.c.Do(req)


### PR DESCRIPTION
#### What is the purpose of this change?

The WebDAV implementation already permits redirects on PROPFIND for listing paths in the `listAll` method but does not permit this for metadata in `readMetaDataForPath`.  This results in a strange experience for endpoints that heavily use redirects -

```
rclone lsl endpoint:
```

functions and lists `hello_world.txt` in its output but

```
rclone lsl endpoint:hello_world.txt
```

Fails with a HTTP 307.

The git history for this setting indicates this was done to avoid an issue where redirects cause a verb change to GET in the Go HTTP client; it does not appear to be problematic with HTTP 307 (issue #2350, solved by @ncw in https://github.com/rclone/rclone/commit/1550f70865245f917c63330039b18876bb214c8f).

#### Was the change discussed in an issue or in the forum before?

No - but it seems trivial.  Would be happy to open an issue if deeper discussion is desired

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)

I would appreciate guidance if / what tests and documentation are needed.