### PR TITLE
ci: add GITHUB_TOKEN env and update gui fetch script

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,6 +95,8 @@ jobs:
     name: ${{ matrix.job_name }}
 
     runs-on: ${{ matrix.os }}
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - name: Checkout
@@ -210,6 +212,8 @@ jobs:
     timeout-minutes: 30
     name: "lint"
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - name: Get runner parameters
@@ -310,6 +314,8 @@ jobs:
     timeout-minutes: 30
     name: "android-all"
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ github.token }}
 
     steps:
       - name: Checkout

--- a/bin/fetch-gui-dist.sh
+++ b/bin/fetch-gui-dist.sh
@@ -13,10 +13,18 @@ DEST="cmd/gui/dist"
 TAG_FILE="${DEST}/.tag"
 
 CURL_OPTS=(-fSs --retry 5 --retry-delay 2 --retry-all-errors)
+API_HEADERS=(-H "Accept: application/vnd.github+json")
+
+# Use token auth in CI to avoid GitHub API rate limits.
+TOKEN="${GITHUB_TOKEN:-${GH_TOKEN:-}}"
+if [[ -n "${TOKEN}" ]]; then
+    API_HEADERS+=(-H "Authorization: Bearer ${TOKEN}")
+fi
 
 # Get the latest release info
 echo "Checking latest release of ${REPO}..."
 RELEASE_JSON=$(curl "${CURL_OPTS[@]}" \
+    "${API_HEADERS[@]}" \
     "https://api.github.com/repos/${REPO}/releases/latest") || {
     echo "Error: failed to fetch release info from GitHub API" >&2
     exit 1


### PR DESCRIPTION
#### What is the purpose of this change?
This change fixes CI/build failures in `make` caused by GitHub API rate-limiting (HTTP 403) when fetching the latest GUI bundle from `rclone/rclone-web`


#### Was the change discussed in an issue or in the forum before?
NA

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
