### PR TITLE
s3: add new Fastly Object Storage regions

### DIFF
--- a/backend/s3/provider/Fastly.yaml
+++ b/backend/s3/provider/Fastly.yaml
@@ -4,20 +4,26 @@ region:
   au-east-1: AU East 1
   eu-central: EU Central
   eu-south-1: EU South 1
+  eu-west-1: EU West 1
   jp-central-1: JP Central 1
   uk-east-1: UK East 1
   us-central-1: US Central 1
   us-east: US East
+  us-east-1: US East 1
   us-west: US West
+  us-west-1: US West 1
 endpoint:
   au-east-1.object.fastlystorage.app: AU East 1
   eu-central.object.fastlystorage.app: EU Central
   eu-south-1.object.fastlystorage.app: EU South 1
+  eu-west-1.object.fastlystorage.app: EU West 1
   jp-central-1.object.fastlystorage.app: JP Central 1
   uk-east-1.object.fastlystorage.app: UK East 1
   us-central-1.object.fastlystorage.app: US Central 1
   us-east.object.fastlystorage.app: US East
+  us-east-1.object.fastlystorage.app: US East 1
   us-west.object.fastlystorage.app: US West
+  us-west-1.object.fastlystorage.app: US West 1
 quirks:
   force_path_style: true
   use_already_exists: false


### PR DESCRIPTION
#### What is the purpose of this change?

Add three new regions and their endpoints for Fastly Object Storage:

- eu-west-1 (Paris)
- us-east-1 (Virginia)
- us-west-1 (Oregon)

These are distinct from the existing us-east, us-west and eu-central endpoints, which are kept in place.

#### Was the change discussed in an issue or in the forum before?

No.

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
