### PR TITLE
docs: clarify Filen password change requires updating both password and API key

### DIFF
--- a/docs/content/filen.md
+++ b/docs/content/filen.md
@@ -10,7 +10,7 @@ The initial setup for Filen requires that you get an API key for your account,
 currently this is only possible using the [Filen CLI](https://github.com/FilenCloudDienste/filen-cli).
 This means you must first download the CLI, login, and then run the `export-api-key` command.
 
-**Note:** If you change your Filen account password, your API key will change. You will need to re-export it using the CLI and update your rclone configuration.
+**Note:** If you change your Filen account password, you will need to update your rclone configuration with the new password and a re-exported API key (via `export-api-key`).
 
 Here is an example of how to make a remote called `FilenRemote`.  First run:
 


### PR DESCRIPTION
Follow-up to #9271. The previous note only mentioned re-exporting the API key after a password change. This corrects it to clarify that both the password and the API key in the rclone configuration need to be updated.