### PR TITLE
s3: set list_version to 2 for FileLu S3 configuration

### DIFF
--- a/backend/s3/provider/FileLu.yaml
+++ b/backend/s3/provider/FileLu.yaml
@@ -15,7 +15,7 @@ endpoint:
 acl: {}
 bucket_acl: true
 quirks:
-  list_version: 1
+  list_version: 2
   force_path_style: true
   list_url_encode: false
   use_multipart_etag: false


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Updates the FileLu S3 backend configuration to use list_version: 2.
FileLu S3 API fully supports ListObjectsV2 and this aligns the configuration with current S3-compatible standards.
No other behavior changes.

#### Was the change discussed in an issue or in the forum before?
No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
