### PR TITLE
lib/rest: fix URLPathEscapeAll encoding RFC 3986 unreserved characters

### DIFF
--- a/lib/rest/url.go
+++ b/lib/rest/url.go
@@ -28,7 +28,9 @@ func URLPathEscape(in string) string {
 
 // URLPathEscapeAll escapes URL path the in string using URL escaping rules
 //
-// It escapes every character except [A-Za-z0-9] and /
+// It escapes every character except the RFC 3986 unreserved characters
+// [A-Za-z0-9-._~] and the path separator /. Unreserved characters MUST NOT
+// be percent-encoded per RFC 3986 §2.3.
 func URLPathEscapeAll(in string) string {
 	var b strings.Builder
 	b.Grow(len(in) * 3) // worst case: every byte escaped
@@ -36,7 +38,8 @@ func URLPathEscapeAll(in string) string {
 	for i := range len(in) {
 		c := in[i]
 		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
-			(c >= '0' && c <= '9') || c == '/' {
+			(c >= '0' && c <= '9') || c == '/' ||
+			c == '-' || c == '.' || c == '_' || c == '~' {
 			b.WriteByte(c)
 		} else {
 			b.WriteByte('%')

--- a/lib/rest/url_test.go
+++ b/lib/rest/url_test.go
@@ -66,7 +66,10 @@ func TestURLPathEscapeAll(t *testing.T) {
 		want string
 	}{
 		{"", ""},
-		{"/hello.txt", "/hello%2Etxt"},
+		// RFC 3986 unreserved characters must not be encoded
+		{"/hello.txt", "/hello.txt"},
+		{"file-name_v2.~bak", "file-name_v2.~bak"},
+		// Reserved and other characters must be encoded
 		{"With Space", "With%20Space"},
 		{"With Colon:", "With%20Colon%3A"},
 		{"With Percent%", "With%20Percent%25"},


### PR DESCRIPTION
#### What is the purpose of this change?

`URLPathEscapeAll` only passes `[A-Za-z0-9/]` through unencoded, causing it to percent-encode the RFC 3986 unreserved characters `-`, `.`, `_`, and `~`.

Per [RFC 3986 §2.3](https://datatracker.ietf.org/doc/html/rfc3986#section-2.3), unreserved characters MUST NOT be percent-encoded, and a URI that unnecessarily encodes them is not equivalent to one that does not. Servers that perform strict path matching without normalising percent-encoded URIs will reject the over-encoded form with a 404.

This fix adds `-`, `.`, `_`, `~` to the set of characters passed through unencoded. Reserved characters (spaces, semicolons, colons, `%`, `?`, `#`, etc.) continue to be encoded as before.

**Before:** `/files/my-report.pdf` → `/files/my%2Dreport%2Epdf`
**After:** `/files/my-report.pdf` → `/files/my-report.pdf`

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)