### PR TITLE
mount2: add --allow-idmap to advertise FUSE_ALLOW_IDMAP

### DIFF
--- a/cmd/mount2/mount.go
+++ b/cmd/mount2/mount.go
@@ -33,6 +33,7 @@ func mountOptions(fsys *FS, f fs.Fs, opt *mountlib.Options) (mountOpts *fuse.Mou
 		MaxReadAhead:       int(fsys.opt.MaxReadAhead),
 		MaxWrite:           1024 * 1024, // Linux v4.20+ caps requests at 1 MiB
 		DisableReadDirPlus: true,
+		IDMappedMount:      opt.AllowIDMap,
 
 		// RememberInodes: true,
 		// SingleThreaded: true,

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -94,6 +94,11 @@ var OptionsInfo = fs.Options{{
 	Help:    "Allow access to other users (not supported on Windows)",
 	Groups:  "Mount",
 }, {
+	Name:    "allow_idmap",
+	Default: false,
+	Help:    "Allow id-mapped mounts (Linux 6.12+, mount2 only)",
+	Groups:  "Mount",
+}, {
 	Name:    "async_read",
 	Default: true,
 	Help:    "Use asynchronous reads (not supported on Windows)",
@@ -172,6 +177,7 @@ type Options struct {
 	AllowNonEmpty      bool          `config:"allow_non_empty"`
 	AllowRoot          bool          `config:"allow_root"`
 	AllowOther         bool          `config:"allow_other"`
+	AllowIDMap         bool          `config:"allow_idmap"`
 	DefaultPermissions bool          `config:"default_permissions"`
 	WritebackCache     bool          `config:"write_back_cache"`
 	Daemon             bool          `config:"daemon"`


### PR DESCRIPTION
#### What is the purpose of this change?

Lets the kernel id-map a mount2 mount into a user namespace (e.g. Kubernetes pods with `hostUsers: false`). Off by default; requires Linux 6.12+ and implies `default_permissions`.

#### Was the change discussed in an issue or in the forum before?

No

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
