### PR TITLE
rc: new config/reconnect route

### DIFF
--- a/docs/content/rc.md
+++ b/docs/content/rc.md
@@ -780,6 +780,19 @@ Note that the Options blocks are in the same format as returned by
 "options/info". They are described in the
 [option blocks](#option-blocks) section.
 
+### config/reconnect: Reconnect (re-authenticate) a remote. {#config-reconnect}
+
+This takes the following parameters:
+
+- name - name of remote
+- opt - a dictionary of options to control the configuration
+    - nonInteractive - don't interact with a user, return questions
+    - continue - continue the config process with an answer
+    - state - state to restart with - used with continue
+    - result - result to restart with - used with continue
+
+See the [config reconnect](/commands/rclone_config_reconnect/) command for more information on the above.
+
 ### config/setpath: Set the path of the config file {#config-setpath}
 
 Parameters:

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -644,6 +644,62 @@ func CreateRemote(ctx context.Context, name string, Type string, keyValues rc.Pa
 	return UpdateRemote(ctx, name, keyValues, opts)
 }
 
+// ReconnectRemoteOpt configures the remote reconnect
+type ReconnectRemoteOpt struct {
+	// Don't interact with the user - return questions
+	NonInteractive bool `json:"nonInteractive"`
+	// If set then supply state and result parameters to continue the process
+	Continue bool `json:"continue"`
+	// State to restart with - used with Continue
+	State string `json:"state"`
+	// Result to return - used with Continue
+	Result string `json:"result"`
+}
+
+// ReconnectRemote re-authenticates the remote by re-running the
+// backend's Config state machine from scratch.
+func ReconnectRemote(ctx context.Context, name string, opt ReconnectRemoteOpt) (*fs.ConfigOut, error) {
+	err := fspath.CheckConfigName(name)
+	if err != nil {
+		return nil, err
+	}
+
+	fsType := GetValue(name, "type")
+	if fsType == "" {
+		return nil, errors.New("couldn't find type field in config")
+	}
+
+	ri, err := fs.Find(fsType)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't find backend for type %q", fsType)
+	}
+
+	if ri.Config == nil {
+		return nil, errors.New("backend doesn't support reconnect or authorize")
+	}
+
+	m := fs.ConfigMap(ri.Prefix, ri.Options, name, nil)
+
+	interactive := !(opt.NonInteractive || opt.Continue)
+	if interactive {
+		err = backendConfig(ctx, name, m, ri, configmap.Simple{}, "")
+		return nil, err
+	}
+
+	// Non-interactive: run one step of the state machine
+	in := fs.ConfigIn{
+		State:  opt.State,
+		Result: opt.Result,
+	}
+	out, err := fs.BackendConfig(ctx, name, m, ri, configmap.Simple{}, in)
+	if err != nil {
+		return nil, err
+	}
+	SaveConfig()
+	cache.ClearConfig(name)
+	return out, nil
+}
+
 // PasswordRemote adds the keyValues passed in to the remote of name.
 // keyValues should be key, value pairs.
 func PasswordRemote(ctx context.Context, name string, keyValues rc.Params) error {

--- a/fs/config/rc.go
+++ b/fs/config/rc.go
@@ -233,6 +233,52 @@ func rcConfig(ctx context.Context, in rc.Params, what string) (out rc.Params, er
 
 func init() {
 	rc.Add(rc.Call{
+		Path:  "config/reconnect",
+		Fn:    rcReconnect,
+		Title: "Reconnect (re-authenticate) a remote.",
+		Help: `This takes the following parameters:
+
+- name - name of remote
+- opt - a dictionary of options to control the configuration
+    - nonInteractive - don't interact with a user, return questions
+    - continue - continue the config process with an answer
+    - state - state to restart with - used with continue
+    - result - result to restart with - used with continue
+
+See the [config reconnect](/commands/rclone_config_reconnect/) command for more information on the above.
+`,
+	})
+}
+
+func rcReconnect(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+	name, err := in.GetString("name")
+	if err != nil {
+		return nil, err
+	}
+	var opt ReconnectRemoteOpt
+	err = in.GetStruct("opt", &opt)
+	if err != nil && !rc.IsErrParamNotFound(err) {
+		return nil, err
+	}
+	configOut, err := ReconnectRemote(ctx, name, opt)
+	if err != nil {
+		return nil, err
+	}
+	if !opt.NonInteractive {
+		return nil, nil
+	}
+	if configOut == nil {
+		configOut = &fs.ConfigOut{}
+	}
+	err = rc.Reshape(&out, configOut)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func init() {
+	rc.Add(rc.Call{
 		Path:  "config/delete",
 		Fn:    rcDelete,
 		Title: "Delete a remote in the config file.",

--- a/fs/config/rc_test.go
+++ b/fs/config/rc_test.go
@@ -238,3 +238,47 @@ func TestRcConfigUnlock(t *testing.T) {
 	assert.ErrorContains(t, err, `Didn't find key "configPassword" in input`)
 	assert.Nil(t, out)
 }
+
+func TestRcReconnect(t *testing.T) {
+	ctx := context.Background()
+	oldConfigFile := config.GetConfigPath()
+	defer func() {
+		require.NoError(t, config.SetConfigPath(oldConfigFile))
+	}()
+	require.NoError(t, config.SetConfigPath(filepath.Join(t.TempDir(), "rclone.conf")))
+	configfile.Install()
+
+	// Create a local remote (local doesn't support reconnect)
+	call := rc.Calls.Get("config/create")
+	require.NotNil(t, call)
+	in := rc.Params{
+		"name":       testName,
+		"type":       "local",
+		"parameters": rc.Params{},
+	}
+	_, err := call.Fn(ctx, in)
+	require.NoError(t, err)
+
+	// Test that reconnect returns an error for backends that don't support it
+	call = rc.Calls.Get("config/reconnect")
+	require.NotNil(t, call)
+	in = rc.Params{
+		"name": testName,
+	}
+	_, err = call.Fn(ctx, in)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backend doesn't support reconnect")
+
+	// Test nonexistent remote
+	in = rc.Params{
+		"name": "nonexistent",
+	}
+	_, err = call.Fn(ctx, in)
+	require.Error(t, err)
+
+	// Clean up
+	call = rc.Calls.Get("config/delete")
+	require.NotNil(t, call)
+	_, err = call.Fn(ctx, rc.Params{"name": testName})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
#### What is the purpose of this change?

Adds a `config/reconnect` RC endpoint that re-authenticates a remote, equivalent to the existing `rclone config reconnect` CLI command.

Since reconnect may require multiple rounds of user interaction (e.g. OAuth flows), the endpoint uses the same stateful pattern as `config/update` — each request advances the config state machine by one step, and the client drives the loop.

#### Usage

Start:
```json
{"name": "myremote", "opt": {"nonInteractive": true}}
```

Continue (if the response contains a question):
```json
{"name": "myremote", "opt": {"nonInteractive": true, "continue": true, "state": "...", "result": "..."}}
```


#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
