### PR TITLE
drime: recognize file doesn't exist when trying to delete

### DIFF
--- a/backend/drime/drime.go
+++ b/backend/drime/drime.go
@@ -765,11 +765,18 @@ func (f *Fs) deleteObject(ctx context.Context, id string) error {
 		DeleteForever: f.opt.HardDelete,
 	}
 	var result api.DeleteResponse
+	var resp *http.Response
 	err := f.pacer.Call(func() (bool, error) {
-		resp, err := f.srv.CallJSON(ctx, &opts, &request, &result)
+		var err error
+		resp, err = f.srv.CallJSON(ctx, &opts, &request, &result)
 		return shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
+		// If Drime returns 422 with invalid ID, the object is already gone.
+		// Map this to a standard not-found error.
+		if resp != nil && resp.StatusCode == http.StatusUnprocessableEntity {
+			return fs.ErrorObjectNotFound
+		}
 		return fmt.Errorf("failed to delete item: %w", err)
 	}
 	// Check the individual result codes also
@@ -1598,7 +1605,11 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 			fs.Debugf(o, "Removing old object on successful upload")
 			deleteErr := o.fs.deleteObject(ctx, id)
 			if deleteErr != nil {
-				err = fmt.Errorf("failed to delete existing object: %w", deleteErr)
+				if errors.Is(deleteErr, fs.ErrorObjectNotFound) {
+					fs.Debugf(o, "Old object already deleted, safely ignoring")
+				} else {
+					err = fmt.Errorf("failed to delete existing object: %w", deleteErr)
+				}
 			}
 		}()
 	}

--- a/backend/drime/drime.go
+++ b/backend/drime/drime.go
@@ -765,16 +765,14 @@ func (f *Fs) deleteObject(ctx context.Context, id string) error {
 		DeleteForever: f.opt.HardDelete,
 	}
 	var result api.DeleteResponse
-	var resp *http.Response
 	err := f.pacer.Call(func() (bool, error) {
-		var err error
-		resp, err = f.srv.CallJSON(ctx, &opts, &request, &result)
+		resp, err := f.srv.CallJSON(ctx, &opts, &request, &result)
 		return shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
-		// If Drime returns 422 with invalid ID, the object is already gone.
-		// Map this to a standard not-found error.
-		if resp != nil && resp.StatusCode == http.StatusUnprocessableEntity {
+		// If Drime returns 422 with invalid entry ID, the object is already gone.
+		// Map this to a standard not-found error
+		if strings.Contains(err.Error(), "entry ids is invalid") {
 			return fs.ErrorObjectNotFound
 		}
 		return fmt.Errorf("failed to delete item: %w", err)


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?
When using rcat to upload a new version of a file that already exist, the file upload would succeed. The subsequent deletion of the old file is attempted after the upload. Drime appears to handle the deletion of the old file automatically and returns HTTP status code 422, stating the "The selected entry ids is invalid."

The deletion and the rcat would fail before this change. This is with file history enabled on my Drime account.

Drime's API at the time of writing is also asking for a duplicate check before uploading by calling the '/uploads/validate' endpoint. As long as Drime's API continues to allow overwriting an existing file, the current implementation works.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] I'm done, this Pull Request is ready for review :-)
