### PR TITLE
oauthutil: clarify token replacement prompt wording

### DIFF
--- a/backend/sugarsync/sugarsync.go
+++ b/backend/sugarsync/sugarsync.go
@@ -88,7 +88,7 @@ func init() {
 				if opt.RefreshToken == "" {
 					return fs.ConfigGoto("username")
 				}
-				return fs.ConfigConfirm("refresh", true, "config_refresh", "Already have a token - refresh?")
+				return fs.ConfigConfirm("refresh", true, "config_refresh", "Token already configured - replace it?")
 			case "refresh":
 				if config.Result == "false" {
 					return nil, nil

--- a/docs/content/box.md
+++ b/docs/content/box.md
@@ -183,7 +183,7 @@ y) Yes
 n) No
 y/n> n
 Remote config
-Already have a token - refresh?
+Token already configured - replace it?
 y) Yes
 n) No
 y/n> y

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -2009,7 +2009,7 @@ Scroll down and click "+ Add users". Add yourself as a test user and press save.
 10. Provide the noted client ID and client secret to rclone.
 
 11. Run the web-based authorization flow from within `rclone config`, by answering
-    "Y" when it asks "Already have a token - refresh?".
+    "Y" when it asks "Token already configured - replace it?".
 
 Be aware that, due to the "enhanced security" recently introduced by
 Google, you are theoretically expected to "submit your app for verification"

--- a/docs/content/onedrive.md
+++ b/docs/content/onedrive.md
@@ -1243,7 +1243,7 @@ If you see the error above after enabling multi-factor authentication for your
 account, you can fix it by refreshing your OAuth refresh token. To do that, run
 `rclone config`, and choose to edit your OneDrive backend. Then, you don't need
 to actually make any changes until you reach this question:
-`Already have a token - refresh?`. For this question, answer `y` and go through
+`Token already configured - replace it?`. For this question, answer `y` and go through
 the process to refresh your token, just like the first time the backend is
 configured. After this, rclone should work again for this backend.
 

--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -624,7 +624,7 @@ func ConfigOAuth(ctx context.Context, name string, m configmap.Mapper, ri *fs.Re
 		// See if already have a token
 		tokenString, ok := m.Get("token")
 		if ok && tokenString != "" {
-			return fs.ConfigConfirm(newState("*oauth-confirm"), true, "config_refresh_token", "Already have a token - refresh?")
+			return fs.ConfigConfirm(newState("*oauth-confirm"), true, "config_refresh_token", "Token already configured - replace it?")
 		}
 		return fs.ConfigGoto(newState("*oauth-confirm"))
 	case "*oauth-confirm":


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

<!--
Describe the changes here
-->

The previous wording "Already have a token - refresh?" was misleading because answering yes triggers a full re-authorization flow, not an OAuth2 refresh token grant. It also could be interpreted as "refresh existing token (instead of getting a new one)?" which would have the opposite meaning. Updated to "Token already configured - replace it?" to accurately describe what happens.

Also updated the SugarSync backend which has its own copy of the prompt, and the docs for box, drive, and onedrive that reference it.

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
