### PR TITLE
iclouddrive: request Drive PCS cookies for ADP accounts

### DIFF
--- a/backend/iclouddrive/api/session.go
+++ b/backend/iclouddrive/api/session.go
@@ -539,18 +539,35 @@ func (s *Session) AuthWithToken(ctx context.Context) error {
 	return nil
 }
 
-// hasPCSCookies checks if the required PCS cookies for Photos are already present
-func (s *Session) hasPCSCookies() bool {
-	var hasPhotos, hasSharing bool
+var requiredPCSCookieNames = []string{
+	"X-APPLE-WEBAUTH-PCS-Documents",
+	"X-APPLE-WEBAUTH-PCS-Photos",
+	"X-APPLE-WEBAUTH-PCS-Sharing",
+}
+
+var pcsAppNames = []string{"iclouddrive", "photos"}
+
+// missingPCSCookies returns the required PCS cookies that are not already present.
+func (s *Session) missingPCSCookies() []string {
+	present := make(map[string]bool, len(s.Cookies))
 	for _, c := range s.Cookies {
-		switch c.Name {
-		case "X-APPLE-WEBAUTH-PCS-Photos":
-			hasPhotos = true
-		case "X-APPLE-WEBAUTH-PCS-Sharing":
-			hasSharing = true
+		if c.Value != "" {
+			present[c.Name] = true
 		}
 	}
-	return hasPhotos && hasSharing
+
+	var missing []string
+	for _, name := range requiredPCSCookieNames {
+		if !present[name] {
+			missing = append(missing, name)
+		}
+	}
+	return missing
+}
+
+// hasPCSCookies checks if the required PCS cookies for iCloud Drive/Photos are already present.
+func (s *Session) hasPCSCookies() bool {
+	return len(s.missingPCSCookies()) == 0
 }
 
 // acquirePCSCookies requests PCS cookies for ADP-enabled accounts
@@ -560,41 +577,48 @@ func (s *Session) acquirePCSCookies(ctx context.Context) error {
 	const maxAttempts = 30 // 30 * 10s = 5 minutes max
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		fs.Debugf(nil, "iclouddrive: requestPCS outgoing cookies: %v", cookieJarDebugSummaries(s.Cookies))
-		values := map[string]any{
-			"appName":               "photos",
-			"derivedFromUserAction": true,
-		}
-		body, err := IntoReader(values)
-		if err != nil {
-			return fmt.Errorf("requestPCS: %w", err)
-		}
-		opts := rest.Opts{
-			Method:       "POST",
-			Path:         "/requestPCS",
-			ExtraHeaders: s.GetHeaders(map[string]string{}),
-			RootURL:      setupEndpoint,
-		}
-		opts.Body = body
-		var pcsResp struct {
-			Status  string `json:"status"`
-			Message string `json:"message"`
-		}
-		resp, err := s.Request(ctx, opts, nil, &pcsResp)
-		if err != nil {
-			return fmt.Errorf("requestPCS: %w", err)
-		}
-		fs.Debugf(nil, "iclouddrive: requestPCS response cookies: %v", cookieDebugSummaries(resp.Cookies()))
-		fs.Debugf(nil, "iclouddrive: requestPCS response: status=%q message=%q cookies=%d",
-			pcsResp.Status, pcsResp.Message, len(resp.Cookies()))
-		if pcsResp.Status == "success" {
-			if !s.hasPCSCookies() {
-				return fmt.Errorf("requestPCS: server returned success but PCS cookies missing")
+		waitingForApproval := false
+		for _, appName := range pcsAppNames {
+			values := map[string]any{
+				"appName":               appName,
+				"derivedFromUserAction": true,
 			}
+			body, err := IntoReader(values)
+			if err != nil {
+				return fmt.Errorf("requestPCS %s: %w", appName, err)
+			}
+			opts := rest.Opts{
+				Method:       "POST",
+				Path:         "/requestPCS",
+				ExtraHeaders: s.GetHeaders(map[string]string{}),
+				RootURL:      setupEndpoint,
+			}
+			opts.Body = body
+			var pcsResp struct {
+				Status  string `json:"status"`
+				Message string `json:"message"`
+			}
+			resp, err := s.Request(ctx, opts, nil, &pcsResp)
+			if err != nil {
+				return fmt.Errorf("requestPCS %s: %w", appName, err)
+			}
+			fs.Debugf(nil, "iclouddrive: requestPCS %s response cookies: %v", appName, cookieDebugSummaries(resp.Cookies()))
+			fs.Debugf(nil, "iclouddrive: requestPCS %s response: status=%q message=%q cookies=%d",
+				appName, pcsResp.Status, pcsResp.Message, len(resp.Cookies()))
+			if pcsResp.Status != "success" {
+				// Device consent required - poll until approved
+				fs.Logf(nil, "iclouddrive: waiting for device approval for PCS (%s)", pcsResp.Message)
+				waitingForApproval = true
+				break
+			}
+		}
+		if s.hasPCSCookies() {
 			fs.Logf(nil, "iclouddrive: PCS cookies acquired")
 			return nil
 		}
-		// Device consent required - poll until approved
-		fs.Logf(nil, "iclouddrive: waiting for device approval for PCS (%s)", pcsResp.Message)
+		if !waitingForApproval {
+			fs.Debugf(nil, "iclouddrive: missing PCS cookies after requestPCS: %v", s.missingPCSCookies())
+		}
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/backend/iclouddrive/api/session_test.go
+++ b/backend/iclouddrive/api/session_test.go
@@ -38,3 +38,46 @@ func TestExtractHeadersDeletesEmptyCookies(t *testing.T) {
 	assert.Equal(t, "keep", s.Cookies[0].Name)
 	assert.Equal(t, "keep=value", s.GetCookieString())
 }
+
+func TestHasPCSCookiesRequiresDriveDocumentsCookie(t *testing.T) {
+	s := NewSession()
+	s.Cookies = []*http.Cookie{
+		{Name: "X-APPLE-WEBAUTH-PCS-Photos", Value: "photos"},
+		{Name: "X-APPLE-WEBAUTH-PCS-Sharing", Value: "sharing"},
+	}
+
+	assert.False(t, s.hasPCSCookies())
+	assert.Equal(t, []string{"X-APPLE-WEBAUTH-PCS-Documents"}, s.missingPCSCookies())
+}
+
+func TestHasPCSCookiesRequiresPhotosAndSharingCookies(t *testing.T) {
+	s := NewSession()
+	s.Cookies = []*http.Cookie{{Name: "X-APPLE-WEBAUTH-PCS-Documents", Value: "documents"}}
+
+	assert.False(t, s.hasPCSCookies())
+	assert.Equal(t, []string{"X-APPLE-WEBAUTH-PCS-Photos", "X-APPLE-WEBAUTH-PCS-Sharing"}, s.missingPCSCookies())
+}
+
+func TestHasPCSCookiesIgnoresEmptyCookies(t *testing.T) {
+	s := NewSession()
+	s.Cookies = []*http.Cookie{
+		{Name: "X-APPLE-WEBAUTH-PCS-Documents", Value: "documents"},
+		{Name: "X-APPLE-WEBAUTH-PCS-Photos", Value: "photos"},
+		{Name: "X-APPLE-WEBAUTH-PCS-Sharing", Value: ""},
+	}
+
+	assert.False(t, s.hasPCSCookies())
+	assert.Equal(t, []string{"X-APPLE-WEBAUTH-PCS-Sharing"}, s.missingPCSCookies())
+}
+
+func TestHasPCSCookiesAcceptsDocumentsPhotosAndSharing(t *testing.T) {
+	s := NewSession()
+	s.Cookies = []*http.Cookie{
+		{Name: "X-APPLE-WEBAUTH-PCS-Documents", Value: "documents"},
+		{Name: "X-APPLE-WEBAUTH-PCS-Photos", Value: "photos"},
+		{Name: "X-APPLE-WEBAUTH-PCS-Sharing", Value: "sharing"},
+	}
+
+	assert.True(t, s.hasPCSCookies())
+	assert.Empty(t, s.missingPCSCookies())
+}


### PR DESCRIPTION
## What

Fix iCloud Drive access for ADP-enabled accounts by requesting PCS cookies for both iCloud Drive and Photos.

The existing ADP flow only requests PCS with `appName: "photos"` and considers `X-APPLE-WEBAUTH-PCS-Photos` plus `X-APPLE-WEBAUTH-PCS-Sharing` sufficient. For iCloud Drive, Apple can also require `X-APPLE-WEBAUTH-PCS-Documents`; without it, Drive listing still fails with:

```text
HTTP error 423 (423 Locked): Missing PCS cookies from the request
```

even after reconnect logs:

```text
Advanced Data Protection enabled, requesting PCS cookies
PCS cookies acquired
```

## Changes

- Request PCS for both `iclouddrive` and `photos` app names.
- Require the Documents, Photos, and Sharing PCS cookies before treating PCS acquisition as complete.
- Add tests covering missing Documents, Photos/Sharing, and empty PCS-cookie values.
- Add debug output listing missing PCS cookies when `requestPCS` returns success but the cookie set is still incomplete.

## Verification

- `go test ./backend/iclouddrive/api ./backend/iclouddrive`
- `go build -o /tmp/rclone-pr-check ./rclone.go`
- Live smoke test against an ADP-enabled iCloud account that previously reproduced the failure:
  - before: `rclone lsd icloud-baby:` returned `HTTP 423 Missing PCS cookies`
  - after: rebuilt rclone lists iCloud Drive successfully and the saved cookie set includes `X-APPLE-WEBAUTH-PCS-Documents`, `X-APPLE-WEBAUTH-PCS-Photos`, and `X-APPLE-WEBAUTH-PCS-Sharing`
