### PR TITLE
http: dark mode for browser

### DIFF
--- a/lib/http/templates/index.html
+++ b/lib/http/templates/index.html
@@ -187,6 +187,64 @@ footer {
 		max-width: 100px;
 	}
 }
+@media (prefers-color-scheme: dark) {
+	body {
+		background-color: #18181B;
+		color: #F4F4F5;
+		color-scheme: dark;
+	}
+	a {
+		color: #99C7FB;
+	}
+	a:hover,
+	h1 a:hover {
+		color: #CCE3FD;
+	}
+	header {
+		background-color: #27272A;
+	}
+	h1 {
+		color: #A1A1AA;
+	}
+	h1 a {
+		color: #FAFAFA;
+	}
+	.meta {
+		border-bottom: 1px solid #52525B;
+	}
+	#filter {
+		background-color: #27272A;
+		border: 1px solid #71717A;
+		color: #F4F4F5;
+	}
+	#filter::placeholder {
+		color: #A1A1AA;
+	}
+	tr {
+		border-bottom: 1px dashed #3F3F46;
+	}
+	tbody tr:hover {
+		background-color: #3F3F46;
+	}
+	th a {
+		color: #FAFAFA;
+	}
+	a svg {
+		color: #D4D4D8;
+	}
+	a:hover svg {
+		color: #CCE3FD;
+	}
+	a svg use,
+	a svg path:not([fill]),
+	a svg path[fill="#000"],
+	a svg path[fill="#000000"],
+	a svg [stroke="#000"],
+	a svg [stroke="#000000"] {
+		fill: currentColor;
+		stroke: currentColor;
+	}
+}
 td .zip {
 	opacity: 0;
 	margin-left: 6px;


### PR DESCRIPTION
#### What is the purpose of this change?

After getting blasted by the native browser one too many times, I've taken the step to add dark mode styles to the `index.html` template. 

This also lets me remove the manual overrides in Rclone UI and cleans up the code. Given the improvements `rclone`'s browser has seen lately (zip downloads, various fixes), it makes sense to invest in it rather than keep working around it.

#### Was the change discussed in an issue or in the forum before?

Not to my knowledge.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

https://github.com/user-attachments/assets/f44876d3-d367-449d-a2c7-67b4640f0ce8
