### PR TITLE
local: add configurable I/O block size for reads and writes

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -330,6 +330,39 @@ only useful for reading.
 				Advanced: true,
 				Default:  encoder.OS,
 			},
+			{
+				Name: "io_size",
+				Help: `Set the I/O block size for reads and writes.
+
+This controls how much data is read or written per syscall.
+The default of 1M works well for most cases, but larger values
+(4M-16M) can improve throughput on parallel/network filesystems
+or RAID arrays.
+
+Must be 4K-aligned (e.g., 4K, 1M, 4M, 16M).`,
+				Default:  fs.SizeSuffix(1024 * 1024),
+				Advanced: true,
+			},
+			{
+				Name: "read_io_size",
+				Help: `Override the I/O block size for reads only.
+
+If set to 0, --local-io-size is used.
+
+Must be 4K-aligned.`,
+				Default:  fs.SizeSuffix(0),
+				Advanced: true,
+			},
+			{
+				Name: "write_io_size",
+				Help: `Override the I/O block size for writes only.
+
+If set to 0, --local-io-size is used.
+
+Must be 4K-aligned.`,
+				Default:  fs.SizeSuffix(0),
+				Advanced: true,
+			},
 		},
 	}
 	fs.Register(fsi)
@@ -354,6 +387,25 @@ type Options struct {
 	Hashes            fs.CommaSepList      `config:"hashes"`
 	Enc               encoder.MultiEncoder `config:"encoding"`
 	NoClone           bool                 `config:"no_clone"`
+	IOSize            fs.SizeSuffix        `config:"io_size"`
+	ReadIOSize        fs.SizeSuffix        `config:"read_io_size"`
+	WriteIOSize       fs.SizeSuffix        `config:"write_io_size"`
+}
+
+// readIOSize returns the effective read I/O block size
+func (f *Fs) readIOSize() int {
+	if f.opt.ReadIOSize > 0 {
+		return int(f.opt.ReadIOSize)
+	}
+	return int(f.opt.IOSize)
+}
+
+// writeIOSize returns the effective write I/O block size
+func (f *Fs) writeIOSize() int {
+	if f.opt.WriteIOSize > 0 {
+		return int(f.opt.WriteIOSize)
+	}
+	return int(f.opt.IOSize)
 }
 
 // Fs represents a local filesystem rooted at root
@@ -415,6 +467,24 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 	if opt.TranslateSymlinks && opt.FollowSymlinks {
 		return nil, errLinksAndCopyLinks
+	}
+	// Validate I/O size options
+	const ioSizeAlign = 4096
+	const ioSizeDefault = 1024 * 1024
+	if opt.IOSize == 0 {
+		opt.IOSize = ioSizeDefault
+	}
+	if opt.IOSize < ioSizeAlign {
+		return nil, fmt.Errorf("--local-io-size must be at least 4K, got %v", opt.IOSize)
+	}
+	if int(opt.IOSize)%ioSizeAlign != 0 {
+		return nil, fmt.Errorf("--local-io-size %v must be 4K-aligned", opt.IOSize)
+	}
+	if opt.ReadIOSize > 0 && int(opt.ReadIOSize)%ioSizeAlign != 0 {
+		return nil, fmt.Errorf("--local-read-io-size %v must be 4K-aligned", opt.ReadIOSize)
+	}
+	if opt.WriteIOSize > 0 && int(opt.WriteIOSize)%ioSizeAlign != 0 {
+		return nil, fmt.Errorf("--local-write-io-size %v must be 4K-aligned", opt.WriteIOSize)
 	}
 
 	f := &Fs{
@@ -1476,7 +1546,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		in = io.TeeReader(in, hasher)
 	}
 
-	bp := pool.Global()
+	bp := pool.GlobalWithSize(o.fs.writeIOSize())
 	buf := bp.Get()
 	_, err = io.CopyBuffer(out, in, buf)
 	bp.Put(buf)

--- a/backend/local/local_internal_test.go
+++ b/backend/local/local_internal_test.go
@@ -707,3 +707,73 @@ func TestWriteUsesPool(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, data, got)
 }
