### PR TITLE
drime: fix chunk-uploaded files ignoring workspace ID

### DIFF
--- a/backend/drime/api/types.go
+++ b/backend/drime/api/types.go
@@ -224,6 +224,7 @@ type MultiPartEntriesRequest struct {
 	ClientExtension string      `json:"clientExtension"`
 	ParentID        json.Number `json:"parent_id"`
 	RelativePath    string      `json:"relativePath"`
+	WorkspaceID     string      `json:"workspaceId,omitempty"`
 }
 
 // MultiPartEntriesResponse is the result of POST /s3/entries

--- a/backend/drime/drime.go
+++ b/backend/drime/drime.go
@@ -1314,6 +1314,7 @@ func (s *drimeChunkWriter) Close(ctx context.Context) error {
 		ClientExtension: s.extension,
 		ParentID:        s.parentID,
 		RelativePath:    s.relativePath,
+		WorkspaceID:     s.f.opt.WorkspaceID,
 	}
 
 	entriesOpts := rest.Opts{


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

When specifying --drime-workspace-id, a file greater than the limit at which file uploads get chunked would ignore the specified ID and get put into the default workspace instead.

Completes the fix described in commit 2360e65 by properly closing the chunkwriter by providing the workspace ID to the Drime API call.

#### Was the change discussed in an issue or in the forum before?

Not sure.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
