### PR TITLE
docs: clarify DeleteFile does not honour --backup-dir

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -545,8 +545,12 @@ func SuffixName(ctx context.Context, remote string) string {
 // DeleteFileWithBackupDir deletes a single file respecting --dry-run
 // and accumulating stats and errors.
 //
-// If backupDir is set then it moves the file to there instead of
-// deleting
+// If backupDir is non-nil the file is moved there instead of being
+// deleted. Callers pass in the backupDir [fs.Fs] (usually obtained
+// via [BackupDir]) rather than having it looked up here: [BackupDir]
+// is a relatively expensive operation, so when deleting many files
+// in a loop you should resolve the backup directory once before the
+// loop and pass it in on each iteration.
 func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs) (err error) {
 	tr := accounting.Stats(ctx).NewCheckingTransfer(dst, "deleting")
 	defer func() {
@@ -577,10 +581,13 @@ func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs
 	return err
 }
 
-// DeleteFile deletes a single file respecting --dry-run and accumulating stats and errors.
+// DeleteFile deletes a single file respecting --dry-run and
+// accumulating stats and errors.
 //
-// If useBackupDir is set and --backup-dir is in effect then it moves
-// the file to there instead of deleting
+// DeleteFile does NOT honour --backup-dir — it always deletes the
+// file outright. If the caller needs --backup-dir support, use
+// [DeleteFileWithBackupDir] instead, after resolving the backup
+// directory once via [BackupDir].
 func DeleteFile(ctx context.Context, dst fs.Object) (err error) {
 	return DeleteFileWithBackupDir(ctx, dst, nil)
 }


### PR DESCRIPTION
Refs #7566.

## Problem

`operations.DeleteFile` is documented as:

> If useBackupDir is set and `--backup-dir` is in effect then it moves the file to there instead of deleting

but the body is simply:

~~~go
func DeleteFile(ctx context.Context, dst fs.Object) (err error) {
    return DeleteFileWithBackupDir(ctx, dst, nil)
}
~~~

The `backupDir` it hands to `DeleteFileWithBackupDir` is unconditionally `nil`, so `--backup-dir` is never applied. The comment is misleading: callers reading the doc assume `DeleteFile` does the right thing in `--backup-dir` mode, when in fact they need to resolve `BackupDir` themselves and call `DeleteFileWithBackupDir`.

## Fix

This PR implements steps 1 and 2 of @ncw's suggested fix in #7566 — the pure-docs portion:

1. `DeleteFile` — replace the misleading comment with an explicit statement that it does **not** honour `--backup-dir`, and point readers at `DeleteFileWithBackupDir` + `BackupDir` when they need that behaviour.
2. `DeleteFileWithBackupDir` — add a note that `BackupDir` is expensive and should be resolved once outside any delete loop.

No behaviour changes. Step 3 (auditing each `DeleteFile` callsite to decide whether it should instead use `DeleteFileWithBackupDir`) is deliberately left for follow-ups because each callsite needs its own semantic reasoning (bisync, ncdu, rc, sync, dedupe — each has different backup expectations).