### PR TITLE
huaweidrive: replace fullwidth encoding with percent-encoding (%XX) to fix NFKC normalization failures

### DIFF
--- a/backend/huaweidrive/huaweidrive.go
+++ b/backend/huaweidrive/huaweidrive.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"sync"
 	"time"
+	"unicode/utf8"
 
 	"github.com/rclone/rclone/backend/huaweidrive/api"
 	"github.com/rclone/rclone/fs"
@@ -158,41 +159,16 @@ Custom metadata keys can be any string and will be stored in the file's properti
 			Help:     "Cutoff for switching to resumable upload.\n\nAny files larger than this will be uploaded using resumable upload.\nThe minimum is 0 and the maximum is 20 MiB (Huawei Drive API limit for single request uploads).",
 			Default:  20 * fs.Mebi,
 			Advanced: true,
-		}, {
-			Name:     config.ConfigEncoding,
-			Help:     config.ConfigEncodingHelp,
-			Advanced: true,
-			// Huawei Drive has strict filename restrictions
-			// API error: "The fileName can not be blank and can not contain '<>|:\"*?/\\', cannot equal .. or . and not exceed max limit."
-			// Additionally encode slash and some Unicode characters that might cause issues
-			Default: (encoder.Display |
-				encoder.EncodeBackSlash |
-				encoder.EncodeSlash |
-				encoder.EncodeInvalidUtf8 |
-				encoder.EncodeRightSpace |
-				encoder.EncodeLeftSpace |
-				encoder.EncodeLeftTilde |
-				encoder.EncodeRightPeriod |
-				encoder.EncodeLeftPeriod |
-				encoder.EncodeColon |
-				encoder.EncodePipe |
-				encoder.EncodeDoubleQuote |
-				encoder.EncodeLtGt |
-				encoder.EncodeQuestion |
-				encoder.EncodeAsterisk |
-				encoder.EncodeCtl |
-				encoder.EncodeDot),
 		}}...),
 	})
 }
 
 // Options defines the configuration for this backend
 type Options struct {
-	RootFolderID string               `config:"root_folder_id"`
-	ChunkSize    fs.SizeSuffix        `config:"chunk_size"`
-	ListChunk    int                  `config:"list_chunk"`
-	UploadCutoff fs.SizeSuffix        `config:"upload_cutoff"`
-	Enc          encoder.MultiEncoder `config:"encoding"`
+	RootFolderID string        `config:"root_folder_id"`
+	ChunkSize    fs.SizeSuffix `config:"chunk_size"`
+	ListChunk    int           `config:"list_chunk"`
+	UploadCutoff fs.SizeSuffix `config:"upload_cutoff"`
 }
 
 // itemMeta stores cached metadata for an item, used to resolve old paths
@@ -203,9 +179,149 @@ type itemMeta struct {
 	isDir    bool   // whether this is a directory
 }
 
