### PR TITLE
serve webdav: set modtime on MOVE destination

### DIFF
--- a/cmd/serve/webdav/postprocess_test.go
+++ b/cmd/serve/webdav/postprocess_test.go
@@ -1,0 +1,142 @@
+package webdav
+
+import (
+	"context"
+	"log/slog"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	_ "github.com/rclone/rclone/backend/local"
+	"github.com/rclone/rclone/cmd/serve/proxy"
+	"github.com/rclone/rclone/fs"
+	fslog "github.com/rclone/rclone/fs/log"
+	"github.com/rclone/rclone/vfs/vfscommon"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newPostprocessTestWebDAV(t *testing.T, root string) *WebDAV {
+	t.Helper()
+
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, root)
+	require.NoError(t, err)
+
+	opt := Opt
+	opt.HTTP.ListenAddr = []string{"localhost:0"}
+	vfsOpt := vfscommon.Opt
+	w, err := newWebDAV(ctx, f, &opt, &vfsOpt, &proxy.Opt)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		assert.NoError(t, w.Shutdown())
+		w._vfs.Shutdown()
+	})
+
+	return w
+}
+
+func capturePostprocessLogs(t *testing.T) *strings.Builder {
+	t.Helper()
+
+	var logs strings.Builder
+	fslog.Handler.SetOutput(func(_ slog.Level, text string) {
+		logs.WriteString(text)
+		logs.WriteByte('\n')
+	})
+	t.Cleanup(fslog.Handler.ResetOutput)
+
+	oldHandlerLevel := fslog.Handler.SetLevel(slog.LevelError)
+	t.Cleanup(func() {
+		fslog.Handler.SetLevel(oldHandlerLevel)
+	})
+
+	ci := fs.GetConfig(context.Background())
+	oldLogLevel := ci.LogLevel
+	ci.LogLevel = fs.LogLevelError
+	t.Cleanup(func() {
+		ci.LogLevel = oldLogLevel
+	})
+
+	return &logs
+}
+
+func TestPostprocessMoveWithoutMtimeHeaderDoesNotStatSource(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "test.txt"), []byte("hello\n"), 0o666))
+
+	w := newPostprocessTestWebDAV(t, root)
+	require.NoError(t, w.Rename(context.Background(), "test.txt", "renamed.txt"))
+	_, err := os.Stat(filepath.Join(root, "test.txt"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	logs := capturePostprocessLogs(t)
+	req := httptest.NewRequest("MOVE", "/test.txt", nil)
+	w.postprocess(req, "test.txt")
+
+	assert.NotContains(t, logs.String(), "Failed to stat node")
+	_, err = os.Stat(filepath.Join(root, "renamed.txt"))
+	require.NoError(t, err)
+}
+
+func TestPostprocessMoveWithMtimeHeaderUsesDestination(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "test.txt"), []byte("hello\n"), 0o666))
+
+	w := newPostprocessTestWebDAV(t, root)
+	require.NoError(t, w.Rename(context.Background(), "test.txt", "renamed.txt"))
+	_, err := os.Stat(filepath.Join(root, "test.txt"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+
+	logs := capturePostprocessLogs(t)
+	req := httptest.NewRequest("MOVE", "/test.txt", nil)
+	want := time.Unix(1234567890, 0)
+	req.Header.Set("Destination", "http://example.com/renamed.txt")
+	req.Header.Set("X-OC-Mtime", "1234567890")
+	w.postprocess(req, "test.txt")
+
+	assert.NotContains(t, logs.String(), "Failed to stat node")
+	info, err := os.Stat(filepath.Join(root, "renamed.txt"))
+	require.NoError(t, err)
+	assert.WithinDuration(t, want, info.ModTime(), time.Second)
+}
+
+func TestPostprocessMoveWithMtimeHeaderUsesDestinationBehindBaseURL(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(root, "test.txt"), []byte("hello\n"), 0o666))
+
+	w := newPostprocessTestWebDAV(t, root)
+	w.opt.HTTP.BaseURL = "/prefix"
+	require.NoError(t, w.Rename(context.Background(), "test.txt", "renamed.txt"))
+
+	logs := capturePostprocessLogs(t)
+	req := httptest.NewRequest("MOVE", "/prefix/test.txt", nil)
+	want := time.Unix(1234567890, 0)
+	req.Header.Set("Destination", "http://example.com/prefix/renamed.txt")
+	req.Header.Set("X-OC-Mtime", "1234567890")
+	w.postprocess(req, "test.txt")
+
+	assert.NotContains(t, logs.String(), "Failed to stat node")
+	info, err := os.Stat(filepath.Join(root, "renamed.txt"))
+	require.NoError(t, err)
+	assert.WithinDuration(t, want, info.ModTime(), time.Second)
+}
+
+func TestPostprocessPutWithMtimeHeaderSetsModTime(t *testing.T) {
+	root := t.TempDir()
+	filePath := filepath.Join(root, "test.txt")
+	require.NoError(t, os.WriteFile(filePath, []byte("hello\n"), 0o666))
+
+	w := newPostprocessTestWebDAV(t, root)
+	req := httptest.NewRequest("PUT", "/test.txt", nil)
+	want := time.Unix(1234567890, 0)
+	req.Header.Set("X-OC-Mtime", "1234567890")
+	w.postprocess(req, "test.txt")
+
+	info, err := os.Stat(filePath)
+	require.NoError(t, err)
+	assert.WithinDuration(t, want, info.ModTime(), time.Second)
+}

