### PR TITLE
fshttp: add opt-in domain fronting for HTTP backends

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1429,6 +1429,34 @@ which does not respect [`--ignore-case`](/filtering/#ignore-case-make-searches-c
 - on remotes that do not support server-side move, `--fix-case` will require
 downloading the file and re-uploading it. To avoid this, do not use `--fix-case`.
 
+### --fronting-domains stringArray
+
+Comma-separated hostname patterns eligible for fronting.
+Supported values are exact hosts (for example `example.com`) and
+wildcard patterns like `*.example.com`.
+Required with `--fronting-enable`.
+
+Unmatched hosts are never fronted.
+
+### --fronting-enable
+
+Enable HTTP domain fronting in shared transport.
+
+When enabled, requests are fronted only if their logical destination
+matches `--fronting-domains`.
+
+### --fronting-sni string
+
+TLS SNI override for fronted requests.
+Defaults to `--fronting-target`.
+
+Use a hostname value.
+
+### --fronting-target string
+
+Fronting target hostname used for network dial.
+Required with `--fronting-enable`.
+
 ### --fs-cache-expire-duration Duration
 
 When using rclone via the API rclone caches created remotes for 5

--- a/fs/config.go
+++ b/fs/config.go
@@ -566,6 +566,26 @@ var ConfigOptionsInfo = Options{{
 	Default: "",
 	Help:    "HTTP proxy URL.",
 	Groups:  "Networking",
+}, {
+	Name:    "fronting_enable",
+	Default: false,
+	Help:    "Enable HTTP domain fronting in shared transport.",
+	Groups:  "Networking",
+}, {
+	Name:    "fronting_target",
+	Default: "",
+	Help:    "Fronting target hostname used for network dial (required with --fronting-enable).",
+	Groups:  "Networking",
+}, {
+	Name:    "fronting_domains",
+	Default: []string{},
+	Help:    "Comma-separated hostname patterns eligible for fronting (exact host or wildcard like *.example.com) (required with --fronting-enable).",
+	Groups:  "Networking",
+}, {
+	Name:    "fronting_sni",
+	Default: "",
+	Help:    "TLS SNI override for fronted requests (defaults to --fronting-target).",
+	Groups:  "Networking",
 }}
 
 // ConfigInfo is filesystem config options
@@ -680,6 +700,10 @@ type ConfigInfo struct {
 	MaxConnections             int               `config:"max_connections"`
 	NameTransform              []string          `config:"name_transform"`
 	HTTPProxy                  string            `config:"http_proxy"`
+	FrontingEnable             bool              `config:"fronting_enable"`
+	FrontingTarget             string            `config:"fronting_target"`
+	FrontingDomains            []string          `config:"fronting_domains"`
+	FrontingSNI                string            `config:"fronting_sni"`
 }
 
 func init() {
@@ -730,6 +754,27 @@ func (ci *ConfigInfo) Reload(ctx context.Context) error {
 		return fmt.Errorf("--partial-suffix: Expecting suffix length not greater than %d but got %d", 16, len(ci.PartialSuffix))
 	}
 
+	// Check domain fronting config
+	if ci.FrontingEnable {
+		if strings.TrimSpace(ci.FrontingTarget) == "" {
+			return fmt.Errorf("--fronting-target is required when --fronting-enable is set")
+		}
+		if len(ci.FrontingDomains) == 0 {
+			return fmt.Errorf("--fronting-domains is required when --fronting-enable is set")
+		}
+		if strings.Contains(strings.TrimSpace(ci.FrontingTarget), ":") {
+			return fmt.Errorf("--fronting-target must be a hostname only (no :port)")
+		}
+		if strings.Contains(strings.TrimSpace(ci.FrontingSNI), ":") {
+			return fmt.Errorf("--fronting-sni must be a hostname only (no :port)")
+		}
+		if err := validateFrontingDomainRules(ci.FrontingDomains); err != nil {
+			return err
+		}
+	} else if strings.TrimSpace(ci.FrontingTarget) != "" || len(ci.FrontingDomains) > 0 || strings.TrimSpace(ci.FrontingSNI) != "" {
+		return fmt.Errorf("--fronting-target/--fronting-domains/--fronting-sni require --fronting-enable")
+	}
+
 	// Make sure some values are > 0
 	nonZero := func(pi *int) {
 		if *pi <= 0 {
@@ -750,6 +795,30 @@ func (ci *ConfigInfo) Reload(ctx context.Context) error {
 	nonZero(&ci.Checkers)
 
 	return LogReload(ci)
+}
+
+func validateFrontingDomainRules(domains []string) error {
+	raw := strings.Join(domains, ",")
+	for _, part := range strings.Split(raw, ",") {
+		rule := strings.ToLower(strings.TrimSpace(part))
+		if rule == "" {
+			continue
+		}
+		if rule == "*" || (strings.Contains(rule, "*") && !strings.HasPrefix(rule, "*.")) {
+			return fmt.Errorf("--fronting-domains has unsupported wildcard rule %q (use exact host or wildcard like *.example.com)", part)
+		}
+		if strings.HasPrefix(rule, "*.") {
+			suffix := rule[1:]
+			if suffix == "." || len(suffix) < 3 {
+				return fmt.Errorf("--fronting-domains has invalid wildcard rule %q", part)
+			}
+			continue
+		}
+		if strings.Contains(rule, "*") {
+			return fmt.Errorf("--fronting-domains has invalid rule %q", part)
+		}
+	}
+	return nil
 }
 
 // InitialLogLevel performs a simple check for debug flags to enable

--- a/fs/fshttp/fronting.go
+++ b/fs/fshttp/fronting.go
@@ -1,0 +1,170 @@
+package fshttp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/rclone/rclone/fs"
+)
+
+type frontingRule struct {
+	raw      string
+	suffix   string
+	isSuffix bool
+}
+
+func (r frontingRule) matches(host string) bool {
+	if r.isSuffix {
+		return len(host) > len(r.suffix) && strings.HasSuffix(host, r.suffix)
+	}
+	return host == r.raw
+}
+
+type frontingConfig struct {
+	targetHost string
+	sniHost    string
+	rules      []frontingRule
+}
+
+type frontingSNIContextKeyType struct{}
+
+var frontingSNIContextKey = frontingSNIContextKeyType{}
+
+func parseFrontingConfig(ci *fs.ConfigInfo) (*frontingConfig, error) {
+	if !ci.FrontingEnable {
+		return nil, nil
+	}
+
+	targetHost, err := parseFrontingTarget(ci.FrontingTarget)
+	if err != nil {
+		return nil, err
+	}
+
+	rules, err := parseFrontingRules(ci.FrontingDomains)
+	if err != nil {
+		return nil, err
+	}
+	if len(rules) == 0 {
+		return nil, fmt.Errorf("fronting: no valid --fronting-domains rules configured")
+	}
+
+	sniHost := normalizeHost(ci.FrontingSNI)
+	if sniHost == "" {
+		sniHost = targetHost
+	} else if strings.Contains(sniHost, ":") {
+		return nil, fmt.Errorf("fronting: --fronting-sni must be a hostname only (no :port), got %q", ci.FrontingSNI)
+	}
+
+	return &frontingConfig{
+		targetHost: targetHost,
+		sniHost:    sniHost,
+		rules:      rules,
+	}, nil
+}
+
+func parseFrontingTarget(input string) (host string, err error) {
+	in := strings.TrimSpace(input)
+	if in == "" {
+		return "", fmt.Errorf("fronting: empty --fronting-target")
+	}
+
+	if strings.Contains(in, ":") {
+		return "", fmt.Errorf("fronting: --fronting-target must be a hostname only (no :port), got %q", input)
+	}
+	host = normalizeHost(in)
+	if host == "" {
+		return "", fmt.Errorf("fronting: invalid --fronting-target %q", input)
+	}
+	return host, nil
+}
+
+func parseFrontingRules(inputs []string) ([]frontingRule, error) {
+	rawSource := strings.Join(inputs, ",")
+	parts := strings.Split(rawSource, ",")
+	rules := make([]frontingRule, 0, len(parts))
+	for _, part := range parts {
+		rule := normalizeHost(part)
+		if rule == "" {
+			continue
+		}
+		if rule == "*" || strings.Contains(rule, "*") && !strings.HasPrefix(rule, "*.") {
+			return nil, fmt.Errorf("fronting: unsupported wildcard rule %q (use exact host or wildcard like *.example.com)", part)
+		}
+		if strings.HasPrefix(rule, "*.") {
+			suffix := rule[1:]
+			if suffix == "." || len(suffix) < 3 {
+				return nil, fmt.Errorf("fronting: invalid wildcard rule %q", part)
+			}
+			rules = append(rules, frontingRule{
+				raw:      rule,
+				suffix:   suffix,
+				isSuffix: true,
+			})
+			continue
+		}
+		if strings.Contains(rule, "*") {
+			return nil, fmt.Errorf("fronting: invalid rule %q", part)
+		}
+		rules = append(rules, frontingRule{raw: rule})
+	}
+	return rules, nil
+}
+
+func normalizeHost(host string) string {
+	h := strings.ToLower(strings.TrimSpace(host))
+	h = strings.TrimSuffix(h, ".")
+	return h
+}
+
+func hostOnlyFromRequest(req *http.Request) string {
+	host := req.URL.Hostname()
+	if req.Host != "" {
+		host = req.Host
+	}
+	if splitHost, _, err := net.SplitHostPort(host); err == nil {
+		host = splitHost
+	}
+	return normalizeHost(host)
+}
+
+func requestPort(req *http.Request) string {
+	if req.URL != nil {
+		if port := req.URL.Port(); port != "" {
+			return port
+		}
+		switch strings.ToLower(req.URL.Scheme) {
+		case "http":
+			return "80"
+		case "https":
+			return "443"
+		}
+	}
+	return "443"
+}
+
+func withFrontingSNI(ctx context.Context, sni string) context.Context {
+	return context.WithValue(ctx, frontingSNIContextKey, sni)
+}
+
+func frontingSNIFromContext(ctx context.Context) (string, bool) {
+	if ctx == nil {
+		return "", false
+	}
+	sni, ok := ctx.Value(frontingSNIContextKey).(string)
+	return sni, ok && sni != ""
+}
+
+func (fc *frontingConfig) matchRule(host string) string {
+	if fc == nil {
+		return ""
+	}
+	for _, rule := range fc.rules {
+		if rule.matches(host) {
+			return rule.raw
+		}
+	}
+	return ""
+}

--- a/fs/fshttp/fronting_test.go
+++ b/fs/fshttp/fronting_test.go
@@ -1,0 +1,214 @@
+package fshttp
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testFrontingConfig(t *testing.T) context.Context {
+	ctx, ci := fs.AddConfig(context.Background())
+	ci.FrontingEnable = true
+	ci.FrontingTarget = "front.example"
+	ci.FrontingDomains = []string{"*.googleapis.com,example.com"}
+	return ctx
+}
+
+func TestParseFrontingRules(t *testing.T) {
+	rules, err := parseFrontingRules([]string{"*.googleapis.com,example.com"})
+	require.NoError(t, err)
+	require.Len(t, rules, 2)
+	assert.Equal(t, "*.googleapis.com", rules[0].raw)
+	assert.Equal(t, "example.com", rules[1].raw)
+
+	fc := &frontingConfig{rules: rules}
+	assert.Equal(t, "*.googleapis.com", fc.matchRule("www.googleapis.com"))
+	assert.Equal(t, "example.com", fc.matchRule("example.com"))
+	assert.Empty(t, fc.matchRule("googleapis.com"))
+	assert.Empty(t, fc.matchRule("not-example.com"))
+}
+
+func TestParseFrontingRulesInvalid(t *testing.T) {
+	_, err := parseFrontingRules([]string{"*foo.example.com"})
+	require.Error(t, err)
+}
+
+func TestFrontingDisabledPassthrough(t *testing.T) {
+	var gotHost string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ctx, ci := fs.AddConfig(context.Background())
+	ci.FrontingEnable = false
+	client := NewClient(ctx)
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/ping", nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, req.URL.Host, gotHost)
+}
+
+func TestFrontingEnabledMatchedHostRewritesDialTarget(t *testing.T) {
+	var gotHost, filterURLHost string
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotHost = r.Host
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer target.Close()
+
+	ctx, ci := fs.AddConfig(context.Background())
+	ci.FrontingEnable = true
+	frontHost, frontPort, err := net.SplitHostPort(target.Listener.Addr().String())
+	require.NoError(t, err)
+	ci.FrontingTarget = frontHost
+	ci.FrontingDomains = []string{"*.googleapis.com"}
+
+	client := NewClient(ctx)
+	client.Transport.(*Transport).SetRequestFilter(func(req *http.Request) {
+		filterURLHost = req.URL.Host
+	})
+	req, err := http.NewRequest(http.MethodGet, "http://storage.googleapis.com:"+frontPort+"/upload", nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, "storage.googleapis.com:"+frontPort, gotHost)
+	assert.Equal(t, "storage.googleapis.com:"+frontPort, filterURLHost)
+}
+
+func TestFrontingEnabledUnmatchedHostNoRewrite(t *testing.T) {
+	var originalHits, frontHits int
+	original := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		originalHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer original.Close()
+	front := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		frontHits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer front.Close()
+
+	ctx, ci := fs.AddConfig(context.Background())
+	ci.FrontingEnable = true
+	frontHost, _, splitErr := net.SplitHostPort(front.Listener.Addr().String())
+	require.NoError(t, splitErr)
+	ci.FrontingTarget = frontHost
+	ci.FrontingDomains = []string{"*.googleapis.com"}
+
+	client := NewClient(ctx)
+	req, err := http.NewRequest(http.MethodGet, original.URL+"/noop", nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.NoError(t, err)
+	assert.Equal(t, 1, originalHits)
+	assert.Equal(t, 0, frontHits)
+}
+
+func TestFrontingSNIOverride(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		gotSNI string
+	)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		GetConfigForClient: func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+			mu.Lock()
+			gotSNI = chi.ServerName
+			mu.Unlock()
+			return &tls.Config{Certificates: srv.TLS.Certificates}, nil
+		},
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	ctx, ci := fs.AddConfig(context.Background())
+	ci.InsecureSkipVerify = true
+	ci.FrontingEnable = true
+	frontHost, _, splitErr := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, splitErr)
+	ci.FrontingTarget = frontHost
+	ci.FrontingDomains = []string{"*.googleapis.com"}
+	ci.FrontingSNI = "allowed-front.example"
+
+	client := NewClient(ctx)
+	_, tlsPort, splitErr := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, splitErr)
+	req, err := http.NewRequest(http.MethodGet, "https://drive.googleapis.com:"+tlsPort+"/v3/files", nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "allowed-front.example", gotSNI)
+}
+
+func TestFrontingSNIOverrideNotAppliedToUnmatchedRequest(t *testing.T) {
+	var (
+		mu     sync.Mutex
+		gotSNI string
+	)
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.TLS = &tls.Config{
+		GetConfigForClient: func(chi *tls.ClientHelloInfo) (*tls.Config, error) {
+			mu.Lock()
+			gotSNI = chi.ServerName
+			mu.Unlock()
+			return &tls.Config{Certificates: srv.TLS.Certificates}, nil
+		},
+	}
+	srv.StartTLS()
+	defer srv.Close()
+
+	ctx, ci := fs.AddConfig(context.Background())
+	ci.InsecureSkipVerify = true
+	ci.FrontingEnable = true
+	ci.FrontingTarget = "localhost"
+	ci.FrontingDomains = []string{"*.googleapis.com"}
+	ci.FrontingSNI = "allowed-front.example"
+
+	client := NewClient(ctx)
+	_, tlsPort, splitErr := net.SplitHostPort(srv.Listener.Addr().String())
+	require.NoError(t, splitErr)
+	req, err := http.NewRequest(http.MethodGet, "https://localhost:"+tlsPort+"/v3/files", nil)
+	require.NoError(t, err)
+	_, err = client.Do(req)
+	require.NoError(t, err)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, "localhost", gotSNI)
+}
+
+func TestParseFrontingConfigValidation(t *testing.T) {
+	ctx := testFrontingConfig(t)
+	ci := fs.GetConfig(ctx)
+	ci.FrontingTarget = ""
+	_, err := parseFrontingConfig(ci)
+	require.Error(t, err)
+
+	ci.FrontingTarget = "front.example:443"
+	_, err = parseFrontingConfig(ci)
+	require.Error(t, err)
+
+	ci.FrontingTarget = "front.example"
+	ci.FrontingSNI = "front.example:443"
+	_, err = parseFrontingConfig(ci)
+	require.Error(t, err)
+}

