### PR TITLE
s3: add Zadara Object Storage provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ directories to and from different cloud storage providers.
 - Wasabi [:page_facing_up:](https://rclone.org/s3/#wasabi)
 - WebDAV [:page_facing_up:](https://rclone.org/webdav/)
 - Yandex Disk [:page_facing_up:](https://rclone.org/yandex/)
+- Zadara Object Storage [:page_facing_up:](https://rclone.org/s3/#zadara)
 - Zoho WorkDrive [:page_facing_up:](https://rclone.org/zoho/)
 - Zata.ai [:page_facing_up:](https://rclone.org/s3/#Zata)
 - The local filesystem [:page_facing_up:](https://rclone.org/local/)

--- a/backend/s3/provider/Zadara.yaml
+++ b/backend/s3/provider/Zadara.yaml
@@ -1,0 +1,9 @@
+name: Zadara
+description: Zadara Object Storage
+region:
+  us-east-1: |-
+    The default region.
+    Leave location constraint empty.
+endpoint: {}
+quirks:
+  force_path_style: true

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -219,6 +219,7 @@ WebDAV or S3, that work out of the box.)
 {{< provider name="Wasabi" home="https://wasabi.com/" config="/s3/#wasabi" >}}
 {{< provider name="WebDAV" home="https://en.wikipedia.org/wiki/WebDAV" config="/webdav/" >}}
 {{< provider name="Yandex Disk" home="https://disk.yandex.com/" config="/yandex/" >}}
+{{< provider name="Zadara Object Storage" home="https://www.zadara.com" config="/s3/#zadara" >}}
 {{< provider name="Zoho WorkDrive" home="https://www.zoho.com/workdrive/" config="/zoho/" >}}
 {{< provider name="Zata" home="https://zata.ai/" config="/s3/#Zata" end="true" >}}
 {{< provider name="The local filesystem" home="/local/" config="/local/" end="true">}}

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -55,7 +55,8 @@ The S3 backend can be used with a number of different providers:
 {{< provider name="Storj" home="https://storj.io/" config="/s3/#storj" >}}
 {{< provider name="Synology C2 Object Storage" home="https://c2.synology.com/en-global/object-storage/overview" config="/s3/#synology-c2" >}}
 {{< provider name="Tencent Cloud Object Storage (COS)" home="https://intl.cloud.tencent.com/product/cos" config="/s3/#tencent-cos" >}}
-{{< provider name="Wasabi" home="https://wasabi.com/" config="/s3/#wasabi" end="true" >}}
+{{< provider name="Wasabi" home="https://wasabi.com/" config="/s3/#wasabi" >}}
+{{< provider name="Zadara Object Storage" home="https://www.zadara.com" config="/s3/#zadara" >}}
 {{< provider name="Zata" home="https://zata.ai/" config="/s3/#Zata" end="true" >}}
 {{< /provider_list >}}
 
@@ -9172,6 +9173,125 @@ location_constraint =
 acl =
 server_side_encryption =
 storage_class =
+```
+
+### Zadara Object Storage {#zadara}
+
+[Zadara Object Storage](https://www.zadara.com) is a fully-managed, 
+enterprise-grade, S3-compatible storage solution that provides scalable, 
+multi-tenant object storage with flexible deployment options (on-prem, 
+hybrid, or cloud). 
+
+Zadara Object Storage can be configured using `rclone config` with `s3` as 
+the type and `Zadara` as the provider name. Here is an example
+run of the configurator.
+
+Authentication and endpoint information, including the region field, 
+should be fetched from Zadara’s Object Storage management interface
+
+To configure access to Zadara Object Storage, first run:
+
+```console
+rclone config
+```
+
+```text
+This will guide you through an interactive setup process:
+
+No remotes found, make a new one\?
+n) New remote
+s) Set configuration password
+n/s> n
+
+Enter name for new remote.
+name> Zadara-Object-Storage
+
+Option Storage.
+Type of storage to configure.
+Choose a number from below, or type in your own value.
+ 
+ XX / Amazon S3 Compliant Storage Providers including AWS ...
+   \ (s3)
+
+Storage> s3
+
+Option provider.
+Choose your S3 provider.
+Choose a number from below, or type in your own value.
+Press Enter to leave empty.
+ 
+XX / Zadara Object Storage
+   \ (Zadara)
+
+provider> Zadara
+
+Option env_auth.
+Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars).
+Only applies if access_key_id and secret_access_key is blank.
+Choose a number from below, or type in your own boolean value (true or false).
+Press Enter for the default (false).
+ 1 / Enter AWS credentials in the next step.
+   \ (false)
+ 2 / Get AWS credentials from the environment (env vars or IAM).
+   \ (true)
+env_auth> 
+
+Option access_key_id.
+AWS Access Key ID.
+Leave blank for anonymous access or runtime credentials.
+Enter a value. Press Enter to leave empty.
+access_key_id> S3_ACCESS_KEY
+
+Option secret_access_key.
+AWS Secret Access Key (password).
+Leave blank for anonymous access or runtime credentials.
+Enter a value. Press Enter to leave empty.
+secret_access_key> S3_SECRET_KEY
+
+Option region.
+Region to connect to.
+Leave blank if you are using an S3 clone and you don't have a region.
+Choose a number from below, or type in your own value.
+Press Enter to leave empty.
+   / The default region.
+ 1 | Leave location constraint empty.
+   \ (us-east-1)
+region> 
+
+Option endpoint.
+Endpoint for S3 API.
+Required when using an S3 clone.
+Enter a value. Press Enter to leave empty.
+endpoint> https://vsa-00000001-public-zadara-cloud-01.zadarazios.com
+
+Edit advanced config?
+y) Yes
+n) No (default)
+y/n> 
+
+Configuration complete.
+Options:
+- type: s3
+- provider: Zadara
+- access_key_id: S3_ACCESS_KEY
+- secret_access_key: S3_SECRET_KEY
+- endpoint: https://vsa-00000001-public-zadara-cloud-01.zadarazios.com
+Keep this "Zadara-Object-Storage" remote?
+y) Yes this is OK (default)
+e) Edit this remote
+d) Delete this remote
+y/e/d> y
+```
+
+This will leave the config file looking like this.
+
+```ini
+[Zadara-Object-Storage]
+type = s3
+provider = Zadara
+access_key_id = S3_ACCESS_KEY
+secret_access_key = S3_SECRET_KEY
+endpoint = https://vsa-00000001-public-zadara-cloud-01.zadarazios.com
 ```
 
 ### Zata Object Storage {#Zata}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

- Add Zadara Object Storage as a new S3-compatible provider
- Provider definition with `force_path_style` and `us-east-1` default region
- Documentation section with configuration walkthrough

**Test results**
Integration tests pass with 3 known failures, all related to returning HTTP 400 for object keys containing special punctuation characters (e.g. `< > " ' & ? +`). Will be fixed in a future version.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
