### PR TITLE
fs/operations: clarify that DeleteFile/DeleteFiles do not honour --backup-dir

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -577,10 +577,12 @@ func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs
 	return err
 }
 
-// DeleteFile deletes a single file respecting --dry-run and accumulating stats and errors.
+// DeleteFile deletes a single file respecting --dry-run and
+// accumulating stats and errors.
 //
-// If useBackupDir is set and --backup-dir is in effect then it moves
-// the file to there instead of deleting
+// This always deletes - it does not honour --backup-dir. Callers that
+// need --backup-dir to be respected must resolve the backup Fs (see
+// [BackupDir]) and call [DeleteFileWithBackupDir] instead.
 func DeleteFile(ctx context.Context, dst fs.Object) (err error) {
 	return DeleteFileWithBackupDir(ctx, dst, nil)
 }
@@ -627,7 +629,11 @@ func DeleteFilesWithBackupDir(ctx context.Context, toBeDeleted fs.ObjectsChan, b
 	return nil
 }
 
-// DeleteFiles removes all the files passed in the channel
+// DeleteFiles removes all the files passed in the channel.
+//
+// This always deletes - it does not honour --backup-dir. Callers that
+// need --backup-dir to be respected must resolve the backup Fs (see
+// [BackupDir]) and call [DeleteFilesWithBackupDir] instead.
 func DeleteFiles(ctx context.Context, toBeDeleted fs.ObjectsChan) error {
 	return DeleteFilesWithBackupDir(ctx, toBeDeleted, nil)
 }

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -1078,6 +1078,63 @@ func TestMoveFileBackupDir(t *testing.T) {
 	r.CheckRemoteItems(t, file1old, file1)
 }
 
+// TestDeleteFileDoesNotUseBackupDir locks in the documented behaviour
+// that operations.DeleteFile does NOT honour --backup-dir, even when
+// one is configured. Callers that need backup-dir handling must use
+// operations.DeleteFileWithBackupDir instead. See issue #7566.
+func TestDeleteFileDoesNotUseBackupDir(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	r := fstest.NewRun(t)
+	if !operations.CanServerSideMove(r.Fremote) {
+		t.Skip("Skipping test as remote does not support server-side move or copy")
+	}
+
+	ci.BackupDir = r.FremoteName + "/backup"
+
+	file1 := r.WriteObject(ctx, "dst/file1", "file1 contents", t1)
+	r.CheckRemoteItems(t, file1)
+
+	obj, err := r.Fremote.NewObject(ctx, file1.Path)
+	require.NoError(t, err)
+
+	err = operations.DeleteFile(ctx, obj)
+	require.NoError(t, err)
+
+	// File must be gone and nothing must have been written under backup/.
+	r.CheckRemoteItems(t)
+}
+
+// TestDeleteFileWithBackupDir is the contrast to
+// TestDeleteFileDoesNotUseBackupDir: when callers explicitly resolve a
+// backup Fs and pass it to DeleteFileWithBackupDir, the file is moved
+// to backup-dir instead of being deleted.
+func TestDeleteFileWithBackupDir(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	r := fstest.NewRun(t)
+	if !operations.CanServerSideMove(r.Fremote) {
+		t.Skip("Skipping test as remote does not support server-side move or copy")
+	}
+
+	ci.BackupDir = r.FremoteName + "/backup"
+
+	file1 := r.WriteObject(ctx, "dst/file1", "file1 contents", t1)
+	r.CheckRemoteItems(t, file1)
+
+	obj, err := r.Fremote.NewObject(ctx, file1.Path)
+	require.NoError(t, err)
+
+	backupDir, err := operations.BackupDir(ctx, r.Fremote, r.Fremote, file1.Path)
+	require.NoError(t, err)
+
+	err = operations.DeleteFileWithBackupDir(ctx, obj, backupDir)
+	require.NoError(t, err)
+
+	file1.Path = "backup/dst/file1"
+	r.CheckRemoteItems(t, file1)
+}
+
 // testFsInfo is for unit testing fs.Info
 type testFsInfo struct {
 	name      string


### PR DESCRIPTION
## What's the purpose of this pull request?

- [x] Bugfix
- [ ] New feature
- [x] Documentation
- [ ] Other

Fixes #7566.

## What is the issue

The doc comment on `operations.DeleteFile` referenced a `useBackupDir` parameter that does not exist on the function and claimed `--backup-dir` was honoured, but the implementation unconditionally passes `nil` for `backupDir` so the file is always deleted. The misleading comment looks like a leftover from an older signature.

## What this PR does

- Updates the doc comments on `DeleteFile` and `DeleteFiles` to describe what they actually do (always delete, never honour `--backup-dir`) and points callers that need `--backup-dir` handling at `DeleteFileWithBackupDir` / `DeleteFilesWithBackupDir`, which take a pre-resolved backup `fs.Fs` (typically obtained via `BackupDir`).
- No behaviour change.
- Adds two regression tests:
  - `TestDeleteFileDoesNotUseBackupDir` — confirms `DeleteFile` ignores `ci.BackupDir` and removes the file outright.
  - `TestDeleteFileWithBackupDir` — confirms the explicit-backup variant moves the file into the backup hierarchy.

## Notes on caller audit

The original issue suggests some callers of `DeleteFile` may need to be calling `DeleteFileWithBackupDir` instead. I read each callsite and they all line up with the documented `--backup-dir` semantics (sync/copy/move only, destination-side):

- `fs/sync/sync.go` already pre-handles destination backup at the sync layer (see `pair.Dst = nil` after `MoveBackupDir` around line 421-428), so by the time `DeleteFile`/inner `move()` see `dst`, it is already nil when `--backup-dir` applied.
- The `DeleteFile(ctx, src)` calls in `move()` and `moveOrCopyFile` delete the *source* after a move; `--backup-dir` is destination-side so source removal must not be backed up.
- The user-invoked `delete`, `deletefile`, `dedupe`, `ncdu`, and `purge` commands are out of scope per the documented `--backup-dir` semantics ("When using sync, copy or move...").

So no behaviour change is needed to fix the bug — just the misleading comment. Happy to follow up with a separate PR if maintainers want to extend `--backup-dir` semantics to the user-invoked delete commands.