### PR TITLE
iclouddrive: add region option for China Mainland iCloud access

### DIFF
--- a/backend/iclouddrive/api/client.go
+++ b/backend/iclouddrive/api/client.go
@@ -19,11 +19,45 @@ import (
 	"github.com/rclone/rclone/lib/rest"
 )
 
-const (
-	baseEndpoint  = "https://www.icloud.com"
-	setupEndpoint = "https://setup.icloud.com/setup/ws/1"
-	authEndpoint  = "https://idmsa.apple.com/appleauth/auth"
+// Endpoints holds the iCloud API endpoints.
+type Endpoints struct {
+	Base  string
+	Setup string
+	Auth  string
+}
+
+var (
+	defaultEndpoints = Endpoints{
+		Base:  "https://www.icloud.com",
+		Setup: "https://setup.icloud.com/setup/ws/1",
+		Auth:  "https://idmsa.apple.com/appleauth/auth",
+	}
+	chinaMainlandEndpoints = Endpoints{
+		Base:  "https://www.icloud.com.cn",
+		Setup: "https://setup.icloud.com.cn/setup/ws/1",
+		Auth:  "https://idmsa.apple.com.cn/appleauth/auth",
+	}
 )
+
+// DefaultEndpoints returns the global iCloud endpoints.
+func DefaultEndpoints() Endpoints {
+	return defaultEndpoints
+}
+
+// ChinaMainlandEndpoints returns the China Mainland iCloud endpoints.
+func ChinaMainlandEndpoints() Endpoints {
+	return chinaMainlandEndpoints
+}
+
+// EndpointsForRegion returns the appropriate API endpoints based on the region option.
+func EndpointsForRegion(region string) Endpoints {
+	switch strings.ToLower(region) {
+	case "chinamainland":
+		return chinaMainlandEndpoints
+	default:
+		return defaultEndpoints
+	}
+}
 
 // Webservice keys in AccountInfo.Webservices map
 const (
@@ -51,14 +85,14 @@ type Client struct {
 // New creates a new iCloud API client and initializes its HTTP session
 // pcsWSKey scopes PCS cookie acquisition to the caller's webservice (WsDrive, WsPhotos);
 // empty string skips PCS entirely
-func New(appleID, password, trustToken string, clientID string, cookies []*http.Cookie, sessionSaveCallback sessionSave, remoteName string, pcsWSKey string) (*Client, error) {
+func New(appleID, password, trustToken string, clientID string, cookies []*http.Cookie, sessionSaveCallback sessionSave, remoteName string, pcsWSKey string, endpoints Endpoints) (*Client, error) {
 	icloud := &Client{
 		appleID:             strings.ToLower(appleID), // Apple SRP requires lowercase in client-side proof
 		password:            password,
 		remoteName:          filepath.Base(remoteName),
 		pcsWSKey:            pcsWSKey,
 		srv:                 rest.NewClient(fshttp.NewClient(context.Background())),
-		Session:             NewSession(),
+		Session:             NewSession(endpoints),
 		sessionSaveCallback: sessionSaveCallback,
 	}
 

--- a/backend/iclouddrive/api/photos_test.go
+++ b/backend/iclouddrive/api/photos_test.go
@@ -36,7 +36,7 @@ func newHTTPTestPhotosService(t *testing.T, remoteName string, handler http.Hand
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
 
-	session := NewSession()
+	session := NewSession(DefaultEndpoints())
 	session.srv = rest.NewClient(server.Client())
 
 	return &PhotosService{

--- a/backend/iclouddrive/api/session.go
+++ b/backend/iclouddrive/api/session.go
@@ -37,9 +37,10 @@ type Session struct {
 	Cookies        []*http.Cookie `json:"cookies"`
 	AccountInfo    AccountInfo    `json:"account_info"`
 
-	mu       sync.Mutex   `json:"-"` // protects session fields during concurrent Request calls
-	srv      *rest.Client `json:"-"`
-	needs2FA bool         `json:"-"` // set when SRP signin returns 409
+	mu        sync.Mutex   `json:"-"` // protects session fields during concurrent Request calls
+	srv       *rest.Client `json:"-"`
+	needs2FA  bool         `json:"-"` // set when SRP signin returns 409
+	endpoints Endpoints    `json:"-"`
 }
 
 // srpInitResponse is the server response from /auth/signin/init
@@ -283,7 +284,7 @@ func (s *Session) authStart(ctx context.Context) error {
 			"Accept":     "*/*",
 			"User-Agent": iCloudUserAgent,
 		},
-		RootURL:    authEndpoint,
+		RootURL:    s.endpoints.Auth,
 		NoResponse: true,
 	}
 
@@ -317,7 +318,7 @@ func (s *Session) authFederate(ctx context.Context, accountName string) error {
 		Path:         "/federate",
 		Parameters:   url.Values{"isRememberMeEnabled": {"true"}},
 		ExtraHeaders: s.getSRPAuthHeaders(),
-		RootURL:      authEndpoint,
+		RootURL:      s.endpoints.Auth,
 		Body:         body,
 		NoResponse:   true,
 	}
@@ -352,7 +353,7 @@ func (s *Session) authSRPInit(ctx context.Context, aBase64, accountName string) 
 		Method:       "POST",
 		Path:         "/signin/init",
 		ExtraHeaders: s.getSRPAuthHeaders(),
-		RootURL:      authEndpoint,
+		RootURL:      s.endpoints.Auth,
 		Body:         body,
 	}
 
@@ -392,7 +393,7 @@ func (s *Session) authSRPComplete(ctx context.Context, accountName, m1Base64, m2
 		Path:         "/signin/complete",
 		Parameters:   url.Values{"isRememberMeEnabled": {"true"}},
 		ExtraHeaders: s.getSRPAuthHeaders(),
-		RootURL:      authEndpoint,
+		RootURL:      s.endpoints.Auth,
 		IgnoreStatus: true,
 		Body:         body,
 	}
@@ -436,7 +437,7 @@ func (s *Session) authRepairComplete(ctx context.Context) error {
 		Method:       "POST",
 		Path:         "/repair/complete",
 		ExtraHeaders: s.getSRPAuthHeaders(),
-		RootURL:      authEndpoint,
+		RootURL:      s.endpoints.Auth,
 		IgnoreStatus: true,
 		NoResponse:   true,
 		Body:         body,
@@ -455,14 +456,14 @@ func (s *Session) authRepairComplete(ctx context.Context) error {
 
 // getAuthOrigin returns the origin URL for auth requests
 // Supports both global (idmsa.apple.com) and China (idmsa.apple.com.cn) endpoints
-func getAuthOrigin() string {
-	return strings.TrimSuffix(authEndpoint, "/appleauth/auth")
+func (s *Session) getAuthOrigin() string {
+	return strings.TrimSuffix(s.endpoints.Auth, "/appleauth/auth")
 }
 
 // getSRPAuthHeaders returns headers needed for SRP auth requests
 func (s *Session) getSRPAuthHeaders() map[string]string {
 	frameTag := "auth-" + s.FrameID
-	authOrigin := getAuthOrigin()
+	authOrigin := s.getAuthOrigin()
 	headers := map[string]string{
 		"Accept":                           "application/json",
 		"Content-Type":                     "application/json",
@@ -510,8 +511,8 @@ func (s *Session) AuthWithToken(ctx context.Context) error {
 	opts := rest.Opts{
 		Method:       "POST",
 		Path:         "/accountLogin",
-		ExtraHeaders: GetCommonHeaders(map[string]string{}),
-		RootURL:      setupEndpoint,
+		ExtraHeaders: s.getCommonHeaders(map[string]string{}),
+		RootURL:      s.endpoints.Setup,
 		Body:         body,
 	}
 
@@ -592,7 +593,7 @@ func (s *Session) acquirePCSCookiesFor(ctx context.Context, appName string, cook
 			Method:       "POST",
 			Path:         "/requestPCS",
 			ExtraHeaders: s.GetHeaders(map[string]string{}),
-			RootURL:      setupEndpoint,
+			RootURL:      s.endpoints.Setup,
 			Body:         body,
 		}
 		var pcsResp struct {
@@ -635,7 +636,7 @@ func (s *Session) RequestPushNotification(ctx context.Context) error {
 		Method:       "PUT",
 		Path:         "/verify/trusteddevice/securitycode",
 		ExtraHeaders: s.GetAuthHeaders(map[string]string{}),
-		RootURL:      authEndpoint,
+		RootURL:      s.endpoints.Auth,
 		NoResponse:   true,
 	}
 
@@ -655,7 +656,7 @@ func (s *Session) Validate2FACode(ctx context.Context, code string) error {
 		Method:       "POST",
 		Path:         "/verify/trusteddevice/securitycode",
 		ExtraHeaders: s.GetAuthHeaders(map[string]string{}),
-		RootURL:      authEndpoint,
+		RootURL:      s.endpoints.Auth,
 		Body:         body,
 		NoResponse:   true,
 	}
@@ -698,7 +699,7 @@ func (s *Session) GetAuthState(ctx context.Context) (*AuthStateResponse, error) 
 		Method:        "GET",
 		Path:          "",
 		ExtraHeaders:  s.GetAuthHeaders(map[string]string{}),
-		RootURL:       authEndpoint,
+		RootURL:       s.endpoints.Auth,
 		ContentLength: int64Ptr(0),
 	}
 	// Use srv.Call directly to capture the raw response body for debugging
@@ -758,7 +759,7 @@ func (s *Session) RequestSMSCode(ctx context.Context, phoneID int, mode string) 
 		Method:       "PUT",
 		Path:         "/verify/phone",
 		ExtraHeaders: s.GetAuthHeaders(map[string]string{}),
-		RootURL:      authEndpoint,
+		RootURL:      s.endpoints.Auth,
 		Body:         body,
 		NoResponse:   true,
 	}
@@ -784,7 +785,7 @@ func (s *Session) ValidateSMSCode(ctx context.Context, code string, phoneID int,
 		Method:       "POST",
 		Path:         "/verify/phone/securitycode",
 		ExtraHeaders: s.GetAuthHeaders(map[string]string{}),
-		RootURL:      authEndpoint,
+		RootURL:      s.endpoints.Auth,
 		Body:         body,
 		NoResponse:   true,
 	}
@@ -804,7 +805,7 @@ func (s *Session) TrustSession(ctx context.Context) error {
 		Method:        "GET",
 		Path:          "/2sv/trust",
 		ExtraHeaders:  s.GetAuthHeaders(map[string]string{}),
-		RootURL:       authEndpoint,
+		RootURL:       s.endpoints.Auth,
 		NoResponse:    true,
 		ContentLength: int64Ptr(0),
 	}
@@ -823,7 +824,7 @@ func (s *Session) ValidateSession(ctx context.Context) error {
 		Method:        "POST",
 		Path:          "/validate",
 		ExtraHeaders:  s.GetHeaders(map[string]string{}),
-		RootURL:       setupEndpoint,
+		RootURL:       s.endpoints.Setup,
 		ContentLength: int64Ptr(0),
 	}
 	_, err := s.Request(ctx, opts, nil, &s.AccountInfo)
@@ -845,7 +846,7 @@ func (s *Session) GetAuthHeaders(overwrite map[string]string) map[string]string 
 
 // GetHeaders returns the authentication headers required for a request
 func (s *Session) GetHeaders(overwrite map[string]string) map[string]string {
-	headers := GetCommonHeaders(map[string]string{})
+	headers := s.getCommonHeaders(nil)
 	headers["Cookie"] = s.GetCookieString()
 	maps.Copy(headers, overwrite)
 	return headers
@@ -870,12 +871,12 @@ func (s *Session) GetCookieString() string {
 	return b.String()
 }
 
-// GetCommonHeaders generates common HTTP headers with optional overwrite
-func GetCommonHeaders(overwrite map[string]string) map[string]string {
+// getCommonHeaders generates common HTTP headers with optional overwrite
+func (s *Session) getCommonHeaders(overwrite map[string]string) map[string]string {
 	headers := map[string]string{
 		"Content-Type": "application/json",
-		"Origin":       baseEndpoint,
-		"Referer":      fmt.Sprintf("%s/", baseEndpoint),
+		"Origin":       s.endpoints.Base,
+		"Referer":      fmt.Sprintf("%s/", s.endpoints.Base),
 		"User-Agent":   iCloudUserAgent,
 	}
 	maps.Copy(headers, overwrite)
@@ -884,10 +885,11 @@ func GetCommonHeaders(overwrite map[string]string) map[string]string {
 
 func int64Ptr(v int64) *int64 { return &v }
 
-// NewSession creates a new Session instance with default values
-func NewSession() *Session {
+// NewSession creates a new Session instance for the given endpoints
+func NewSession(endpoints Endpoints) *Session {
 	session := &Session{
-		FrameID: strings.ToLower(uuid.New().String()),
+		FrameID:   strings.ToLower(uuid.New().String()),
+		endpoints: endpoints,
 	}
 	httpClient := fshttp.NewClient(context.Background())
 	if tr, ok := httpClient.Transport.(*fshttp.Transport); ok {
@@ -895,7 +897,7 @@ func NewSession() *Session {
 			req.Header.Set("User-Agent", iCloudUserAgent)
 		})
 	}
-	session.srv = rest.NewClient(httpClient).SetRoot(baseEndpoint)
+	session.srv = rest.NewClient(httpClient).SetRoot(endpoints.Base)
 	return session
 }
 

--- a/backend/iclouddrive/api/session_test.go
+++ b/backend/iclouddrive/api/session_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestExtractHeadersMergesCookies(t *testing.T) {
-	s := NewSession()
+	s := NewSession(DefaultEndpoints())
 	s.Cookies = []*http.Cookie{{Name: "existing", Value: "old"}}
 
 	resp := &http.Response{Header: make(http.Header)}
@@ -26,7 +26,7 @@ func TestExtractHeadersMergesCookies(t *testing.T) {
 }
 
 func TestExtractHeadersDeletesEmptyCookies(t *testing.T) {
-	s := NewSession()
+	s := NewSession(DefaultEndpoints())
 	s.Cookies = []*http.Cookie{{Name: "X-APPLE-WEBAUTH-HSA-LOGIN", Value: "stale"}, {Name: "keep", Value: "value"}}
 
 	resp := &http.Response{Header: make(http.Header)}

--- a/backend/iclouddrive/icloud.go
+++ b/backend/iclouddrive/icloud.go
@@ -91,12 +91,12 @@ func restoreAuthSession(icloud *api.Client, st *configAuthState) {
 
 // resumeConfigClient recreates an API client and restores session state saved
 // from a previous Config() step. Used across 2FA states to avoid re-authenticating
-func resumeConfigClient(m configmap.Mapper, appleid, password, trustToken, clientID string, cookies []*http.Cookie) (*api.Client, *configAuthState, error) {
+func resumeConfigClient(m configmap.Mapper, appleid, password, trustToken, clientID string, cookies []*http.Cookie, endpoints api.Endpoints) (*api.Client, *configAuthState, error) {
 	st, err := loadAuthSession(m)
 	if err != nil {
 		return nil, nil, err
 	}
-	icloud, err := api.New(appleid, password, trustToken, clientID, cookies, nil, "_config", "")
+	icloud, err := api.New(appleid, password, trustToken, clientID, cookies, nil, "_config", "", endpoints)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -212,6 +212,20 @@ func init() {
 				Help:  "iCloud Photos",
 			}},
 		}, {
+			Name:     configRegion,
+			Help:     "Region for iCloud endpoints.",
+			Required: false,
+			Advanced: false,
+			Default:  "global",
+			Examples: []fs.OptionExample{{
+				Value: "global",
+				Help:  "Global (default)",
+			}, {
+				Value: "chinamainland",
+				Help:  "China Mainland",
+			}},
+			Exclusive: true,
+		}, {
 			Name:      configAppleID,
 			Help:      "Apple ID.",
 			Required:  true,
@@ -273,6 +287,8 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 	trustToken, _ := m.Get(configTrustToken)
 	cookieRaw, _ := m.Get(configCookies)
 	clientID, _ := m.Get(configClientID)
+	region, _ := m.Get(configRegion)
+	endpoints := api.EndpointsForRegion(region)
 	cookies := ReadCookies(cookieRaw)
 
 	switch {
@@ -280,7 +296,7 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 		// Force fresh SRP authentication - ignore stale trust token and cookies
 		// so that reconnect always prompts for 2FA
 		m.Set(configAuthSession, "")
-		icloud, err := api.New(appleid, password, "", clientID, nil, nil, "_config", "")
+		icloud, err := api.New(appleid, password, "", clientID, nil, nil, "_config", "", endpoints)
 		if err != nil {
 			return nil, err
 		}
@@ -321,7 +337,7 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 
 		// Restore session from initial sign-in instead of re-authenticating
 		// This avoids a redundant SRP roundtrip and extra push on pre-26.4
-		icloud, _, err := resumeConfigClient(m, appleid, password, trustToken, clientID, cookies)
+		icloud, _, err := resumeConfigClient(m, appleid, password, trustToken, clientID, cookies, endpoints)
 		if err != nil {
 			return nil, err
 		}
@@ -354,7 +370,7 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 		if mode == "" {
 			mode = "sms"
 		}
-		icloud, smsState, err := resumeConfigClient(m, appleid, password, trustToken, clientID, cookies)
+		icloud, smsState, err := resumeConfigClient(m, appleid, password, trustToken, clientID, cookies, endpoints)
 		if err != nil {
 			return nil, err
 		}
@@ -391,7 +407,7 @@ func Config(ctx context.Context, name string, m configmap.Mapper, config fs.Conf
 			mode = "sms"
 		}
 
-		icloud, _, err := resumeConfigClient(m, appleid, password, trustToken, clientID, cookies)
+		icloud, _, err := resumeConfigClient(m, appleid, password, trustToken, clientID, cookies, endpoints)
 		if err != nil {
 			return nil, err
 		}
@@ -444,6 +460,7 @@ func newICloudClient(ctx context.Context, name string, m configmap.Mapper, pcsWS
 		callback,
 		name,
 		pcsWSKey,
+		api.EndpointsForRegion(opt.Region),
 	)
 	if err != nil {
 		return nil, nil, err

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -36,6 +36,7 @@ import (
 */
 
 const (
+	configRegion     = "region"
 	configAppleID    = "apple_id"
 	configPassword   = "password"
 	configClientID   = "client_id"
@@ -49,6 +50,7 @@ const (
 
 // Options defines the configuration for this backend
 type Options struct {
+	Region     string               `config:"region"`
 	AppleID    string               `config:"apple_id"`
 	Password   string               `config:"password"`
 	TrustToken string               `config:"trust_token"`

--- a/docs/content/iclouddrive.md
+++ b/docs/content/iclouddrive.md
@@ -72,6 +72,15 @@ Press Enter for the default (drive).
  2 / iCloud Photos
    \ (photos)
 service> 2
+Option region.
+Region for iCloud endpoints.
+Choose a number from below, or type in your own value of type string.
+Press Enter for the default (global).
+ 1 / Global (default)
+   \ (global)
+ 2 / China Mainland
+   \ (chinamainland)
+region> 1
 Option apple_id.
 Apple ID.
 Enter a value.
@@ -99,6 +108,7 @@ Remote config
 [icloudphotos]
 - type: iclouddrive
 - service: photos
+- region: global
 - apple_id: APPLEID
 - password: *** ENCRYPTED ***
 - cookies: ****************************


### PR DESCRIPTION
## What is the purpose of this change?

iCloud accounts registered in Mainland China use separate `.com.cn` (GCBD) endpoints for authentication and API access. Currently rclone hardcodes the global endpoints, causing HTTP 302 redirect errors that prevent Chinese users from authenticating at all.

This PR adds a `region` config option to the iclouddrive backend. When set to `chinamainland`, the backend uses the China Mainland endpoints instead of the global ones.

Supersedes #8818

## How does it work?

Two sets of endpoint constants are defined (global and China Mainland). A `region` option (default: `global`) selects which set to use at client creation time. Each remote instance holds its own endpoints, so concurrent remotes with different regions work correctly.

This follows the same per-instance endpoint pattern used by the B2 and S3 backends, avoiding global mutable state.

## Configuration example

```
rclone config
# ...
Storage> iclouddrive
Option region.
Region for iCloud endpoints.
Choose a number from below, or type in your own value of type string.
Press Enter for the default (global).
 1 / Global (default)
   \ (global)
 2 / China Mainland
   \ (chinamainland)
region> 2
```

Or via environment variable: `RCLONE_ICLOUDDRIVE_REGION=chinamainland`

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix)
- [x] I have added tests for all changes in this PR if appropriate
- [x] I have added documentation for the changes if appropriate
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages)
- [x] I'm done, this Pull Request is ready for review :-)

Fixes #8257