### PR TITLE
docs: note that Filen API key changes on password change

### DIFF
--- a/docs/content/filen.md
+++ b/docs/content/filen.md
@@ -10,6 +10,8 @@ The initial setup for Filen requires that you get an API key for your account,
 currently this is only possible using the [Filen CLI](https://github.com/FilenCloudDienste/filen-cli).
 This means you must first download the CLI, login, and then run the `export-api-key` command.
 
+**Note:** If you change your Filen account password, your API key will change. You will need to re-export it using the CLI and update your rclone configuration.
+
 Here is an example of how to make a remote called `FilenRemote`.  First run:
 
      rclone config


### PR DESCRIPTION
Adds a note to the Filen backend documentation that changing the Filen account password invalidates the API key and requires re-exporting it.

This has come up in community discussions and on the rclone forum where users changed their password and then got `DecryptMetadataV2: cipher: message authentication failed` errors without understanding why.