### PR TITLE
added instructions for viewing docs locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ MANUAL.txt:	MANUAL.md
 commanddocs: rclone
 	go generate ./lib/transform
 	-@rmdir -p '$$HOME/.config/rclone'
-	XDG_CACHE_HOME="" XDG_CONFIG_HOME="" HOME="\$$HOME" USER="\$$USER" rclone gendocs --config=/notfound docs/content/
+	XDG_CACHE_HOME="" XDG_CONFIG_HOME="" HOME="\$$HOME" USER="\$$USER" ./rclone gendocs --config=/notfound docs/content/
 	@[ ! -e '$$HOME' ] || (echo 'Error: created unwanted directory named $$HOME' && exit 1)
 	go run bin/make_bisync_docs.go ./docs/content/
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,12 @@ If you want to change the layout then the main files to edit are
 Running `make serve` in a terminal give a live preview of the website
 so it is easy to tweak stuff.
 
+## Changes on commands
+
+If you have worked on the commands in `cmd/*` and you want to see the
+changed docs locally, you can run `make commanddocs serve` to
+regenerate the command docs and serve the website locally.
+
 ## What are all these files
 
 ```


### PR DESCRIPTION
After editing the source code and adding new commands or flags the documentation needs to be built again. Therefore rclone needs to be built from the source code. Then one needs to run `rclone gendocs`. But there is also a make target 'commanddocs' which automates this but wasn't documented anywhere.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

I am a new contributor and while working on another PR i had a hard time figuring out why my local version of the docs didn't show up correctly.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
