### PR TITLE
Fix headers hierarchy for mount.md

### DIFF
--- a/cmd/mountlib/mount.md
+++ b/cmd/mountlib/mount.md
@@ -324,7 +324,7 @@ full new copy of the file.
 When mounting with `--read-only`, attempts to write to files will fail *silently*
 as opposed to with a clear warning as in macFUSE.
 
-## Mounting on Linux
+### Mounting on Linux
 
 On newer versions of Ubuntu, you may encounter the following error when running
 `rclone mount`:


### PR DESCRIPTION
#### What is the purpose of this change?

Similar to "Mounting on macOS", "Mounting on Linux" needs to be a sub-heading of the general "rclone". This also fixes the missing anchor overlay on hover.

#### Was the change discussed in an issue or in the forum before?

Second attempt after #9040.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
