### PR TITLE
gui: serve static files with gzip/deflate compression

### DIFF
--- a/cmd/gui/gui.go
+++ b/cmd/gui/gui.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/rc"
@@ -191,6 +192,7 @@ For more help see [the GUI docs](/gui/).
 		if err != nil || spaHandler == nil {
 			return fmt.Errorf("failed to start GUI handler: %w", err)
 		}
+		guiServer.Router().Use(middleware.Compress(5))
 		guiServer.Router().Get("/*", spaHandler.ServeHTTP)
 		guiServer.Router().Head("/*", spaHandler.ServeHTTP)
 		guiServer.Serve()

--- a/cmd/gui/gui_test.go
+++ b/cmd/gui/gui_test.go
@@ -2,6 +2,7 @@ package gui
 
 import (
 	"archive/zip"
+	"compress/gzip"
 	"io"
 	iofs "io/fs"
 	"net/http"
@@ -11,6 +12,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/chi/v5/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -301,4 +304,38 @@ func TestHandlerSPAFallbackDeepPath(t *testing.T) {
 
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
 	assert.Contains(t, string(body), "<div id=\"root\"></div>")
+}
+
+func TestHandlerServesGzip(t *testing.T) {
+	dir := writeTestDir(t)
+	srcFS, cleanup, err := guiSourceFS(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanup() })
+
+	h, err := guiHandler(srcFS)
+	require.NoError(t, err)
+
+	// Build a chi router with Compress middleware, mirroring the
+	// production setup in the gui command.
+	r := chi.NewRouter()
+	r.Use(middleware.Compress(5))
+	r.Get("/*", h.ServeHTTP)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("Accept-Encoding", "gzip")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	resp := w.Result()
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "gzip", resp.Header.Get("Content-Encoding"),
+		"response should be gzip-encoded when client accepts it")
+
+	// Decompress and verify the content is correct.
+	gr, err := gzip.NewReader(resp.Body)
+	require.NoError(t, err)
+	body, err := io.ReadAll(gr)
+	require.NoError(t, err)
+	require.NoError(t, gr.Close())
+	assert.Contains(t, string(body), `<div id="root"></div>`)
 }


### PR DESCRIPTION
#### What is the purpose of this change?
Before this change, the GUI server sent all static files uncompressed, meaning the browser had to download the full size of every JS, CSS, and HTML asset.

After this change, the GUI server uses chi's Compress middleware at level 5, which negotiates gzip or deflate encoding based on the client's Accept-Encoding header.

This reduces transfer sizes significantly for the web UI assets, for example assets/index-CvfdU_RR.js is 874 KB uncompressed, and 265 KB compressed.

This is consistent with how rclone serve http, webdav, and restic already compress their responses.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
