### PR TITLE
protondrive: fix nil pointer dereference (SIGSEGV) in Open

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -999,7 +999,7 @@ func (o *Object) Storable() bool {
 
 // Open opens the file for read.  Call Close() on the returned io.ReadCloser
 func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
-	fs.FixRangeOption(options, *o.originalSize)
+	fs.FixRangeOption(options, o.Size())
 	var offset, limit int64 = 0, -1
 	for _, option := range options { // if the caller passes in nil for options, it will become array of nil
 		switch x := option.(type) {

--- a/backend/protondrive/protondrive_internal_test.go
+++ b/backend/protondrive/protondrive_internal_test.go
@@ -5,6 +5,83 @@ import (
 	"testing"
 )
 
+// TestObjectOpenNilOriginalSizePanic demonstrates the before/after of issue #9117.
+// The old code called fs.FixRangeOption(options, *o.originalSize) which panics
+// when originalSize is nil. The fix calls o.Size() instead, which guards against nil.
+func TestObjectOpenNilOriginalSizePanic(t *testing.T) {
+	f := &Fs{opt: Options{ReportOriginalSize: true}}
+	o := &Object{fs: f, size: 42}
+	// o.originalSize is intentionally nil — as occurs when readMetaDataForLink
+	// returns nil fileSystemAttrs, or for objects built via createObject.
+
+	// Verify the old code path (*o.originalSize) would have panicked.
+	oldCodePanicked := func() (panicked bool) {
+		defer func() {
+			if recover() != nil {
+				panicked = true
+			}
+		}()
+		_ = *o.originalSize // mirrors the removed line: fs.FixRangeOption(options, *o.originalSize)
+		return false
+	}()
+	if !oldCodePanicked {
+		t.Fatal("expected nil pointer dereference to panic — test setup is wrong")
+	}
+
+	// Verify the new code path (o.Size()) does not panic and returns the fallback.
+	if got := o.Size(); got != 42 {
+		t.Fatalf("Size() = %d, want 42", got)
+	}
+}
+
+func TestObjectSize(t *testing.T) {
+	originalSize := int64(100)
+
+	for _, tc := range []struct {
+		name               string
+		originalSize       *int64
+		size               int64
+		reportOriginalSize bool
+		want               int64
+	}{
+		{
+			// Regression test for SIGSEGV: Open() called *o.originalSize which
+			// panics when originalSize is nil. Objects whose metadata could not
+			// be fetched (nil fileSystemAttrs returned from readMetaDataForLink,
+			// or objects constructed via createObject before any upload) have a
+			// nil originalSize. Size() must fall back to the encrypted size
+			// instead of dereferencing the nil pointer.
+			name:               "nil originalSize falls back to encrypted size",
+			originalSize:       nil,
+			size:               42,
+			reportOriginalSize: true,
+			want:               42,
+		},
+		{
+			name:               "non-nil originalSize returned when ReportOriginalSize is true",
+			originalSize:       &originalSize,
+			size:               42,
+			reportOriginalSize: true,
+			want:               100,
+		},
+		{
+			name:               "encrypted size returned when ReportOriginalSize is false",
+			originalSize:       &originalSize,
+			size:               42,
+			reportOriginalSize: false,
+			want:               42,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &Fs{opt: Options{ReportOriginalSize: tc.reportOriginalSize}}
+			o := &Object{fs: f, size: tc.size, originalSize: tc.originalSize}
+			if got := o.Size(); got != tc.want {
+				t.Fatalf("Size() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 var protonDriveAppVersionPattern = regexp.MustCompile(`(?i)^external-drive(-[a-z_]+)+@[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?-((stable|beta|RC|alpha)(([.-]?\d+)*)?)?([.-]?dev)?(\+.*)?$`)
 
 func TestProtonDriveAppVersionFromRcloneVersion(t *testing.T) {


### PR DESCRIPTION
**What is the purpose of this change?**

Fixes a nil pointer dereference (SIGSEGV) in `(*Object).Open` reported in #9117. The crash is reproducible with `rclone bisync` against a Proton Drive remote.

**Root cause**

`Object.originalSize` is a `*int64` that is only populated when `readMetaDataForLink` returns non-nil `fileSystemAttrs`. Objects constructed via `createObject` during `Put`, or any file whose metadata fetch yields nil attrs, are left with `originalSize == nil`. The first line of `Open` dereferences it unconditionally:

```backend/protondrive/protondrive.go#L999-L1001
// Open opens the file for read.  Call Close() on the returned io.ReadCloser
func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
	fs.FixRangeOption(options, *o.originalSize)
```

**Fix**

Replace `*o.originalSize` with `o.Size()`, which already has a nil guard and falls back to the encrypted server size. This is also consistent with the `x.Decode(o.Size())` call four lines below in the same function, the two calls were simply inconsistent with each other.

**Tests**

Two test functions are added to `protondrive_internal_test.go`:

- `TestObjectOpenNilOriginalSizePanic` the primary proof of the fix. It constructs an `Object` with nil `originalSize`, confirms the old dereference `*o.originalSize` does panic (via `recover`), then confirms `o.Size()` does not panic and returns the correct fallback. This demonstrates the before/after without requiring a live account.
- `TestObjectSize` table-driven test covering the full contract of `Size()`: nil `originalSize` with `ReportOriginalSize` true, non-nil `originalSize` with `ReportOriginalSize` true, and `ReportOriginalSize` false.

**Was the change discussed in an issue or in the forum before?**

#9117. Tagging @tomholford who has been working on related Proton Drive reliability fixes (#9080, #9081) in case it's useful context alongside that work.

**Checklist**

- [x] I have read the contribution guidelines.
- [x] I have added tests for all changes in this PR.
- [x] All commit messages are in house style.
- [x] I'm done, this Pull Request is ready for review.