+// hwEncodeFilename encodes a Standard-encoded rclone filename into a safe form
+// for the Huawei Drive API.
+//
+// The Huawei Drive API rejects filenames containing '<', '>', '|', ':', '"',
+// '*', '?', '/', '\', as well as the whole-name values "." and "..". Some API
+// deployments also apply NFKC normalization before validation, which converts
+// fullwidth Unicode substitutes (e.g., ．→ .) back to their ASCII originals,
+// defeating any fullwidth-character encoding scheme.
+//
+// To remain stable under NFKC normalization, we use percent-encoding (%XX).
+// The '%' character is not on the API blacklist and is plain ASCII, so %XX
+// sequences are preserved verbatim by NFKC.
+func hwEncodeFilename(stdName string) string {
+	// Decode Standard encoding (e.g., ／→/, ．→ .) to get the raw filename.
+	raw := encoder.Standard.Decode(stdName)
+	return hwEncodeRaw(raw)
+}
+
+// hwEncodeRaw applies Huawei-safe percent-encoding to a raw (unencoded) filename.
+func hwEncodeRaw(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	// Whole-name dot forms that the API rejects outright.
+	if raw == "." {
+		return "%2E"
+	}
+	if raw == ".." {
+		return "%2E%2E"
+	}
+
+	var out strings.Builder
+	out.Grow(len(raw))
+	input := raw
+	first := true
+	for len(input) > 0 {
+		r, size := utf8.DecodeRuneInString(input)
+		isLast := len(input) == size
+
+		if r == utf8.RuneError && size == 1 {
+			// Invalid UTF-8 byte: percent-encode it.
+			fmt.Fprintf(&out, "%%%02X", input[0])
+			input = input[1:]
+			first = false
+			continue
+		}
+
+		// Characters always rejected by the Huawei Drive API.
+		switch r {
+		case '<', '>', '|', ':', '"', '*', '?', '/', '\\':
+			fmt.Fprintf(&out, "%%%02X", r)
+			input = input[size:]
+			first = false
+			continue
+		case '%':
+			// Escape our own escape character to keep encoding invertible.
+			out.WriteString("%25")
+			input = input[size:]
+			first = false
+			continue
+		}
+
+		// Control characters (U+0000–U+001F) and DEL (U+007F).
+		if r <= 0x1F || r == 0x7F {
+			fmt.Fprintf(&out, "%%%02X", r)
+			input = input[size:]
+			first = false
+			continue
+		}
+
+		// Leading characters that the API rejects.
+		if first {
+			switch r {
+			case ' ':
+				out.WriteString("%20")
+				input = input[size:]
+				first = false
+				continue
+			case '.':
+				out.WriteString("%2E")
+				input = input[size:]
+				first = false
+				continue
+			case '~':
+				out.WriteString("%7E")
+				input = input[size:]
+				first = false
+				continue
+			}
+		}
+
+		// Trailing characters that the API rejects.
+		if isLast {
+			switch r {
+			case ' ':
+				out.WriteString("%20")
+				input = input[size:]
+				continue
+			case '.':
+				out.WriteString("%2E")
+				input = input[size:]
+				continue
+			}
+		}
+
+		// All other characters (including non-ASCII Unicode) pass through.
+		out.WriteString(input[:size])
+		input = input[size:]
+		first = false
+	}
+	return out.String()
+}
+
+// hwDecodeFilename converts a Huawei Drive API filename back to Standard
+// rclone encoding.
+func hwDecodeFilename(apiName string) string {
+	raw := hwDecodeRaw(apiName)
+	return encoder.Standard.Encode(raw)
+}
+
+// hwDecodeRaw undoes percent-encoding applied by hwEncodeRaw.
+func hwDecodeRaw(s string) string {
+	if !strings.Contains(s, "%") {
+		return s
+	}
+	var out strings.Builder
+	out.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] == '%' && i+2 < len(s) {
+			if b, err := strconv.ParseUint(s[i+1:i+3], 16, 8); err == nil {
+				out.WriteByte(byte(b))
+				i += 3
+				continue
+			}
+		}
+		out.WriteByte(s[i])
+		i++
+	}
+	return out.String()
+}
+
 // Fs represents a remote Huawei Drive
