### PR TITLE
oauthutil: add bearer_token_command for external token providers

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -3,6 +3,7 @@
 package onedrive
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"encoding/base64"
@@ -13,6 +14,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os/exec"
 	"path"
 	"regexp"
 	"strconv"
@@ -41,6 +43,7 @@ import (
 	"github.com/rclone/rclone/lib/pacer"
 	"github.com/rclone/rclone/lib/readers"
 	"github.com/rclone/rclone/lib/rest"
+	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -422,6 +425,10 @@ isn't always desirable to set the permissions from the metadata.
 			Default:  rwOff,
 			Examples: rwExamples,
 		}, {
+			Name:     "bearer_token_command",
+			Help:     "Command to run to get a bearer token.",
+			Advanced: true,
+		}, {
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,
 			Advanced: true,
@@ -782,6 +789,7 @@ type Options struct {
 	HashType                string               `config:"hash_type"`
 	AVOverride              bool                 `config:"av_override"`
 	Delta                   bool                 `config:"delta"`
+	BearerTokenCommand      fs.SpaceSepList      `config:"bearer_token_command"`
 	Enc                     encoder.MultiEncoder `config:"encoding"`
 	MetadataPermissions     rwChoice             `config:"metadata_permissions"`
 }
@@ -871,6 +879,105 @@ var (
 	gatewayTimeoutError     sync.Once
 	errAsyncJobAccessDenied = errors.New("async job failed - access denied")
 )
+
+// bearerTokenTransport is an http.RoundTripper that adds a Bearer token
+// obtained from an external command. On 401 responses it re-fetches the
+// token and retries the request once.
+type bearerTokenTransport struct {
+	cmd   fs.SpaceSepList
+	mu    sync.Mutex
+	token string
+	wrap  http.RoundTripper
+	sf    singleflight.Group
+}
+
+// newBearerTokenTransport creates a transport that fetches a bearer token
+// from cmd and injects it into every request. It fetches an initial token
+// before returning.
+func newBearerTokenTransport(cmd fs.SpaceSepList, wrap http.RoundTripper) (*bearerTokenTransport, error) {
+	t := &bearerTokenTransport{
+		cmd:  cmd,
+		wrap: wrap,
+	}
+	token, err := t.fetchToken()
+	if err != nil {
+		return nil, err
+	}
+	t.token = token
+	return t, nil
+}
+
+// fetchToken runs the bearer_token_command and returns the token string.
+func (t *bearerTokenTransport) fetchToken() (string, error) {
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+		c      = exec.Command(t.cmd[0], t.cmd[1:]...)
+	)
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	var (
+		err          = c.Run()
+		stdoutString = strings.TrimSpace(stdout.String())
+		stderrString = strings.TrimSpace(stderr.String())
+	)
+	if err != nil {
+		if stderrString == "" {
+			stderrString = stdoutString
+		}
+		return "", fmt.Errorf("failed to get bearer token using %q: %s: %w", t.cmd, stderrString, err)
+	}
+	return stdoutString, nil
+}
+
+// refreshToken re-fetches the token using singleflight to prevent
+// concurrent refreshes.
+func (t *bearerTokenTransport) refreshToken() (string, error) {
+	v, err, _ := t.sf.Do("refresh", func() (any, error) {
+		token, err := t.fetchToken()
+		if err != nil {
+			return nil, err
+		}
+		t.mu.Lock()
+		t.token = token
+		t.mu.Unlock()
+		return token, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+// RoundTrip implements http.RoundTripper. It sets the Authorization header,
+// and on 401 re-fetches the token and retries once.
+func (t *bearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	token := t.token
+	t.mu.Unlock()
+
+	// Clone the request so we can safely modify headers
+	req2 := req.Clone(req.Context())
+	req2.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := t.wrap.RoundTrip(req2)
+	if err != nil || resp.StatusCode != 401 {
+		return resp, err
+	}
+
+	// Got 401 — try to refresh and retry once
+	fs.Debugf(nil, "Bearer token expired, refreshing")
+	_ = resp.Body.Close()
+
+	newToken, refreshErr := t.refreshToken()
+	if refreshErr != nil {
+		return resp, refreshErr
+	}
+
+	req3 := req.Clone(req.Context())
+	req3.Header.Set("Authorization", "Bearer "+newToken)
+	return t.wrap.RoundTrip(req3)
+}
 
 // shouldRetry returns a boolean as to whether this resp and err
 // deserve to be retried.  It returns the err as a convenience
@@ -1070,16 +1177,27 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 
 	rootURL := graphAPIEndpoint[opt.Region] + "/v1.0" + "/drives/" + opt.DriveID
 
-	oauthConfig, err := makeOauthConfig(ctx, opt)
-	if err != nil {
-		return nil, err
-	}
-
 	client := fshttp.NewClient(ctx)
 	root = parsePath(root)
-	oAuthClient, ts, err := oauthutil.NewClientWithBaseClient(ctx, name, m, oauthConfig, client)
-	if err != nil {
-		return nil, fmt.Errorf("failed to configure OneDrive: %w", err)
+
+	var oAuthClient *http.Client
+	var ts *oauthutil.TokenSource
+	if len(opt.BearerTokenCommand) != 0 {
+		// Use a bearer token transport that fetches tokens from the external command
+		bt, err := newBearerTokenTransport(opt.BearerTokenCommand, client.Transport)
+		if err != nil {
+			return nil, err
+		}
+		oAuthClient = &http.Client{Transport: bt}
+	} else {
+		oauthConfig, err := makeOauthConfig(ctx, opt)
+		if err != nil {
+			return nil, err
+		}
+		oAuthClient, ts, err = oauthutil.NewClientWithBaseClient(ctx, name, m, oauthConfig, client)
+		if err != nil {
+			return nil, fmt.Errorf("failed to configure OneDrive: %w", err)
+		}
 	}
 
 	ci := fs.GetConfig(ctx)
@@ -1127,11 +1245,13 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		f.features.ChangeNotify = nil
 	}
 
-	// Renew the token in the background
-	f.tokenRenewer = oauthutil.NewRenew(f.String(), ts, func() error {
-		_, _, err := f.readMetaDataForPath(ctx, "")
-		return err
-	})
+	if ts != nil {
+		// Renew the token in the background (not used with bearer_token_command)
+		f.tokenRenewer = oauthutil.NewRenew(f.String(), ts, func() error {
+			_, _, err := f.readMetaDataForPath(ctx, "")
+			return err
+		})
+	}
 
 	// Get rootID
 	rootID := opt.RootFolderID
@@ -1541,7 +1661,9 @@ func (f *Fs) ListR(ctx context.Context, dir string, callback fs.ListRCallback) (
 
 // Shutdown shutdown the fs
 func (f *Fs) Shutdown(ctx context.Context) error {
-	f.tokenRenewer.Shutdown()
+	if f.tokenRenewer != nil {
+		f.tokenRenewer.Shutdown()
+	}
 	return nil
 }
 

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -3,7 +3,6 @@
 package onedrive
 
 import (
-	"bytes"
 	"context"
 	_ "embed"
 	"encoding/base64"
@@ -14,7 +13,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os/exec"
 	"path"
 	"regexp"
 	"strconv"
@@ -43,7 +41,6 @@ import (
 	"github.com/rclone/rclone/lib/pacer"
 	"github.com/rclone/rclone/lib/readers"
 	"github.com/rclone/rclone/lib/rest"
-	"golang.org/x/sync/singleflight"
 )
 
 const (
@@ -425,10 +422,6 @@ isn't always desirable to set the permissions from the metadata.
 			Default:  rwOff,
 			Examples: rwExamples,
 		}, {
-			Name:     "bearer_token_command",
-			Help:     "Command to run to get a bearer token.",
-			Advanced: true,
-		}, {
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,
 			Advanced: true,
@@ -789,7 +782,6 @@ type Options struct {
 	HashType                string               `config:"hash_type"`
 	AVOverride              bool                 `config:"av_override"`
 	Delta                   bool                 `config:"delta"`
-	BearerTokenCommand      fs.SpaceSepList      `config:"bearer_token_command"`
 	Enc                     encoder.MultiEncoder `config:"encoding"`
 	MetadataPermissions     rwChoice             `config:"metadata_permissions"`
 }
@@ -879,105 +871,6 @@ var (
 	gatewayTimeoutError     sync.Once
 	errAsyncJobAccessDenied = errors.New("async job failed - access denied")
 )
-
-// bearerTokenTransport is an http.RoundTripper that adds a Bearer token
-// obtained from an external command. On 401 responses it re-fetches the
-// token and retries the request once.
-type bearerTokenTransport struct {
-	cmd   fs.SpaceSepList
-	mu    sync.Mutex
-	token string
-	wrap  http.RoundTripper
-	sf    singleflight.Group
-}
-
-// newBearerTokenTransport creates a transport that fetches a bearer token
-// from cmd and injects it into every request. It fetches an initial token
-// before returning.
-func newBearerTokenTransport(cmd fs.SpaceSepList, wrap http.RoundTripper) (*bearerTokenTransport, error) {
-	t := &bearerTokenTransport{
-		cmd:  cmd,
-		wrap: wrap,
-	}
-	token, err := t.fetchToken()
-	if err != nil {
-		return nil, err
-	}
-	t.token = token
-	return t, nil
-}
-
-// fetchToken runs the bearer_token_command and returns the token string.
-func (t *bearerTokenTransport) fetchToken() (string, error) {
-	var (
-		stdout bytes.Buffer
-		stderr bytes.Buffer
-		c      = exec.Command(t.cmd[0], t.cmd[1:]...)
-	)
-	c.Stdout = &stdout
-	c.Stderr = &stderr
-	var (
-		err          = c.Run()
-		stdoutString = strings.TrimSpace(stdout.String())
-		stderrString = strings.TrimSpace(stderr.String())
-	)
-	if err != nil {
-		if stderrString == "" {
-			stderrString = stdoutString
-		}
-		return "", fmt.Errorf("failed to get bearer token using %q: %s: %w", t.cmd, stderrString, err)
-	}
-	return stdoutString, nil
-}
-
-// refreshToken re-fetches the token using singleflight to prevent
-// concurrent refreshes.
-func (t *bearerTokenTransport) refreshToken() (string, error) {
-	v, err, _ := t.sf.Do("refresh", func() (any, error) {
-		token, err := t.fetchToken()
-		if err != nil {
-			return nil, err
-		}
-		t.mu.Lock()
-		t.token = token
-		t.mu.Unlock()
-		return token, nil
-	})
-	if err != nil {
-		return "", err
-	}
-	return v.(string), nil
-}
-
-// RoundTrip implements http.RoundTripper. It sets the Authorization header,
-// and on 401 re-fetches the token and retries once.
-func (t *bearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	t.mu.Lock()
-	token := t.token
-	t.mu.Unlock()
-
-	// Clone the request so we can safely modify headers
-	req2 := req.Clone(req.Context())
-	req2.Header.Set("Authorization", "Bearer "+token)
-
-	resp, err := t.wrap.RoundTrip(req2)
-	if err != nil || resp.StatusCode != 401 {
-		return resp, err
-	}
-
-	// Got 401 — try to refresh and retry once
-	fs.Debugf(nil, "Bearer token expired, refreshing")
-	_ = resp.Body.Close()
-
-	newToken, refreshErr := t.refreshToken()
-	if refreshErr != nil {
-		return resp, refreshErr
-	}
-
-	req3 := req.Clone(req.Context())
-	req3.Header.Set("Authorization", "Bearer "+newToken)
-	return t.wrap.RoundTrip(req3)
-}
 
 // shouldRetry returns a boolean as to whether this resp and err
 // deserve to be retried.  It returns the err as a convenience
@@ -1177,27 +1070,16 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 
 	rootURL := graphAPIEndpoint[opt.Region] + "/v1.0" + "/drives/" + opt.DriveID
 
+	oauthConfig, err := makeOauthConfig(ctx, opt)
+	if err != nil {
+		return nil, err
+	}
+
 	client := fshttp.NewClient(ctx)
 	root = parsePath(root)
-
-	var oAuthClient *http.Client
-	var ts *oauthutil.TokenSource
-	if len(opt.BearerTokenCommand) != 0 {
-		// Use a bearer token transport that fetches tokens from the external command
-		bt, err := newBearerTokenTransport(opt.BearerTokenCommand, client.Transport)
-		if err != nil {
-			return nil, err
-		}
-		oAuthClient = &http.Client{Transport: bt}
-	} else {
-		oauthConfig, err := makeOauthConfig(ctx, opt)
-		if err != nil {
-			return nil, err
-		}
-		oAuthClient, ts, err = oauthutil.NewClientWithBaseClient(ctx, name, m, oauthConfig, client)
-		if err != nil {
-			return nil, fmt.Errorf("failed to configure OneDrive: %w", err)
-		}
+	oAuthClient, ts, err := oauthutil.NewClientWithBaseClient(ctx, name, m, oauthConfig, client)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure OneDrive: %w", err)
 	}
 
 	ci := fs.GetConfig(ctx)
@@ -1245,13 +1127,11 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		f.features.ChangeNotify = nil
 	}
 
-	if ts != nil {
-		// Renew the token in the background (not used with bearer_token_command)
-		f.tokenRenewer = oauthutil.NewRenew(f.String(), ts, func() error {
-			_, _, err := f.readMetaDataForPath(ctx, "")
-			return err
-		})
-	}
+	// Renew the token in the background
+	f.tokenRenewer = oauthutil.NewRenew(f.String(), ts, func() error {
+		_, _, err := f.readMetaDataForPath(ctx, "")
+		return err
+	})
 
 	// Get rootID
 	rootID := opt.RootFolderID
@@ -1661,9 +1541,7 @@ func (f *Fs) ListR(ctx context.Context, dir string, callback fs.ListRCallback) (
 
 // Shutdown shutdown the fs
 func (f *Fs) Shutdown(ctx context.Context) error {
-	if f.tokenRenewer != nil {
-		f.tokenRenewer.Shutdown()
-	}
+	f.tokenRenewer.Shutdown()
 	return nil
 }
 

--- a/backend/onedrive/onedrive_unit_test.go
+++ b/backend/onedrive/onedrive_unit_test.go
@@ -3,17 +3,12 @@ package onedrive
 import (
 	"context"
 	"errors"
-	"io"
 	"net/http"
-	"runtime"
-	"strings"
 	"testing"
 
 	"github.com/rclone/rclone/backend/onedrive/api"
-	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestShouldRetry(t *testing.T) {
@@ -93,165 +88,5 @@ func TestShouldRetry(t *testing.T) {
 		retry, err := shouldRetry(ctx, resp, errors.New("bad gateway"))
 		assert.True(t, retry)
 		assert.Error(t, err)
-	})
-}
-
-func TestBearerTokenTransport_FetchToken(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-
-	t.Run("Success", func(t *testing.T) {
-		bt := &bearerTokenTransport{
-			cmd: fs.SpaceSepList{"echo", "my-token"},
-		}
-		token, err := bt.fetchToken()
-		assert.NoError(t, err)
-		assert.Equal(t, "my-token", token)
-	})
-
-	t.Run("TrimsWhitespace", func(t *testing.T) {
-		bt := &bearerTokenTransport{
-			cmd: fs.SpaceSepList{"printf", "  token-with-spaces  \n"},
-		}
-		token, err := bt.fetchToken()
-		assert.NoError(t, err)
-		assert.Equal(t, "token-with-spaces", token)
-	})
-
-	t.Run("CommandFailure", func(t *testing.T) {
-		bt := &bearerTokenTransport{
-			cmd: fs.SpaceSepList{"false"},
-		}
-		_, err := bt.fetchToken()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to get bearer token")
-	})
-
-	t.Run("CommandNotFound", func(t *testing.T) {
-		bt := &bearerTokenTransport{
-			cmd: fs.SpaceSepList{"nonexistent-command-xyz"},
-		}
-		_, err := bt.fetchToken()
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to get bearer token")
-	})
-}
-
-func TestNewBearerTokenTransport(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-
-	t.Run("Success", func(t *testing.T) {
-		bt, err := newBearerTokenTransport(
-			fs.SpaceSepList{"echo", "initial-token"},
-			http.DefaultTransport,
-		)
-		require.NoError(t, err)
-		assert.Equal(t, "initial-token", bt.token)
-	})
-
-	t.Run("CommandFailure", func(t *testing.T) {
-		_, err := newBearerTokenTransport(
-			fs.SpaceSepList{"false"},
-			http.DefaultTransport,
-		)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "failed to get bearer token")
-	})
-}
-
-// mockRoundTripper records requests and returns a configurable response.
-type mockRoundTripper struct {
-	statusCode int
-	requests   []*http.Request
-}
-
-func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	m.requests = append(m.requests, req)
-	return &http.Response{
-		StatusCode: m.statusCode,
-		Header:     http.Header{},
-		Body:       io.NopCloser(strings.NewReader("")),
-	}, nil
-}
-
-func TestBearerTokenTransport_RoundTrip(t *testing.T) {
-	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
-		mock := &mockRoundTripper{statusCode: 200}
-		bt := &bearerTokenTransport{
-			cmd:   fs.SpaceSepList{"echo", "test-token"},
-			token: "test-token",
-			wrap:  mock,
-		}
-		req, _ := http.NewRequest("GET", "https://example.com", nil)
-		resp, err := bt.RoundTrip(req)
-		require.NoError(t, err)
-		assert.Equal(t, 200, resp.StatusCode)
-		assert.Len(t, mock.requests, 1)
-		assert.Equal(t, "Bearer test-token", mock.requests[0].Header.Get("Authorization"))
-	})
-
-	t.Run("DoesNotMutateOriginalRequest", func(t *testing.T) {
-		mock := &mockRoundTripper{statusCode: 200}
-		bt := &bearerTokenTransport{
-			cmd:   fs.SpaceSepList{"echo", "test-token"},
-			token: "test-token",
-			wrap:  mock,
-		}
-		req, _ := http.NewRequest("GET", "https://example.com", nil)
-		_, err := bt.RoundTrip(req)
-		require.NoError(t, err)
-		assert.Empty(t, req.Header.Get("Authorization"))
-	})
-}
-
-// mockRoundTripperSequence returns different status codes on successive calls.
-type mockRoundTripperSequence struct {
-	codes    []int
-	call     int
-	requests []*http.Request
-}
-
-func (m *mockRoundTripperSequence) RoundTrip(req *http.Request) (*http.Response, error) {
-	m.requests = append(m.requests, req)
-	code := m.codes[m.call]
-	if m.call < len(m.codes)-1 {
-		m.call++
-	}
-	return &http.Response{
-		StatusCode: code,
-		Header:     http.Header{},
-		Body:       io.NopCloser(strings.NewReader("")),
-	}, nil
-}
-
-func TestBearerTokenTransport_RefreshOn401(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("skipping on windows")
-	}
-
-	t.Run("RefreshesAndRetries", func(t *testing.T) {
-		mock := &mockRoundTripperSequence{codes: []int{401, 200}}
-		bt := &bearerTokenTransport{
-			cmd:   fs.SpaceSepList{"echo", "refreshed-token"},
-			token: "stale-token",
-			wrap:  mock,
-		}
-
-		req, _ := http.NewRequest("GET", "https://example.com", nil)
-		resp, err := bt.RoundTrip(req)
-		require.NoError(t, err)
-		assert.Equal(t, 200, resp.StatusCode)
-
-		// Should have made 2 requests
-		assert.Len(t, mock.requests, 2)
-		// First request had the stale token
-		assert.Equal(t, "Bearer stale-token", mock.requests[0].Header.Get("Authorization"))
-		// Second request has the refreshed token
-		assert.Equal(t, "Bearer refreshed-token", mock.requests[1].Header.Get("Authorization"))
-		// Token on transport is updated
-		assert.Equal(t, "refreshed-token", bt.token)
 	})
 }

--- a/backend/onedrive/onedrive_unit_test.go
+++ b/backend/onedrive/onedrive_unit_test.go
@@ -1,0 +1,257 @@
+package onedrive
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/rclone/rclone/backend/onedrive/api"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/fserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestShouldRetry(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("NilResponse", func(t *testing.T) {
+		retry, err := shouldRetry(ctx, nil, nil)
+		assert.False(t, retry)
+		assert.NoError(t, err)
+	})
+
+	t.Run("200OK", func(t *testing.T) {
+		resp := &http.Response{StatusCode: 200, Header: http.Header{}}
+		retry, err := shouldRetry(ctx, resp, nil)
+		assert.False(t, retry)
+		assert.NoError(t, err)
+	})
+
+	t.Run("401ExpiredToken", func(t *testing.T) {
+		resp := &http.Response{
+			StatusCode: 401,
+			Header:     http.Header{"Www-Authenticate": []string{"Bearer realm=\"\", error=\"expired_token\""}},
+		}
+		retry, err := shouldRetry(ctx, resp, errors.New("unauthorized"))
+		assert.True(t, retry)
+		assert.Error(t, err)
+	})
+
+	t.Run("401RPSError", func(t *testing.T) {
+		resp := &http.Response{
+			StatusCode: 401,
+			Header:     http.Header{},
+		}
+		retry, err := shouldRetry(ctx, resp, errors.New("Unable to initialize RPS"))
+		assert.True(t, retry)
+		assert.Error(t, err)
+	})
+
+	t.Run("401NoSpecialCase", func(t *testing.T) {
+		resp := &http.Response{
+			StatusCode: 401,
+			Header:     http.Header{},
+		}
+		retry, err := shouldRetry(ctx, resp, errors.New("unauthorized"))
+		assert.False(t, retry)
+		assert.Error(t, err)
+	})
+
+	t.Run("400PathTooLong", func(t *testing.T) {
+		resp := &http.Response{StatusCode: 400, Header: http.Header{}}
+		apiErr := &api.Error{}
+		apiErr.ErrorInfo.InnerError.Code = "pathIsTooLong"
+		retry, err := shouldRetry(ctx, resp, apiErr)
+		assert.False(t, retry)
+		assert.True(t, fserrors.IsNoRetryError(err))
+	})
+
+	t.Run("429RetryAfter", func(t *testing.T) {
+		resp := &http.Response{
+			StatusCode: 429,
+			Header:     http.Header{"Retry-After": []string{"5"}},
+		}
+		retry, err := shouldRetry(ctx, resp, errors.New("too many requests"))
+		assert.True(t, retry)
+		assert.Error(t, err)
+	})
+
+	t.Run("507InsufficientStorage", func(t *testing.T) {
+		resp := &http.Response{StatusCode: 507, Header: http.Header{}}
+		retry, err := shouldRetry(ctx, resp, errors.New("storage full"))
+		assert.False(t, retry)
+		assert.True(t, fserrors.IsFatalError(err))
+	})
+
+	t.Run("502Retry", func(t *testing.T) {
+		resp := &http.Response{StatusCode: 502, Header: http.Header{}}
+		retry, err := shouldRetry(ctx, resp, errors.New("bad gateway"))
+		assert.True(t, retry)
+		assert.Error(t, err)
+	})
+}
+
+func TestBearerTokenTransport_FetchToken(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		bt := &bearerTokenTransport{
+			cmd: fs.SpaceSepList{"echo", "my-token"},
+		}
+		token, err := bt.fetchToken()
+		assert.NoError(t, err)
+		assert.Equal(t, "my-token", token)
+	})
+
+	t.Run("TrimsWhitespace", func(t *testing.T) {
+		bt := &bearerTokenTransport{
+			cmd: fs.SpaceSepList{"printf", "  token-with-spaces  \n"},
+		}
+		token, err := bt.fetchToken()
+		assert.NoError(t, err)
+		assert.Equal(t, "token-with-spaces", token)
+	})
+
+	t.Run("CommandFailure", func(t *testing.T) {
+		bt := &bearerTokenTransport{
+			cmd: fs.SpaceSepList{"false"},
+		}
+		_, err := bt.fetchToken()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get bearer token")
+	})
+
+	t.Run("CommandNotFound", func(t *testing.T) {
+		bt := &bearerTokenTransport{
+			cmd: fs.SpaceSepList{"nonexistent-command-xyz"},
+		}
+		_, err := bt.fetchToken()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get bearer token")
+	})
+}
+
+func TestNewBearerTokenTransport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		bt, err := newBearerTokenTransport(
+			fs.SpaceSepList{"echo", "initial-token"},
+			http.DefaultTransport,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "initial-token", bt.token)
+	})
+
+	t.Run("CommandFailure", func(t *testing.T) {
+		_, err := newBearerTokenTransport(
+			fs.SpaceSepList{"false"},
+			http.DefaultTransport,
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get bearer token")
+	})
+}
+
+// mockRoundTripper records requests and returns a configurable response.
+type mockRoundTripper struct {
+	statusCode int
+	requests   []*http.Request
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.requests = append(m.requests, req)
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func TestBearerTokenTransport_RoundTrip(t *testing.T) {
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		mock := &mockRoundTripper{statusCode: 200}
+		bt := &bearerTokenTransport{
+			cmd:   fs.SpaceSepList{"echo", "test-token"},
+			token: "test-token",
+			wrap:  mock,
+		}
+		req, _ := http.NewRequest("GET", "https://example.com", nil)
+		resp, err := bt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Len(t, mock.requests, 1)
+		assert.Equal(t, "Bearer test-token", mock.requests[0].Header.Get("Authorization"))
+	})
+
+	t.Run("DoesNotMutateOriginalRequest", func(t *testing.T) {
+		mock := &mockRoundTripper{statusCode: 200}
+		bt := &bearerTokenTransport{
+			cmd:   fs.SpaceSepList{"echo", "test-token"},
+			token: "test-token",
+			wrap:  mock,
+		}
+		req, _ := http.NewRequest("GET", "https://example.com", nil)
+		_, err := bt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Empty(t, req.Header.Get("Authorization"))
+	})
+}
+
+// mockRoundTripperSequence returns different status codes on successive calls.
+type mockRoundTripperSequence struct {
+	codes    []int
+	call     int
+	requests []*http.Request
+}
+
+func (m *mockRoundTripperSequence) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.requests = append(m.requests, req)
+	code := m.codes[m.call]
+	if m.call < len(m.codes)-1 {
+		m.call++
+	}
+	return &http.Response{
+		StatusCode: code,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func TestBearerTokenTransport_RefreshOn401(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	t.Run("RefreshesAndRetries", func(t *testing.T) {
+		mock := &mockRoundTripperSequence{codes: []int{401, 200}}
+		bt := &bearerTokenTransport{
+			cmd:   fs.SpaceSepList{"echo", "refreshed-token"},
+			token: "stale-token",
+			wrap:  mock,
+		}
+
+		req, _ := http.NewRequest("GET", "https://example.com", nil)
+		resp, err := bt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		// Should have made 2 requests
+		assert.Len(t, mock.requests, 2)
+		// First request had the stale token
+		assert.Equal(t, "Bearer stale-token", mock.requests[0].Header.Get("Authorization"))
+		// Second request has the refreshed token
+		assert.Equal(t, "Bearer refreshed-token", mock.requests[1].Header.Get("Authorization"))
+		// Token on transport is updated
+		assert.Equal(t, "refreshed-token", bt.token)
+	})
+}

--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -244,11 +244,13 @@ access tokens (for example, Azure CLI, a managed identity helper, or
 an OIDC token agent), you can use `bearer_token_command` to supply
 the token to rclone instead of using the built-in OAuth flow.
 
+This is a shared option available on all OAuth-based backends.
+
 When `bearer_token_command` is set, rclone will skip its normal OAuth
 authentication entirely. Instead, it will run the specified command to
-obtain a bearer token and use it for all Microsoft Graph API requests.
-If the token expires (HTTP 401), rclone will automatically re-run the
-command to fetch a fresh token and retry the request.
+obtain a bearer token and use it for all API requests. If the token
+expires (HTTP 401), rclone will automatically re-run the command to
+fetch a fresh token and retry the request.
 
 You still need to configure `drive_id` and `drive_type` in the rclone
 config. You can obtain these by first configuring the remote normally
@@ -869,17 +871,6 @@ Properties:
     - Read and Write the value.
   - "failok"
     - If writing fails log errors only, don't fail the transfer
-
-#### --onedrive-bearer-token-command
-
-Command to run to get a bearer token.
-
-Properties:
-
-- Config:      bearer_token_command
-- Env Var:     RCLONE_ONEDRIVE_BEARER_TOKEN_COMMAND
-- Type:        string
-- Required:    false
 
 #### --onedrive-encoding
 

--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -237,6 +237,47 @@ credentials.
 anyone with the *Client ID* and *Client Secret* can access your
 OneDrive files. Take care to safeguard these credentials.
 
+### Using an external token command
+
+If you already have a mechanism for obtaining Microsoft Graph API
+access tokens (for example, Azure CLI, a managed identity helper, or
+an OIDC token agent), you can use `bearer_token_command` to supply
+the token to rclone instead of using the built-in OAuth flow.
+
+When `bearer_token_command` is set, rclone will skip its normal OAuth
+authentication entirely. Instead, it will run the specified command to
+obtain a bearer token and use it for all Microsoft Graph API requests.
+If the token expires (HTTP 401), rclone will automatically re-run the
+command to fetch a fresh token and retry the request.
+
+You still need to configure `drive_id` and `drive_type` in the rclone
+config. You can obtain these by first configuring the remote normally
+with OAuth, noting the drive ID and type, and then switching to
+`bearer_token_command`.
+
+Example using Azure CLI:
+
+```ini
+[onedrive]
+type = onedrive
+drive_id = b!xxxxxxxxxxxxxxx
+drive_type = business
+bearer_token_command = az account get-access-token --resource https://graph.microsoft.com --query accessToken --output tsv
+```
+
+Example using a custom script:
+
+```ini
+[onedrive]
+type = onedrive
+drive_id = b!xxxxxxxxxxxxxxx
+drive_type = business
+bearer_token_command = /path/to/get-token.sh
+```
+
+The command must print the access token to stdout. If the command
+fails, rclone will report the stderr output in the error message.
+
 ### Modification times and hashes
 
 OneDrive allows modification times to be set on objects accurate to 1
@@ -828,6 +869,17 @@ Properties:
     - Read and Write the value.
   - "failok"
     - If writing fails log errors only, don't fail the transfer
+
+#### --onedrive-bearer-token-command
+
+Command to run to get a bearer token.
+
+Properties:
+
+- Config:      bearer_token_command
+- Env Var:     RCLONE_ONEDRIVE_BEARER_TOKEN_COMMAND
+- Type:        string
+- Required:    false
 
 #### --onedrive-encoding
 

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -49,6 +49,10 @@ const (
 	// ConfigClientCredentials - use OAUTH2 client credentials
 	ConfigClientCredentials = "client_credentials"
 
+	// ConfigBearerTokenCommand is the config key for an external command
+	// that provides a bearer token, bypassing the normal OAuth flow.
+	ConfigBearerTokenCommand = "bearer_token_command"
+
 	// ConfigEncoding is the config key to change the encoding for a backend
 	ConfigEncoding = "encoding"
 

--- a/lib/oauthutil/bearertoken.go
+++ b/lib/oauthutil/bearertoken.go
@@ -1,0 +1,114 @@
+// Bearer token transport for external token providers.
+
+package oauthutil
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/rclone/rclone/fs"
+	"golang.org/x/sync/singleflight"
+)
+
+// bearerTokenTransport is an http.RoundTripper that adds a Bearer token
+// obtained from an external command. On 401 responses it re-fetches the
+// token and retries the request once.
+type bearerTokenTransport struct {
+	cmd   fs.SpaceSepList
+	mu    sync.Mutex
+	token string
+	wrap  http.RoundTripper
+	sf    singleflight.Group
+}
+
+// newBearerTokenTransport creates a transport that fetches a bearer token
+// from cmd and injects it into every request. It fetches an initial token
+// before returning.
+func newBearerTokenTransport(cmd fs.SpaceSepList, wrap http.RoundTripper) (*bearerTokenTransport, error) {
+	t := &bearerTokenTransport{
+		cmd:  cmd,
+		wrap: wrap,
+	}
+	token, err := t.fetchToken()
+	if err != nil {
+		return nil, err
+	}
+	t.token = token
+	return t, nil
+}
+
+// fetchToken runs the bearer_token_command and returns the token string.
+func (t *bearerTokenTransport) fetchToken() (string, error) {
+	var (
+		stdout bytes.Buffer
+		stderr bytes.Buffer
+		c      = exec.Command(t.cmd[0], t.cmd[1:]...)
+	)
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	var (
+		err          = c.Run()
+		stdoutString = strings.TrimSpace(stdout.String())
+		stderrString = strings.TrimSpace(stderr.String())
+	)
+	if err != nil {
+		if stderrString == "" {
+			stderrString = stdoutString
+		}
+		return "", fmt.Errorf("failed to get bearer token using %q: %s: %w", t.cmd, stderrString, err)
+	}
+	return stdoutString, nil
+}
+
+// refreshToken re-fetches the token using singleflight to prevent
+// concurrent refreshes.
+func (t *bearerTokenTransport) refreshToken() (string, error) {
+	v, err, _ := t.sf.Do("refresh", func() (any, error) {
+		token, err := t.fetchToken()
+		if err != nil {
+			return nil, err
+		}
+		t.mu.Lock()
+		t.token = token
+		t.mu.Unlock()
+		return token, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+// RoundTrip implements http.RoundTripper. It sets the Authorization header,
+// and on 401 re-fetches the token and retries once.
+func (t *bearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.mu.Lock()
+	token := t.token
+	t.mu.Unlock()
+
+	// Clone the request so we can safely modify headers
+	req2 := req.Clone(req.Context())
+	req2.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := t.wrap.RoundTrip(req2)
+	if err != nil || resp.StatusCode != 401 {
+		return resp, err
+	}
+
+	// Got 401 — try to refresh and retry once
+	fs.Debugf(nil, "Bearer token expired, refreshing")
+	_ = resp.Body.Close()
+
+	newToken, refreshErr := t.refreshToken()
+	if refreshErr != nil {
+		return resp, refreshErr
+	}
+
+	req3 := req.Clone(req.Context())
+	req3.Header.Set("Authorization", "Bearer "+newToken)
+	return t.wrap.RoundTrip(req3)
+}

--- a/lib/oauthutil/bearertoken_test.go
+++ b/lib/oauthutil/bearertoken_test.go
@@ -1,0 +1,224 @@
+package oauthutil
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClientWithBaseClient_BearerTokenCommand(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	t.Run("UsesTokenCommandWhenSet", func(t *testing.T) {
+		m := configmap.Simple{
+			"bearer_token_command": "echo test-token",
+		}
+		oauthConfig := &Config{
+			ClientID: "unused",
+			TokenURL: "https://unused.example.com/token",
+			AuthURL:  "https://unused.example.com/auth",
+		}
+		client, ts, err := NewClientWithBaseClient(context.Background(), "test", m, oauthConfig, &http.Client{})
+		require.NoError(t, err)
+		assert.NotNil(t, client)
+		assert.NotNil(t, ts, "TokenSource should be non-nil (inert) when using bearer_token_command")
+
+		// Verify the transport is a bearerTokenTransport
+		bt, ok := client.Transport.(*bearerTokenTransport)
+		require.True(t, ok, "client transport should be bearerTokenTransport")
+		assert.Equal(t, "test-token", bt.token)
+	})
+
+	t.Run("SkippedWhenNotSet", func(t *testing.T) {
+		m := configmap.Simple{}
+		oauthConfig := &Config{
+			ClientID: "test-client",
+			TokenURL: "https://unused.example.com/token",
+			AuthURL:  "https://unused.example.com/auth",
+		}
+		// This will fail because there's no token in the config, but it
+		// proves the bearer_token_command path was NOT taken
+		_, _, err := NewClientWithBaseClient(context.Background(), "test", m, oauthConfig, &http.Client{})
+		assert.Error(t, err, "should fail because no token exists (normal OAuth path)")
+	})
+
+	t.Run("FailsOnBadCommand", func(t *testing.T) {
+		m := configmap.Simple{
+			"bearer_token_command": "nonexistent-command-xyz",
+		}
+		oauthConfig := &Config{}
+		_, _, err := NewClientWithBaseClient(context.Background(), "test", m, oauthConfig, &http.Client{})
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get bearer token")
+	})
+}
+
+func TestBearerTokenTransport_FetchToken(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		bt := &bearerTokenTransport{
+			cmd: fs.SpaceSepList{"echo", "my-token"},
+		}
+		token, err := bt.fetchToken()
+		assert.NoError(t, err)
+		assert.Equal(t, "my-token", token)
+	})
+
+	t.Run("TrimsWhitespace", func(t *testing.T) {
+		bt := &bearerTokenTransport{
+			cmd: fs.SpaceSepList{"printf", "  token-with-spaces  \n"},
+		}
+		token, err := bt.fetchToken()
+		assert.NoError(t, err)
+		assert.Equal(t, "token-with-spaces", token)
+	})
+
+	t.Run("CommandFailure", func(t *testing.T) {
+		bt := &bearerTokenTransport{
+			cmd: fs.SpaceSepList{"false"},
+		}
+		_, err := bt.fetchToken()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get bearer token")
+	})
+
+	t.Run("CommandNotFound", func(t *testing.T) {
+		bt := &bearerTokenTransport{
+			cmd: fs.SpaceSepList{"nonexistent-command-xyz"},
+		}
+		_, err := bt.fetchToken()
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get bearer token")
+	})
+}
+
+func TestNewBearerTokenTransport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		bt, err := newBearerTokenTransport(
+			fs.SpaceSepList{"echo", "initial-token"},
+			http.DefaultTransport,
+		)
+		require.NoError(t, err)
+		assert.Equal(t, "initial-token", bt.token)
+	})
+
+	t.Run("CommandFailure", func(t *testing.T) {
+		_, err := newBearerTokenTransport(
+			fs.SpaceSepList{"false"},
+			http.DefaultTransport,
+		)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to get bearer token")
+	})
+}
+
+// mockRoundTripper records requests and returns a configurable response.
+type mockRoundTripper struct {
+	statusCode int
+	requests   []*http.Request
+}
+
+func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.requests = append(m.requests, req)
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func TestBearerTokenTransport_RoundTrip(t *testing.T) {
+	t.Run("SetsAuthorizationHeader", func(t *testing.T) {
+		mock := &mockRoundTripper{statusCode: 200}
+		bt := &bearerTokenTransport{
+			cmd:   fs.SpaceSepList{"echo", "test-token"},
+			token: "test-token",
+			wrap:  mock,
+		}
+		req, _ := http.NewRequest("GET", "https://example.com", nil)
+		resp, err := bt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.Len(t, mock.requests, 1)
+		assert.Equal(t, "Bearer test-token", mock.requests[0].Header.Get("Authorization"))
+	})
+
+	t.Run("DoesNotMutateOriginalRequest", func(t *testing.T) {
+		mock := &mockRoundTripper{statusCode: 200}
+		bt := &bearerTokenTransport{
+			cmd:   fs.SpaceSepList{"echo", "test-token"},
+			token: "test-token",
+			wrap:  mock,
+		}
+		req, _ := http.NewRequest("GET", "https://example.com", nil)
+		_, err := bt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Empty(t, req.Header.Get("Authorization"))
+	})
+}
+
+// mockRoundTripperSequence returns different status codes on successive calls.
+type mockRoundTripperSequence struct {
+	codes    []int
+	call     int
+	requests []*http.Request
+}
+
+func (m *mockRoundTripperSequence) RoundTrip(req *http.Request) (*http.Response, error) {
+	m.requests = append(m.requests, req)
+	code := m.codes[m.call]
+	if m.call < len(m.codes)-1 {
+		m.call++
+	}
+	return &http.Response{
+		StatusCode: code,
+		Header:     http.Header{},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}, nil
+}
+
+func TestBearerTokenTransport_RefreshOn401(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	t.Run("RefreshesAndRetries", func(t *testing.T) {
+		mock := &mockRoundTripperSequence{codes: []int{401, 200}}
+		bt := &bearerTokenTransport{
+			cmd:   fs.SpaceSepList{"echo", "refreshed-token"},
+			token: "stale-token",
+			wrap:  mock,
+		}
+
+		req, _ := http.NewRequest("GET", "https://example.com", nil)
+		resp, err := bt.RoundTrip(req)
+		require.NoError(t, err)
+		assert.Equal(t, 200, resp.StatusCode)
+
+		// Should have made 2 requests
+		assert.Len(t, mock.requests, 2)
+		// First request had the stale token
+		assert.Equal(t, "Bearer stale-token", mock.requests[0].Header.Get("Authorization"))
+		// Second request has the refreshed token
+		assert.Equal(t, "Bearer refreshed-token", mock.requests[1].Header.Get("Authorization"))
+		// Token on transport is updated
+		assert.Equal(t, "refreshed-token", bt.token)
+	})
+}

