### PR TITLE
webdav: honour auth_redirect on listAll PROPFIND - fixes #9159

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -796,6 +796,7 @@ func (f *Fs) listAll(ctx context.Context, dir string, directoriesOnly bool, file
 		ExtraHeaders: map[string]string{
 			"Depth": depth,
 		},
+		AuthRedirect: f.opt.AuthRedirect, // allow redirects to preserve Auth
 	}
 	if f.hasOCMD5 || f.hasOCSHA1 {
 		opts.Body = bytes.NewBuffer(owncloudProps)

--- a/backend/webdav/webdav_internal_test.go
+++ b/backend/webdav/webdav_internal_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/configfile"
 	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -79,6 +80,44 @@ func TestHeaders(t *testing.T) {
 	// send an About response since that is all the dummy server can return
 	_, err := f.Features().About(context.Background())
 	require.NoError(t, err)
+}
+
+// TestListAllAuthRedirect checks auth_redirect is honoured on listAll PROPFIND.
+func TestListAllAuthRedirect(t *testing.T) {
+	var targetAuth string
+	var targetHits int
+
+	target := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		targetHits++
+		targetAuth = r.Header.Get("Authorization")
+		_, err := fmt.Fprint(w, `<d:multistatus xmlns:d="DAV:"></d:multistatus>`)
+		require.NoError(t, err)
+	}))
+	defer target.Close()
+
+	// Redirect via a different hostname so net/http strips Authorization on cross-host redirect.
+	targetURL := strings.Replace(target.URL, "127.0.0.1", "localhost", 1)
+	source := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, targetURL+r.URL.Path, http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	configfile.Install()
+	m := configmap.Simple{
+		"type":          "webdav",
+		"url":           source.URL,
+		"user":          "alice",
+		"pass":          obscure.MustObscure("secret"),
+		"auth_redirect": "true",
+	}
+
+	f, err := webdav.NewFs(context.Background(), remoteName, "", m)
+	require.NoError(t, err)
+
+	_, _ = f.List(context.Background(), "")
+
+	assert.GreaterOrEqual(t, targetHits, 1, "redirect target should receive the request")
+	assert.NotEmpty(t, targetAuth, "Authorization header should be preserved across redirect")
 }
 
 // TestReservedCharactersInPathAreEscaped verifies that reserved characters


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

`listAll` builds a PROPFIND `rest.Opts` without `AuthRedirect`, so `auth_redirect=true` had no effect on listing. `rclone lsd` against a WebDAV server that returns a cross-host 301/307 dropped the `Authorization` header on the redirect and failed with 401. This passes `f.opt.AuthRedirect` through, matching `Object.Open`, and adds a regression test using two `httptest` servers redirected across hostnames.

#### Was the change discussed in an issue or in the forum before?

Fixes #9159.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
