### PR TITLE
s3: Add OVHcloud Object Storage S3 storage classes

### DIFF
--- a/backend/s3/provider/OVHcloud.yaml
+++ b/backend/s3/provider/OVHcloud.yaml
@@ -32,5 +32,20 @@ endpoint:
   s3.us-east-va.io.cloud.ovh.us: OVHcloud Vint Hill, Virginia, USA
   s3.us-west-or.io.cloud.ovh.us: OVHcloud Hillsboro, Oregon, USA
   s3.rbx-archive.io.cloud.ovh.net: OVHcloud Roubaix, France (Cold Archive)
+storage_class:
+  "": Default.
+  STANDARD: |-
+    The Standard storage class offers a scalable object storage service, compatible with the vast majority of use cases, adapted to any type of volume.
+  EXPRESS_ONEZONE: |-
+    The High Performance storage class is a high-performance object storage space for applications that have high bandwidth requirements and require extremely fast and intensive read and write access to data.
+  GLACIER: |-
+    The Active Archive storage class is designed for long-term data retention, while ensuring immediate access when needed. 
+    This storage class is optimized for data that is rarely accessed but must always remain instantly available.
+  ONEZONE_IA: |-
+    The Infrequent Access storage class is designed for infrequently accessed data, also known as "cool" data storage, requiring fast data retrieval. 
+    It offers similar performance (ms TTFB, low latency) and availability than Standard Object Storage but with a lower cost per GiB-hour and a per GiB retrieval fee.
+  DEEP_ARCHIVE: |-
+    Cold Archive is designed for long-term data storage and data archiving with a very low cost per GiB-hour and per GiB restore fee. 
+    Indeed, data in the Cold Archive class is not available in real-time and needs to be restored before being available.
 acl: {}
 bucket_acl: true


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

OVHcloud's S3-compatible Object Storage supports several storage classes, which are not available in rclone under its provider entry. This change adds and documents these storage classes, with their descriptions taken from [the KB article on choosing a storage class](https://help.ovhcloud.com/csm/en-ie-public-cloud-storage-s3-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0047293), and their S3 mapping definitions taken from [the KB article on supported S3 endpoints](https://help.ovhcloud.com/csm/en-ie-public-cloud-storage-s3-location?id=kb_article_view&sysparm_article=KB0047393).

#### Was the change discussed in an issue or in the forum before?

I was unable to find any forum discussions or GitHub issues regarding the S3-compatible storage implementation. I am aware that some documentation is available for the OpenStack Swift-compatible version of this storage product.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