--- a/fs/fshttp/http.go
+++ b/fs/fshttp/http.go
@@ -274,6 +274,40 @@ func NewTransportCustom(ctx context.Context, customize func(*http.Transport)) *T
 	t.IdleConnTimeout = 60 * time.Second
 	t.ExpectContinueTimeout = time.Duration(ci.ExpectContinueTimeout)
 
+	fronting, err := parseFrontingConfig(ci)
+	if err != nil {
+		fs.Fatalf(nil, "%v", err)
+	}
+
+	if fronting != nil && ci.FrontingSNI != "" {
+		t.DialTLSContext = func(reqCtx context.Context, network, addr string) (net.Conn, error) {
+			dialContext := t.DialContext
+			if dialContext == nil {
+				dialContext = NewDialer(ctx).DialContext
+			}
+			rawConn, err := dialContext(reqCtx, network, addr)
+			if err != nil {
+				return nil, err
+			}
+			host, _, splitErr := net.SplitHostPort(addr)
+			if splitErr != nil {
+				host = addr
+			}
+			serverName := normalizeHost(host)
+			if frontingSNI, ok := frontingSNIFromContext(reqCtx); ok && serverName == fronting.targetHost {
+				serverName = frontingSNI
+			}
+			tlsConfig := t.TLSClientConfig.Clone()
+			tlsConfig.ServerName = serverName
+			tlsConn := tls.Client(rawConn, tlsConfig)
+			if err := tlsConn.HandshakeContext(reqCtx); err != nil {
+				_ = rawConn.Close()
+				return nil, err
+			}
+			return tlsConn, nil
+		}
+	}
+
 	if ci.Dump&(fs.DumpHeaders|fs.DumpBodies|fs.DumpAuth|fs.DumpRequests|fs.DumpResponses) != 0 {
 		fs.Debugf(nil, "You have specified to dump information. Please be noted that the "+
 			"Accept-Encoding as shown may not be correct in the request and the response may not show "+
@@ -291,7 +325,7 @@ func NewTransportCustom(ctx context.Context, customize func(*http.Transport)) *T
 	}
 
 	// Wrap that http.Transport in our own transport
-	return newTransport(ci, t)
+	return newTransport(ci, t, fronting)
 }
 
 // NewTransport returns an http.RoundTripper with the correct timeouts
