### PR TITLE
vfs/vfscache: fix silent write failure when mounting with remote:.

### DIFF
--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -97,6 +97,7 @@ func New(ctx context.Context, fremote fs.Fs, opt *vfscommon.Options, avFn AddVir
 		}
 	}
 	relativeDirPath = fremote.Name() + "/" + relativeDirPath
+	relativeDirPath = clean(relativeDirPath)
 	relativeDirOSPath := toOSPath(relativeDirPath)
 
 	// Create cache root dirs


### PR DESCRIPTION
When mounting with `remote:.` (dot notation for current directory) and
`--vfs-cache-mode full` (or `writes`), writes appear to succeed but are
never uploaded to the backend.

## Root cause

In `cache.go:New()`, the cache root path is built as:

```
relativeDirPath = remoteName + "/" + remoteRoot   // e.g. "test/."
relativeDirOSPath = toOSPath(relativeDirPath)     // "test/." → "test/．" (full-width!)
```

`toOSPath()` splits the path by `/` and encodes each component. The `.`
component hits `EncodeDot` in `lib/encoder/encoder.go:231`, which maps
`"."` → `"．"` (U+FF0E, fullwidth full stop). The VFS cache then writes
data to `.../vfs/test/．` while the local cache backend is initialized
at the canonical `.../vfs/test` — paths mismatch, uploads never find
the cached data.

## Fix

Add `clean()` call on `relativeDirPath` before `toOSPath()`, matching
what every other cache operation (`put`, `get`, `InUse`, `DirtyItem`,
`Remove`) already does. `clean()` calls `path.Clean()` which strips the
trailing `/.` → `"test"`, so the dot never reaches the encoder.

```
relativeDirPath = clean(relativeDirPath)  // "test/." → "test"
relativeDirOSPath = toOSPath(relativeDirPath)  // "test" (no encoding)
```

## Verification

Before (broken):
```
vfs cache: data root is ".../vfs/test/．"  ← full-width dot U+FF0E
```

After (fixed):
```
vfs cache: data root is ".../vfs/test"    ← correct
```

Tested with `rclone mount test:. /mnt --vfs-cache-mode full` on WebDAV:
writes now successfully upload to the remote.

Existing tests pass: `go test ./vfs/vfscache/` — all PASS.

<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Fix silent write failure when mounting with `remote:.` + `--vfs-cache-mode full`/`writes`. A missing `clean()` call let the `.` path component be encoded to full-width dot, causing VFS cache path mismatch.

#### Was the change discussed in an issue or in the forum before?

I searched for existing issues but found none directly discussing this problem.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)