### PR TITLE
docs: Document unsupported S3 object keys with double slashes

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -671,6 +671,20 @@ work with the SDK properly:
 | .         | ．          |
 | ..        | ．．         |
 
+#### Important note about double slashes (`//`)
+
+Object keys containing consecutive forward slashes (`//`) are **not supported** by rclone. 
+
+When rclone encounters an object key with `//` (e.g., `a//b`), it will normalize the path to use a single slash (e.g., `a/b`). This normalization can cause "object not found" errors when trying to access the original object, as rclone will look for the normalized path instead of the actual object key.
+
+**Example:**
+- Original S3 object key: `folder//file.txt`
+- rclone interprets it as: `folder/file.txt`
+- Result: "object not found" error when trying to access `folder//file.txt`
+
+**Workaround:**
+Avoid using consecutive forward slashes (`//`) in S3 object keys when using rclone. If you have existing objects with `//` in their keys, you will need to rename them to use single slashes or access them through other means.
+
 ### Multipart uploads
 
 rclone supports multipart uploads with S3 which means that it can


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

Fixes #5063 by documenting that S3 object keys containing consecutive forward slashes (//) are not supported by rclone.

The issue occurs because rclone normalizes paths like "a//b" to "a/b", causing "object not found" errors when trying to access the original object. This documentation addition explicitly warns users about this limitation and provides workarounds.

Changes:
- Added new subsection "Important note about double slashes (//)" under "Restricted filename characters" in S3 documentation
- Explains the normalization behaviour and its consequences
- Provides clear examples and workarounds

AI Model/Tool Attribution:
- Implemented using opencode AI assistant with [OpenCode Zen](https://www.crackedaiengineering.com/ai-models/provider/opencode) Big Pickle. Followed by a human review.

#### Was the change discussed in an issue or in the forum before?

Resolves: #5063

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- ~[ ] I have added tests for all changes in this PR if appropriate.~
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
