### PR TITLE
Fix code comment regarding cmount tag

### DIFF
--- a/lib/buildinfo/tags.go
+++ b/lib/buildinfo/tags.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Tags contains slice of build tags.
-// The `cmount` tag is added by cmd/cmount/mount.go only if build is static.
+// The `cmount` tag is added by cmd/cmount/mount.go only if cmount command is supported.
 // The `noselfupdate` tag is added by cmd/selfupdate/noselfupdate.go
 // Other tags including `cgo` are detected in this package.
 var Tags []string


### PR DESCRIPTION
#### What is the purpose of this change?

Not exactly important, but while testing different build configurations in Windows and Linux I was confused by this, so I though it would be good to get it confirmed and avoid future confusion.

Examples from `rclone --version` output:
- A Windows build built with `-tags cmount` and gcc available reports:
  - go/linking: dynamic
  - go/tags: cmount
- A Linux build built with `-tags cmount,fuse3` and gcc available reports:
  - go/linking: dynamic
  - go/tags: cmount
- A Linux build built with `-tags cmount` but CGO_ENABLED=0 reports:
  - go/linking: static
  - go/tags: none
  
#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
