### PR TITLE
crypt: make scrypt memory parameter configurable

### DIFF
--- a/backend/crypt/cipher.go
+++ b/backend/crypt/cipher.go
@@ -184,7 +184,7 @@ type Cipher struct {
 }
 
 // newCipher initialises the cipher.  If salt is "" then it uses a built in salt val
-func newCipher(mode NameEncryptionMode, password, salt string, dirNameEncrypt bool, enc fileNameEncoding) (*Cipher, error) {
+func newCipher(mode NameEncryptionMode, password, salt string, dirNameEncrypt bool, enc fileNameEncoding, scryptN int) (*Cipher, error) {
 	c := &Cipher{
 		mode:            mode,
 		fileNameEnc:     enc,
@@ -195,7 +195,7 @@ func newCipher(mode NameEncryptionMode, password, salt string, dirNameEncrypt bo
 	c.buffers.New = func() any {
 		return new([blockSize]byte)
 	}
-	err := c.Key(password, salt)
+	err := c.Key(password, salt, scryptN)
 	if err != nil {
 		return nil, err
 	}
@@ -228,7 +228,7 @@ func (c *Cipher) setPassBadBlocks(passBadBlocks bool) {
 //
 // Note that empty password makes all 0x00 keys which is used in the
 // tests.
-func (c *Cipher) Key(password, salt string) (err error) {
+func (c *Cipher) Key(password, salt string, scryptN int) (err error) {
 	const keySize = len(c.dataKey) + len(c.nameKey) + len(c.nameTweak)
 	var saltBytes = defaultSalt
 	if salt != "" {
@@ -238,7 +238,7 @@ func (c *Cipher) Key(password, salt string) (err error) {
 	if password == "" {
 		key = make([]byte, keySize)
 	} else {
-		key, err = scrypt.Key([]byte(password), saltBytes, 16384, 8, 1, keySize)
+		key, err = scrypt.Key([]byte(password), saltBytes, scryptN, 8, 1, keySize)
 		if err != nil {
 			return err
 		}

--- a/backend/crypt/cipher_test.go
+++ b/backend/crypt/cipher_test.go
@@ -188,7 +188,7 @@ func TestDecodeFileNameBase32768(t *testing.T) {
 
 func testEncryptSegment(t *testing.T, encoding string, testCases []EncodingTestCase, caseInsensitive bool) {
 	enc, _ := NewNameEncoding(encoding)
-	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc)
+	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc, 16384)
 	for _, test := range testCases {
 		actual := c.encryptSegment(test.in)
 		assert.Equal(t, test.expected, actual, fmt.Sprintf("Testing %q", test.in))
@@ -277,7 +277,7 @@ func TestDecryptSegmentBase32(t *testing.T) {
 		longName[i] = 'a'
 	}
 	enc, _ := NewNameEncoding("base32")
-	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc)
+	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc, 16384)
 	for _, test := range []struct {
 		in          string
 		expectedErr error
@@ -301,7 +301,7 @@ func TestDecryptSegmentBase64(t *testing.T) {
 		longName[i] = 'a'
 	}
 	enc, _ := NewNameEncoding("base64")
-	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc)
+	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc, 16384)
 	for _, test := range []struct {
 		in          string
 		expectedErr error
@@ -322,7 +322,7 @@ func TestDecryptSegmentBase32768(t *testing.T) {
 	// We've tested the forwards above, now concentrate on the errors
 	longName := strings.Repeat("怪", 1280)
 	enc, _ := NewNameEncoding("base32768")
-	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc)
+	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc, 16384)
 	for _, test := range []struct {
 		in          string
 		expectedErr error
@@ -342,12 +342,12 @@ func TestDecryptSegmentBase32768(t *testing.T) {
 func testStandardEncryptFileName(t *testing.T, encoding string, testCasesEncryptDir []EncodingTestCase, testCasesNoEncryptDir []EncodingTestCase) {
 	// First standard mode
 	enc, _ := NewNameEncoding(encoding)
-	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc)
+	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc, 16384)
 	for _, test := range testCasesEncryptDir {
 		assert.Equal(t, test.expected, c.EncryptFileName(test.in))
 	}
 	// Standard mode with directory name encryption off
-	c, _ = newCipher(NameEncryptionStandard, "", "", false, enc)
+	c, _ = newCipher(NameEncryptionStandard, "", "", false, enc, 16384)
 	for _, test := range testCasesNoEncryptDir {
 		assert.Equal(t, test.expected, c.EncryptFileName(test.in))
 	}
@@ -403,24 +403,24 @@ func TestStandardEncryptFileNameBase32768(t *testing.T) {
 
 func TestNonStandardEncryptFileName(t *testing.T) {
 	// Off mode
-	c, _ := newCipher(NameEncryptionOff, "", "", true, nil)
+	c, _ := newCipher(NameEncryptionOff, "", "", true, nil, 16384)
 	assert.Equal(t, "1/12/123.bin", c.EncryptFileName("1/12/123"))
 	// Off mode with custom suffix
-	c, _ = newCipher(NameEncryptionOff, "", "", true, nil)
+	c, _ = newCipher(NameEncryptionOff, "", "", true, nil, 16384)
 	c.setEncryptedSuffix(".jpg")
 	assert.Equal(t, "1/12/123.jpg", c.EncryptFileName("1/12/123"))
 	// Off mode with empty suffix
 	c.setEncryptedSuffix("none")
 	assert.Equal(t, "1/12/123", c.EncryptFileName("1/12/123"))
 	// Obfuscation mode
-	c, _ = newCipher(NameEncryptionObfuscated, "", "", true, nil)
+	c, _ = newCipher(NameEncryptionObfuscated, "", "", true, nil, 16384)
 	assert.Equal(t, "49.6/99.23/150.890/53.!!lipps", c.EncryptFileName("1/12/123/!hello"))
 	assert.Equal(t, "49.6/99.23/150.890/53-v2001-02-03-040506-123.!!lipps", c.EncryptFileName("1/12/123/!hello-v2001-02-03-040506-123"))
 	assert.Equal(t, "49.6/99.23/150.890/162.uryyB-v2001-02-03-040506-123.GKG", c.EncryptFileName("1/12/123/hello-v2001-02-03-040506-123.txt"))
 	assert.Equal(t, "161.\u00e4", c.EncryptFileName("\u00a1"))
 	assert.Equal(t, "160.\u03c2", c.EncryptFileName("\u03a0"))
 	// Obfuscation mode with directory name encryption off
-	c, _ = newCipher(NameEncryptionObfuscated, "", "", false, nil)
+	c, _ = newCipher(NameEncryptionObfuscated, "", "", false, nil, 16384)
 	assert.Equal(t, "1/12/123/53.!!lipps", c.EncryptFileName("1/12/123/!hello"))
 	assert.Equal(t, "1/12/123/53-v2001-02-03-040506-123.!!lipps", c.EncryptFileName("1/12/123/!hello-v2001-02-03-040506-123"))
 	assert.Equal(t, "161.\u00e4", c.EncryptFileName("\u00a1"))
@@ -431,12 +431,12 @@ func testStandardDecryptFileName(t *testing.T, encoding string, testCases []Enco
 	enc, _ := NewNameEncoding(encoding)
 	for _, test := range testCases {
 		// Test when dirNameEncrypt=true
-		c, _ := newCipher(NameEncryptionStandard, "", "", true, enc)
+		c, _ := newCipher(NameEncryptionStandard, "", "", true, enc, 16384)
 		actual, actualErr := c.DecryptFileName(test.in)
 		assert.NoError(t, actualErr)
 		assert.Equal(t, test.expected, actual)
 		if caseInsensitive {
-			c, _ := newCipher(NameEncryptionStandard, "", "", true, enc)
+			c, _ := newCipher(NameEncryptionStandard, "", "", true, enc, 16384)
 			actual, actualErr := c.DecryptFileName(strings.ToUpper(test.in))
 			assert.NoError(t, actualErr)
 			assert.Equal(t, test.expected, actual)
@@ -450,7 +450,7 @@ func testStandardDecryptFileName(t *testing.T, encoding string, testCases []Enco
 		if strings.LastIndex(test.expected, "/") != -1 {
 			noDirEncryptIn = test.expected[:strings.LastIndex(test.expected, "/")] + test.in[strings.LastIndex(test.in, "/"):]
 		}
-		c, _ = newCipher(NameEncryptionStandard, "", "", false, enc)
+		c, _ = newCipher(NameEncryptionStandard, "", "", false, enc, 16384)
 		actual, actualErr = c.DecryptFileName(noDirEncryptIn)
 		assert.NoError(t, actualErr)
 		assert.Equal(t, test.expected, actual)
@@ -507,7 +507,7 @@ func TestNonStandardDecryptFileName(t *testing.T) {
 			{NameEncryptionObfuscated, false, "1/12/123/53.!!lipps", "1/12/123/!hello", nil, ""},
 			{NameEncryptionObfuscated, false, "1/12/123/53-v2001-02-03-040506-123.!!lipps", "1/12/123/!hello-v2001-02-03-040506-123", nil, ""},
 		} {
-			c, _ := newCipher(test.mode, "", "", test.dirNameEncrypt, enc)
+			c, _ := newCipher(test.mode, "", "", test.dirNameEncrypt, enc, 16384)
 			if test.customSuffix != "" {
 				c.setEncryptedSuffix(test.customSuffix)
 			}
@@ -531,7 +531,7 @@ func TestEncDecMatches(t *testing.T) {
 			{NameEncryptionObfuscated, "1/2/3/4/!hello\u03a0"},
 			{NameEncryptionObfuscated, "Avatar The Last Airbender"},
 		} {
-			c, _ := newCipher(test.mode, "", "", true, enc)
+			c, _ := newCipher(test.mode, "", "", true, enc, 16384)
 			out, err := c.DecryptFileName(c.EncryptFileName(test.in))
 			what := fmt.Sprintf("Testing %q (mode=%v)", test.in, test.mode)
 			assert.Equal(t, out, test.in, what)
@@ -542,7 +542,7 @@ func TestEncDecMatches(t *testing.T) {
 
 func testStandardEncryptDirName(t *testing.T, encoding string, testCases []EncodingTestCase) {
 	enc, _ := NewNameEncoding(encoding)
-	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc)
+	c, _ := newCipher(NameEncryptionStandard, "", "", true, enc, 16384)
 	// First standard mode
 	for _, test := range testCases {
 		assert.Equal(t, test.expected, c.EncryptDirName(test.in))
@@ -576,11 +576,11 @@ func TestStandardEncryptDirNameBase32768(t *testing.T) {
 func TestNonStandardEncryptDirName(t *testing.T) {
 	for _, encoding := range []string{"base32", "base64", "base32768"} {
 		enc, _ := NewNameEncoding(encoding)
-		c, _ := newCipher(NameEncryptionStandard, "", "", false, enc)
+		c, _ := newCipher(NameEncryptionStandard, "", "", false, enc, 16384)
 		assert.Equal(t, "1/12", c.EncryptDirName("1/12"))
 		assert.Equal(t, "1/12/123", c.EncryptDirName("1/12/123"))
 		// Now off mode
-		c, _ = newCipher(NameEncryptionOff, "", "", true, enc)
+		c, _ = newCipher(NameEncryptionOff, "", "", true, enc, 16384)
 		assert.Equal(t, "1/12/123", c.EncryptDirName("1/12/123"))
 	}
 }
@@ -589,7 +589,7 @@ func testStandardDecryptDirName(t *testing.T, encoding string, testCases []Encod
 	enc, _ := NewNameEncoding(encoding)
 	for _, test := range testCases {
 		// Test dirNameEncrypt=true
-		c, _ := newCipher(NameEncryptionStandard, "", "", true, enc)
+		c, _ := newCipher(NameEncryptionStandard, "", "", true, enc, 16384)
 		actual, actualErr := c.DecryptDirName(test.in)
 		assert.Equal(t, test.expected, actual)
 		assert.NoError(t, actualErr)
@@ -602,7 +602,7 @@ func testStandardDecryptDirName(t *testing.T, encoding string, testCases []Encod
 		assert.Equal(t, "", actual)
 		assert.Equal(t, ErrorNotAMultipleOfBlocksize, actualErr)
 		// Test dirNameEncrypt=false
-		c, _ = newCipher(NameEncryptionStandard, "", "", false, enc)
+		c, _ = newCipher(NameEncryptionStandard, "", "", false, enc, 16384)
 		actual, actualErr = c.DecryptDirName(test.in)
 		assert.Equal(t, test.in, actual)
 		assert.NoError(t, actualErr)
@@ -630,7 +630,7 @@ for _, test := range []struct {
 	{NameEncryptionStandard, false, "p0e52nreeaj0a5ea7s64m4j72s/l42g6771hnv3an9cgc8cr2n1ng", "p0e52nreeaj0a5ea7s64m4j72s/l42g6771hnv3an9cgc8cr2n1ng", nil},
 	{NameEncryptionStandard, false, "1/12/123", "1/12/123", nil},
 } {
-	c, _ := newCipher(test.mode, "", "", test.dirNameEncrypt, enc)
+	c, _ := newCipher(test.mode, "", "", test.dirNameEncrypt, enc, 16384)
 	actual, actualErr := c.DecryptDirName(test.in)
 	what := fmt.Sprintf("Testing %q (mode=%v)", test.in, test.mode)
 	assert.Equal(t, test.expected, actual, what)
@@ -674,7 +674,7 @@ func TestNonStandardDecryptDirName(t *testing.T) {
 		{NameEncryptionOff, true, "1/12/123", "1/12/123", nil},
 		{NameEncryptionOff, true, ".bin", ".bin", nil},
 	} {
-		c, _ := newCipher(test.mode, "", "", test.dirNameEncrypt, nil)
+		c, _ := newCipher(test.mode, "", "", test.dirNameEncrypt, nil, 16384)
 		actual, actualErr := c.DecryptDirName(test.in)
 		what := fmt.Sprintf("Testing %q (mode=%v)", test.in, test.mode)
 		assert.Equal(t, test.expected, actual, what)
@@ -683,7 +683,7 @@ func TestNonStandardDecryptDirName(t *testing.T) {
 }
 
 func TestEncryptedSize(t *testing.T) {
-	c, _ := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, _ := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	for _, test := range []struct {
 		in       int64
 		expected int64
@@ -707,7 +707,7 @@ func TestEncryptedSize(t *testing.T) {
 
 func TestDecryptedSize(t *testing.T) {
 	// Test the errors since we tested the reverse above
-	c, _ := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, _ := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	for _, test := range []struct {
 		in          int64
 		expectedErr error
@@ -1078,7 +1078,7 @@ func (z *zeroes) Read(p []byte) (n int, err error) {
 
 // Test encrypt decrypt with different buffer sizes
 func testEncryptDecrypt(t *testing.T, bufSize int, copySize int64) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 	c.cryptoRand = &zeroes{} // zero out the nonce
 	buf := make([]byte, bufSize)
@@ -1148,7 +1148,7 @@ func TestEncryptData(t *testing.T) {
 		{[]byte{1}, file1},
 		{[]byte{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}, file16},
 	} {
-		c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+		c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 		assert.NoError(t, err)
 		c.cryptoRand = newRandomSource(1e8) // nodge the crypto rand generator
 
@@ -1171,7 +1171,7 @@ func TestEncryptData(t *testing.T) {
 }
 
 func TestNewEncrypter(t *testing.T) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 	c.cryptoRand = newRandomSource(1e8) // nodge the crypto rand generator
 
@@ -1192,7 +1192,7 @@ func TestNewEncrypter(t *testing.T) {
 // Test the stream returning 0, io.ErrUnexpectedEOF - this used to
 // cause a fatal loop
 func TestNewEncrypterErrUnexpectedEOF(t *testing.T) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 
 	in := &readers.ErrorReader{Err: io.ErrUnexpectedEOF}
@@ -1221,7 +1221,7 @@ func (c *closeDetector) Close() error {
 }
 
 func TestNewDecrypter(t *testing.T) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 	c.cryptoRand = newRandomSource(1e8) // nodge the crypto rand generator
 
@@ -1264,7 +1264,7 @@ func TestNewDecrypter(t *testing.T) {
 
 // Test the stream returning 0, io.ErrUnexpectedEOF
 func TestNewDecrypterErrUnexpectedEOF(t *testing.T) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 
 	in2 := &readers.ErrorReader{Err: io.ErrUnexpectedEOF}
@@ -1280,7 +1280,7 @@ func TestNewDecrypterErrUnexpectedEOF(t *testing.T) {
 }
 
 func TestNewDecrypterSeekLimit(t *testing.T) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 	c.cryptoRand = &zeroes{} // nodge the crypto rand generator
 
@@ -1483,7 +1483,7 @@ func TestDecrypterCalculateUnderlying(t *testing.T) {
 }
 
 func TestDecrypterRead(t *testing.T) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 
 	// Test truncating the file at each possible point
@@ -1560,7 +1560,7 @@ func TestDecrypterRead(t *testing.T) {
 }
 
 func TestDecrypterClose(t *testing.T) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 
 	cd := newCloseDetector(bytes.NewBuffer(file16))
@@ -1598,7 +1598,7 @@ func TestDecrypterClose(t *testing.T) {
 }
 
 func TestPutGetBlock(t *testing.T) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 
 	block := c.getBlock()
@@ -1607,7 +1607,7 @@ func TestPutGetBlock(t *testing.T) {
 }
 
 func TestKey(t *testing.T) {
-	c, err := newCipher(NameEncryptionStandard, "", "", true, nil)
+	c, err := newCipher(NameEncryptionStandard, "", "", true, nil, 16384)
 	assert.NoError(t, err)
 
 	// Check zero keys OK
@@ -1615,27 +1615,27 @@ func TestKey(t *testing.T) {
 	assert.Equal(t, [32]byte{}, c.nameKey)
 	assert.Equal(t, [16]byte{}, c.nameTweak)
 
-	require.NoError(t, c.Key("potato", ""))
+	require.NoError(t, c.Key("potato", "", 16384))
 	assert.Equal(t, [32]byte{0x74, 0x55, 0xC7, 0x1A, 0xB1, 0x7C, 0x86, 0x5B, 0x84, 0x71, 0xF4, 0x7B, 0x79, 0xAC, 0xB0, 0x7E, 0xB3, 0x1D, 0x56, 0x78, 0xB8, 0x0C, 0x7E, 0x2E, 0xAF, 0x4F, 0xC8, 0x06, 0x6A, 0x9E, 0xE4, 0x68}, c.dataKey)
 	assert.Equal(t, [32]byte{0x76, 0x5D, 0xA2, 0x7A, 0xB1, 0x5D, 0x77, 0xF9, 0x57, 0x96, 0x71, 0x1F, 0x7B, 0x93, 0xAD, 0x63, 0xBB, 0xB4, 0x84, 0x07, 0x2E, 0x71, 0x80, 0xA8, 0xD1, 0x7A, 0x9B, 0xBE, 0xC1, 0x42, 0x70, 0xD0}, c.nameKey)
 	assert.Equal(t, [16]byte{0xC1, 0x8D, 0x59, 0x32, 0xF5, 0x5B, 0x28, 0x28, 0xC5, 0xE1, 0xE8, 0x72, 0x15, 0x52, 0x03, 0x10}, c.nameTweak)
 
-	require.NoError(t, c.Key("Potato", ""))
+	require.NoError(t, c.Key("Potato", "", 16384))
 	assert.Equal(t, [32]byte{0xAE, 0xEA, 0x6A, 0xD3, 0x47, 0xDF, 0x75, 0xB9, 0x63, 0xCE, 0x12, 0xF5, 0x76, 0x23, 0xE9, 0x46, 0xD4, 0x2E, 0xD8, 0xBF, 0x3E, 0x92, 0x8B, 0x39, 0x24, 0x37, 0x94, 0x13, 0x3E, 0x5E, 0xF7, 0x5E}, c.dataKey)
 	assert.Equal(t, [32]byte{0x54, 0xF7, 0x02, 0x6E, 0x8A, 0xFC, 0x56, 0x0A, 0x86, 0x63, 0x6A, 0xAB, 0x2C, 0x9C, 0x51, 0x62, 0xE5, 0x1A, 0x12, 0x23, 0x51, 0x83, 0x6E, 0xAF, 0x50, 0x42, 0x0F, 0x98, 0x1C, 0x86, 0x0A, 0x19}, c.nameKey)
 	assert.Equal(t, [16]byte{0xF8, 0xC1, 0xB6, 0x27, 0x2D, 0x52, 0x9B, 0x4A, 0x8F, 0xDA, 0xEB, 0x42, 0x4A, 0x28, 0xDD, 0xF3}, c.nameTweak)
 
-	require.NoError(t, c.Key("potato", "sausage"))
+	require.NoError(t, c.Key("potato", "sausage", 16384))
 	assert.Equal(t, [32]uint8{0x8e, 0x9b, 0x6b, 0x99, 0xf8, 0x69, 0x4, 0x67, 0xa0, 0x71, 0xf9, 0xcb, 0x92, 0xd0, 0xaa, 0x78, 0x7f, 0x8f, 0xf1, 0x78, 0xbe, 0xc9, 0x6f, 0x99, 0x9f, 0xd5, 0x20, 0x6e, 0x64, 0x4a, 0x1b, 0x50}, c.dataKey)
 	assert.Equal(t, [32]uint8{0x3e, 0xa9, 0x5e, 0xf6, 0x81, 0x78, 0x2d, 0xc9, 0xd9, 0x95, 0x5d, 0x22, 0x5b, 0xfd, 0x44, 0x2c, 0x6f, 0x5d, 0x68, 0x97, 0xb0, 0x29, 0x1, 0x5c, 0x6f, 0x46, 0x2e, 0x2a, 0x9d, 0xae, 0x2c, 0xe3}, c.nameKey)
 	assert.Equal(t, [16]uint8{0xf1, 0x7f, 0xd7, 0x14, 0x1d, 0x65, 0x27, 0x4f, 0x36, 0x3f, 0xc2, 0xa0, 0x4d, 0xd2, 0x14, 0x8a}, c.nameTweak)
 
-	require.NoError(t, c.Key("potato", "Sausage"))
+	require.NoError(t, c.Key("potato", "Sausage", 16384))
 	assert.Equal(t, [32]uint8{0xda, 0x81, 0x8c, 0x67, 0xef, 0x11, 0xf, 0xc8, 0xd5, 0xc8, 0x62, 0x4b, 0x7f, 0xe2, 0x9e, 0x35, 0x35, 0xb0, 0x8d, 0x79, 0x84, 0x89, 0xac, 0xcb, 0xa0, 0xff, 0x2, 0x72, 0x3, 0x1a, 0x5e, 0x64}, c.dataKey)
 	assert.Equal(t, [32]uint8{0x2, 0x81, 0x7e, 0x7b, 0xea, 0x99, 0x81, 0x5a, 0xd0, 0x2d, 0xb9, 0x64, 0x48, 0xb0, 0x28, 0x27, 0x7c, 0x20, 0xb4, 0xd4, 0xa4, 0x68, 0xad, 0x4e, 0x5c, 0x29, 0xf, 0x79, 0xef, 0xee, 0xdb, 0x3b}, c.nameKey)
 	assert.Equal(t, [16]uint8{0x9a, 0xb5, 0xb, 0x3d, 0xcb, 0x60, 0x59, 0x55, 0xa5, 0x4d, 0xe6, 0xb6, 0x47, 0x3, 0x23, 0xe2}, c.nameTweak)
 
-	require.NoError(t, c.Key("", ""))
+	require.NoError(t, c.Key("", "", 16384))
 	assert.Equal(t, [32]byte{}, c.dataKey)
 	assert.Equal(t, [32]byte{}, c.nameKey)
 	assert.Equal(t, [16]byte{}, c.nameTweak)

--- a/backend/crypt/crypt.go
+++ b/backend/crypt/crypt.go
@@ -172,6 +172,11 @@ Setting suffix to "none" will result in an empty suffix. This may be useful
 when the path length is critical.`,
 			Default:  ".bin",
 			Advanced: true,
+		}, {
+			Name:     "scrypt_n",
+			Help:     "N parameter for scrypt key derivation.\n\nThe memory usage is N * 128 * r bytes where r=8. Default is 16384 (16MB).\nMust be a power of 2. Higher values use more memory but provide better security.",
+			Default:  16384,
+			Advanced: true,
 		}},
 	})
 }
@@ -200,7 +205,11 @@ func newCipherForConfig(opt *Options) (*Cipher, error) {
 	if err != nil {
 		return nil, err
 	}
-	cipher, err := newCipher(mode, password, salt, opt.DirectoryNameEncryption, enc)
+	scryptN := opt.ScryptN
+	if scryptN == 0 {
+		scryptN = 16384
+	}
+	cipher, err := newCipher(mode, password, salt, opt.DirectoryNameEncryption, enc, scryptN)
 	if err != nil {
 		return nil, fmt.Errorf("failed to make cipher: %w", err)
 	}
@@ -314,6 +323,7 @@ type Options struct {
 	FilenameEncoding        string `config:"filename_encoding"`
 	Suffix                  string `config:"suffix"`
 	StrictNames             bool   `config:"strict_names"`
+	ScryptN                 int    `config:"scrypt_n"`
 }
 
 // Fs represents a wrapped fs.Fs


### PR DESCRIPTION
#### What is the purpose of this change?

Scrypt is a memory-hard key derivation algorithm but the current default value 16384 (16MB) is outdated and barely protects against modern GPU attacks. This commit makes the N parameter configurable to help protect against brute-force attacks. Default remains 16384 (16MB) although I would recommend a way higher value in 2026.

#### Was the change discussed in an issue or in the forum before?

No. It's a small, reasonable and optional change.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
