### PR TITLE
rc: include OAuth authorization URL in rc config/oauthstatus response

### DIFF
--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -813,13 +813,13 @@ func init() {
 
 Returns a JSON object:
 - status - "running" or "stopped"
-- url - URL for the authorization (only if status is "running")
+- authUrl - URL for the authorization (only if status is "running")
 
 Eg
 
     {
         "status": "running",
-        "url": "http://127.0.0.1:53682/auth?state=..."
+        "authUrl": "http://127.0.0.1:53682/auth?state=..."
     }
 `,
 	})
@@ -833,7 +833,7 @@ func rcOAuthStatus(ctx context.Context, in rc.Params) (out rc.Params, err error)
 	if oauthCancelFn != nil {
 		status = "running"
 		params["status"] = status
-		params["url"] = oauthURL
+		params["authUrl"] = oauthURL
 	}
 	return params, nil
 }

--- a/lib/oauthutil/oauthutil.go
+++ b/lib/oauthutil/oauthutil.go
@@ -34,8 +34,10 @@ var (
 
 	// oauthCancelFn stores the cancel function for the currently active OAuth flow
 	oauthCancelFn context.CancelFunc
-	// oauthCancelMu protects oauthCancelFn
+	// oauthCancelMu protects oauthCancelFn and oauthURL
 	oauthCancelMu sync.Mutex
+	// oauthURL stores the URL for the currently active OAuth flow
+	oauthURL string
 )
 
 const (
@@ -798,6 +800,7 @@ func rcOAuthStop(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	}
 	oauthCancelFn()
 	oauthCancelFn = nil
+	oauthURL = ""
 	return nil, nil
 }
 
@@ -810,11 +813,13 @@ func init() {
 
 Returns a JSON object:
 - status - "running" or "stopped"
+- url - URL for the authorization (only if status is "running")
 
 Eg
 
     {
-        "status": "running"
+        "status": "running",
+        "url": "http://127.0.0.1:53682/auth?state=..."
     }
 `,
 	})
@@ -824,10 +829,13 @@ func rcOAuthStatus(ctx context.Context, in rc.Params) (out rc.Params, err error)
 	oauthCancelMu.Lock()
 	defer oauthCancelMu.Unlock()
 	status := "stopped"
+	params := rc.Params{"status": status}
 	if oauthCancelFn != nil {
 		status = "running"
+		params["status"] = status
+		params["url"] = oauthURL
 	}
-	return rc.Params{"status": status}, nil
+	return params, nil
 }
 
 // Return true if can run without a webserver and just entering a code
@@ -914,20 +922,23 @@ func configSetup(ctx context.Context, id, name string, m configmap.Mapper, oauth
 	if err != nil {
 		return "", fmt.Errorf("failed to start auth webserver: %w", err)
 	}
+	authURL = "http://" + bindAddress + "/auth?state=" + state
+
 	oauthCtx, cancel := context.WithCancel(ctx)
 	oauthCancelMu.Lock()
 	oauthCancelFn = cancel
+	oauthURL = authURL
 	oauthCancelMu.Unlock()
 
 	go server.Serve()
 	defer func() {
 		oauthCancelMu.Lock()
 		oauthCancelFn = nil
+		oauthURL = ""
 		oauthCancelMu.Unlock()
 		cancel()
 		server.Stop()
 	}()
-	authURL = "http://" + bindAddress + "/auth?state=" + state
 
 	if !authorizeNoAutoBrowser {
 		// Open the URL for the user to visit

--- a/lib/oauthutil/rc_test.go
+++ b/lib/oauthutil/rc_test.go
@@ -37,7 +37,7 @@ func TestRcOAuthStatus(t *testing.T) {
 	out, err = call.Fn(ctx2, rc.Params{})
 	require.NoError(t, err)
 	assert.Equal(t, "running", out["status"])
-	assert.Equal(t, "http://127.0.0.1:53682/auth?state=xyz", out["url"])
+	assert.Equal(t, "http://127.0.0.1:53682/auth?state=xyz", out["authUrl"])
 }
 
 func TestRcOAuthStop(t *testing.T) {

--- a/lib/oauthutil/rc_test.go
+++ b/lib/oauthutil/rc_test.go
@@ -24,10 +24,12 @@ func TestRcOAuthStatus(t *testing.T) {
 	defer cancel()
 	oauthCancelMu.Lock()
 	oauthCancelFn = cancel
+	oauthURL = "http://127.0.0.1:53682/auth?state=xyz"
 	oauthCancelMu.Unlock()
 	defer func() {
 		oauthCancelMu.Lock()
 		oauthCancelFn = nil
+		oauthURL = ""
 		oauthCancelMu.Unlock()
 	}()
 
@@ -35,6 +37,7 @@ func TestRcOAuthStatus(t *testing.T) {
 	out, err = call.Fn(ctx2, rc.Params{})
 	require.NoError(t, err)
 	assert.Equal(t, "running", out["status"])
+	assert.Equal(t, "http://127.0.0.1:53682/auth?state=xyz", out["url"])
 }
 
 func TestRcOAuthStop(t *testing.T) {


### PR DESCRIPTION
#### What is the purpose of this change?

Expose the active local OAuth authentication URL in the `config/oauthstatus` RC (Remote Control) response when the status is `"running"`.

Currently, `config/oauthstatus` only returns whether the local OAuth authentication server is `"running"` or `"stopped"`. With this change, the JSON response will now also include a `url` parameter containing the localhost authorization URL (e.g., `http://127.0.0.1:53682/auth?state=...`) when active. 

This enables external GUIs, web interfaces, and third-party frontends controlling a remote rclone instance via the RC API to easily retrieve the correct local authorization URL and present it directly to the end user for a much smoother configuration experience.

#### Was the change discussed in an issue or in the forum before?

This makes configuring OAuth-based remotes remotely via the RC interface more user-friendly for end-users of GUI frontends.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
