### PR TITLE
protondrive: avoid nil deref in Object.Open when originalSize is unset

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -999,7 +999,7 @@ func (o *Object) Storable() bool {
 
 // Open opens the file for read.  Call Close() on the returned io.ReadCloser
 func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
-	fs.FixRangeOption(options, *o.originalSize)
+	fs.FixRangeOption(options, o.Size())
 	var offset, limit int64 = 0, -1
 	for _, option := range options { // if the caller passes in nil for options, it will become array of nil
 		switch x := option.(type) {


### PR DESCRIPTION
Fixes #9377.

`Object.Open` dereferenced `*o.originalSize` directly. When the original size is missing on the object (e.g., file system attrs not yet hydrated), this segfaults. Use `o.Size()`, which already handles the nil pointer.