### PR TITLE
backend/filelu: fix recursive listing path handling and file filtering

### DIFF
--- a/backend/filelu/filelu.go
+++ b/backend/filelu/filelu.go
@@ -222,38 +222,36 @@ func (f *Fs) List(ctx context.Context, dir string) (fs.DirEntries, error) {
 		return nil, err
 	}
 
-	fldMap := map[string]bool{}
 	for _, folder := range result.Result.Folders {
-		fldMap[folder.FldID.String()] = true
 		if f.root == "" && dir == "" && strings.Contains(folder.Path, "/") {
 			continue
 		}
 
-		paths := strings.Split(folder.Path, fullPath+"/")
-		remote := paths[0]
-		if len(paths) > 1 {
-			remote = paths[1]
+		folderPath := strings.Trim(folder.Path, "/")
+		root := strings.Trim(f.root, "/")
+
+		remotePathWithoutRoot := folderPath
+
+		if root != "" {
+			if remotePathWithoutRoot == root {
+				continue
+			}
+			remotePathWithoutRoot = strings.TrimPrefix(remotePathWithoutRoot, root+"/")
 		}
 
-		if strings.Contains(remote, "/") {
+		remotePathWithoutRoot = strings.TrimPrefix(remotePathWithoutRoot, "/")
+
+		if remotePathWithoutRoot == "" {
 			continue
 		}
 
-		pathsWithoutRoot := strings.Split(folder.Path, "/"+f.root+"/")
-		remotePathWithoutRoot := pathsWithoutRoot[0]
-		if len(pathsWithoutRoot) > 1 {
-			remotePathWithoutRoot = pathsWithoutRoot[1]
-		}
-		remotePathWithoutRoot = strings.TrimPrefix(remotePathWithoutRoot, "/")
 		entries = append(entries, fs.NewDir(remotePathWithoutRoot, time.Now()))
 	}
+
 	for _, file := range result.Result.Files {
-		if _, ok := fldMap[file.FldID.String()]; ok {
-			continue
-		}
 		remote := path.Join(dir, file.Name)
-		// trim leading slashes
 		remote = strings.TrimPrefix(remote, "/")
+
 		obj := &Object{
 			fs:      f,
 			remote:  remote,


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

**1. Recursive listing path handling**

Recursive operations such as:

rclone lsf remote:path -R
rclone check

could fail to descend into nested folders correctly because the backend relied on:

`strings.Split(folder.Path, "/"+f.root+"/")`

This expected a leading slash in folder.Path, but the API returns paths without a leading slash.

This caused recursive listings to stop early or incorrectly ignore nested entries.

**2. File filtering issue**

The previous implementation filtered files using folder IDs:

```
if _, ok := fldMap[file.FldID.String()]; ok {
    continue
}
```

This could incorrectly skip valid files during recursive listing and check operations.

<!--
Describe the changes here
-->

#### Was the change discussed in an issue or in the forum before?

No public issue/forum discussion yet. This was found while testing the FileLu backend with deeply nested folders and rclone check.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
