### PR TITLE
refactor: use slices.Contains to simplify code

### DIFF
--- a/backend/huaweidrive/huaweidrive.go
+++ b/backend/huaweidrive/huaweidrive.go
@@ -15,6 +15,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1166,14 +1167,7 @@ func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object,
 			fs.Debugf(f, "Cross-directory move returned no parentFolder. Falling back to copy+delete.")
 			return nil, fs.ErrorCantMove
 		}
-		parentFound := false
-		for _, actualParent := range info.ParentFolder {
-			if actualParent == dstDirectoryID {
-				parentFound = true
-				break
-			}
-		}
-		if !parentFound {
+		if !slices.Contains(info.ParentFolder, dstDirectoryID) {
 			fs.Debugf(f, "Cross-directory move failed: expected parent=%q, got=%v. Falling back to copy+delete.",
 				dstDirectoryID, info.ParentFolder)
 			return nil, fs.ErrorCantMove

--- a/backend/huaweidrive/huaweidrive_test.go
+++ b/backend/huaweidrive/huaweidrive_test.go
@@ -7,6 +7,7 @@ import (
 	"mime"
 	"net/http"
 	"path"
+	"slices"
 	"testing"
 	"time"
 
@@ -433,15 +434,7 @@ func TestMimeTypeDetection(t *testing.T) {
 			}
 
 			// Check if detected MIME type is in the list of expected types
-			found := false
-			for _, expected := range tc.expectedMimes {
-				if detected == expected {
-					found = true
-					break
-				}
-			}
-
-			if !found {
+			if !slices.Contains(tc.expectedMimes, detected) {
 				t.Errorf("expected one of MIME types %v for %q, got %q", tc.expectedMimes, tc.filename, detected)
 			}
 		})

--- a/backend/iclouddrive/api/photos.go
+++ b/backend/iclouddrive/api/photos.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1417,11 +1418,8 @@ func (lib *Library) applyPendingDelta(ctx context.Context) bool {
 		// Route new photos to smart albums based on classifySmartAlbums()
 		if isSmart {
 			for _, p := range addedPhotos {
-				for _, sa := range p.SmartAlbums {
-					if sa == album.Name {
-						filtered = append(filtered, p)
-						break
-					}
+				if slices.Contains(p.SmartAlbums, album.Name) {
+					filtered = append(filtered, p)
 				}
 			}
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

There is a [new function](https://pkg.go.dev/slices@go1.21.0#Contains) added in the go1.21 standard library, which can make the code more concise and easy to read.


<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
