### PR TITLE
webdav: request only required properties in listAll

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -225,7 +225,7 @@ type Fs struct {
 	hasOCMD5           bool          // set if can use owncloud style checksums for MD5
 	hasOCSHA1          bool          // set if can use owncloud style checksums for SHA1
 	hasMESHA1          bool          // set if can use fastmail style checksums for SHA1
-	useStandardProps   bool          // set if should use standard props for PROPFIND (for "other" vendor)
+	useStandardProps   bool          // set if should use standard props for PROPFIND
 	ntlmAuthMu         sync.Mutex    // mutex to serialize NTLM auth roundtrips
 	chunksUploadURL    string        // upload URL for nextcloud chunked
 	canChunk           bool          // set if nextcloud and nextcloud_chunk_size is set


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
This PR optimizes the `PROPFIND` requests in the `webdav` backend to only ask for the specific properties `rclone` actually needs.

Currently, the generic webdav backend sends an empty XML body during directory listing (`listAll`), which causes the server to fall back to `allprops` by default. This forces the server to return properties we never use, such as `getcontenttype`.

Fetching `getcontenttype` can be a very expensive operation on the server side. For instance, in the official `golang.org/x/net/webdav` library, determining the content type requires the server to open the file and read the first 500 bytes.

For a directory with 1,300 files in my environment, rclone ls time dropped from ~30s to ~4s (as fast as native ls).


#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
