### PR TITLE
docs: fix typo

### DIFF
--- a/docs/content/overview.md
+++ b/docs/content/overview.md
@@ -333,7 +333,7 @@ parameter in the config file.
 
 ##### Encoding example: Windows
 
-As a nother example, take a Windows system where there is a file with
+As another example, take a Windows system where there is a file with
 name `Test：1.jpg`, where `：` is the Unicode fullwidth colon symbol.
 When using rclone to copy this to a remote which supports `:`,
 the regular (halfwidth) colon (such as Google Drive), you will notice


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fixes a very simple typo in "Overview" page in the doc

"a nother" → "another"

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
