### PR TITLE
lib/http: add bcrypt auth result caching - fixes #7892

### DIFF
--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -2,16 +2,25 @@ package http
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
 	"net/http"
 	"regexp"
 	"strings"
 	"sync"
+	"time"
 
 	goauth "github.com/abbot/go-http-auth"
 	"github.com/rclone/rclone/fs"
+	libcache "github.com/rclone/rclone/lib/cache"
 )
+
+// authCacheEntry stores a cached authentication result for any hash algorithm.
+type authCacheEntry struct {
+	passwordHash [sha256.Size]byte // sha256(plaintext password) at cache time
+	secret       string            // htpasswd hash string at cache time
+}
 
 // parseAuthorization parses the Authorization header into user, pass
 // it returns a boolean as to whether the parse was successful
@@ -56,6 +65,7 @@ func NewLoggedBasicAuthenticator(realm string, secrets goauth.SecretProvider) *L
 
 // Helper to generate required interface for middleware
 func basicAuth(authenticator *LoggedBasicAuth) func(next http.Handler) http.Handler {
+	cache := libcache.New().SetExpireDuration(5 * time.Minute)
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// skip auth for CORS preflight
@@ -64,11 +74,45 @@ func basicAuth(authenticator *LoggedBasicAuth) func(next http.Handler) http.Hand
 				return
 			}
 
+			user, pass, ok := parseAuthorization(r)
+			if !ok {
+				authenticator.RequireAuth(w, r)
+				return
+			}
+
+			// Fetch the current secret for this user. This also triggers
+			// htpasswd file reload if the file has changed (handled by goauth).
+			secret := authenticator.Secrets(user, authenticator.Realm)
+			if secret == "" {
+				// Unknown user
+				fs.Infof(r.URL.Path, "%s: Unauthorized request from %s", r.RemoteAddr, user)
+				authenticator.RequireAuth(w, r)
+				return
+			}
+
+			providedHash := sha256.Sum256([]byte(pass))
+
+			// Check cache: valid only when secret hasn't changed AND password matches.
+			if cachedValue, found := cache.GetMaybe(user); found {
+				entry, ok := cachedValue.(authCacheEntry)
+				if ok && entry.secret == secret && entry.passwordHash == providedHash {
+					ctx := context.WithValue(r.Context(), ctxKeyUser, user)
+					next.ServeHTTP(w, r.WithContext(ctx))
+					return
+				}
+				// Secret changed or wrong password — fall through to full verification.
+			}
+
+			// Cache miss or stale — perform full verification via goauth.
 			username := authenticator.CheckAuth(r)
 			if username == "" {
 				authenticator.RequireAuth(w, r)
 				return
 			}
+
+			// Store result; next request for same user+password+secret is free.
+			cache.Put(user, authCacheEntry{passwordHash: providedHash, secret: secret})
+
 			ctx := context.WithValue(r.Context(), ctxKeyUser, username)
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})

--- a/lib/http/middleware_test.go
+++ b/lib/http/middleware_test.go
@@ -7,9 +7,12 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	goauth "github.com/abbot/go-http-auth"
 	"github.com/stretchr/testify/require"
 )
 
@@ -654,5 +657,163 @@ func TestMiddlewareResponseHeaders(t *testing.T) {
 				require.Equal(t, vals, resp.Header.Values(key), "header value should match")
 			}
 		})
