### PR TITLE
vfs: add --vfs-lazy-dir-read to skip full directory listing on stat

### DIFF
--- a/docs/content/commands/rclone_mount.md
+++ b/docs/content/commands/rclone_mount.md
@@ -937,6 +937,57 @@ norm-dupes` prevents this confusion by detecting this scenario, hiding the
 duplicates, and logging an error, similar to how this is handled in `rclone
 sync`.
 
+## VFS Lazy Directory Read
+
+By default, whenever rclone needs to look up a single file (e.g. when the
+kernel issues a `stat` or `Lookup` call), it fetches and caches the **entire**
+listing of the parent directory. On remotes with millions of objects in a flat
+hierarchy (such as a large S3 bucket), this triggers a full `ListObjectsV2` of
+the entire "directory" for every single file access — which can be very slow.
+
+The `--vfs-lazy-dir-read` flag changes this behaviour: instead of listing the
+whole directory, rclone uses a direct object lookup (e.g. `HeadObject` for S3)
+to answer the question "does this specific file exist?". The lookup order is:
+
+1. **Cache hit** — if the item is already in the VFS directory cache, return it
+   immediately with no network call.
+2. **Direct object lookup** — one `HeadObject` (S3) / `stat` (SFTP) / `PROPFIND`
+   (WebDAV) for the specific key. If found, the result is stored in the VFS
+   cache without marking the directory as fully read.
+3. **Virtual directory probe** — if the direct lookup fails, a bounded
+   `ListObjectsV2` with `prefix="leaf/"` and at most one page is issued to
+   check whether the name is a virtual directory prefix. This is O(1) in the
+   common case.
+
+`ReadDirAll` (triggered by `ls`, `find`, etc.) still performs a full directory
+listing — only single-file stat lookups are affected.
+
+**Incompatible flags:** `--vfs-lazy-dir-read` is automatically disabled (falls
+back to full listing) when any of the following are active, because they all
+require scanning the full directory to work correctly:
+
+- `--vfs-case-insensitive` (or the platform default: `true` on Windows and macOS)
+- `--ignore-case-sync` (global flag for case-insensitive sync)
+- unicode normalization is active (i.e. `--no-unicode-normalization` is **not** set —
+  the default on all platforms)
+- `--vfs-block-norm-dupes`
+
+**Important for macOS and Windows users:** both `--vfs-case-insensitive` and
+unicode normalization default to `true` on these platforms. You must explicitly
+disable both to activate lazy stat:
+
+```
+rclone mount s3:my-huge-bucket /mnt/data \
+  --vfs-lazy-dir-read \
+  --vfs-case-insensitive=false \
+  --no-unicode-normalization \
+  --read-only
+```
+
+This is safe when the object keys in the remote are stored in a canonical form
+(e.g. hex hashes or ASCII-only names) and you do not need case-folding or
+unicode equivalence matching.
+
 ## VFS Disk Options
 
 This flag allows you to manually set the statistics about the filing system.
@@ -1047,6 +1098,7 @@ rclone mount remote:path /path/to/mountpoint [flags]
       --vfs-disk-space-total-size SizeSuffix   Specify the total space of disk (default off)
       --vfs-fast-fingerprint                   Use fast (less accurate) fingerprints for change detection
       --vfs-handle-caching Duration            Time to keep file handle and downloaders alive after last close (default 5s)
+      --vfs-lazy-dir-read                      Use direct object lookup (e.g. HeadObject) instead of a full directory listing for single-file stat operations; automatically disabled when --vfs-case-insensitive, --ignore-case-sync, unicode normalization (default), or --vfs-block-norm-dupes are active
       --vfs-links                              Translate symlinks to/from regular files with a '.rclonelink' extension for the VFS
       --vfs-metadata-extension string          Set the extension to read metadata from
       --vfs-read-ahead SizeSuffix              Extra read ahead over --buffer-size when using cache-mode full

--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -1,6 +1,7 @@
 package vfs
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -869,6 +870,20 @@ func (d *Dir) statMetadata(leaf, baseLeaf string) (metaNode Node, err error) {
 // returns a custom error if directory on a case-insensitive file system
 // contains files with names that differ only by case.
 func (d *Dir) stat(leaf string) (Node, error) {
+	ci := fs.GetConfig(d.vfs.ctx)
+	normUnicode := !ci.NoUnicodeNormalization
+	normCase := ci.IgnoreCaseSync || d.vfs.Opt.CaseInsensitive
+
+	// Lazy dir read: use NewObject (e.g. HeadObject for S3) instead of listing
+	// the whole directory. Disabled whenever any form of name normalization is
+	// active (case folding via --vfs-case-insensitive or --ignore-case-sync,
+	// unicode normalization unless --no-unicode-normalization is set) because
+	// those features need the full directory listing to find matching names.
+	// Also disabled when --vfs-block-norm-dupes is set.
+	if d.vfs.Opt.LazyDirRead && !normCase && !normUnicode && !d.vfs.Opt.BlockNormDupes {
+		return d.statLazy(leaf)
+	}
+
 	d.mu.Lock()
 	err := d._readDir()
 	if err != nil {
@@ -891,9 +906,6 @@ func (d *Dir) stat(leaf string) (Node, error) {
 		}
 	}
 
-	ci := fs.GetConfig(d.vfs.ctx)
-	normUnicode := !ci.NoUnicodeNormalization
-	normCase := ci.IgnoreCaseSync || d.vfs.Opt.CaseInsensitive
 	if !ok && (normUnicode || normCase) {
 		leafNormalized := operations.ToNormal(leaf, normUnicode, normCase) // this handles both case and unicode normalization
 		d.mu.Lock()
@@ -916,6 +928,80 @@ func (d *Dir) stat(leaf string) (Node, error) {
 		return nil, ENOENT
 	}
 	return item, nil
+}
+
+// statLazy looks up a single item using the backend's NewObject (e.g. S3
+// HeadObject) rather than listing the full directory. It is used when
+// --vfs-lazy-dir-read is set.
+//
+// The lookup order is:
+//  1. Items already in the directory cache — returned without any network call.
+//  2. NewObject — a single object lookup (HeadObject for S3).
+//  3. A bounded List call to detect virtual (prefix-only) directories.
+//
+// Items found via NewObject are added to d.items without updating d.read, so
+// subsequent lookups of the same leaf are served from cache. A full _readDir()
+// is still performed when ReadDirAll is called.
+func (d *Dir) statLazy(leaf string) (Node, error) {
+	// 1. Check the existing cache first.
+	d.mu.Lock()
+	item, ok := d.items[leaf]
+	d.mu.Unlock()
+	if ok {
+		return item, nil
+	}
+
+	// Look for a metadata file before going to the network.
+	if baseLeaf, found := d.vfs.isMetadataFile(leaf); found {
+		node, err := d.statMetadata(leaf, baseLeaf)
+		if err != nil {
+			return nil, err
+		}
+		d.addObject(node)
+		return node, nil
+	}
+
+	// 2. Try a direct object lookup — HeadObject for S3.
+	fullPath := path.Join(d.path, leaf)
+	o, err := d.f.NewObject(context.TODO(), fullPath)
+	if err == nil {
+		// Found as a regular file. Create the node and cache it.
+		node := newFile(d, d.path, o, leaf)
+		d.mu.Lock()
+		// Another goroutine may have populated this in the meantime.
+		if existing, ok := d.items[leaf]; ok {
+			d.mu.Unlock()
+			return existing, nil
+		}
+		d.items[leaf] = node
+		d.mu.Unlock()
+		fs.Debugf(d.path, "lazy stat: found %q via NewObject", leaf)
+		return node, nil
+	}
+	if err != fs.ErrorObjectNotFound && err != fs.ErrorNotAFile && err != fs.ErrorIsDir {
+		return nil, err
+	}
+
+	// 3. Not found as a file. Check whether the leaf is a virtual directory by
+	// doing a bounded list. This issues a ListObjectsV2 with prefix="leaf/" and
+	// stops after the first result — it does NOT list the whole directory.
+	entries, listErr := d.f.List(context.TODO(), fullPath)
+	if listErr == nil && len(entries) > 0 {
+		// The leaf exists as a directory prefix. Find or create the Dir node.
+		d.mu.Lock()
+		if existing, ok := d.items[leaf]; ok {
+			d.mu.Unlock()
+			return existing, nil
+		}
+		entry := fs.NewDir(fullPath, time.Now())
+		dir := newDir(d.vfs, d.f, d, entry)
+		d.items[leaf] = dir
+		d.mu.Unlock()
+		fs.Debugf(d.path, "lazy stat: found %q as directory via List", leaf)
+		return dir, nil
+	}
+
+	return nil, ENOENT
 }
 
 // Check to see if a directory is empty

--- a/vfs/dir_test.go
+++ b/vfs/dir_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fstest"
+	"github.com/rclone/rclone/vfs/vfscommon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -762,4 +763,293 @@ func TestDirMetadataExtension(t *testing.T) {
 	if features.ReadDirMetadata {
 		assert.Equal(t, modTime.Format(time.RFC3339Nano), metadata["mtime"])
 	}
+}
+
+// TestDirStatLazy verifies that --vfs-lazy-dir-read uses NewObject (HeadObject
+// for S3) instead of a full directory listing when stat-ing a single file.
+func TestDirStatLazy(t *testing.T) {
+	opt := vfscommon.Opt
+	opt.LazyDirRead = true
+	opt.CaseInsensitive = false // default is true on macOS/Windows; must be false for lazy stat to activate
+
+	// Unicode normalization (NoUnicodeNormalization=false by default) also
+	// triggers a full listing fallback. Disable it so the lazy path is active.
+	ci := fs.GetConfig(context.Background())
+	oldNorm := ci.NoUnicodeNormalization
+	ci.NoUnicodeNormalization = true
+	t.Cleanup(func() { ci.NoUnicodeNormalization = oldNorm })
+	r, vfs := newTestVFSOpt(t, &opt)
+
+	// Write a test file directly to the remote.
+	file1 := r.WriteObject(context.Background(), "file1", "hello lazy", t1)
+	r.CheckRemoteItems(t, file1)
+
+	// stat the root — this stat triggers lazy lookup, not full listing.
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	// The directory cache is empty at this point (no full listing has run).
+	root.mu.Lock()
+	cacheEmpty := root.read.IsZero()
+	root.mu.Unlock()
+	assert.True(t, cacheEmpty, "directory cache should be empty before lazy stat")
+
+	// Stat the single file — should use NewObject, not List.
+	node, err := root.Stat("file1")
+	require.NoError(t, err)
+	_, ok := node.(*File)
+	assert.True(t, ok)
+	assert.Equal(t, "file1", node.Name())
+	assert.Equal(t, int64(10), node.Size())
+
+	// After lazy stat, the item should be in cache but d.read should still be
+	// zero (no full listing has been done yet).
+	root.mu.Lock()
+	_, inCache := root.items["file1"]
+	stillNoFullRead := root.read.IsZero()
+	root.mu.Unlock()
+	assert.True(t, inCache, "lazily fetched item should be in dir cache")
+	assert.True(t, stillNoFullRead, "full dir listing should not have been triggered")
+
+	// A second stat of the same file should be a pure cache hit.
+	node2, err := root.Stat("file1")
+	require.NoError(t, err)
+	assert.Equal(t, node, node2, "second stat should return the cached node")
+
+	// Stat of a non-existent file should return ENOENT.
+	_, err = root.Stat("does-not-exist")
+	assert.Equal(t, ENOENT, err)
+}
+
+// TestDirStatLazyCacheHit verifies that when a full listing has already been
+// performed, a subsequent lazy stat returns the cached value without a network
+// round-trip (the cache mechanism works the same in lazy mode).
+func TestDirStatLazyCacheHit(t *testing.T) {
+	opt := vfscommon.Opt
+	opt.LazyDirRead = true
+	opt.CaseInsensitive = false
+
+	ci := fs.GetConfig(context.Background())
+	oldNorm := ci.NoUnicodeNormalization
+	ci.NoUnicodeNormalization = true
+	t.Cleanup(func() { ci.NoUnicodeNormalization = oldNorm })
+	r, vfs := newTestVFSOpt(t, &opt)
+
+	file1 := r.WriteObject(context.Background(), "file1", "hello", t1)
+	r.CheckRemoteItems(t, file1)
+
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	// Trigger a full listing via ReadDirAll.
+	_, err = root.ReadDirAll()
+	require.NoError(t, err)
+
+	root.mu.Lock()
+	fullyRead := !root.read.IsZero()
+	root.mu.Unlock()
+	assert.True(t, fullyRead, "ReadDirAll should mark dir as fully read")
+
+	// Now stat should return the cached result.
+	node, err := root.Stat("file1")
+	require.NoError(t, err)
+	assert.Equal(t, "file1", node.Name())
+}
+
+// TestDirStatLazyCaseInsensitiveFallback verifies that lazy stat is disabled
+// when --vfs-case-insensitive is set OR when --ignore-case-sync is set,
+// because case folding requires the full directory listing.
+func TestDirStatLazyCaseInsensitiveFallback(t *testing.T) {
+	opt := vfscommon.Opt
+	opt.LazyDirRead = true
+	opt.CaseInsensitive = true
+
+	// Disable unicode normalization to isolate the CaseInsensitive check.
+	ci := fs.GetConfig(context.Background())
+	oldNorm := ci.NoUnicodeNormalization
+	ci.NoUnicodeNormalization = true
+	t.Cleanup(func() { ci.NoUnicodeNormalization = oldNorm })
+	r, vfs := newTestVFSOpt(t, &opt)
+
+	file1 := r.WriteObject(context.Background(), "file1", "hello ci", t1)
+	r.CheckRemoteItems(t, file1)
+
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	// With CaseInsensitive, stat() should fall back to full _readDir().
+	node, err := root.Stat("FILE1")
+	require.NoError(t, err)
+	assert.Equal(t, "file1", node.Name(), "case-insensitive match should work via full listing")
+
+	// A full read must have been done.
+	root.mu.Lock()
+	fullyRead := !root.read.IsZero()
+	root.mu.Unlock()
+	assert.True(t, fullyRead, "case-insensitive stat should have triggered a full directory listing")
+}
+
+// TestDirStatLazyUnicodeNormFallback verifies that lazy stat is disabled when
+// unicode normalization is active (i.e. --no-unicode-normalization is NOT set),
+// because normalization matching requires the full directory listing.
+func TestDirStatLazyUnicodeNormFallback(t *testing.T) {
+	opt := vfscommon.Opt
+	opt.LazyDirRead = true
+	opt.CaseInsensitive = false // isolate unicode normalization check
+
+	// Ensure unicode normalization is active (NoUnicodeNormalization = false).
+	ci := fs.GetConfig(context.Background())
+	oldNorm := ci.NoUnicodeNormalization
+	ci.NoUnicodeNormalization = false // normalization ON → lazy stat must fall back
+	t.Cleanup(func() { ci.NoUnicodeNormalization = oldNorm })
+
+	r, vfs := newTestVFSOpt(t, &opt)
+
+	file1 := r.WriteObject(context.Background(), "file1", "hello norm", t1)
+	r.CheckRemoteItems(t, file1)
+
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	// stat() should fall back to full _readDir() because unicode normalization
+	// is active (NoUnicodeNormalization == false).
+	node, err := root.Stat("file1")
+	require.NoError(t, err)
+	assert.Equal(t, "file1", node.Name())
+
+	root.mu.Lock()
+	fullyRead := !root.read.IsZero()
+	root.mu.Unlock()
+	assert.True(t, fullyRead, "unicode-normalization stat should have triggered a full directory listing")
+}
+
+// statLazySetup creates a VFS with LazyDirRead=true and all normalization
+// disabled, so statLazy() is guaranteed to be the active code path.
+// It returns the root Dir ready for statLazy tests.
+func statLazySetup(t *testing.T) (r *fstest.Run, root *Dir) {
+t.Helper()
+opt := vfscommon.Opt
+opt.LazyDirRead = true
+opt.CaseInsensitive = false
+r2, vfs := newTestVFSOpt(t, &opt)
+
+ci := fs.GetConfig(context.Background())
+oldNorm := ci.NoUnicodeNormalization
+ci.NoUnicodeNormalization = true
+t.Cleanup(func() { ci.NoUnicodeNormalization = oldNorm })
+
+rootDir, err := vfs.Root()
+if err != nil {
+t.Fatal(err)
+}
+return r2, rootDir
+}
+
+// TestStatLazyFileFound verifies that statLazy returns a *File node when the
+// object exists, caches it in d.items, and does NOT update d.read.
+func TestStatLazyFileFound(t *testing.T) {
+r, root := statLazySetup(t)
+
+r.WriteObject(context.Background(), "lazyme", "contents", t1)
+
+node, err := root.statLazy("lazyme")
+require.NoError(t, err)
+
+_, isFile := node.(*File)
+assert.True(t, isFile, "expected *File node")
+assert.Equal(t, "lazyme", node.Name())
+assert.Equal(t, int64(8), node.Size())
+
+root.mu.Lock()
+_, inCache := root.items["lazyme"]
+readIsZero := root.read.IsZero()
+root.mu.Unlock()
+assert.True(t, inCache, "node should be in d.items after lazy lookup")
+assert.True(t, readIsZero, "d.read must stay zero — no full listing should have occurred")
+}
+
+// TestStatLazyFileNotFound verifies that statLazy returns ENOENT for a key
+// that does not exist as a file or as a virtual directory prefix.
+func TestStatLazyFileNotFound(t *testing.T) {
+r, root := statLazySetup(t)
+_ = r
+
+_, err := root.statLazy("does-not-exist")
+assert.Equal(t, ENOENT, err)
+}
+
+// TestStatLazyDir verifies that statLazy returns a *Dir node when the leaf
+// does not exist as a plain object but has children (i.e. it is a virtual
+// directory prefix in a flat-namespace remote).
+func TestStatLazyDir(t *testing.T) {
+r, root := statLazySetup(t)
+
+// Create a file inside a "subdirectory" so the prefix "subdir/" exists.
+r.WriteObject(context.Background(), "subdir/child.txt", "hi", t1)
+
+node, err := root.statLazy("subdir")
+require.NoError(t, err)
+
+_, isDir := node.(*Dir)
+assert.True(t, isDir, "expected *Dir node for virtual directory prefix")
+assert.Equal(t, "subdir", node.Name())
+
+root.mu.Lock()
+_, inCache := root.items["subdir"]
+readIsZero := root.read.IsZero()
+root.mu.Unlock()
+assert.True(t, inCache, "Dir node should be cached in d.items")
+assert.True(t, readIsZero, "d.read must stay zero — only a bounded List was issued")
+}
+
+// TestStatLazyCacheHitNoop verifies that a second call to statLazy for the
+// same leaf is a pure cache hit — the node is returned from d.items with no
+// additional network round-trip (d.read stays zero throughout).
+func TestStatLazyCacheHitNoop(t *testing.T) {
+r, root := statLazySetup(t)
+
+r.WriteObject(context.Background(), "once", "data", t1)
+
+// First call: populates the cache.
+node1, err := root.statLazy("once")
+require.NoError(t, err)
+
+// Second call: must return the exact same node from cache.
+node2, err := root.statLazy("once")
+require.NoError(t, err)
+assert.Equal(t, node1, node2, "second statLazy call should return the cached node")
+
+root.mu.Lock()
+readIsZero := root.read.IsZero()
+root.mu.Unlock()
+assert.True(t, readIsZero, "d.read must remain zero after two statLazy calls")
+}
+
+// TestStatLazySubdirFile verifies that statLazy resolves files nested inside a
+// sub-directory. The VFS path join must be correct for both root-level and
+// nested directories.
+func TestStatLazySubdirFile(t *testing.T) {
+r, root := statLazySetup(t)
+
+r.WriteObject(context.Background(), "a/b/deep.txt", "deep", t1)
+
+// Stat "a" from root — should be a Dir.
+aNode, err := root.statLazy("a")
+require.NoError(t, err)
+aDir, ok := aNode.(*Dir)
+assert.True(t, ok, "expected *Dir for 'a'")
+
+// From aDir, stat "b" — should also be a Dir.
+bNode, err := aDir.statLazy("b")
+require.NoError(t, err)
+_, ok = bNode.(*Dir)
+assert.True(t, ok, "expected *Dir for 'a/b'")
+
+// From bDir, stat "deep.txt" — should be a File.
+bDir := bNode.(*Dir)
+fileNode, err := bDir.statLazy("deep.txt")
+require.NoError(t, err)
+_, ok = fileNode.(*File)
+assert.True(t, ok, "expected *File for 'a/b/deep.txt'")
+assert.Equal(t, "deep.txt", fileNode.Name())
 }

--- a/vfs/vfscommon/options.go
+++ b/vfs/vfscommon/options.go
@@ -171,6 +171,23 @@ var OptionsInfo = fs.Options{{
 	Help:    "Time to keep file handle and downloaders alive after last close",
 	Groups:  "VFS",
 }, {
+	Name:    "vfs_lazy_dir_read",
+	Default: false,
+	Help: `Use HeadObject instead of listing the directory on stat
+
+When set, looking up a single file (e.g. via stat or FUSE Lookup) will use
+NewObject (HeadObject for S3) instead of listing the whole directory.
+This avoids fetching the full directory listing for large flat buckets when
+only specific files are accessed.
+
+If the object is not found it will attempt a bounded list to check whether
+the name is a directory.
+
+Note: this option has no effect when --vfs-case-insensitive or
+--vfs-block-norm-dupes are set, as those features require a full directory
+listing to operate correctly.`,
+	Groups: "VFS",
+}, {
 	Name:    "vfs_metadata_extension",
 	Default: "",
 	Help:    "Set the extension to read metadata from.",
@@ -216,6 +233,7 @@ type Options struct {
 	DiskSpaceTotalSize fs.SizeSuffix `config:"vfs_disk_space_total_size"`
 	HandleCaching      fs.Duration   `config:"vfs_handle_caching"`     // time to keep handle alive after last close
 	MetadataExtension  string        `config:"vfs_metadata_extension"` // if set respond to files with this extension with metadata
+	LazyDirRead        bool          `config:"vfs_lazy_dir_read"`      // if set use HeadObject instead of listing on stat
 }
 
 // Opt is the default options modified by the environment variables and command line flags


### PR DESCRIPTION
#### What is the purpose of this change?

Use S3 buckets ( or any remote storage ) that has a huge number of files under the same folder without having to fetch the entire file list of such folder.

#### Was the change discussed in an issue or in the forum before?

https://forum.rclone.org/t/big-syncs-with-millions-of-files/40182/6
https://github.com/rclone/rclone/issues/9348

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