--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -157,6 +157,10 @@ var SharedOptions = []fs.Option{{
 	Default:  false,
 	Help:     "Use client credentials OAuth flow.\n\nThis will use the OAUTH2 client Credentials Flow as described in RFC 6749.\n\nNote that this option is NOT supported by all backends.",
 	Advanced: true,
+}, {
+	Name:     config.ConfigBearerTokenCommand,
+	Help:     "Command to run to get a bearer token.\n\nWhen set, the normal OAuth flow is skipped. Instead, the command is run to obtain a bearer token which is used for all API requests. If the token expires (HTTP 401), the command is re-run to fetch a fresh token.",
+	Advanced: true,
 }}
 
 // oldToken contains an end-user's tokens.
@@ -403,10 +407,7 @@ func (ts *TokenSource) Expire() error {
 // Call with the lock held
 func (ts *TokenSource) timeToExpiry() time.Duration {
 	t := ts.token
-	if t == nil {
-		return 0
-	}
-	if t.Expiry.IsZero() {
+	if t == nil || t.Expiry.IsZero() {
 		return 3e9 * time.Second // ~95 years
 	}
 	return time.Until(t.Expiry)
@@ -481,6 +482,27 @@ func OverrideCredentials(name string, m configmap.Mapper, origConfig *Config) (n
 // TokenSource which Invalidate may need to be called on.  It uses the
 // httpClient passed in as the base client.
 func NewClientWithBaseClient(ctx context.Context, name string, m configmap.Mapper, config *Config, baseClient *http.Client) (*http.Client, *TokenSource, error) {
+	// Check for bearer_token_command — if set, skip OAuth entirely
+	if cmdStr, ok := m.Get("bearer_token_command"); ok && cmdStr != "" {
+		cmd := fs.SpaceSepList{}
+		if err := cmd.Set(cmdStr); err != nil {
+			return nil, nil, fmt.Errorf("failed to parse bearer_token_command: %w", err)
+		}
+		bt, err := newBearerTokenTransport(cmd, baseClient.Transport)
+		if err != nil {
+			return nil, nil, err
+		}
+		fs.Debugf(name, "Using bearer token from external command")
+		// Return an inert TokenSource — token lifecycle is managed by the
+		// bearer token transport, but callers get a non-nil TokenSource
+		// they can safely pass to NewRenew etc.
+		ts := &TokenSource{
+			name: name,
+			m:    m,
+		}
+		return &http.Client{Transport: bt}, ts, nil
+	}
+
 	config, _ = OverrideCredentials(name, m, config)
 	token, err := GetToken(name, m)
 	if err != nil && !config.ClientCredentialFlow {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
The WebDAV backend supports bearer_token_command to obtain tokens from an external command, but the OneDrive backend requires using rclone's built-in OAuth flow. This doesn't work well for headless servers with managed identities, CI/CD pipelines, or setups where token acquisition is already handled by another tool like Azure CLI. 

I've refactored the design to apply to oauthutil instead - so that all OAuth providers will benefit from this option instead of just the OneDrive provider.

<!--
Describe the changes here
-->
Add bearer_token_command to the oauthprovider backend, mirroring the WebDAV implementation:

- When set, skip the normal OAuth flow and use a plain HTTP client
- Run the command to get an access token, set it as a Bearer header
- On HTTP 401, re-run the command and retry the request
- Use singleflight to prevent concurrent token fetches

#### Was the change discussed in an issue or in the forum before?

Issue #9344.

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