+
+func TestIOSizeOptions(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		m := configmap.Simple{}
+		f, err := NewFs(context.Background(), "local", t.TempDir(), m)
+		require.NoError(t, err)
+		lf := f.(*Fs)
+		assert.Equal(t, 1024*1024, lf.readIOSize())
+		assert.Equal(t, 1024*1024, lf.writeIOSize())
+	})
+	t.Run("CustomIOSize", func(t *testing.T) {
+		m := configmap.Simple{
+			"io_size": "4M",
+		}
+		f, err := NewFs(context.Background(), "local", t.TempDir(), m)
+		require.NoError(t, err)
+		lf := f.(*Fs)
+		assert.Equal(t, 4*1024*1024, lf.readIOSize())
+		assert.Equal(t, 4*1024*1024, lf.writeIOSize())
+	})
+	t.Run("ReadWriteOverride", func(t *testing.T) {
+		m := configmap.Simple{
+			"io_size":       "1M",
+			"read_io_size":  "4M",
+			"write_io_size": "8M",
+		}
+		f, err := NewFs(context.Background(), "local", t.TempDir(), m)
+		require.NoError(t, err)
+		lf := f.(*Fs)
+		assert.Equal(t, 4*1024*1024, lf.readIOSize())
+		assert.Equal(t, 8*1024*1024, lf.writeIOSize())
+	})
+	t.Run("MisalignedIOSize", func(t *testing.T) {
+		m := configmap.Simple{
+			"io_size": "5000B",
+		}
+		_, err := NewFs(context.Background(), "local", t.TempDir(), m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "4K-aligned")
+	})
+	t.Run("TooSmallIOSize", func(t *testing.T) {
+		m := configmap.Simple{
+			"io_size": "1000B",
+		}
+		_, err := NewFs(context.Background(), "local", t.TempDir(), m)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least 4K")
+	})
+	t.Run("WriteWithCustomIOSize", func(t *testing.T) {
+		ctx := context.Background()
+		m := configmap.Simple{
+			"write_io_size": "4M",
+		}
+		tmpDir := t.TempDir()
+		f, err := NewFs(ctx, "local", tmpDir, m)
+		require.NoError(t, err)
+		lf := f.(*Fs)
+		assert.Equal(t, 4*1024*1024, lf.writeIOSize())
+
+		// Write a file and verify contents
+		data := bytes.Repeat([]byte("x"), 100000)
+		src := object.NewStaticObjectInfo("testfile.txt", time.Now(), int64(len(data)), true, nil, nil)
+		_, err = f.Put(ctx, io.NopCloser(bytes.NewReader(data)), src)
+		require.NoError(t, err)
+
+		got, err := os.ReadFile(filepath.Join(tmpDir, "testfile.txt"))
+		require.NoError(t, err)
+		assert.Equal(t, data, got)
+	})
+}

--- a/fs/asyncreader/asyncreader.go
+++ b/fs/asyncreader/asyncreader.go
@@ -27,37 +27,48 @@ var ErrorStreamAbandoned = errors.New("stream abandoned")
 // This should be fully transparent, except that once an error
 // has been returned from the Reader, it will not recover.
 type AsyncReader struct {
-	in      io.ReadCloser  // Input reader
-	ready   chan *buffer   // Buffers ready to be handed to the reader
-	token   chan struct{}  // Tokens which allow a buffer to be taken
-	exit    chan struct{}  // Closes when finished
-	buffers int            // Number of buffers
-	err     error          // If an error has occurred it is here
-	cur     *buffer        // Current buffer being served
-	exited  chan struct{}  // Channel is closed been the async reader shuts down
-	size    int            // size of buffer to use
-	closed  bool           // whether we have closed the underlying stream
-	mu      sync.Mutex     // lock for Read/WriteTo/Abandon/Close
-	ci      *fs.ConfigInfo // for reading config
-	pool    *pool.Pool     // pool to get memory from
+	in         io.ReadCloser  // Input reader
+	ready      chan *buffer   // Buffers ready to be handed to the reader
+	token      chan struct{}  // Tokens which allow a buffer to be taken
+	exit       chan struct{}  // Closes when finished
+	buffers    int            // Number of buffers
+	err        error          // If an error has occurred it is here
+	cur        *buffer        // Current buffer being served
+	exited     chan struct{}  // Channel is closed been the async reader shuts down
+	size       int            // size of buffer to use (soft-start)
+	bufferSize int            // target size for each buffer
+	closed     bool           // whether we have closed the underlying stream
+	mu         sync.Mutex     // lock for Read/WriteTo/Abandon/Close
+	ci         *fs.ConfigInfo // for reading config
+	pool       *pool.Pool     // pool to get memory from
 }
 
 // New returns a reader that will asynchronously read from
