### PR TITLE
operations: fix DeleteFile godoc, it doesn't honor --backup-dir

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -577,10 +577,12 @@ func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs
 	return err
 }
 
-// DeleteFile deletes a single file respecting --dry-run and accumulating stats and errors.
+// DeleteFile deletes a single file respecting --dry-run and accumulating
+// stats and errors.
 //
-// If useBackupDir is set and --backup-dir is in effect then it moves
-// the file to there instead of deleting
+// DeleteFile does not honor --backup-dir; it always removes the file.
+// Callers that need backup-dir semantics should use
+// [DeleteFileWithBackupDir] and pass a non-nil backupDir.
 func DeleteFile(ctx context.Context, dst fs.Object) (err error) {
 	return DeleteFileWithBackupDir(ctx, dst, nil)
 }


### PR DESCRIPTION
Closes #7566.

\`DeleteFile\` always calls \`DeleteFileWithBackupDir(ctx, dst, nil)\`, so the comment claiming \"if useBackupDir is set and --backup-dir is in effect then it moves the file to there\" was wrong on two counts: there's no \`useBackupDir\` argument, and the function has no way to read the global --backup-dir setting.

Document what it actually does and point callers that need backup-dir semantics at \`DeleteFileWithBackupDir\`. No code change.