-type Fs struct {
-	name string // name of this remote
+type Fs struct {	name string // name of this remote
 	root string // root path in the remote
 
 	opt      Options            // parsed options
@@ -506,7 +622,7 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 // FindLeaf finds a directory of name leaf in the folder with ID pathID
 func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (pathIDOut string, found bool, err error) {
 	// Encode the leaf name to match the stored (encoded) name in the API
-	encodedLeaf := f.opt.Enc.FromStandardName(leaf)
+	encodedLeaf := hwEncodeFilename(leaf)
 	// Find the leaf in pathID
 	found, err = f.listAll(ctx, pathID, func(item *api.File) bool {
 		if item.FileName == encodedLeaf && item.IsDir() {
@@ -521,7 +637,7 @@ func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (pathIDOut strin
 // CreateDir makes a directory with pathID as parent and name leaf
 func (f *Fs) CreateDir(ctx context.Context, pathID, leaf string) (newID string, err error) {
 	// Encode the directory name
-	encodedLeaf := f.opt.Enc.FromStandardName(leaf)
+	encodedLeaf := hwEncodeFilename(leaf)
 	if encodedLeaf == "" {
 		return "", fmt.Errorf("invalid directory name: cannot be empty")
 	}
@@ -754,7 +870,7 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 	}
 	var iErr error
 	_, err = f.listAll(ctx, directoryID, func(info *api.File) bool {
-		remote := path.Join(dir, f.opt.Enc.ToStandardName(info.FileName))
+		remote := path.Join(dir, hwDecodeFilename(info.FileName))
 		if info.IsDir() {
 			// cache the directory ID for later lookups
 			f.dirCache.Put(remote, info.ID)
@@ -1015,7 +1131,7 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 	}
 
 	copyReq := api.CopyFileRequest{
-		FileName: f.opt.Enc.FromStandardName(leaf),
+		FileName: hwEncodeFilename(leaf),
 	}
 
 	// Set parent folder for the copy destination
@@ -1141,7 +1257,7 @@ func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object,
 
 	// Set filename if we need to rename
 	if needsRename {
-		moveReq.FileName = f.opt.Enc.FromStandardName(dstLeaf)
+		moveReq.FileName = hwEncodeFilename(dstLeaf)
 	}
 
 	var info *api.File
@@ -1238,7 +1354,7 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 	fs.Debugf(f, "DirMove: srcID=%q srcDirectoryID=%q srcLeaf=%q dstDirectoryID=%q dstLeaf=%q", srcID, srcDirectoryID, srcLeaf, dstDirectoryID, dstLeaf)
 
 	moveReq := api.UpdateFileRequest{
-		FileName: f.opt.Enc.FromStandardName(dstLeaf),
+		FileName: hwEncodeFilename(dstLeaf),
 	}
 
 	var info *api.File
@@ -1330,7 +1446,7 @@ func (f *Fs) listRRecursive(ctx context.Context, dir string, directoryID string,
 
 	// List current directory
 	_, err := f.listAll(ctx, directoryID, func(info *api.File) bool {
-		remote := path.Join(dir, f.opt.Enc.ToStandardName(info.FileName))
+		remote := path.Join(dir, hwDecodeFilename(info.FileName))
 
 		if info.IsDir() {
 			// It's a directory
@@ -1491,7 +1607,7 @@ func (f *Fs) readMetaDataForPath(ctx context.Context, path string) (info *api.Fi
 
 	found, err := f.listAll(ctx, directoryID, func(item *api.File) bool {
 		// Convert the API filename to standard name for comparison
-		standardName := f.opt.Enc.ToStandardName(item.FileName)
+		standardName := hwDecodeFilename(item.FileName)
 		if standardName == leaf && !item.IsDir() {
 			info = item
 			return true
@@ -1577,7 +1693,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		return err
 	}
 
-	leaf = o.fs.opt.Enc.FromStandardName(leaf)
+	leaf = hwEncodeFilename(leaf)
 
 	// Handle unknown size by spooling to a temp file to determine size
 	if size < 0 {
@@ -2316,7 +2432,7 @@ func (f *Fs) changeNotifyRunner(ctx context.Context, notifyFunc func(string, fs.
 					entryType = fs.EntryDirectory
 				}
 				if parentPath, ok := f.dirCache.GetInv(cached.parentID); ok {
-					oldPath := path.Join(parentPath, f.opt.Enc.ToStandardName(cached.name))
+					oldPath := path.Join(parentPath, hwDecodeFilename(cached.name))
 					pathsToClear = append(pathsToClear, entryInfo{path: oldPath, entryType: entryType})
 				}
 				// Remove stale entry; future List calls will repopulate
@@ -2330,7 +2446,7 @@ func (f *Fs) changeNotifyRunner(ctx context.Context, notifyFunc func(string, fs.
 				if change.File.IsDir() {
 					entryType = fs.EntryDirectory
 				}
-				fileName := f.opt.Enc.ToStandardName(change.File.FileName)
+				fileName := hwDecodeFilename(change.File.FileName)
 				if len(change.File.ParentFolder) > 0 {
 					for _, parent := range change.File.ParentFolder {
 						if parentPath, ok := f.dirCache.GetInv(parent); ok {

--- a/backend/huaweidrive/huaweidrive.go
+++ b/backend/huaweidrive/huaweidrive.go
@@ -321,7 +321,8 @@ func hwDecodeRaw(s string) string {
 }
 
 // Fs represents a remote Huawei Drive
-type Fs struct {	name string // name of this remote
+type Fs struct {
+	name string // name of this remote
 	root string // root path in the remote
 
 	opt      Options            // parsed options

--- a/backend/huaweidrive/huaweidrive_test.go
+++ b/backend/huaweidrive/huaweidrive_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fstest/fstests"
-	"github.com/rclone/rclone/lib/encoder"
 )
 
 // TestIntegration runs integration tests against the remote
@@ -119,93 +118,50 @@ func TestTimeFormats(t *testing.T) {
 
 // TestEncoding tests filename encoding for Huawei Drive restrictions
 func TestEncoding(t *testing.T) {
-	// Create encoder with Huawei Drive restrictions
-	enc := encoder.MultiEncoder( //nolint:unconvert
-		encoder.Display |
-			encoder.EncodeBackSlash |
-			encoder.EncodeSlash |
-			encoder.EncodeInvalidUtf8 |
-			encoder.EncodeRightSpace |
-			encoder.EncodeLeftSpace |
-			encoder.EncodeLeftTilde |
-			encoder.EncodeRightPeriod |
-			encoder.EncodeLeftPeriod |
-			encoder.EncodeColon |
-			encoder.EncodePipe |
-			encoder.EncodeDoubleQuote |
-			encoder.EncodeLtGt |
-			encoder.EncodeQuestion |
-			encoder.EncodeAsterisk |
-			encoder.EncodeCtl |
-			encoder.EncodeDot)
-
-	// Test cases for problematic characters that should be encoded
+	// Test cases: raw filename → expected percent-encoded API filename
 	testCases := []struct {
 		name     string
 		input    string
 		expected string
 	}{
-		{"angle_brackets", "file<>name", "file＜＞name"},
-		{"quotes", "file\"name", "file＂name"},
-		{"pipe", "file|name", "file｜name"},
-		{"colon", "file:name", "file：name"},
-		{"asterisk", "file*name", "file＊name"},
-		{"question", "file?name", "file？name"},
-		{"backslash", "file\\name", "file＼name"},
-		{"forward_slash", "file/name", "file／name"},
-		{"leading_space", " filename", "␠filename"},
-		{"trailing_space", "filename ", "filename␠"},
-		{"leading_dot", ".filename", "．filename"},
-		{"control_chars", "file\tname\ntest", "file␉name␊test"},
+		{"angle_brackets", "file<>name", "file%3C%3Ename"},
+		{"quotes", "file\"name", "file%22name"},
+		{"pipe", "file|name", "file%7Cname"},
+		{"colon", "file:name", "file%3Aname"},
+		{"asterisk", "file*name", "file%2Aname"},
+		{"question", "file?name", "file%3Fname"},
+		{"backslash", "file\\name", "file%5Cname"},
+		{"forward_slash", "file/name", "file%2Fname"},
+		{"leading_space", " filename", "%20filename"},
+		{"trailing_space", "filename ", "filename%20"},
+		{"leading_dot", ".filename", "%2Efilename"},
+		{"control_chars", "file\tname\ntest", "file%09name%0Atest"},
+		{"percent_escape", "file%2Fname", "file%252Fname"},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			encoded := enc.FromStandardName(tc.input)
+			encoded := hwEncodeRaw(tc.input)
 			if encoded != tc.expected {
 				t.Errorf("encoding %q: expected %q, got %q", tc.input, tc.expected, encoded)
 			}
 
-			// Test decoding back - only for reversible encodings
-			// Some characters like forward slash and control chars are one-way encoded
-			decoded := enc.ToStandardName(encoded)
-			if tc.name != "forward_slash" && tc.name != "control_chars" {
-				if decoded != tc.input {
-					t.Errorf("decoding %q: expected %q, got %q", encoded, tc.input, decoded)
-				}
+			// Every encoding must round-trip correctly
+			decoded := hwDecodeRaw(encoded)
+			if decoded != tc.input {
+				t.Errorf("decoding %q: expected %q, got %q", encoded, tc.input, decoded)
 			}
 		})
 	}
 }
 
-// TestFileNameEncoding tests that problematic characters are properly encoded
+// TestFileNameEncoding tests that the hwEncodeFilename/hwDecodeFilename functions
+// correctly handle Huawei Drive API filename restrictions.
 func TestFileNameEncoding(t *testing.T) {
-	// Create a mock Fs with default encoding options
-	opts := Options{}
-	// Set the default encoding from our config
-	opts.Enc = (encoder.Display |
-		encoder.EncodeBackSlash |
-		encoder.EncodeInvalidUtf8 |
-		encoder.EncodeRightSpace |
-		encoder.EncodeLeftSpace |
-		encoder.EncodeLeftTilde |
-		encoder.EncodeRightPeriod |
-		encoder.EncodeLeftPeriod |
-		encoder.EncodeColon |
-		encoder.EncodePipe |
-		encoder.EncodeDoubleQuote |
-		encoder.EncodeLtGt |
-		encoder.EncodeQuestion |
-		encoder.EncodeAsterisk |
-		encoder.EncodeCtl |
-		encoder.EncodeDot)
-
-	f := &Fs{opt: opts}
-
-	// Test problematic characters that Huawei Drive rejects
+	// Test cases: raw filename → expected encoded API filename → decoded back to raw
 	testCases := []struct {
-		input string
-		desc  string
+		rawInput string
+		desc     string
 	}{
 		{`file<name>.txt`, "angle brackets"},
 		{`file|name.txt`, "pipe character"},
@@ -214,28 +170,41 @@ func TestFileNameEncoding(t *testing.T) {
 		{`file*name.txt`, "asterisk"},
 		{`file?name.txt`, "question mark"},
 		{`file\name.txt`, "backslash"},
-		{` leading_space.txt`, "leading space"},
-		{`trailing_space.txt `, "trailing space"},
-		{`.leading_dot.txt`, "leading dot"},
-		{`trailing_dot.txt.`, "trailing dot"},
-		{`~leading_tilde.txt`, "leading tilde"},
-		{"file\x00name.txt", "control character"},
+		{` leading space.txt`, "leading space"},
+		{`trailing space.txt `, "trailing space"},
+		{`.leading dot.txt`, "leading dot"},
+		{`trailing dot.txt.`, "trailing dot"},
+		{`~leading tilde.txt`, "leading tilde"},
+		{"file\x00name.txt", "NUL control character"},
+		{"file\x1fname.txt", "US control character"},
+		{`file%2Fname.txt`, "literal percent-encoded sequence"},
 	}
 
 	for _, tc := range testCases {
-		encoded := f.opt.Enc.FromStandardName(tc.input)
-		// The encoded name should be different from input (meaning it was encoded)
-		if encoded == tc.input {
-			t.Errorf("Expected %s (%q) to be encoded, but got same string", tc.desc, tc.input)
+		// hwEncodeRaw takes a raw filename (not Standard-encoded)
+		encoded := hwEncodeRaw(tc.rawInput)
+		// The encoded name must differ from the raw input for restricted inputs
+		if encoded == tc.rawInput {
+			t.Errorf("%s (%q): expected encoding to change the name, got same string", tc.desc, tc.rawInput)
 		}
 
-		// Test that we can decode it back (skip control characters as they are not reversible)
-		decoded := f.opt.Enc.ToStandardName(encoded)
-		if tc.desc != "control character" && decoded != tc.input {
-			t.Errorf("Round-trip failed for %s: input=%q, encoded=%q, decoded=%q", tc.desc, tc.input, encoded, decoded)
+		// Round-trip: decode must restore the original raw name
+		decoded := hwDecodeRaw(encoded)
+		if decoded != tc.rawInput {
+			t.Errorf("%s: round-trip failed: raw=%q encoded=%q decoded=%q", tc.desc, tc.rawInput, encoded, decoded)
 		}
 
-		t.Logf("✓ %s: %q → %q → %q", tc.desc, tc.input, encoded, decoded)
+		t.Logf("✓ %s: %q → %q → %q", tc.desc, tc.rawInput, encoded, decoded)
+	}
+
+	// Test whole-name special cases
+	for _, whole := range []string{".", ".."} {
+		encoded := hwEncodeRaw(whole)
+		decoded := hwDecodeRaw(encoded)
+		if decoded != whole {
+			t.Errorf("whole-name %q round-trip failed: encoded=%q decoded=%q", whole, encoded, decoded)
+		}
+		t.Logf("✓ whole-name %q: → %q → %q", whole, encoded, decoded)
 	}
 }
 
@@ -788,48 +757,10 @@ func TestRetryErrorCodes(t *testing.T) {
 	}
 }
 
-// TestEncodingConfiguration tests the encoding configuration matches requirements
+// TestEncodingConfiguration tests that hwEncodeRaw handles all Huawei Drive
+// restricted characters with percent-encoding, which is stable under NFKC
+// normalization unlike the previous fullwidth-character scheme.
 func TestEncodingConfiguration(t *testing.T) {
-	// This should match the default encoding set in the config
-	expectedEncoding := (encoder.Display |
-		encoder.EncodeBackSlash |
-		encoder.EncodeSlash |
-		encoder.EncodeInvalidUtf8 |
-		encoder.EncodeRightSpace |
-		encoder.EncodeLeftSpace |
-		encoder.EncodeLeftTilde |
-		encoder.EncodeRightPeriod |
-		encoder.EncodeLeftPeriod |
-		encoder.EncodeColon |
-		encoder.EncodePipe |
-		encoder.EncodeDoubleQuote |
-		encoder.EncodeLtGt |
-		encoder.EncodeQuestion |
-		encoder.EncodeAsterisk |
-		encoder.EncodeCtl |
-		encoder.EncodeDot)
-
-	// Test that all required encodings are present
-	requiredEncodings := []encoder.MultiEncoder{
-		encoder.EncodeBackSlash,   // \
-		encoder.EncodeSlash,       // /
-		encoder.EncodeColon,       // :
-		encoder.EncodePipe,        // |
-		encoder.EncodeDoubleQuote, // "
-		encoder.EncodeLtGt,        // < >
-		encoder.EncodeQuestion,    // ?
-		encoder.EncodeAsterisk,    // *
-		encoder.EncodeCtl,         // Control characters
-	}
-
-	for _, required := range requiredEncodings {
-		if (expectedEncoding & required) == 0 {
-			t.Errorf("encoding configuration missing required encoding: %v", required)
-		}
-	}
-
-	// Test that the encoding handles Huawei Drive restricted characters
-	enc := expectedEncoding
 	restrictedChars := []struct {
 		char string
 		desc string
@@ -847,9 +778,14 @@ func TestEncodingConfiguration(t *testing.T) {
 
 	for _, rc := range restrictedChars {
 		testName := "test" + rc.char + "file.txt"
-		encoded := enc.FromStandardName(testName)
+		encoded := hwEncodeRaw(testName)
 		if encoded == testName {
 			t.Errorf("character %s (%s) was not encoded", rc.char, rc.desc)
+		}
+		// Must round-trip correctly
+		decoded := hwDecodeRaw(encoded)
+		if decoded != testName {
+			t.Errorf("character %s (%s): round-trip failed: got %q", rc.char, rc.desc, decoded)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

Fixes #9410 — follow-up to #8886

Since the Huawei Drive backend was merged (#8886, 2026-05-01), the CI runner at integration.rclone.org shows **19 fixed failures** every day (18 FsEncoding subtests + FsPutFiles), all returning HTTP 400 errorCode 21004002:

```
fileName can not be blank and can not contain '<>|:"*?/\'
```

### Root Cause

The previous scheme substituted restricted characters with their Unicode **fullwidth equivalents** (e.g. `?` → `？` U+FF1F). This works on most Huawei Drive deployments, but the CI account's API applies **NFKC normalization** before filename validation, which converts fullwidth ASCII variants straight back to their ASCII originals:

| Stored | After NFKC → | Hits blacklist |
|--------|--------------|----------------|
| `？` U+FF1F | `?` | ✓ |
| `．` U+FF0E | `.` | ✓ (whole-name) |
| `＜` U+FF1C | `<` | ✓ |
| `｜` U+FF5C | `|` | ✓ |

### Fix

Replace the `opt.Enc`-based fullwidth scheme with a custom **percent-encoding** scheme (`hwEncodeFilename` / `hwDecodeFilename`):

- Blacklist chars (`<>|:"*?\/`) → `%XX`
- `%` itself → `%25` (keeps encoding invertible)
- Leading space/dot/tilde, trailing space/dot → `%XX`
- Control chars (U+0000–U+001F, U+007F) → `%XX`
- Invalid UTF-8 bytes → byte-by-byte `%XX`
- `..` → `%2E%2E`, `.` → `%2E`
- All other Unicode passes through unchanged

`%` is not on the Huawei blacklist, and pure ASCII `%XX` sequences are completely stable under NFKC normalization.

The `encoding` config option has been removed — the backend now manages filename encoding internally via the new functions.

### Verification

Full local integration test run (all 79 s, 0 FAIL):

```
--- PASS: TestIntegration/FsMkdir/FsEncoding/control_chars
--- PASS: TestIntegration/FsMkdir/FsEncoding/dot
--- PASS: TestIntegration/FsMkdir/FsEncoding/dot_dot
--- PASS: TestIntegration/FsMkdir/FsEncoding/punctuation
--- PASS: TestIntegration/FsMkdir/FsEncoding/leading_space
--- PASS: TestIntegration/FsMkdir/FsEncoding/leading_tilde
--- PASS: TestIntegration/FsMkdir/FsEncoding/leading_CR/LF/HT/VT
--- PASS: TestIntegration/FsMkdir/FsEncoding/leading_dot
--- PASS: TestIntegration/FsMkdir/FsEncoding/trailing_space/CR/LF/HT/VT/dot
--- PASS: TestIntegration/FsMkdir/FsEncoding/invalid_UTF-8
--- PASS: TestIntegration/FsMkdir/FsEncoding/URL_encoding
--- PASS: TestIntegration/FsMkdir/FsPutFiles  (including "hello? sausage" path)
PASS
ok      github.com/rclone/rclone/backend/huaweidrive  79.597s
```

Unit tests: TestEncoding (13 cases), TestFileNameEncoding (17 cases), TestEncodingConfiguration (9 cases) — all PASS.