--- a/cmd/serve/webdav/webdav.go
+++ b/cmd/serve/webdav/webdav.go
@@ -9,6 +9,7 @@ import (
 	"mime"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path"
 	"strconv"
@@ -355,6 +356,11 @@ func (w *WebDAV) postprocess(r *http.Request, remote string) {
 	// set modtime from requests, don't write to client because status is already written
 	switch r.Method {
 	case "COPY", "MOVE", "PUT":
+		mh := r.Header.Get("X-OC-Mtime")
+		if mh == "" {
+			return
+		}
+
 		VFS, err := w.getVFS(r.Context())
 		if err != nil {
 			fs.Errorf(nil, "Failed to get VFS: %v", err)
@@ -362,25 +368,58 @@ func (w *WebDAV) postprocess(r *http.Request, remote string) {
 		}
 
 		// Get the node
+		if r.Method == "COPY" || r.Method == "MOVE" {
+			if destinationRemote, ok := w.destinationRemote(r); ok {
+				remote = destinationRemote
+			}
+		}
 		node, err := VFS.Stat(remote)
 		if err != nil {
 			fs.Errorf(nil, "Failed to stat node: %v", err)
 			return
 		}
 
-		mh := r.Header.Get("X-OC-Mtime")
-		if mh != "" {
-			modtimeUnix, err := strconv.ParseInt(mh, 10, 64)
-			if err == nil {
-				err = node.SetModTime(time.Unix(modtimeUnix, 0))
-				if err != nil {
-					fs.Errorf(nil, "Failed to set modtime: %v", err)
-				}
-			} else {
-				fs.Errorf(nil, "Failed to parse modtime: %v", err)
+		modtimeUnix, err := strconv.ParseInt(mh, 10, 64)
+		if err == nil {
+			err = node.SetModTime(time.Unix(modtimeUnix, 0))
+			if err != nil {
+				fs.Errorf(nil, "Failed to set modtime: %v", err)
 			}
+		} else {
+			fs.Errorf(nil, "Failed to parse modtime: %v", err)
 		}
 	}
+}
+
+func (w *WebDAV) destinationRemote(r *http.Request) (string, bool) {
+	destination := r.Header.Get("Destination")
+	if destination == "" {
+		return "", false
+	}
+	u, err := url.Parse(destination)
+	if err != nil {
+		return "", false
+	}
+	destinationPath, err := url.PathUnescape(u.EscapedPath())
+	if err != nil {
+		destinationPath = u.Path
+	}
+
+	baseURL := w.opt.HTTP.BaseURL
+	if baseURL == "" {
+		baseURL = "/"
+	}
+	if baseURL != "/" {
+		if destinationPath == baseURL {
+			destinationPath = ""
+		} else if strings.HasPrefix(destinationPath, baseURL+"/") {
+			destinationPath = strings.TrimPrefix(destinationPath, baseURL)
+		} else {
+			return "", false
+		}
+	}
+
+	return strings.Trim(destinationPath, "/"), true
 }
 
 func (w *WebDAV) ServeHTTP(rw http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
#### What is the purpose of this change?

`serve webdav` postprocessing applies the `X-OC-Mtime` header after successful WebDAV writes. For `MOVE`, the existing code statted the request path, which is the source path and no longer exists after the move. That made successful `rclone moveto` operations log `Failed to stat node: file does not exist` on the server.

This resolves the WebDAV `Destination` header for `COPY` and `MOVE` before applying `X-OC-Mtime`, and skips the postprocess stat when no `X-OC-Mtime` header was sent.

Fixes #8725

#### Was the change discussed in an issue or in the forum before?

#8725

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

#### Test Plan

- Reproduced #8725 locally before the fix with `rclone serve webdav` and `rclone moveto`: the move succeeded and the server logged `Failed to stat node: file does not exist`.
- Rebuilt and reran the same local `rclone serve webdav` / `rclone moveto` workflow after the fix: the move succeeded, the renamed file was present, and the server no longer logged `Failed to stat node`.
- `go test -run 'TestPostprocess' -v ./cmd/serve/webdav`
- `go test ./cmd/serve/webdav`
- `go build -o /tmp/rclone-prrun/rclone .`
- `go test -run '^$' ./backend/webdav`
