### PR TITLE
s3: fix regression where PutObject fails with non-seekable readers

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -4648,7 +4648,7 @@ func (o *Object) uploadSinglepartPutObject(ctx context.Context, req *s3.PutObjec
 	if err != nil {
 		return etag, lastModified, nil, err
 	}
-	req.Body = in
+	req.Body = io.NopCloser(in)
 	var options = []func(*s3.Options){}
 	if o.fs.opt.UseUnsignedPayload.Value {
 		options = append(options, s3.WithAPIOptions(


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fixes a regression introduced in a3e1312d where `io.NopCloser(in)` was
accidentally replaced with a bare `io.Reader` when assigning `req.Body`
in `uploadSinglepartPutObject`.

rclone wraps upload readers in an `accounting.Account` for progress
tracking. When the AWS SDK calls `Seek` on the body, `Account.Seek` does
a type assert on the inner reader. With a bare `io.Reader` the type is
unexpected and causes a serialization error for non-seekable readers
(e.g. `rclone copyurl` and `rclone rcat`):

  operation error S3: PutObject, serialization failed: internal error:
  Seek not implemented for io.nopCloser

Restores `io.NopCloser(in)` to wrap the reader correctly in all cases.

#### Was the change discussed in an issue or in the forum before?

No — this is a direct bug fix for a regression, no prior discussion needed
per CONTRIBUTING.md.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate. / Not needed
- [x] I have added documentation for the changes if appropriate. / Not needed
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
