### PR TITLE
add missing options to bisync --help and docs

### DIFF
--- a/cmd/bisync/cmd.go
+++ b/cmd/bisync/cmd.go
@@ -162,7 +162,7 @@ var commandDefinition = &cobra.Command{
 	Long:  longHelp,
 	Annotations: map[string]string{
 		"versionIntroduced": "v1.58",
-		"groups":            "Filter,Copy,Important",
+		"groups":            "Filter,Copy,Important,Sync",
 	},
 	RunE: func(command *cobra.Command, args []string) error {
 		// NOTE: avoid putting too much handling here, as it won't apply to the rc.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

The `--track-renames` option is missing in the docs and the cli option `--help` of bisync. However, it is available and works.

In fact all options inherited from the sync command weren't displayed.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/bisync-documentation-misses-track-renames-description-shows-v1-58-on-the-top-right/53449

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
