### PR TITLE
drime: fix User.EntryPermissions JSON unmarshalling

### DIFF
--- a/backend/drime/api/types.go
+++ b/backend/drime/api/types.go
@@ -21,7 +21,7 @@ type User struct {
 	Avatar           string      `json:"avatar"`
 	ModelType        string      `json:"model_type"`
 	OwnsEntry        bool        `json:"owns_entry"`
-	EntryPermissions []any       `json:"entry_permissions"`
+	EntryPermissions any         `json:"entry_permissions"`
 	DisplayName      string      `json:"display_name"`
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

`json:"entry_permissions"` is known to be either empty [] or of structure {string: boolean}. This may have been a breaking API change on Drime's side. Because EntryPermissions is not used, the type was changed to `any` to capture both cases, otherwise we could implement custom unmarshalling for that type.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
