### PR TITLE
docs: clarify Web GUI repository reference

### DIFF
--- a/docs/content/gui.md
+++ b/docs/content/gui.md
@@ -105,7 +105,7 @@ Or instead of htpasswd if you just want a single user and password:
 
 ## Project
 
-The GUI is being developed in the: [rclone/rclone-webui-react repository](https://github.com/rclone/rclone-webui-react).
+The Web GUI source code and release artifacts are hosted in the [rclone/rclone-webui-react repository](https://github.com/rclone/rclone-webui-react).
 
 Bug reports and contributions are very welcome :-)
 

--- a/docs/content/gui.md
+++ b/docs/content/gui.md
@@ -105,7 +105,8 @@ Or instead of htpasswd if you just want a single user and password:
 
 ## Project
 
-The Web GUI source code and release artifacts are hosted in the [rclone/rclone-webui-react repository](https://github.com/rclone/rclone-webui-react).
+The Web GUI source code and release artifacts are hosted in the
+[rclone/rclone-webui-react repository](https://github.com/rclone/rclone-webui-react).
 
 Bug reports and contributions are very welcome :-)
 


### PR DESCRIPTION
#### What is the purpose of this change?

The GUI documentation said that the Web GUI "is being developed" in the rclone/rclone-webui-react repository.

That wording was misleading. The repository is still the location for the Web GUI source code and release artifacts, but the docs should not claim active ongoing development there.

Before this change, the documentation described that repository as the active development location. After this change, it simply states that the source code and release artifacts are hosted there, which is more accurate and less likely to become outdated again.

Fixes https://github.com/rclone/rclone/issues/9259

#### Was the change discussed in an issue or in the forum before?

Yes, https://github.com/rclone/rclone/issues/9259

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)