### PR TITLE
vfs/cache: fix exponentially growing error messages in download retries

### DIFF
--- a/vfs/vfscache/downloaders/downloaders.go
+++ b/vfs/vfscache/downloaders/downloaders.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"sync"
 	"time"
 
@@ -31,6 +32,8 @@ const (
 	// If a downloader is within this range or --buffer-size
 	// whichever is the larger, we will reuse the downloader
 	minWindow = 1024 * 1024
+	// error prefix used when wrapping cache write errors
+	errCacheWritePrefix = "vfs reader: failed to write to cache file"
 )
 
 // Item is the interface that an item to download must obey
@@ -623,7 +626,15 @@ func (dl *downloader) download() (n int64, err error) {
 	// defer log.Trace(dl.dls.src, "")("err=%v", &err)
 	n, err = dl.in.WriteTo(dl)
 	if err != nil && !errors.Is(err, asyncreader.ErrorStreamAbandoned) {
-		return n, fmt.Errorf("vfs reader: failed to write to cache file: %w", err)
+		// Avoid re-wrapping errors that already contain our prefix.
+		// This can happen when kickWaiters() propagates a lastErr
+		// (from a previous download attempt) back through Write(),
+		// causing each retry to add another layer of the same prefix,
+		// leading to exponentially growing error messages in the logs.
+		if strings.Contains(err.Error(), errCacheWritePrefix) {
+			return n, err
+		}
+		return n, fmt.Errorf("%s: %w", errCacheWritePrefix, err)
 	}
 
 	return n, nil


### PR DESCRIPTION
## Summary

Fixes #4998

When the VFS cache runs out of disk space (or encounters repeated download errors), each retry in the downloader wraps the previous error with the same `"vfs reader: failed to write to cache file:"` prefix. This happens because:

1. `download()` wraps any error from `WriteTo()` with the prefix
2. On failure, the wrapped error is stored as `lastErr` via `countErrors()`
3. `kickWaiters()` propagates `lastErr` back through `Write()` as the return error
4. `WriteTo()` returns this error to `download()`, which wraps it **again**

After ~243 retries, the error message contains the prefix repeated 243 times, producing log lines that are tens of kilobytes long and causing massive log file growth.

## Fix

In `download()`, check whether the error already contains the `"vfs reader: failed to write to cache file"` prefix before wrapping it again. The prefix string is extracted into a named constant (`errCacheWritePrefix`) to keep the check DRY.

This is a minimal, targeted fix that prevents the exponential error message growth while preserving the full error chain for the first occurrence.

## Test plan

- [x] `go build ./vfs/vfscache/downloaders/` compiles cleanly
- [x] `go test ./vfs/vfscache/downloaders/` passes (6.764s)
- [ ] Manual verification: mount with `--vfs-cache-mode=full` and a small `--vfs-cache-max-size`, trigger cache-full condition, verify log messages no longer grow exponentially