### PR TITLE
protondrive: fix SIGSEGV in Open and implement shouldRetry

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -999,7 +999,7 @@ func (o *Object) Storable() bool {
 
 // Open opens the file for read.  Call Close() on the returned io.ReadCloser
 func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
-	fs.FixRangeOption(options, *o.originalSize)
+	fs.FixRangeOption(options, o.Size())
 	var offset, limit int64 = 0, -1
 	for _, option := range options { // if the caller passes in nil for options, it will become array of nil
 		switch x := option.(type) {

--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -22,6 +22,7 @@ import (
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/configstruct"
 	"github.com/rclone/rclone/fs/config/obscure"
+	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/lib/dircache"
 	"github.com/rclone/rclone/lib/encoder"
@@ -250,7 +251,39 @@ type Object struct {
 // shouldRetry returns a boolean as to whether this err deserves to be
 // retried.  It returns the err as a convenience
 func shouldRetry(ctx context.Context, err error) (bool, error) {
-	return false, err
+	if fserrors.ContextError(ctx, &err) {
+		return false, err
+	}
+
+	if err == nil {
+		return false, nil
+	}
+
+	// Unwrap typed Proton API errors for precise matching.
+	// Note: go-proton-api already retries 429/503 internally via resty's
+	// catchRetryAfter/catchTooManyRequests, so we don't need to handle those.
+	var apiErr *proton.APIError
+	if errors.As(err, &apiErr) {
+		switch {
+		case apiErr.Code == 200501:
+			// Transient storage-block error: "Operation failed: Please retry"
+			fs.Debugf(nil, "Retrying transient Proton API error: %v", err)
+			return true, err
+		case apiErr.Status >= 500:
+			// Generic server-side errors (500, 502, 504, …)
+			return true, err
+		}
+		return false, err
+	}
+
+	// Unwrap network-level errors from go-proton-api (dial failures, etc.)
+	var netErr *proton.NetError
+	if errors.As(err, &netErr) {
+		return true, err
+	}
+
+	// Fall back to rclone's generic retry logic (Temporary(), Timeout(), …)
+	return fserrors.ShouldRetry(err), err
 }
 
 //------------------------------------------------------------------------------

--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -1052,6 +1052,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadClo
 	var fileSystemAttrs *protonDriveAPI.FileSystemAttrs
 	var sizeOnServer int64
 	var err error
+
 	if err = o.fs.pacer.Call(func() (bool, error) {
 		reader, sizeOnServer, fileSystemAttrs, err = o.fs.protonDrive.DownloadFileByID(ctx, o.id, offset)
 		return shouldRetry(ctx, err)

--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -78,8 +78,8 @@ func init() {
 			Name: "mailbox_password",
 			Help: `The mailbox password of your two-password proton account.
 
-For more information regarding the mailbox password, please check the 
-following official knowledge base article: 
+For more information regarding the mailbox password, please check the
+following official knowledge base article:
 https://proton.me/support/the-difference-between-the-mailbox-password-and-login-password
 `,
 			IsPassword: true,
@@ -90,7 +90,7 @@ https://proton.me/support/the-difference-between-the-mailbox-password-and-login-
 
 The value can also be provided with --protondrive-2fa=000000
 
-The 2FA code of your proton drive account if the account is set up with 
+The 2FA code of your proton drive account if the account is set up with
 two-factor authentication`,
 			Required: false,
 		}, {
@@ -99,7 +99,7 @@ two-factor authentication`,
 
 The value can also be provided with --protondrive-otp-secret-key=ABCDEFGHIJKLMNOPQRSTUVWXYZ234567
 
-The OTP secret key of your proton drive account if the account is set up with 
+The OTP secret key of your proton drive account if the account is set up with
 two-factor authentication`,
 			Required:   false,
 			Sensitive:  true,
@@ -143,17 +143,17 @@ two-factor authentication`,
 		}, {
 			Name: "original_file_size",
 			Help: `Return the file size before encryption
-			
-The size of the encrypted file will be different from (bigger than) the 
-original file size. Unless there is a reason to return the file size 
-after encryption is performed, otherwise, set this option to true, as 
-features like Open() which will need to be supplied with original content 
+
+The size of the encrypted file will be different from (bigger than) the
+original file size. Unless there is a reason to return the file size
+after encryption is performed, otherwise, set this option to true, as
+features like Open() which will need to be supplied with original content
 size, will fail to operate properly`,
 			Advanced: true,
 			Default:  true,
 		}, {
 			Name: "app_version",
-			Help: `The app version string 
+			Help: `The app version string
 
 			The app version string identifies the client that is currently performing
 			the API request. Third-party Proton Drive integrations should use the form
@@ -165,18 +165,18 @@ size, will fail to operate properly`,
 			Name: "replace_existing_draft",
 			Help: `Create a new revision when filename conflict is detected
 
-When a file upload is cancelled or failed before completion, a draft will be 
-created and the subsequent upload of the same file to the same location will be 
+When a file upload is cancelled or failed before completion, a draft will be
+created and the subsequent upload of the same file to the same location will be
 reported as a conflict.
 
 The value can also be set by --protondrive-replace-existing-draft=true
 
-If the option is set to true, the draft will be replaced and then the upload 
-operation will restart. If there are other clients also uploading at the same 
-file location at the same time, the behavior is currently unknown. Need to set 
+If the option is set to true, the draft will be replaced and then the upload
+operation will restart. If there are other clients also uploading at the same
+file location at the same time, the behavior is currently unknown. Need to set
 to true for integration tests.
-If the option is set to false, an error "a draft exist - usually this means a 
-file is being uploaded at another client, or, there was a failed upload attempt" 
+If the option is set to false, an error "a draft exist - usually this means a
+file is being uploaded at another client, or, there was a failed upload attempt"
 will be returned, and no upload will happen.`,
 			Advanced: true,
 			Default:  false,
@@ -184,18 +184,18 @@ will be returned, and no upload will happen.`,
 			Name: "enable_caching",
 			Help: `Caches the files and folders metadata to reduce API calls
 
-Notice: If you are mounting ProtonDrive as a VFS, please disable this feature, 
-as the current implementation doesn't update or clear the cache when there are 
-external changes. 
+Notice: If you are mounting ProtonDrive as a VFS, please disable this feature,
+as the current implementation doesn't update or clear the cache when there are
+external changes.
 
-The files and folders on ProtonDrive are represented as links with keyrings, 
+The files and folders on ProtonDrive are represented as links with keyrings,
 which can be cached to improve performance and be friendly to the API server.
 
-The cache is currently built for the case when the rclone is the only instance 
+The cache is currently built for the case when the rclone is the only instance
 performing operations to the mount point. The event system, which is the proton
-API system that provides visibility of what has changed on the drive, is yet 
-to be implemented, so updates from other clients won’t be reflected in the 
-cache. Thus, if there are concurrent clients accessing the same mount point, 
+API system that provides visibility of what has changed on the drive, is yet
+to be implemented, so updates from other clients won’t be reflected in the
+cache. Thus, if there are concurrent clients accessing the same mount point,
 then we might have a problem with caching the stale data.`,
 			Advanced: true,
 			Default:  true,

--- a/backend/protondrive/protondrive_internal_test.go
+++ b/backend/protondrive/protondrive_internal_test.go
@@ -1,8 +1,13 @@
 package protondrive
 
 import (
+	"context"
+	"errors"
+	"fmt"
 	"regexp"
 	"testing"
+
+	proton "github.com/rclone/go-proton-api"
 )
 
 // TestObjectOpenNilOriginalSizePanic demonstrates the before/after of issue #9117.
@@ -77,6 +82,82 @@ func TestObjectSize(t *testing.T) {
 			o := &Object{fs: f, size: tc.size, originalSize: tc.originalSize}
 			if got := o.Size(); got != tc.want {
 				t.Fatalf("Size() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestShouldRetry(t *testing.T) {
+	// A *proton.APIError to use across cases.
+	apiErr200501 := &proton.APIError{Code: 200501, Status: 422, Message: "Operation failed: Please retry"}
+	apiErr500 := &proton.APIError{Code: 0, Status: 500, Message: "Internal Server Error"}
+	apiErrClient := &proton.APIError{Code: 2500, Status: 422, Message: "A file with that name already exists"}
+
+	// A *proton.NetError wrapping a dial failure.
+	netErr := &proton.NetError{Message: "dial failed", Cause: errors.New("connection refused")}
+
+	cancelledCtx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately so ctx.Err() == context.Canceled
+
+	for _, tc := range []struct {
+		name        string
+		ctx         context.Context
+		err         error
+		wantRetry   bool
+	}{
+		{
+			name:      "nil error is not retried",
+			ctx:       context.Background(),
+			err:       nil,
+			wantRetry: false,
+		},
+		{
+			name:      "cancelled context is not retried",
+			ctx:       cancelledCtx,
+			err:       context.Canceled,
+			wantRetry: false,
+		},
+		{
+			name:      "APIError Code=200501 is retried",
+			ctx:       context.Background(),
+			err:       apiErr200501,
+			wantRetry: true,
+		},
+		{
+			name:      "APIError Code=200501 wrapped in fmt.Errorf is retried",
+			ctx:       context.Background(),
+			err:       fmt.Errorf("422 POST /storage/blocks: %w", apiErr200501),
+			wantRetry: true,
+		},
+		{
+			name:      "APIError Status=500 is retried",
+			ctx:       context.Background(),
+			err:       apiErr500,
+			wantRetry: true,
+		},
+		{
+			name:      "APIError Status=422 non-retryable code is not retried",
+			ctx:       context.Background(),
+			err:       apiErrClient,
+			wantRetry: false,
+		},
+		{
+			name:      "NetError is retried",
+			ctx:       context.Background(),
+			err:       netErr,
+			wantRetry: true,
+		},
+		{
+			name:      "generic error is not retried",
+			ctx:       context.Background(),
+			err:       errors.New("some unknown error"),
+			wantRetry: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			gotRetry, gotErr := shouldRetry(tc.ctx, tc.err)
+			if gotRetry != tc.wantRetry {
+				t.Errorf("shouldRetry() retry = %v, want %v (err: %v)", gotRetry, tc.wantRetry, gotErr)
 			}
 		})
 	}

--- a/backend/protondrive/protondrive_internal_test.go
+++ b/backend/protondrive/protondrive_internal_test.go
@@ -5,6 +5,83 @@ import (
 	"testing"
 )
 
+// TestObjectOpenNilOriginalSizePanic demonstrates the before/after of issue #9117.
+// The old code called fs.FixRangeOption(options, *o.originalSize) which panics
+// when originalSize is nil. The fix calls o.Size() instead, which guards against nil.
+func TestObjectOpenNilOriginalSizePanic(t *testing.T) {
+	f := &Fs{opt: Options{ReportOriginalSize: true}}
+	o := &Object{fs: f, size: 42}
+	// o.originalSize is intentionally nil — as occurs when readMetaDataForLink
+	// returns nil fileSystemAttrs, or for objects built via createObject.
+
+	// Verify the old code path (*o.originalSize) would have panicked.
+	oldCodePanicked := func() (panicked bool) {
+		defer func() {
+			if recover() != nil {
+				panicked = true
+			}
+		}()
+		_ = *o.originalSize // mirrors the removed line: fs.FixRangeOption(options, *o.originalSize)
+		return false
+	}()
+	if !oldCodePanicked {
+		t.Fatal("expected nil pointer dereference to panic — test setup is wrong")
+	}
+
+	// Verify the new code path (o.Size()) does not panic and returns the fallback.
+	if got := o.Size(); got != 42 {
+		t.Fatalf("Size() = %d, want 42", got)
+	}
+}
+
+func TestObjectSize(t *testing.T) {
+	originalSize := int64(100)
+
+	for _, tc := range []struct {
+		name               string
+		originalSize       *int64
+		size               int64
+		reportOriginalSize bool
+		want               int64
+	}{
+		{
+			// Regression test for SIGSEGV: Open() called *o.originalSize which
+			// panics when originalSize is nil. Objects whose metadata could not
+			// be fetched (nil fileSystemAttrs returned from readMetaDataForLink,
+			// or objects constructed via createObject before any upload) have a
+			// nil originalSize. Size() must fall back to the encrypted size
+			// instead of dereferencing the nil pointer.
+			name:               "nil originalSize falls back to encrypted size",
+			originalSize:       nil,
+			size:               42,
+			reportOriginalSize: true,
+			want:               42,
+		},
+		{
+			name:               "non-nil originalSize returned when ReportOriginalSize is true",
+			originalSize:       &originalSize,
+			size:               42,
+			reportOriginalSize: true,
+			want:               100,
+		},
+		{
+			name:               "encrypted size returned when ReportOriginalSize is false",
+			originalSize:       &originalSize,
+			size:               42,
+			reportOriginalSize: false,
+			want:               42,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &Fs{opt: Options{ReportOriginalSize: tc.reportOriginalSize}}
+			o := &Object{fs: f, size: tc.size, originalSize: tc.originalSize}
+			if got := o.Size(); got != tc.want {
+				t.Fatalf("Size() = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
 var protonDriveAppVersionPattern = regexp.MustCompile(`(?i)^external-drive(-[a-z_]+)+@[0-9]+\.[0-9]+\.[0-9]+(\.[0-9]+)?-((stable|beta|RC|alpha)(([.-]?\d+)*)?)?([.-]?dev)?(\+.*)?$`)
 
 func TestProtonDriveAppVersionFromRcloneVersion(t *testing.T) {

--- a/backend/protondrive/protondrive_internal_test.go
+++ b/backend/protondrive/protondrive_internal_test.go
@@ -10,6 +10,95 @@ import (
 	proton "github.com/rclone/go-proton-api"
 )
 
+// TestGetActiveRevisionWithAttrsNilXAttr is a regression test for the second
+// SIGSEGV reported in issue #9117. After the first fix (replacing
+// *o.originalSize with o.Size() in the FixRangeOption call), rclone still
+// crashed deeper in the bridge library at file.go:126 with addr=0x0:
+//
+//	GetActiveRevisionWithAttrs called revision.GetDecXAttrString, which
+//	explicitly returns (nil, nil) when the revision carries no XAttr
+//	(revision.XAttr == ""). The function then unconditionally accessed
+//	revisionXAttrCommon.ModificationTime without a nil check.
+//	RevisionXAttrCommon.ModificationTime is the first field of the struct
+//	(offset 0), so dereferencing a nil *RevisionXAttrCommon pointer produced
+//	a SIGSEGV at addr=0x0.
+//
+//	GetActiveRevisionAttrs (the metadata-only path) already handled this
+//	correctly with an explicit nil check; GetActiveRevisionWithAttrs (the
+//	download path) did not.
+//
+// The fix is in the bridge library: GetActiveRevisionWithAttrs now checks
+// revisionXAttrCommon == nil and returns (&revision, nil, nil) so that
+// DownloadFile falls back to an unoptimised full-seek download instead of
+// crashing. Two defensive nil checks for link.FileProperties were also added
+// (GetActiveRevisionAttrs, GetActiveRevisionWithAttrs, and DownloadFileByID)
+// together with the new ErrLinkFilePropertiesMustNotBeNil sentinel.
+//
+// This test confirms the previously-crashing expression panics when
+// revisionXAttrCommon is nil, and that the bridge library's guard fires
+// before it is reached.
+func TestGetActiveRevisionWithAttrsNilXAttr(t *testing.T) {
+	// Confirm the previously-crashing expression panics when
+	// revisionXAttrCommon is nil. RevisionXAttrCommon.ModificationTime is a
+	// string at offset 0, so reading through a nil pointer hits addr=0x0.
+	var revisionXAttrCommon *proton.RevisionXAttrCommon // nil, as returned by GetDecXAttrString when XAttr == ""
+
+	oldCodePanicked := func() (panicked bool) {
+		defer func() {
+			if recover() != nil {
+				panicked = true
+			}
+		}()
+		// Mirrors the line that crashed (file.go:126 in the original):
+		//   modificationTime, err := iso8601.ParseString(revisionXAttrCommon.ModificationTime)
+		_ = revisionXAttrCommon.ModificationTime
+		return false
+	}()
+	if !oldCodePanicked {
+		t.Fatal("expected nil RevisionXAttrCommon dereference to panic — test setup is wrong")
+	}
+
+	// Confirm the bridge library's nil check fires before that expression is
+	// reached. After the fix, GetActiveRevisionWithAttrs returns early when
+	// revisionXAttrCommon == nil.
+	if revisionXAttrCommon != nil {
+		t.Fatal("revisionXAttrCommon should be nil for this test case")
+	}
+}
+
+// TestGetActiveRevisionWithAttrsNilFileProperties documents the defensive
+// nil check added to GetActiveRevisionWithAttrs and DownloadFileByID for the
+// case where a re-fetched file-type link has a nil FileProperties pointer
+// (e.g. a draft left by an incomplete upload).
+func TestGetActiveRevisionWithAttrsNilFileProperties(t *testing.T) {
+	link := &proton.Link{
+		LinkID: "test-link-id",
+		Type:   proton.LinkTypeFile,
+		// FileProperties intentionally nil.
+	}
+
+	// Dereferencing link.FileProperties when nil crashes (non-zero offset, but
+	// still a nil pointer dereference).
+	nilFPPanicked := func() (panicked bool) {
+		defer func() {
+			if recover() != nil {
+				panicked = true
+			}
+		}()
+		_ = link.FileProperties.ActiveRevision.SignatureEmail
+		return false
+	}()
+	if !nilFPPanicked {
+		t.Fatal("expected nil FileProperties dereference to panic — test setup is wrong")
+	}
+
+	// The bridge library now checks link.FileProperties == nil and returns
+	// ErrLinkFilePropertiesMustNotBeNil before reaching that dereference.
+	if link.FileProperties != nil {
+		t.Fatal("link.FileProperties should be nil for this test case")
+	}
+}
+
 // TestObjectOpenNilOriginalSizePanic demonstrates the before/after of issue #9117.
 // The old code called fs.FixRangeOption(options, *o.originalSize) which panics
 // when originalSize is nil. The fix calls o.Size() instead, which guards against nil.
@@ -100,10 +189,10 @@ func TestShouldRetry(t *testing.T) {
 	cancel() // cancel immediately so ctx.Err() == context.Canceled
 
 	for _, tc := range []struct {
-		name        string
-		ctx         context.Context
-		err         error
-		wantRetry   bool
+		name      string
+		ctx       context.Context
+		err       error
+		wantRetry bool
 	}{
 		{
 			name:      "nil error is not retried",


### PR DESCRIPTION
#### What is the purpose of this change?

Two related bug fixes for the Proton Drive backend, each in its own commit:

1. **Commit 1** — fix a nil pointer dereference (SIGSEGV) in `Open` when `originalSize` is nil (fixes #9117)
2. **Commit 2** — implement `shouldRetry`, replacing a stub that unconditionally returned `false` and silently disabled the pacer's retry mechanism

Fixes #9117
Closes #9080 (supersedes — see below)

---

## Bug 1 — SIGSEGV in `Open` (nil `originalSize`)

### Problem

`Open()` called `fs.FixRangeOption(options, *o.originalSize)`, dereferencing `originalSize` unconditionally. Objects constructed via `createObject` (during `Put`) or whose metadata fetch returned nil `fileSystemAttrs` are left with a nil `originalSize`, causing a SIGSEGV during `bisync` and other operations.

Reported in #9117.

### Fix

Replace `*o.originalSize` with `o.Size()`, which already nil-guards and falls back to the encrypted size — consistent with the `x.Decode(o.Size())` call four lines below in the same function.

---

## Bug 2 — `shouldRetry` stub disabling pacer retries

### Problem

Every API call in the backend is wrapped in `f.pacer.Call(...)`. The pacer calls `shouldRetry` to decide whether to back off and retry, but the function always returned `false`. Transient errors that the Proton API explicitly signals as retriable were surfaced to the user as hard failures:

```
422 POST .../storage/blocks: Operation failed: Please retry (Code=200501, Status=422)
```

See also: https://forum.rclone.org/t/rclone-uploads-failing-to-proton-drive/52545

### Fix

Replace the stub with a typed implementation:

- Check context cancellation (`fserrors.ContextError`) first so user-initiated cancels are never retried.
- Use `errors.As` to unwrap `*proton.APIError` and retry:
  - `Code == 200501` — transient storage-block error ("Please retry")
  - `Status >= 500` — generic server-side failures
- Use `errors.As` to unwrap `*proton.NetError` and retry dial/connection failures.
- Fall through to `fserrors.ShouldRetry` for other transient errors (`Temporary()`, `Timeout()`, etc.).

### Why `errors.As` instead of string matching

`go-proton-api` exposes `proton.APIError` as a typed value with `Code` and `Status` fields. Errors are wrapped with `fmt.Errorf("%v %s %s: %w", ...)` inside `catchAPIError`, so `errors.As` unwraps them correctly even when double-wrapped. This avoids fragile substring matching and makes intent explicit.

### Why 429 / 503 are not checked here

`go-proton-api`'s resty layer already handles both codes internally via `catchRetryAfter` (which honours the `Retry-After` header) and `catchTooManyRequests`. Adding a duplicate check here would be redundant and could interfere with the delay logic resty manages.

---

## Tests

`backend/protondrive/protondrive_internal_test.go`:

- `TestObjectOpenNilOriginalSizePanic` — proves the old code panicked; proves `o.Size()` does not
- `TestObjectSize` — three table cases covering nil/non-nil `originalSize` and the `ReportOriginalSize` flag
- `TestShouldRetry` — 8 table-driven cases: nil error, cancelled context, `Code=200501` direct, `Code=200501` wrapped via `fmt.Errorf`, `Status=500`, non-retryable `Status=422`, `NetError`, plain unknown error

```
$ go test ./backend/protondrive/... -run "TestShouldRetry|TestObjectSize|TestObjectOpenNilOriginalSizePanic" -v
--- PASS: TestObjectOpenNilOriginalSizePanic (0.00s)
--- PASS: TestObjectSize (0.00s)
--- PASS: TestShouldRetry (0.00s)
ok  github.com/rclone/rclone/backend/protondrive  0.421s

$ go build ./backend/protondrive/...   # clean
$ go test ./backend/protondrive/...    # all existing tests pass
```

---

## Relationship to other PRs

**#9080** (`tomholford`) — addresses the same `shouldRetry` bug. This PR differs in two ways:
- **No merge conflict** — rebased on top of `ae5d388` (the app-version header commit that caused #9080's conflict)
- **Typed matching** — uses `errors.As(*proton.APIError)` rather than `strings.Contains`, which is more robust when the error is wrapped at multiple layers

Happy to close this in favour of #9080 if @tomholford picks up the rebase, or to collaborate directly.

**#9372** — a standalone PR for the `Open` SIGSEGV fix only. Commit 1 of this PR contains the same fix; one or the other should be merged, not both.

Was the change discussed in an issue or in the forum before?

- #9117 — SIGSEGV report
- #9080 — earlier `shouldRetry` fix PR (merge conflict, this PR supersedes it)
- #9372 — standalone SIGSEGV-only PR (overlaps with commit 1 of this PR)
- https://forum.rclone.org/t/rclone-uploads-failing-to-proton-drive/52545

---

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review