### PR TITLE
mega: fix crash when logging in with previous auth keys fails

### DIFF
--- a/backend/mega/mega.go
+++ b/backend/mega/mega.go
@@ -284,7 +284,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 			}
 			err = srv.LoginWithKeys(opt.SessionID, decodedMasterKey)
 			if err != nil {
-				fs.Debugf(f, "login with previous auth keys failed: %v", err)
+				return nil, fmt.Errorf("login with previous auth keys failed: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

When `Mega.LoginWithKeys()` fails to make the API request, it leaves the object in a state where `Mega.FS.root` is `nil` because it could never query any information about the filesystem tree. An easy way for this to happen is if the device is not connected to the internet.

Previously, these failures would be ignored, but `Fs.findRoot()` on the rclone side is written in a way that assumes the go-meta filesystem will have a non-nil root. This leads to an immediate nil pointer dereference when `NewFs()` calls `Fs.findRoot()`.

This commit fixes the problem by making `LoginWithKeys()` failures hard failures, similar to the `MultiFactorLogin()` path.

#### Was the change discussed in an issue or in the forum before?

The issue was reported to me in my downstream project: https://github.com/chenxiaolong/RSAF/issues/268

I've also submitted PR https://github.com/t3rm1n4l/go-mega/pull/61 for fixing go-mega returning bad error messages when API calls fail, which was causing misleading error messages to be shown when this crash fix is applied.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