-// the supplied Reader into a number of buffers each of size BufferSize
+// the supplied Reader into a number of buffers each of size BufferSize.
 // It will start reading from the input at once, maybe even before this
 // function has returned.
 // The input can be read from the returned reader.
 // When done use Close to release the buffers and close the supplied input.
 func New(ctx context.Context, rd io.ReadCloser, buffers int) (*AsyncReader, error) {
+	return NewSize(ctx, rd, buffers, BufferSize)
+}
+
+// NewSize returns a reader like New but with a configurable buffer size.
+// If bufferSize <= 0, BufferSize is used.
+func NewSize(ctx context.Context, rd io.ReadCloser, buffers int, bufferSize int) (*AsyncReader, error) {
 	if buffers <= 0 {
 		return nil, errors.New("number of buffers too small")
 	}
 	if rd == nil {
 		return nil, errors.New("nil reader supplied")
 	}
+	if bufferSize <= 0 {
+		bufferSize = BufferSize
+	}
 	a := &AsyncReader{
-		ci:   fs.GetConfig(ctx),
-		pool: pool.Global(),
+		ci:         fs.GetConfig(ctx),
+		pool:       pool.GlobalWithSize(bufferSize),
+		bufferSize: bufferSize,
 	}
 	a.init(rd, buffers)
 	return a, nil
@@ -87,7 +98,7 @@ func (a *AsyncReader) init(rd io.ReadCloser, buffers int) {
 			select {
 			case <-a.token:
 				b := a.getBuffer()
-				if a.size < BufferSize {
+				if a.size < a.bufferSize {
 					b.buf = b.buf[:a.size]
 					a.size <<= 1
 				}
@@ -217,7 +228,7 @@ func (a *AsyncReader) SkipBytes(skip int) (ok bool) {
 		return false
 	}
 	// early return if skip is past the maximum buffer capacity
-	if skip >= (len(a.ready)+1)*BufferSize {
+	if skip >= (len(a.ready)+1)*a.bufferSize {
 		return false
 	}
 

--- a/fs/asyncreader/asyncreader_test.go
+++ b/fs/asyncreader/asyncreader_test.go
@@ -76,6 +76,33 @@ func TestAsyncWriteTo(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAsyncReaderNewSize(t *testing.T) {
+	ctx := context.Background()
+
+	// Test with a custom buffer size
+	data := make([]byte, 256*1024)
+	for i := range data {
+		data[i] = byte(i % 251)
+	}
+	ar, err := NewSize(ctx, io.NopCloser(bytes.NewReader(data)), 4, 64*1024)
+	require.NoError(t, err)
+
+	var dst bytes.Buffer
+	n, err := io.Copy(&dst, ar)
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(data)), n)
+	assert.Equal(t, data, dst.Bytes())
+	err = ar.Close()
+	require.NoError(t, err)
+
+	// Test NewSize with 0 falls back to BufferSize
+	ar, err = NewSize(ctx, io.NopCloser(bytes.NewReader(data)), 4, 0)
+	require.NoError(t, err)
+	assert.Equal(t, BufferSize, ar.bufferSize)
+	err = ar.Close()
+	require.NoError(t, err)
+}
+
 func TestAsyncReaderErrors(t *testing.T) {
 	ctx := context.Background()
 

--- a/lib/pool/pool.go
+++ b/lib/pool/pool.go
@@ -338,12 +338,33 @@ func (bp *Pool) PutN(bufs [][]byte) {
 var bufferPool *Pool
 var bufferPoolOnce sync.Once
 
+// sizedPools holds pools keyed by buffer size
+var sizedPools sync.Map // map[int]*Pool
+
 // Global gets a global pool of BufferSize, BufferCacheSize, BufferCacheFlushTime.
 func Global() *Pool {
 	bufferPoolOnce.Do(func() {
 		// Initialise the buffer pool when used
 		ci := fs.GetConfig(context.Background())
 		bufferPool = New(BufferCacheFlushTime, BufferSize, BufferCacheSize, ci.UseMmap)
+		sizedPools.Store(BufferSize, bufferPool)
 	})
 	return bufferPool
+}
+
+// GlobalWithSize returns a pool for the given buffer size. For the
+// default BufferSize this returns the same pool as Global(). For
+// other sizes a new pool is created (once) and cached.
+func GlobalWithSize(size int) *Pool {
+	Global()
+	if size == BufferSize {
+		return bufferPool
+	}
+	if p, ok := sizedPools.Load(size); ok {
+		return p.(*Pool)
+	}
+	ci := fs.GetConfig(context.Background())
+	p := New(BufferCacheFlushTime, size, BufferCacheSize, ci.UseMmap)
+	actual, _ := sizedPools.LoadOrStore(size, p)
+	return actual.(*Pool)
 }


### PR DESCRIPTION
#### What is the purpose of this change?

Add `--local-io-size` (default 1M), `--local-read-io-size`, and
`--local-write-io-size` flags to control the I/O block size
used by the local backend.

Different storage benefits from different I/O sizes:

- Spinning disks: larger I/O (1-4MB) reduces seeks
- Parallel/network filesystems (Lustre, GPFS, CephFS, NFS):
  typically 1-16MB for bulk transfers
- Some RAID controllers have sweet spots at specific sizes

The write path uses the configured size via `io.CopyBuffer`.
The AsyncReader gains a `NewSize` constructor for custom buffer
sizes, available for future read path integration.

Values must be 4K-aligned.

Fixes #9281

**Note:** This touches the AsyncReader in the same area as
#9284 (soft-start removal). Whichever lands first, the other
will need a trivial rebase.