### PR TITLE
docs: add max rclone version info for macOS 10.15 (Catalina)

### DIFF
--- a/docs/content/downloads.md
+++ b/docs/content/downloads.md
@@ -143,6 +143,7 @@ The latest `rclone` version working for:
 | Windows Server 2012 | v1.63.1 |
 | Windows XP | v1.42 |
 | Windows Vista | v1.42 |
+| macOS 10.15 (Catalina) | v1.70.3 |
 | macOS 10.14 (Mojave) | v1.63.1 |
 | macOS 10.13 (High Sierra) | v1.63.1 |
 | macOS 10.12 (Sierra) | v1.56.0 |


### PR DESCRIPTION
due to min golang requirements macOS Catalina (10.15) can not run newer rclone versions

I discovered it when installing rclone on older macs - so it is tested:)