### PR TITLE
azureblob: add support for blob level SAS URLs

### DIFF
--- a/backend/azureblob/auth/auth.go
+++ b/backend/azureblob/auth/auth.go
@@ -56,7 +56,7 @@ Leave blank to use SAS URL or Emulator.`,
 	Sensitive: true,
 }, {
 	Name: "sas_url",
-	Help: `SAS URL for container level access only.
+	Help: `SAS URL for container or blob level access.
 
 Leave blank if using account/key or Emulator.`,
 	Sensitive: true,
@@ -317,6 +317,7 @@ type NewClientResult[Client any] struct {
 	UsingSharedKeyCred bool                   // set if using shared key credentials
 	Anonymous          bool                   // true if anonymous authentication was used
 	Container          string                 // Container that SAS URL points to
+	BlobName           string                 // Blob name that SAS URL points to (if blob-level SAS)
 }
 
 // NewClient creates a service client from the rclone options
@@ -383,8 +384,9 @@ func NewClient[Client, ClientOptions, SharedKeyCredential any](ctx context.Conte
 		}
 		endpoint := opt.SASURL
 		r.Container = parts.ContainerName
+		r.BlobName = parts.BlobName
 		// Check if we have container level SAS or account level SAS
-		if conf.Blob && r.Container != "" {
+		if parts.BlobName == "" && conf.Blob && r.Container != "" {
 			// Container level SAS
 			if conf.RootContainer != "" && r.Container != conf.RootContainer {
 				return r, fmt.Errorf("container name in SAS URL (%q) and container provided in command (%q) do not match", r.Container, conf.RootContainer)

--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -410,6 +410,9 @@ type Fs struct {
 	cntSVCcacheMu      sync.Mutex                   // mutex to protect cntSVCcache
 	cntSVCcache        map[string]*container.Client // reference to containerClient per container
 	svc                *service.Client              // client to access azblob
+	containerName      string                       // container Name
+	blobClient         *blob.Client                 // reference to blob Client
+	blobBlockClient    *blockblob.Client            // reference to block blob client
 	cred               azcore.TokenCredential       // how to generate tokens (may be nil)
 	usingSharedKeyCred bool                         // set if using shared key credentials
 	anonymous          bool                         // if this is anonymous access
@@ -677,10 +680,24 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	f.usingSharedKeyCred = res.UsingSharedKeyCred
 	f.anonymous = res.Anonymous
 
-	// if using Container level SAS put the container client into the cache
-	if opt.SASURL != "" && res.Container != "" {
-		_ = f.cntSVC(res.Container)
-		f.isLimited = true
+	// Handle SAS URL scoping
+	if opt.SASURL != "" {
+		if res.BlobName != "" {
+			// Blob level SAS - create blob and block blob clients directly
+			f.containerName = res.Container
+			f.blobClient, err = blob.NewClientWithNoCredential(opt.SASURL, nil)
+			if err != nil {
+				return nil, fmt.Errorf("unable to create SAS URL blob client: %w", err)
+			}
+			f.blobBlockClient, err = blockblob.NewClientWithNoCredential(opt.SASURL, nil)
+			if err != nil {
+				return nil, fmt.Errorf("unable to create SAS URL block blob client: %w", err)
+			}
+		} else if res.Container != "" {
+			// Container level SAS
+			_ = f.cntSVC(res.Container)
+			f.isLimited = true
+		}
 	}
 
 	if f.rootContainer != "" && f.rootDirectory != "" {
@@ -723,6 +740,9 @@ func (f *Fs) newObjectWithInfo(ctx context.Context, remote string, info *contain
 		fs:     f,
 		remote: remote,
 	}
+	if f.containerName != "" {
+		o.remote = f.containerName
+	}
 	if info != nil {
 		err := o.decodeMetaDataFromBlob(info)
 		if err != nil {
@@ -745,12 +765,20 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 
 // getBlobSVC creates a blob client
 func (f *Fs) getBlobSVC(container, containerPath string) *blob.Client {
-	return f.cntSVC(container).NewBlobClient(containerPath)
+	if f.containerName == "" {
+		return f.cntSVC(container).NewBlobClient(containerPath)
+	} else {
+		return f.blobClient
+	}
 }
 
 // getBlockBlobSVC creates a block blob client
 func (f *Fs) getBlockBlobSVC(container, containerPath string) *blockblob.Client {
-	return f.cntSVC(container).NewBlockBlobClient(containerPath)
+	if f.containerName == "" {
+		return f.cntSVC(container).NewBlockBlobClient(containerPath)
+	} else {
+		return f.blobBlockClient
+	}
 }
 
 // updateMetadataWithModTime adds the modTime passed in to o.meta.
@@ -1432,6 +1460,9 @@ func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options .
 		fs:     f,
 		remote: src.Remote(),
 	}
+	if f.containerName != "" {
+		fs.remote = f.containerName
+	}
 	return fs, fs.Update(ctx, in, src, options...)
 }
 
@@ -1973,9 +2004,11 @@ func (f *Fs) copySinglepart(ctx context.Context, remote, dstContainer, dstPath s
 // If it isn't possible then return fs.ErrorCantCopy
 func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
 	dstContainer, dstPath := f.split(remote)
-	err := f.mkdirParent(ctx, remote)
-	if err != nil {
-		return nil, err
+	if f.containerName == "" {
+		err := f.mkdirParent(ctx, remote)
+		if err != nil {
+			return nil, err
+		}
 	}
 	srcObj, ok := src.(*Object)
 	if !ok {
@@ -2974,8 +3007,10 @@ type uploadInfo struct {
 // Prepare the object for upload
 func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options []fs.OpenOption) (ui uploadInfo, err error) {
 	container, containerPath := o.split()
-	if container == "" || containerPath == "" {
-		return ui, fmt.Errorf("can't upload to root - need a container")
+	if o.fs.containerName == "" {
+		if container == "" || containerPath == "" {
+			return ui, fmt.Errorf("can't upload to root - need a container")
+		}
 	}
 	// Create parent dir/bucket if not saving directory marker
 	metadataMu.Lock()

--- a/docs/content/azureblob.md
+++ b/docs/content/azureblob.md
@@ -261,14 +261,14 @@ in the `account` and `key` lines and leave the rest blank.
 
 #### SAS URL
 
-This can be an account level SAS URL or container level SAS URL.
+This can be an account level SAS URL, container level SAS URL, or blob level SAS URL.
 
 To use it leave `account` and `key` blank and fill in `sas_url`.
 
-An account level SAS URL or container level SAS URL can be obtained
+An account level SAS URL, container level SAS URL, or blob level SAS URL can be obtained
 from the Azure portal or the Azure Storage Explorer.  To get a
 container level SAS URL right click on a container in the Azure Blob
-explorer in the Azure portal.
+explorer in the Azure portal. For blob level SAS URL, right click on a blob.
 
 If you use a container level SAS URL, rclone operations are permitted
 only on a particular container, e.g.
@@ -284,6 +284,9 @@ show the container specified by the SAS URL.
 $ rclone lsd azureblob:
 container/
 ```
+
+If you use a blob level SAS URL, rclone operations are permitted
+only on a particular blob.
 
 Note that you can't see or access any other containers - this will
 fail


### PR DESCRIPTION
This PR adds support for blob-level SAS URLs in the Azure Blob backend.

Previously, rclone only supported container-level or account-level SAS URLs. This change allows SAS URLs that are scoped to individual blobs, providing more granular access control.

Changes:
- Detect blob-level SAS by parsing the URL and checking if `BlobName` is present
- Create direct `blob.Client` and `blockblob.Client` instances for blob-level SAS
- Updated help text and documentation to reflect blob-level support

This enables users to use SAS tokens with permissions limited to specific blobs.