### PR TITLE
asyncreader: remove soft-start logic

### DIFF
--- a/fs/asyncreader/asyncreader.go
+++ b/fs/asyncreader/asyncreader.go
@@ -15,8 +15,7 @@ import (
 
 const (
 	// BufferSize is the default size of the async buffer
-	BufferSize       = pool.BufferSize
-	softStartInitial = 4 * 1024
+	BufferSize = pool.BufferSize
 )
 
 // ErrorStreamAbandoned is returned when the input is closed before the end of the stream
@@ -35,7 +34,6 @@ type AsyncReader struct {
 	err     error          // If an error has occurred it is here
 	cur     *buffer        // Current buffer being served
 	exited  chan struct{}  // Channel is closed been the async reader shuts down
-	size    int            // size of buffer to use
 	closed  bool           // whether we have closed the underlying stream
 	mu      sync.Mutex     // lock for Read/WriteTo/Abandon/Close
 	ci      *fs.ConfigInfo // for reading config
@@ -71,7 +69,6 @@ func (a *AsyncReader) init(rd io.ReadCloser, buffers int) {
 	a.exited = make(chan struct{})
 	a.buffers = buffers
 	a.cur = nil
-	a.size = softStartInitial
 
 	// Create tokens
 	for range buffers {
@@ -87,10 +84,6 @@ func (a *AsyncReader) init(rd io.ReadCloser, buffers int) {
 			select {
 			case <-a.token:
 				b := a.getBuffer()
-				if a.size < BufferSize {
-					b.buf = b.buf[:a.size]
-					a.size <<= 1
-				}
 				err := b.read(a.in)
 				a.ready <- b
 				if err != nil {

--- a/fs/asyncreader/asyncreader_test.go
+++ b/fs/asyncreader/asyncreader_test.go
@@ -309,10 +309,10 @@ func TestAsyncReaderSkipBytes(t *testing.T) {
 	require.Equal(t, len(data), n)
 
 	initialReads := []int{0, 1, 100, 2048,
-		softStartInitial - 1, softStartInitial, softStartInitial + 1,
+		4095, 4096, 4097,
 		8000, len(data)}
 	skips := []int{-1000, -101, -100, -99, 0, 1, 2048,
-		softStartInitial - 1, softStartInitial, softStartInitial + 1,
+		4095, 4096, 4097,
 		8000, len(data), BufferSize, 2 * BufferSize}
 
 	for buffers := 1; buffers <= 5; buffers++ {


### PR DESCRIPTION
The AsyncReader's soft-start began reads at 4KB and doubled each read until reaching the full 1MB buffer size.  This added 9 undersized reads at the start of every transfer for no benefit:

- The buffer is already allocated at full size from the pool, so slicing it smaller doesn't save memory.
- The kernel handles small files naturally - read(fd, buf, 1MB) on a 3KB file just returns 3KB.
- Each undersized read is a wasted syscall.

Remove it and always use the full buffer from the first read.

Fixes: #9282

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
Remove unnecessary/strange IO soft-start reader logic.

The AsyncReader's soft-start began reads at 4KB and doubled each read until reaching the full 1MB buffer size.  This added 9 undersized reads at the start of every transfer for no benefit:

- The buffer is already allocated at full size from the pool, so slicing it smaller doesn't save memory.
- The kernel handles small files naturally - read(fd, buf, 1MB) on a 3KB file just returns 3KB.
- Each undersized read is a wasted syscall.

Remove it and always use the full buffer from the first read.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/9282

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
