### PR TITLE
s3: add multi tenant support for cubbit

### DIFF
--- a/backend/s3/provider/Cubbit.yaml
+++ b/backend/s3/provider/Cubbit.yaml
@@ -4,6 +4,7 @@ region:
   eu-west-1: Europe West
 endpoint:
   s3.cubbit.eu: Cubbit DS3 Object Storage endpoint
+  s3.{tenant_name}.cubbit.eu: Multi-tenant endpoint - replace {tenant_name} with your actual tenant name. Do not select this directly
 acl: {}
 bucket_acl: true
 quirks:

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -5133,7 +5133,7 @@ to retrieve these keys. They will be needed when prompted by `rclone config`.
 
 Default region will correspond to `eu-west-1` and the endpoint has to be specified
 as `s3.cubbit.eu`. If you set a custom tenant endpoint, you must use
-`s3.<tenant-name>.cubbit.eu`, because the generic `s3.cubbit.eu` endpoint will not
+`s3.{tenant_name}.cubbit.eu`, because the generic `s3.cubbit.eu` endpoint will not
 work in this case.
 
 Going through the whole process of creating a new remote by running `rclone config`,
@@ -5147,7 +5147,7 @@ env_auth> false
 access_key_id> YOUR_ACCESS_KEY
 secret_access_key> YOUR_SECRET_KEY
 region> eu-west-1 (or leave empty)
-endpoint> s3.cubbit.eu (or s3.<tenant-name>.cubbit.eu)
+endpoint> s3.cubbit.eu (or s3.{tenant_name}.cubbit.eu)
 acl>
 ```
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Add multi tenant support to the already existing S3 provider Cubbit DS3.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

Nope.

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
~~- [ ] I have added tests for all changes in this PR if appropriate.~~
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

#### Tests

Here's the test run :heavy_check_mark: 

<details>

<summary>Details</summary>

```
rclone/backend/s3$ go test -v -remote Cubbit:

=== RUN   TestSignHTTP
--- PASS: TestSignHTTP (0.00s)
=== RUN   TestVersionLess
--- PASS: TestVersionLess (0.00s)
=== RUN   TestMergeDeleteMarkers
--- PASS: TestMergeDeleteMarkers (0.00s)
=== RUN   TestRemoveAWSChunked
=== RUN   TestRemoveAWSChunked/nil
=== RUN   TestRemoveAWSChunked/empty
=== RUN   TestRemoveAWSChunked/only_aws
=== RUN   TestRemoveAWSChunked/leading_aws
=== RUN   TestRemoveAWSChunked/trailing_aws
=== RUN   TestRemoveAWSChunked/middle_aws
=== RUN   TestRemoveAWSChunked/case_insensitive
=== RUN   TestRemoveAWSChunked/duplicates
=== RUN   TestRemoveAWSChunked/no_aws_normalize_spaces
=== RUN   TestRemoveAWSChunked/surrounding_spaces
=== RUN   TestRemoveAWSChunked/no_change
--- PASS: TestRemoveAWSChunked (0.00s)
    --- PASS: TestRemoveAWSChunked/nil (0.00s)
    --- PASS: TestRemoveAWSChunked/empty (0.00s)
    --- PASS: TestRemoveAWSChunked/only_aws (0.00s)
    --- PASS: TestRemoveAWSChunked/leading_aws (0.00s)
    --- PASS: TestRemoveAWSChunked/trailing_aws (0.00s)
    --- PASS: TestRemoveAWSChunked/middle_aws (0.00s)
    --- PASS: TestRemoveAWSChunked/case_insensitive (0.00s)
    --- PASS: TestRemoveAWSChunked/duplicates (0.00s)
    --- PASS: TestRemoveAWSChunked/no_aws_normalize_spaces (0.00s)
    --- PASS: TestRemoveAWSChunked/surrounding_spaces (0.00s)
    --- PASS: TestRemoveAWSChunked/no_change (0.00s)
=== RUN   TestIntegration
    fstests.go:438: Using remote "Cubbit:"
    fstests.go:459: Didn't find "Cubbit:" in config file - skipping tests
--- PASS: TestIntegration (0.00s)
=== RUN   TestIntegration2
    s3_test.go:45: skipping as -remote is set
--- SKIP: TestIntegration2 (0.00s)
=== RUN   TestAWSDualStackOption
--- PASS: TestAWSDualStackOption (0.00s)
=== RUN   TestParseRetainUntilDate
=== RUN   TestParseRetainUntilDate/RFC3339_date
=== RUN   TestParseRetainUntilDate/RFC3339_date_with_timezone
=== RUN   TestParseRetainUntilDate/duration_days
=== RUN   TestParseRetainUntilDate/duration_hours
=== RUN   TestParseRetainUntilDate/duration_minutes
=== RUN   TestParseRetainUntilDate/invalid_input
=== RUN   TestParseRetainUntilDate/empty_input
--- PASS: TestParseRetainUntilDate (0.00s)
    --- PASS: TestParseRetainUntilDate/RFC3339_date (0.00s)
    --- PASS: TestParseRetainUntilDate/RFC3339_date_with_timezone (0.00s)
    --- PASS: TestParseRetainUntilDate/duration_days (0.00s)
    --- PASS: TestParseRetainUntilDate/duration_hours (0.00s)
    --- PASS: TestParseRetainUntilDate/duration_minutes (0.00s)
    --- PASS: TestParseRetainUntilDate/invalid_input (0.00s)
    --- PASS: TestParseRetainUntilDate/empty_input (0.00s)
PASS
ok  	github.com/rclone/rclone/backend/s3	0.027s
```

</details>