+	}
+}
+
+func TestMiddlewareAuthBcryptCache(t *testing.T) {
+	s, err := NewServer(context.Background(),
+		WithConfig(Config{ListenAddr: []string{"127.0.0.1:0"}}),
+		WithAuth(AuthConfig{Realm: "test", HtPasswd: "./testdata/.htpasswd"}),
+	)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, s.Shutdown()) }()
+	s.Router().Mount("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	s.Serve()
+	url := testGetServerURL(t, s)
+	client := &http.Client{}
+
+	sendReq := func(user, pass string) int {
+		req, err := http.NewRequest("GET", url, nil)
+		require.NoError(t, err)
+		if user != "" {
+			req.SetBasicAuth(user, pass)
+		}
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	t.Run("Bcrypt/CacheMiss", func(t *testing.T) {
+		require.Equal(t, http.StatusOK, sendReq("bcrypt", "bcrypt"))
+	})
+	t.Run("Bcrypt/CacheHit", func(t *testing.T) {
+		require.Equal(t, http.StatusOK, sendReq("bcrypt", "bcrypt"))
+	})
+	t.Run("Bcrypt/WrongPasswordFallsThrough", func(t *testing.T) {
+		require.Equal(t, http.StatusUnauthorized, sendReq("bcrypt", "wrongpassword"))
+	})
+	t.Run("Bcrypt/NoCreds", func(t *testing.T) {
+		require.Equal(t, http.StatusUnauthorized, sendReq("", ""))
+	})
+	t.Run("MD5/CachedLikeBcrypt", func(t *testing.T) {
+		require.Equal(t, http.StatusOK, sendReq("md5", "md5"))
+		require.Equal(t, http.StatusOK, sendReq("md5", "md5"))
+		require.Equal(t, http.StatusUnauthorized, sendReq("md5", "wrongpassword"))
+	})
+}
+
+func TestMiddlewareAuthBcryptCachePasswordChange(t *testing.T) {
+	// bcrypt hash of "newpassword" at cost 4 (low cost for test speed)
+	const newHash = "$2a$04$xWq7e2r0F01c5vAQd/pAf.E/28KCJTp4vNZzsPc/eDhBNwUi4FOjO"
+	// original bcrypt hash of "bcrypt" from testdata/.htpasswd
+	const origHash = "$2y$10$K/b3mVXUA6X857TOTYIL9.Lbaeg9oBjMQwUX5NefpVUCcYP0Z5KY2"
+
+	tmpDir, err := os.MkdirTemp("", "htpasswd-test-*")
+	require.NoError(t, err)
+	htpasswd := filepath.Join(tmpDir, ".htpasswd")
+	writeHtpasswd := func(hash string) {
+		require.NoError(t, os.WriteFile(htpasswd, []byte("user:"+hash+"\n"), 0600))
+	}
+
+	writeHtpasswd(origHash)
+	s, err := NewServer(context.Background(),
+		WithConfig(Config{ListenAddr: []string{"127.0.0.1:0"}}),
+		WithAuth(AuthConfig{Realm: "test", HtPasswd: htpasswd}),
+	)
+	require.NoError(t, err)
+	// Shutdown before TempDir cleanup so goauth releases the file handle on Windows.
+	t.Cleanup(func() {
+		require.NoError(t, s.Shutdown())
+		require.NoError(t, os.RemoveAll(tmpDir))
+	})
+	s.Router().Mount("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	s.Serve()
+	url := testGetServerURL(t, s)
+	client := &http.Client{}
+
+	sendReq := func(pass string) int {
+		req, err := http.NewRequest("GET", url, nil)
+		require.NoError(t, err)
+		req.SetBasicAuth("user", pass)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		_ = resp.Body.Close()
+		return resp.StatusCode
+	}
+
+	require.Equal(t, http.StatusOK, sendReq("bcrypt"), "original password should work")
+	require.Equal(t, http.StatusOK, sendReq("bcrypt"), "cache hit should work")
+
+	writeHtpasswd(newHash)
+
+	require.Equal(t, http.StatusUnauthorized, sendReq("bcrypt"), "old password must be rejected after file change")
+	require.Equal(t, http.StatusOK, sendReq("newpassword"), "new password must work after file change")
+}
+
+func newHandler() http.Handler {
+	secretProvider := goauth.HtpasswdFileProvider("./testdata/.htpasswd")
+	authenticator := NewLoggedBasicAuthenticator("test", secretProvider)
+	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	return basicAuth(authenticator)(next)
+}
+
+func BenchmarkBcryptAuthCacheMiss(b *testing.B) {
+	h := newHandler()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/", nil)
+		r.SetBasicAuth("bcrypt", fmt.Sprintf("wrongpassword%d", i))
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusUnauthorized {
+			b.Fatalf("expected 401, got %d", w.Code)
+		}
+	}
+}
+
+func BenchmarkBcryptAuthCacheHit(b *testing.B) {
+	h := newHandler()
+	warmup := httptest.NewRequest("GET", "/", nil)
+	warmup.SetBasicAuth("bcrypt", "bcrypt")
+	h.ServeHTTP(httptest.NewRecorder(), warmup)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/", nil)
+		r.SetBasicAuth("bcrypt", "bcrypt")
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			b.Fatalf("expected 200, got %d", w.Code)
+		}
+	}
+}
+
+func BenchmarkMD5AuthCacheHit(b *testing.B) {
+	h := newHandler()
+	warmup := httptest.NewRequest("GET", "/", nil)
+	warmup.SetBasicAuth("md5", "md5")
+	h.ServeHTTP(httptest.NewRecorder(), warmup)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest("GET", "/", nil)
+		r.SetBasicAuth("md5", "md5")
+		h.ServeHTTP(w, r)
+		if w.Code != http.StatusOK {
+			b.Fatalf("expected 200, got %d", w.Code)
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

WebDAV server with htpasswd authentication using bcrypt-hashed passwords has severe performance degradation. When accessing a directory with many files, each file access triggers multiple authentication requests, and bcrypt verification becomes the bottleneck. Access or listing directory or files more than 1000 can take minutes instead of seconds.


  - cache successful bcrypt verifications for 5 minutes
  - validate cache entries against current htpasswd secret, **secret changes, cache invalid**
  - add tests and benchmarks for cache hit/miss and password change


#### Was the change discussed in an issue or in the forum before?
https://github.com/rclone/rclone/issues/7892



#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
~~- [ ] I have added documentation for the changes if appropriate.~~
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)



```bash
go test -run='^$' -bench='BenchmarkBcryptAuth|BenchmarkMD5Auth' -benchtime=1000x ./lib/http/
goos: linux
goarch: amd64
pkg: github.com/rclone/rclone/lib/http
cpu: 12th Gen Intel(R) Core(TM) i5-12500H
BenchmarkBcryptAuthCacheMiss
BenchmarkBcryptAuthCacheMiss-16             1000          85370347 ns/op           18370 B/op         83 allocs/op
BenchmarkBcryptAuthCacheHit
BenchmarkBcryptAuthCacheHit-16              1000              9155 ns/op            6572 B/op         29 allocs/op
BenchmarkMD5AuthNoCache
BenchmarkMD5AuthNoCache-16                  1000            237678 ns/op           23013 B/op       1038 allocs/op
PASS
ok      github.com/rclone/rclone/lib/http       86.522s

```