### PR TITLE
added text to the label showing .Params.versionIntroduced

### DIFF
--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -36,7 +36,7 @@
             "beta" "This feature is currently in beta must be used with care."
           }}
 
-          {{ if .Params.versionIntroduced }}<span class="badge badge-pill badge-secondary float-right" style="margin-top: 30px; font-size: 100%" title="This feature needs Rclone {{ .Params.versionIntroduced }} or later.">{{ .Params.versionIntroduced }}</span>{{ end }}
+          {{ if .Params.versionIntroduced }}<span class="badge badge-pill badge-secondary float-right" style="margin-top: 30px; font-size: 100%" title="This feature needs Rclone {{ .Params.versionIntroduced }} or later.">added in {{ .Params.versionIntroduced }}</span>{{ end }}
 
           {{ with .Params.status | lower }}
             {{ $statusCode := . }}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Just added the two small words "added in" to the docs.

When I read the docs and noticed that options were missing i scrolled to the top to check the version of the docs. The label "v1.58" gave me the impression that this was the version of the docs and not when this feature was introduced. With this PR i want to mitigate such situations.

Turns out, that the docs haven't been outdated, but are just not comprehensive. See the link below.


#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/bisync-documentation-misses-track-renames-description-shows-v1-58-on-the-top-right/53449

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] ~I have added tests for all changes in this PR if appropriate.~
- [ ] ~I have added documentation for the changes if appropriate.~
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
