### PR TITLE
fix: redact repeated auth headers in HTTP dumps

### DIFF
--- a/fs/fshttp/http.go
+++ b/fs/fshttp/http.go
@@ -402,14 +402,14 @@ func checkServerTime(req *http.Request, resp *http.Response) {
 	checkedHostMu.Unlock()
 }
 
-// cleanAuth gets rid of one authBuf header within the first 4k
-func cleanAuth(buf, authBuf []byte) []byte {
+// cleanAuth gets rid of one authBuf header within the first 4k.
+func cleanAuth(buf, authBuf []byte) (_ []byte, changed bool) {
 	// Find how much buffer to check
 	n := min(len(buf), 4096)
 	// See if there is an Authorization: header
 	i := bytes.Index(buf[:n], authBuf)
 	if i < 0 {
-		return buf
+		return buf, false
 	}
 	i += len(authBuf)
 	// Overwrite the next 4 chars with 'X'
@@ -423,10 +423,10 @@ func cleanAuth(buf, authBuf []byte) []byte {
 	// Snip out to the next '\n'
 	j := bytes.IndexByte(buf[i:], '\n')
 	if j < 0 {
-		return buf[:i]
+		return buf[:i], true
 	}
 	n = copy(buf[i:], buf[i+j:])
-	return buf[:i+n]
+	return buf[:i+n], true
 }
 
 var authBufs = [][]byte{
@@ -437,7 +437,13 @@ var authBufs = [][]byte{
 // cleanAuths gets rid of all the possible Auth headers
 func cleanAuths(buf []byte) []byte {
 	for _, authBuf := range authBufs {
-		buf = cleanAuth(buf, authBuf)
+		for {
+			var changed bool
+			buf, changed = cleanAuth(buf, authBuf)
+			if !changed {
+				break
+			}
+		}
 	}
 	return buf
 }

--- a/fs/fshttp/http_test.go
+++ b/fs/fshttp/http_test.go
@@ -41,8 +41,8 @@ func TestCleanAuth(t *testing.T) {
 		{"Authorization: AAAAAAAAA\nPotato: Help\n", "Authorization: XXXX\nPotato: Help\n"},
 		{"Sausage: 1\nAuthorization: AAAAAAAAA\nPotato: Help\n", "Sausage: 1\nAuthorization: XXXX\nPotato: Help\n"},
 	} {
-		got := string(cleanAuth([]byte(test.in), authBufs[0]))
-		assert.Equal(t, test.want, got, test.in)
+		got, _ := cleanAuth([]byte(test.in), authBufs[0])
+		assert.Equal(t, test.want, string(got), test.in)
 	}
 }
 
@@ -56,6 +56,8 @@ func TestCleanAuths(t *testing.T) {
 		{"Authorization: AAAAAAAAA\nPotato: Help\n", "Authorization: XXXX\nPotato: Help\n"},
 		{"X-Auth-Token: AAAAAAAAA\nPotato: Help\n", "X-Auth-Token: XXXX\nPotato: Help\n"},
 		{"X-Auth-Token: AAAAAAAAA\nAuthorization: AAAAAAAAA\nPotato: Help\n", "X-Auth-Token: XXXX\nAuthorization: XXXX\nPotato: Help\n"},
+		{"Authorization: first\nAuthorization: second\n", "Authorization: XXXX\nAuthorization: XXXX\n"},
+		{"X-Auth-Token: first\nPotato: Help\nX-Auth-Token: second\n", "X-Auth-Token: XXXX\nPotato: Help\nX-Auth-Token: XXXX\n"},
 	} {
 		got := string(cleanAuths([]byte(test.in)))
 		assert.Equal(t, test.want, got, test.in)


### PR DESCRIPTION

**Repo:** rclone/rclone (⭐ 49000)
**Type:** bugfix
**Files changed:** 2
**Lines:** +16/-8

## What
This change fixes the HTTP dump redaction helper in `fs/fshttp` so it removes every occurrence of `Authorization` and `X-Auth-Token` headers from logged request dumps instead of only the first occurrence of each header type. It also adds regression tests covering repeated auth headers to ensure later secrets are redacted too.

## Why
`cleanAuths` was intended to sanitize dumped HTTP requests before logging, but its previous implementation only scrubbed the first matching header for each auth header type. If a request contained duplicate auth headers, later credentials could still appear in debug logs. This patch closes that gap with a minimal, localized fix and test coverage around the leaked-header case.

## Testing
Intended verification: run `go test ./fs/fshttp`.
Local result: unable to complete in this sandbox because Go module downloads require network access and the environment blocks outbound access. The change is small, package-local, and covered by focused regression tests added in `fs/fshttp/http_test.go`.

## Risk
Low / The change only affects log redaction for dumped HTTP requests and adds narrow tests for the updated behavior.