@@ -343,13 +377,14 @@ type Transport struct {
 	userAgent     string
 	headers       []*fs.HTTPOption
 	metrics       *Metrics
+	fronting      *frontingConfig
 	// Mutex for serializing attempts at reloading the certificates
 	reloadMutex sync.Mutex
 }
 
 // newTransport wraps the http.Transport passed in and logs all
 // roundtrips including the body if logBody is set.
-func newTransport(ci *fs.ConfigInfo, transport *http.Transport) *Transport {
+func newTransport(ci *fs.ConfigInfo, transport *http.Transport, fronting *frontingConfig) *Transport {
 	return &Transport{
 		Transport: transport,
 		ci:        ci,
@@ -357,6 +392,7 @@ func newTransport(ci *fs.ConfigInfo, transport *http.Transport) *Transport {
 		userAgent: ci.UserAgent,
 		headers:   ci.Headers,
 		metrics:   DefaultMetrics,
+		fronting:  fronting,
 	}
 }
 
@@ -494,22 +530,43 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 	if t.filterRequest != nil {
 		t.filterRequest(req)
 	}
+
+	reqToSend := req
+	if t.fronting != nil {
+		originalHost := hostOnlyFromRequest(req)
+		if matchedRule := t.fronting.matchRule(originalHost); matchedRule != "" {
+			clonedCtx := req.Context()
+			if t.ci.FrontingSNI != "" {
+				clonedCtx = withFrontingSNI(clonedCtx, t.fronting.sniHost)
+			}
+			cloned := req.Clone(clonedCtx)
+			urlCopy := *req.URL
+			cloned.URL = &urlCopy
+			targetAddr := net.JoinHostPort(t.fronting.targetHost, requestPort(req))
+			cloned.URL.Host = targetAddr
+			if cloned.Host == "" {
+				cloned.Host = req.URL.Host
+			}
+			reqToSend = cloned
+			fs.Debugf(nil, "Domain fronting applied: originalHost=%q matchedRule=%q dialTarget=%q sniTarget=%q", originalHost, matchedRule, targetAddr, t.fronting.sniHost)
+		}
+	}
 	// Logf request
 	if t.dump&(fs.DumpHeaders|fs.DumpBodies|fs.DumpAuth|fs.DumpRequests|fs.DumpResponses) != 0 {
-		buf, _ := httputil.DumpRequestOut(req, t.dump&(fs.DumpBodies|fs.DumpRequests) != 0)
+		buf, _ := httputil.DumpRequestOut(reqToSend, t.dump&(fs.DumpBodies|fs.DumpRequests) != 0)
 		if t.dump&fs.DumpAuth == 0 {
 			buf = cleanAuths(buf)
 		}
 		logMutex.Lock()
 		fs.Debugf(nil, "%s", separatorReq)
-		fs.Debugf(nil, "%s (req %p)", "HTTP REQUEST", req)
+		fs.Debugf(nil, "%s (req %p)", "HTTP REQUEST", reqToSend)
 		fs.Debugf(nil, "%s", string(buf))
 		fs.Debugf(nil, "%s", separatorReq)
 		logMutex.Unlock()
 	}
 	// Dump curl request
 	if t.dump&(fs.DumpCurl) != 0 {
-		cmd, err := http2curl.GetCurlCommand(req)
+		cmd, err := http2curl.GetCurlCommand(reqToSend)
 		if err != nil {
 			fs.Debugf(nil, "Failed to create curl command: %v", err)
 		} else {
@@ -528,12 +585,12 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		}
 	}
 	// Do round trip
-	resp, err = t.Transport.RoundTrip(req)
+	resp, err = t.Transport.RoundTrip(reqToSend)
 	// Logf response
 	if t.dump&(fs.DumpHeaders|fs.DumpBodies|fs.DumpAuth|fs.DumpRequests|fs.DumpResponses) != 0 {
 		logMutex.Lock()
 		fs.Debugf(nil, "%s", separatorResp)
-		fs.Debugf(nil, "%s (req %p)", "HTTP RESPONSE", req)
+		fs.Debugf(nil, "%s (req %p)", "HTTP RESPONSE", reqToSend)
 		if err != nil {
 			fs.Debugf(nil, "Error: %v", err)
 		} else {
@@ -544,10 +601,10 @@ func (t *Transport) RoundTrip(req *http.Request) (resp *http.Response, err error
 		logMutex.Unlock()
 	}
 	// Update metrics
-	t.metrics.onResponse(req, resp)
+	t.metrics.onResponse(reqToSend, resp)
 
 	if err == nil {
-		checkServerTime(req, resp)
+		checkServerTime(reqToSend, resp)
 	}
 	return resp, err
 }


### PR DESCRIPTION
#### What is the purpose of this change?

This PR adds opt-in HTTP domain fronting support in `fshttp` for HTTP-based backends.

It introduces new global flags to control fronting behavior:

- `--fronting-enable`
- `--fronting-target`
- `--fronting-domains`
- `--fronting-sni`

When enabled, requests are fronted only for configured hostname patterns, while preserving logical host semantics and original request port. Unmatched requests keep existing behavior. SNI override is applied only to fronted requests.

The PR also adds validation for fronting configuration, transport integration in `fshttp`, unit tests covering rule parsing/matching, matched vs unmatched behavior, and SNI behavior, plus documentation updates for the new general flags.

#### Was the change discussed in an issue or in the forum before?

No prior issue/forum discussion yet.  
(If there is one, add links here.)

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)