### PR TITLE
Plaintext passwords support

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -195,6 +195,19 @@ are 100% certain you are already passing obscured passwords then use
 |--no-obscure|.  You can also set obscured passwords using the
 |rclone config password| command.
 
+If you want to save the password in plaintext format, set |--plaintext-passwords| flag:
+
+|||sh
+rclone config update --plaintext-passwords myremote pass myplaintextpassword
+|||
+
+**IMPORTANT** You must set this flag when connecting to remotes with plaintext passwords.
+You may want to set |global.plaintext_passwords=true| in your remote configuration
+instead of typing this flag every time (see [global.var](https://rclone.org/docs/#global-var)).
+If you mix remotes with plaintext and obscured passwords in your configuration file,
+you should explicitly set |global.plaintext_passwords| value to all your remotes to avoid
+issues with password revealing.
+
 The flag |--non-interactive| is for use by applications that wish to
 configure rclone themselves, rather than using rclone's text based
 configuration questions. If this flag is set, and rclone needs to ask
@@ -401,6 +414,9 @@ For example, to set password of a remote of name myremote you would do:
 rclone config password myremote fieldname mypassword
 rclone config password myremote fieldname=mypassword
 |||
+
+If you want to save the password in plaintext format, set |--plaintext-passwords| flag.
+See [rclone config update](https://rclone.org/commands/rclone_config_update/) documentation.
 
 This command is obsolete now that "config update" and "config create"
 both support obscuring passwords directly.`, "|", "`"),

--- a/cmd/obscure/obscure.go
+++ b/cmd/obscure/obscure.go
@@ -40,6 +40,9 @@ echo 'secretpassword' | rclone obscure -
 If there is no data on STDIN to read, rclone obscure will default to
 obfuscating the hyphen itself.
 
+If |--plaintext-passwords| flag is set, no obscuring will be done,
+and your password will be outputted in plaintext.
+
 If you want to encrypt the config file then please use config file
 encryption - see [rclone config](/commands/rclone_config/) for more
 info.`,

--- a/fs/config.go
+++ b/fs/config.go
@@ -685,7 +685,7 @@ type ConfigInfo struct {
 	MaxConnections             int               `config:"max_connections"`
 	NameTransform              []string          `config:"name_transform"`
 	HTTPProxy                  string            `config:"http_proxy"`
-	PlaintextPasswords         bool              `config:plaintext_passwords`
+	PlaintextPasswords         bool              `config:"plaintext_passwords"`
 }
 
 func init() {

--- a/fs/config.go
+++ b/fs/config.go
@@ -566,6 +566,11 @@ var ConfigOptionsInfo = Options{{
 	Default: "",
 	Help:    "HTTP proxy URL.",
 	Groups:  "Networking",
+}, {
+	Name:    "plaintext_passwords",
+	Default: false,
+	Help:    "Do not obscure remote password",
+	Groups:  "Config",
 }}
 
 // ConfigInfo is filesystem config options
@@ -680,6 +685,7 @@ type ConfigInfo struct {
 	MaxConnections             int               `config:"max_connections"`
 	NameTransform              []string          `config:"name_transform"`
 	HTTPProxy                  string            `config:"http_proxy"`
+	PlaintextPasswords         bool              `config:plaintext_passwords`
 }
 
 func init() {

--- a/fs/config/obscure/obscure.go
+++ b/fs/config/obscure/obscure.go
@@ -2,6 +2,7 @@
 package obscure
 
 import (
+	"context"
 	"crypto/aes"
 	"crypto/cipher"
 	"crypto/rand"
@@ -10,7 +11,6 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"context"
 
 	"github.com/rclone/rclone/fs"
 )

--- a/fs/config/obscure/obscure.go
+++ b/fs/config/obscure/obscure.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"context"
 
 	"github.com/rclone/rclone/fs"
 )
@@ -48,6 +49,10 @@ func crypt(out, in, iv []byte) error {
 //
 // This is done by encrypting with AES-CTR
 func Obscure(x string) (string, error) {
+	ci := fs.GetConfig(context.Background())
+	if ci.PlaintextPasswords {
+		return x, nil
+	}
 	plaintext := []byte(x)
 	if math.MaxInt32-aes.BlockSize < len(plaintext) {
 		return "", fmt.Errorf("value too large")
@@ -74,6 +79,10 @@ func MustObscure(x string) string {
 
 // Reveal an obscured value
 func Reveal(x string) (string, error) {
+	ci := fs.GetConfig(context.Background())
+	if ci.PlaintextPasswords {
+		return x, nil
+	}
 	ciphertext, err := base64.RawURLEncoding.DecodeString(x)
 	if err != nil {
 		return "", fmt.Errorf("base64 decode failed when revealing password - is it obscured?: %w", err)

--- a/fs/config/obscure/obscure_test.go
+++ b/fs/config/obscure/obscure_test.go
@@ -2,7 +2,6 @@ package obscure
 
 import (
 	"bytes"
-	"crypto/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,6 @@ func TestObscure(t *testing.T) {
 	} {
 		cryptRand = bytes.NewBufferString(test.iv)
 		got, err := Obscure(test.in)
-		cryptRand = rand.Reader
 		assert.NoError(t, err)
 		assert.Equal(t, test.want, got)
 		recoveredIn, err := Reveal(got)
@@ -29,7 +27,6 @@ func TestObscure(t *testing.T) {
 		// Now the Must variants
 		cryptRand = bytes.NewBufferString(test.iv)
 		got = MustObscure(test.in)
-		cryptRand = rand.Reader
 		assert.Equal(t, test.want, got)
 		recoveredIn = MustReveal(got)
 		assert.Equal(t, test.in, recoveredIn, "not bidirectional")
@@ -41,18 +38,15 @@ func TestReveal(t *testing.T) {
 	for _, test := range []struct {
 		in   string
 		want string
-		iv   string
 	}{
-		{"YWFhYWFhYWFhYWFhYWFhYQ", "", "aaaaaaaaaaaaaaaa"},
-		{"YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "potato", "aaaaaaaaaaaaaaaa"},
-		{"YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "potato", "bbbbbbbbbbbbbbbb"},
+		{"YWFhYWFhYWFhYWFhYWFhYQ", ""},
+		{"YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "potato"},
+		{"YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "potato"},
 	} {
-		cryptRand = bytes.NewBufferString(test.iv)
 		got, err := Reveal(test.in)
 		assert.NoError(t, err)
 		assert.Equal(t, test.want, got)
 		// Now the Must variants
-		cryptRand = bytes.NewBufferString(test.iv)
 		got = MustReveal(test.in)
 		assert.Equal(t, test.want, got)
 

--- a/fs/config/obscure/obscure_test.go
+++ b/fs/config/obscure/obscure_test.go
@@ -2,8 +2,8 @@ package obscure
 
 import (
 	"bytes"
-	"testing"
 	"context"
+	"testing"
 
 	"github.com/stretchr/testify/assert"
 
@@ -13,9 +13,9 @@ import (
 func TestObscure(t *testing.T) {
 	ci := fs.GetConfig(context.Background())
 	for _, test := range []struct {
-		in   string
-		want string
-		iv   string
+		in        string
+		want      string
+		iv        string
 		plaintext bool
 	}{
 		{"", "YWFhYWFhYWFhYWFhYWFhYQ", "aaaaaaaaaaaaaaaa", false},
@@ -45,8 +45,8 @@ func TestObscure(t *testing.T) {
 func TestReveal(t *testing.T) {
 	ci := fs.GetConfig(context.Background())
 	for _, test := range []struct {
-		in   string
-		want string
+		in        string
+		want      string
 		plaintext bool
 	}{
 		{"YWFhYWFhYWFhYWFhYWFhYQ", "", false},

--- a/fs/config/obscure/obscure_test.go
+++ b/fs/config/obscure/obscure_test.go
@@ -3,20 +3,28 @@ package obscure
 import (
 	"bytes"
 	"testing"
+	"context"
 
 	"github.com/stretchr/testify/assert"
+
+	"github.com/rclone/rclone/fs"
 )
 
 func TestObscure(t *testing.T) {
+	ci := fs.GetConfig(context.Background())
 	for _, test := range []struct {
 		in   string
 		want string
 		iv   string
+		plaintext bool
 	}{
-		{"", "YWFhYWFhYWFhYWFhYWFhYQ", "aaaaaaaaaaaaaaaa"},
-		{"potato", "YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "aaaaaaaaaaaaaaaa"},
-		{"potato", "YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "bbbbbbbbbbbbbbbb"},
+		{"", "YWFhYWFhYWFhYWFhYWFhYQ", "aaaaaaaaaaaaaaaa", false},
+		{"potato", "YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "aaaaaaaaaaaaaaaa", false},
+		{"potato", "YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "bbbbbbbbbbbbbbbb", false},
+		{"", "", "", true},
+		{"potato", "potato", "", true},
 	} {
+		ci.PlaintextPasswords = test.plaintext
 		cryptRand = bytes.NewBufferString(test.iv)
 		got, err := Obscure(test.in)
 		assert.NoError(t, err)
@@ -35,14 +43,19 @@ func TestObscure(t *testing.T) {
 }
 
 func TestReveal(t *testing.T) {
+	ci := fs.GetConfig(context.Background())
 	for _, test := range []struct {
 		in   string
 		want string
+		plaintext bool
 	}{
-		{"YWFhYWFhYWFhYWFhYWFhYQ", ""},
-		{"YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "potato"},
-		{"YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "potato"},
+		{"YWFhYWFhYWFhYWFhYWFhYQ", "", false},
+		{"YWFhYWFhYWFhYWFhYWFhYXMaGgIlEQ", "potato", false},
+		{"YmJiYmJiYmJiYmJiYmJiYp3gcEWbAw", "potato", false},
+		{"", "", true},
+		{"potato", "potato", true},
 	} {
+		ci.PlaintextPasswords = test.plaintext
 		got, err := Reveal(test.in)
 		assert.NoError(t, err)
 		assert.Equal(t, test.want, got)
@@ -55,6 +68,7 @@ func TestReveal(t *testing.T) {
 
 // Test some error cases
 func TestRevealErrors(t *testing.T) {
+	fs.GetConfig(context.Background()).PlaintextPasswords = false
 	for _, test := range []struct {
 		in      string
 		wantErr string


### PR DESCRIPTION
#### What is the purpose of this change?

This change adds support for plaintext password format. You can set `--plaintext-passwords` to save the remote password without obscuring.

#### Was the change discussed in an issue or in the forum before?

#6423
https://github.com/rclone/rclone/issues/2265#issuecomment-1163907061

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)