### PR TITLE
Amend Google Drive client_id instructions to include running web-based auth flow

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -2008,6 +2008,9 @@ Scroll down and click "+ Add users". Add yourself as a test user and press save.
 
 10. Provide the noted client ID and client secret to rclone.
 
+11. Run the web-based authorization flow from within `rclone config`, by answering
+    "Y" when it asks "Already have a token - refresh?".
+
 Be aware that, due to the "enhanced security" recently introduced by
 Google, you are theoretically expected to "submit your app for verification"
 and then wait a few weeks(!) for their response; in practice, you can go right


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix a minor omission in the docs.

If the user completes step 10 by editing rclone.conf (such as I did), then they will not be prompted to complete the web-based oauth flow. I've added this step explicitly.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
