### PR TITLE
librclone/ctest: add Windows support and fix memory management

### DIFF
--- a/librclone/ctest/Makefile
+++ b/librclone/ctest/Makefile
@@ -1,17 +1,26 @@
 CFLAGS = -g -Wall
-LDFLAGS = -L. -lrclone -lpthread -ldl
 
-ctest: ctest.o librclone.a
+ifeq ($(OS),Windows_NT)
+EXE = .exe
+LIB = librclone.lib
+LDFLAGS = -L. -lrclone -lwinmm -lws2_32 -lole32
+else
+EXE =
+LIB = librclone.a
+LDFLAGS = -L. -lrclone -lpthread -ldl
+endif
+
+ctest$(EXE): ctest.o $(LIB)
 	$(CC) $(CFLAGS) -o $@ $< $(LDFLAGS)
 
 ctest.o: ctest.c librclone.h
 	$(CC) $(CFLAGS) -c $^ $(LDFLAGS)
 
-librclone.a librclone.h:
-	go build --buildmode=c-archive -o librclone.a github.com/rclone/rclone/librclone
+$(LIB) librclone.h:
+	go build --buildmode=c-archive -o $(LIB) github.com/rclone/rclone/librclone
 
-test:	ctest
-	./ctest
+test:	ctest$(EXE)
+	./ctest$(EXE)
 
 clean:
-	rm -f tmp ctest *.o *.a *.h *.gch
+	rm -f tmp ctest ctest.exe *.o *.a *.lib *.h *.gch

--- a/librclone/ctest/ctest.c
+++ b/librclone/ctest/ctest.c
@@ -4,14 +4,13 @@ This is a very simple test/demo program for librclone's C interface
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <dlfcn.h>
 #include "librclone.h"
 
 void testRPC(char *method, char *in) {
     struct RcloneRPCResult out = RcloneRPC(method, in);
     printf("status: %d\n", out.Status);
     printf("output: %s\n", out.Output);
-    free(out.Output);
+    RcloneFreeString(out.Output);
 }
 
 // noop command
@@ -44,7 +43,7 @@ void testNoOp() {
         fprintf(stderr, "Wrong status: want: %d: got: %d\n", 200, out.Status);
         exit(EXIT_FAILURE);
     }
-    free(out.Output);
+    RcloneFreeString(out.Output);
 }
 
 // error command
@@ -83,7 +82,7 @@ void testError() {
         fprintf(stderr, "Wrong status: want: %d: got: %d\n", 500, out.Status);
         exit(EXIT_FAILURE);
     }
-    free(out.Output);
+    RcloneFreeString(out.Output);
 }
 
 // copy file using "operations/copyfile" command


### PR DESCRIPTION
## Summary

- **Add Windows build support to `librclone/ctest/Makefile`**: detect `OS=Windows_NT`, use `.exe` / `.lib` extensions, and link against `winmm`, `ws2_32`, `ole32` instead of `pthread` / `dl`.
- **Fix memory management in `ctest.c`**: replace `free()` with `RcloneFreeString()` for all RPC output strings, which is the correct API per librclone's contract.
- **Remove `#include <dlfcn.h>`** which is Linux-only and unused by the static-link test program.

## Motivation

The existing ctest only compiled on Linux/macOS. These changes let it build and run on Windows with MinGW/GCC, making the C integration test cross-platform.

Using `free()` instead of `RcloneFreeString()` was technically incorrect — the Go runtime allocates these strings via `C.CString()` which uses `C.malloc`, so `free()` happened to work, but the API contract says to use `RcloneFreeString()`. This aligns the test with the documented API.

## Test plan

- [x] `make` in `librclone/ctest/` builds successfully on Windows (MinGW)
- [x] `make test` runs and passes on Windows
- [ ] Verify Linux/macOS build still works (no functional change to non-Windows path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)