### PR TITLE
ONEZONE_IA is available in all zones, GLACIER only in FR-PAR

### DIFF
--- a/backend/s3/provider/Scaleway.yaml
+++ b/backend/s3/provider/Scaleway.yaml
@@ -18,11 +18,11 @@ storage_class:
   GLACIER: |-
     Archived storage.
     Prices are lower, but it needs to be restored first to be accessed.
-    Available in FR-PAR and NL-AMS regions.
+    Available in the FR-PAR region only.
   ONEZONE_IA: |-
     One Zone - Infrequent Access.
     A good choice for storing secondary backup copies or easily re-creatable data.
-    Available in the FR-PAR region only.
+    Available in all regions.
 bucket_acl: true
 quirks:
   max_upload_parts: 1000


### PR DESCRIPTION
I just stumbled upon the wrong documentation while configuring a rclone remote. ONEZONE_IA is available everywhere, but GLACIER only in FR-PAR.

#### What is the purpose of this change?

Fix documentation according to to https://www.scaleway.com/en/docs/account/reference-content/products-availability/

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
