### PR TITLE
webdav: add missing headers for CORS

### DIFF
--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -189,7 +189,7 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
-				w.Header().Add("Access-Control-Allow-Headers", "authorization, Content-Type")
+				w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, TimeOut, Translate")
 				w.Header().Add("Access-Control-Allow-Methods", "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK")
 				w.Header().Add("Access-Control-Max-Age", "86400")
 			}


### PR DESCRIPTION
fix #7492

#### What is the purpose of this change?
Fixing problem with `serve webdav --allow-origin` - some headers was not allowed, that is used by webdav


