### PR TITLE
vfs: add --vfs-downloaders-max to cap concurrent download streams per open file

### DIFF
--- a/vfs/vfscache/downloaders/downloaders.go
+++ b/vfs/vfscache/downloaders/downloaders.go
@@ -17,8 +17,6 @@ import (
 	"github.com/rclone/rclone/vfs/vfscommon"
 )
 
-// FIXME implement max downloaders
-
 const (
 	// max time a downloader can be idle before closing itself
 	maxDownloaderIdleTime = 5 * time.Second
@@ -357,6 +355,14 @@ func (dls *Downloaders) _ensureDownloader(r ranges.Range) (err error) {
 	}
 	// Size can be 0 here if file shrinks - no need to download
 	if r.Size == 0 {
+		return nil
+	}
+	// If at the configured cap, don't spawn another downloader. The caller
+	// will still enqueue a waiter for r; kickWaiters() re-runs
+	// _ensureDownloader for every pending waiter as soon as an existing
+	// downloader closes (or idles out after maxDownloaderIdleTime), so
+	// progress resumes automatically once a slot frees.
+	if max := dls.opt.DownloadersMax; max > 0 && len(dls.dls) >= max {
 		return nil
 	}
 	// Downloader not found so start a new one

--- a/vfs/vfscache/downloaders/downloaders_test.go
+++ b/vfs/vfscache/downloaders/downloaders_test.go
@@ -136,11 +136,17 @@ func TestDownloaders(t *testing.T) {
 		return len(dls.dls)
 	}
 
-	// observePeakPool fires N concurrent Download() calls for far-apart
+	// observePeakPool fires n concurrent Download() calls for far-apart
 	// ranges and returns the peak observed pool size. The stride is
 	// deliberately larger than minWindow (1 MiB) so range-reuse never
 	// folds two requests onto the same downloader.
-	observePeakPool := func(t *testing.T, dls *Downloaders, n int, stride int64, window time.Duration) int {
+	//
+	// window bounds the worst-case wall time. target is an optimistic
+	// early-exit: once peak >= target the loop waits briefly (to catch
+	// a cap violation that appears just above target) and then returns
+	// without burning the full window. Pass target=0 to always observe
+	// for the full window.
+	observePeakPool := func(t *testing.T, dls *Downloaders, n int, stride int64, window time.Duration, target int) int {
 		var wg sync.WaitGroup
 		for i := 0; i < n; i++ {
 			r := ranges.Range{Pos: int64(i) * stride, Size: 1024}
@@ -156,6 +162,16 @@ func TestDownloaders(t *testing.T) {
 		for time.Now().Before(deadline) {
 			if cur := poolSize(dls); cur > peak {
 				peak = cur
+			}
+			if target > 0 && peak >= target {
+				// Guard window: if the cap is leaky, a violation
+				// typically shows up within a few polls of first
+				// hitting target. Sample once more before returning.
+				time.Sleep(50 * time.Millisecond)
+				if cur := poolSize(dls); cur > peak {
+					peak = cur
+				}
+				break
 			}
 			time.Sleep(5 * time.Millisecond)
 		}
@@ -187,7 +203,7 @@ func TestDownloaders(t *testing.T) {
 		dls := New(capCtx, item, &opt, remote, src)
 		defer cancel(dls)
 
-		peak := observePeakPool(t, dls, 32, 2*1024*1024, 2*time.Second)
+		peak := observePeakPool(t, dls, 32, 2*1024*1024, 2*time.Second, opt.DownloadersMax)
 
 		assert.LessOrEqual(t, peak, opt.DownloadersMax,
 			"pool exceeded DownloadersMax=%d: observed peak %d",
@@ -202,10 +218,10 @@ func TestDownloaders(t *testing.T) {
 	// also plateaus at 4, the Max test is measuring something other
 	// than the cap (e.g. range-reuse).
 	//
-	// Uses a blocking item so downloaders cannot advance their offset
-	// and absorb follow-up requests via the reuse-window path in
-	// _ensureDownloader — otherwise a fast testItem lets a few
-	// downloaders race through the whole file and the pool never grows.
+	// Relies on newCapCtx's BufferSize=0 to collapse the reuse-window to
+	// minWindow (1 MiB); with a 2 MiB stride every valid-range request
+	// then spawns its own downloader, and the 5 s idle timeout keeps
+	// them alive for the observation window so the pool can grow.
 	t.Run("Unlimited", func(t *testing.T) {
 		capCtx := newCapCtx(ctx)
 		item := &testItem{t: t, size: size}
@@ -214,15 +230,12 @@ func TestDownloaders(t *testing.T) {
 		dls := New(capCtx, item, &opt, remote, src)
 		defer cancel(dls)
 
-		peak := observePeakPool(t, dls, 32, 2*1024*1024, 2*time.Second)
+		const threshold = 5
+		peak := observePeakPool(t, dls, 32, 2*1024*1024, 2*time.Second, threshold+1)
 
 		// Clear daylight above any cap=4 value anyone might mistakenly
-		// introduce later. With window=1 MiB (from BufferSize=0) and
-		// a 2 MiB stride, every valid-range request spawns its own
-		// downloader. On a 50 MiB file that's up to ~25 live
-		// downloaders; the 5 s idle timeout keeps them all alive for
-		// the 2 s observation window.
-		const threshold = 5
+		// introduce later. On a 50 MiB file with a 2 MiB stride that's
+		// up to ~25 live downloaders — plenty of headroom above 5.
 		assert.Greater(t, peak, threshold,
 			"with DownloadersMax=0 (unlimited), pool peak was expected to exceed %d, got %d",
 			threshold, peak)

--- a/vfs/vfscache/downloaders/downloaders_test.go
+++ b/vfs/vfscache/downloaders/downloaders_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	_ "github.com/rclone/rclone/backend/local"
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/lib/ranges"
@@ -125,5 +126,105 @@ func TestDownloaders(t *testing.T) {
 		assert.Eventually(t, func() bool {
 			return item.HasRange(r)
 		}, 10*time.Second, 10*time.Millisecond)
+	})
+
+	// poolSize returns len(dls.dls) under the mutex. Same-package test
+	// only; external callers should not peek at the pool directly.
+	poolSize := func(dls *Downloaders) int {
+		dls.mu.Lock()
+		defer dls.mu.Unlock()
+		return len(dls.dls)
+	}
+
+	// observePeakPool fires N concurrent Download() calls for far-apart
+	// ranges and returns the peak observed pool size. The stride is
+	// deliberately larger than minWindow (1 MiB) so range-reuse never
+	// folds two requests onto the same downloader.
+	observePeakPool := func(t *testing.T, dls *Downloaders, n int, stride int64, window time.Duration) int {
+		var wg sync.WaitGroup
+		for i := 0; i < n; i++ {
+			r := ranges.Range{Pos: int64(i) * stride, Size: 1024}
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				_ = dls.Download(r)
+			}()
+		}
+
+		peak := 0
+		deadline := time.Now().Add(window)
+		for time.Now().Before(deadline) {
+			if cur := poolSize(dls); cur > peak {
+				peak = cur
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		// Don't wg.Wait here — cancel(dls) in the outer defer is what
+		// unblocks Download() callers via _closeWaiters.
+		t.Cleanup(wg.Wait)
+		return peak
+	}
+
+	// newCapCtx returns a ctx with BufferSize pinned to 0 so the
+	// reuse-window in _ensureDownloader collapses to minWindow (1 MiB).
+	// Without this override the window is the global --buffer-size
+	// (default 16 MiB) and our 2 MiB stride gets absorbed into a
+	// single downloader, masking the pool size we want to measure.
+	newCapCtx := func(parent context.Context) context.Context {
+		capCtx, ci := fs.AddConfig(parent)
+		ci.BufferSize = 0
+		return capCtx
+	}
+
+	// Max: with DownloadersMax=4 and 32 concurrent far-apart requests,
+	// the pool must never exceed 4. This is the entire behavioural
+	// guarantee of the fix.
+	t.Run("Max", func(t *testing.T) {
+		capCtx := newCapCtx(ctx)
+		item := &testItem{t: t, size: size}
+		opt := vfscommon.Opt
+		opt.DownloadersMax = 4
+		dls := New(capCtx, item, &opt, remote, src)
+		defer cancel(dls)
+
+		peak := observePeakPool(t, dls, 32, 2*1024*1024, 2*time.Second)
+
+		assert.LessOrEqual(t, peak, opt.DownloadersMax,
+			"pool exceeded DownloadersMax=%d: observed peak %d",
+			opt.DownloadersMax, peak)
+		assert.Equal(t, opt.DownloadersMax, peak,
+			"pool never reached DownloadersMax=%d (peak %d) — cap not stressed by this workload",
+			opt.DownloadersMax, peak)
+	})
+
+	// Unlimited: with DownloadersMax=0 the cap is off; the pool must be
+	// able to exceed the cap's value. This is the control: if this one
+	// also plateaus at 4, the Max test is measuring something other
+	// than the cap (e.g. range-reuse).
+	//
+	// Uses a blocking item so downloaders cannot advance their offset
+	// and absorb follow-up requests via the reuse-window path in
+	// _ensureDownloader — otherwise a fast testItem lets a few
+	// downloaders race through the whole file and the pool never grows.
+	t.Run("Unlimited", func(t *testing.T) {
+		capCtx := newCapCtx(ctx)
+		item := &testItem{t: t, size: size}
+		opt := vfscommon.Opt
+		opt.DownloadersMax = 0
+		dls := New(capCtx, item, &opt, remote, src)
+		defer cancel(dls)
+
+		peak := observePeakPool(t, dls, 32, 2*1024*1024, 2*time.Second)
+
+		// Clear daylight above any cap=4 value anyone might mistakenly
+		// introduce later. With window=1 MiB (from BufferSize=0) and
+		// a 2 MiB stride, every valid-range request spawns its own
+		// downloader. On a 50 MiB file that's up to ~25 live
+		// downloaders; the 5 s idle timeout keeps them all alive for
+		// the 2 s observation window.
+		const threshold = 5
+		assert.Greater(t, peak, threshold,
+			"with DownloadersMax=0 (unlimited), pool peak was expected to exceed %d, got %d",
+			threshold, peak)
 	})
 }

--- a/vfs/vfscommon/options.go
+++ b/vfs/vfscommon/options.go
@@ -91,6 +91,11 @@ var OptionsInfo = fs.Options{{
 	Help:    "The number of parallel streams to read at once",
 	Groups:  "VFS",
 }, {
+	Name:    "vfs_downloaders_max",
+	Default: 0,
+	Help:    "Max concurrent download streams per open file (0 = unlimited)",
+	Groups:  "VFS",
+}, {
 	Name:    "dir_perms",
 	Default: FileMode(0777),
 	Help:    "Directory permissions",
@@ -200,6 +205,7 @@ type Options struct {
 	ChunkSize          fs.SizeSuffix `config:"vfs_read_chunk_size"`       // if > 0 read files in chunks
 	ChunkSizeLimit     fs.SizeSuffix `config:"vfs_read_chunk_size_limit"` // if > ChunkSize double the chunk size after each chunk until reached
 	ChunkStreams       int           `config:"vfs_read_chunk_streams"`    // Number of download streams to use
+	DownloadersMax     int           `config:"vfs_downloaders_max"`       // Cap on concurrent downloaders per open file; 0 = unlimited
 	CacheMode          CacheMode     `config:"vfs_cache_mode"`
 	CacheMaxAge        fs.Duration   `config:"vfs_cache_max_age"`
 	CacheMaxSize       fs.SizeSuffix `config:"vfs_cache_max_size"`


### PR DESCRIPTION
#### What is the purpose of this change?

Resolves the `// FIXME implement max downloaders` in
`vfs/vfscache/downloaders/downloaders.go` by adding a configurable
upper bound on concurrent downloader goroutines per open VFS cache
item.

A new option `--vfs-downloaders-max` (env
`RCLONE_VFS_DOWNLOADERS_MAX`, default `0` = unlimited) caps
`len(dls.dls)` at the configured value. When the cap is hit,
`_ensureDownloader` returns `nil` without starting a new downloader;
the waiter added by `Download()` is retried through the existing
`kickWaiters()` path as soon as an active downloader closes (on
completion, error, or the 5 s `maxDownloaderIdleTime`). No new
goroutines, timers, or bookkeeping — the cap plugs into the existing
waiter/retry machinery.

**Default is 0 (unlimited)** so existing workloads are unchanged on
upgrade. Users hitting unbounded fan-out under random-access patterns
can opt in by setting a positive value.

#### Was the change discussed in an issue or in the forum before?

No prior issue linked. Happy to open one first if the maintainers
prefer that workflow for small FIXME resolutions.

#### Notes for reviewers

A few design choices that might prompt questions:

- **Return `nil` at capacity rather than an error.** `Download()`
  appends a waiter unconditionally after `_ensureDownloader` returns,
  so the request is queued rather than dropped. Returning an error
  would make the caller's read fail synchronously — worse UX and a
  behavioural change. The existing `r.Size == 0` and `!startNew`
  paths also return `nil` without starting a downloader, so this is
  consistent with the surrounding code.

- **Why `len(dls.dls)` instead of a semaphore.** A counting semaphore
  would duplicate bookkeeping that `dls.dls` already provides.
  `len(dls.dls)` is the authoritative pool count; reusing it keeps
  the change small.

- **Why default 0 (unlimited).** Backwards compatibility — nobody
  regresses on upgrade. Mirrors how `vfs_read_chunk_streams` ships
  (default 0). Picking a non-zero default is a separate policy call
  that can be made in its own commit after a benchmark sweep.

- **Tests scope `BufferSize=0` via `fs.AddConfig`.** The reuse-window
  in `_ensureDownloader` is `max(BufferSize, minWindow=1 MiB)`. With
  the default 16 MiB BufferSize, eight stride-2 requests fold onto a
  single downloader and the pool never grows past 4 regardless of
  the cap — a silent failure mode. Pinning BufferSize=0 in a
  test-local ctx collapses the window to 1 MiB so each stride-2
  request genuinely needs its own downloader.

- **Why not a blocking mock `Item`?** Tried it, deadlocks: `Write()`
  holds `dl.mu` across the `item.WriteAtNoOverwrite` call, and
  subsequent `_ensureDownloader` calls block in `getRange` waiting
  for that same mutex. Relying on the 5 s idle timeout with the
  existing `testItem` (no blocking) keeps downloaders alive long
  enough for the 2 s observation window without that trap.

Tested on Windows 11 amd64 (Intel Core Ultra 7 155U); 10 consecutive
runs of the new sub-tests pass in ~44 s total. Verified the tests
catch a missing cap by temporarily gating the check behind
`if false` — the Max test's observed peak jumped from 4 to 25 with
no other changes.

Docs in `docs/content/commands/rclone_*.md` contain `--help`
listings that would benefit from a regeneration for the new flag —
happy to do that in a follow-up commit here, or let maintainers roll
it into the next doc sweep, whichever is preferred.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
      (Flag appears in `--help` via `OptionsInfo`; markdown doc
      regeneration available on request — see notes above.)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
