### PR TITLE
Add OVHcloud storage classes

### DIFF
--- a/backend/s3/provider/OVHcloud.yaml
+++ b/backend/s3/provider/OVHcloud.yaml
@@ -32,5 +32,15 @@ endpoint:
   s3.us-east-va.io.cloud.ovh.us: OVHcloud Vint Hill, Virginia, USA
   s3.us-west-or.io.cloud.ovh.us: OVHcloud Hillsboro, Oregon, USA
   s3.rbx-archive.io.cloud.ovh.net: OVHcloud Roubaix, France (Cold Archive)
+storage_class:
+  '': Default
+  EXPRESS_ONEZONE: High Performance storage class
+  STANDARD: Standard storage class
+  STANDARD_IA: Standard Infrequent Access storage class
+  ONEZONE_IA: Standard Infrequent Access storage class
+  GLACIER: Active Archive storage class
+  GLACIER_IR: Active Archive storage class
+  DEEP_ARCHIVE: Cold Archive storage class
+  INTELLIGENT_TIERING: Standard storage class
 acl: {}
 bucket_acl: true


### PR DESCRIPTION
Added OVHcloud storage classes according to https://help.ovhcloud.com/csm/en-ie-public-cloud-storage-s3-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0047293 and https://help.ovhcloud.com/csm/en-ie-public-cloud-storage-s3-choosing-right-storage-class?id=kb_article_view&sysparm_article=KB0047293 - fixes  #9268 


## What is the purpose of this change?

Supporting settier when using OVHcloud.


#### Was the change discussed in an issue or in the forum before?

 #9268

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
