### PR TITLE
Add SloppyOptions to mount configuration

### DIFF
--- a/cmd/mountlib/mount.md
+++ b/cmd/mountlib/mount.md
@@ -451,6 +451,7 @@ Description=Mount for /mnt/data
 Type=rclone
 What=sftp1:subdir
 Where=/mnt/data
+SloppyOptions=true # Needed so that systemd doesn't filter out options it doesn't know about
 Options=rw,_netdev,allow_other,args2env,vfs-cache-mode=writes,config=/etc/rclone.conf,cache-dir=/var/rclone
 ```
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

https://www.freedesktop.org/software/systemd/man/latest/systemd.mount.html#SloppyOptions=

systemd filter out unrecognized `Options=`, so the rclone-specific settings won't ever reach it. Instead, we need to set `SloppyOptions=true` so that everything is passed to the mount command.

#### Was the change discussed in an issue or in the forum before?

No, I ran into this while configuring systemd-initiated rclone mounts on my homelab.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] ~~I have added tests for all changes in this PR if appropriate.~~
- [x] I have added documentation for the changes if appropriate.
- [ ] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] I'm done, this Pull Request is ready for review :-)
