### PR TITLE
protondrive: lowercase cached sha1 hashes

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -969,7 +969,7 @@ func (o *Object) Hash(ctx context.Context, t hash.Type) (string, error) {
 	}
 
 	if o.digests != nil {
-		return *o.digests, nil
+		return strings.ToLower(*o.digests), nil
 	}
 
 	// sha1 not cached: we fetch and try to obtain the sha1 of the link


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Some cached SHA1 hashes on proton drive are uppercase, some are not. This leads to false reports of `corrupted on transfer: sha1 hashes differ` when the only difference is in hash case, not the actual contents. Always lowercasing the cached SHA1 hashes should account for this.

#### Was the change discussed in an issue or in the forum before?

#7345

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)