### PR TITLE
vfs: Fix VFS instance leaks on mount/serve failures and support VFS ID reuse

### DIFF
--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -379,11 +379,14 @@ func (m *MountPoint) Mount() (mountDaemon *os.Process, err error) {
 		}
 	}
 
-	m.VFS = vfs.New(context.Background(), m.Fs, &m.VFSOpt)
+	if m.VFS == nil {
+		m.VFS = vfs.New(context.Background(), m.Fs, &m.VFSOpt)
+	}
 
 	var actualMountpoint string
 	m.ErrChan, m.UnmountFn, actualMountpoint, err = m.MountFn(m.VFS, m.MountPoint, &m.MountOpt)
 	if err != nil {
+		m.VFS.Shutdown()
 		if len(os.Args) > 0 && strings.HasPrefix(os.Args[0], "/snap/") {
 			return nil, fmt.Errorf("mounting is not supported when running from snap")
 		}
@@ -405,6 +408,9 @@ func (m *MountPoint) Wait() error {
 			// Unmount only if directory was mounted by rclone, e.g. don't unmount autofs hooks.
 			if err := CheckMountReady(m.MountPoint); err != nil {
 				fs.Debugf(m.MountPoint, "Unmounted externally. Just exit now.")
+				if m.VFS != nil {
+					m.VFS.Shutdown()
+				}
 				return
 			}
 			if err := m.Unmount(); err != nil {
@@ -429,5 +435,9 @@ func (m *MountPoint) Wait() error {
 
 // Unmount the specified mountpoint
 func (m *MountPoint) Unmount() (err error) {
-	return m.UnmountFn()
+	err = m.UnmountFn()
+	if m.VFS != nil {
+		m.VFS.Shutdown()
+	}
+	return err
 }

--- a/cmd/mountlib/rc.go
+++ b/cmd/mountlib/rc.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/rc"
+	"github.com/rclone/rclone/vfs"
 	"github.com/rclone/rclone/vfs/vfscommon"
 )
 
@@ -135,6 +136,15 @@ func mountRc(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	}
 
 	mnt := NewMountPoint(mountFn, mountPoint, fdst, &mountOpt, &vfsOpt)
+	inVfsID, err := in.GetString("vfsId")
+	if err == nil && inVfsID != "" {
+		VFS, err := vfs.GetVFSById(inVfsID)
+		if err != nil {
+			return nil, err
+		}
+		mnt.VFS = VFS
+		delete(in, "vfsId")
+	}
 	_, err = mnt.Mount()
 	if err != nil {
 		fs.Logf(nil, "mount FAILED: %v", err)
@@ -156,8 +166,13 @@ func mountRc(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	liveMounts[actualMountPoint] = mnt
 
 	fs.Debugf(nil, "Mount for %s created at %s using %s", fdst.String(), actualMountPoint, mountType)
+	var vfsID string
+	if mnt.VFS != nil {
+		vfsID = mnt.VFS.ID
+	}
 	return rc.Params{
 		"mountPoint": actualMountPoint,
+		"vfsId":      vfsID,
 	}, nil
 }
 
@@ -259,6 +274,7 @@ type MountInfo struct {
 	Fs         string    `json:"Fs"`
 	MountPoint string    `json:"MountPoint"`
 	MountedOn  time.Time `json:"MountedOn"`
+	VfsID      string    `json:"vfsId"`
 }
 
 // listMountsRc returns a list of current mounts sorted by mount path
@@ -273,10 +289,15 @@ func listMountsRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
 	mountPoints := []MountInfo{}
 	for _, k := range keys {
 		m := liveMounts[k]
+		var vfsID string
+		if m.VFS != nil {
+			vfsID = m.VFS.ID
+		}
 		info := MountInfo{
 			Fs:         fs.ConfigString(m.Fs),
 			MountPoint: m.MountPoint,
 			MountedOn:  m.MountedOn,
+			VfsID:      vfsID,
 		}
 		mountPoints = append(mountPoints, info)
 	}

--- a/cmd/mountlib/rc.go
+++ b/cmd/mountlib/rc.go
@@ -138,7 +138,7 @@ func mountRc(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	mnt := NewMountPoint(mountFn, mountPoint, fdst, &mountOpt, &vfsOpt)
 	inVfsID, err := in.GetString("vfsId")
 	if err == nil && inVfsID != "" {
-		VFS, err := vfs.GetVFSById(inVfsID)
+		VFS, err := vfs.GetVFSByID(inVfsID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/mountlib/rc_test.go
+++ b/cmd/mountlib/rc_test.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/rclone/rclone/cmd/mount"
 	_ "github.com/rclone/rclone/cmd/mount2"
 	"github.com/rclone/rclone/cmd/mountlib"
+	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/configfile"
 	"github.com/rclone/rclone/fs/rc"
 	"github.com/rclone/rclone/fstest/testy"
@@ -26,6 +27,11 @@ func TestRc(t *testing.T) {
 		testy.SkipUnreliable(t)
 	}
 	ctx := context.Background()
+	oldConfigPath := config.GetConfigPath()
+	_ = config.SetConfigPath("")
+	t.Cleanup(func() {
+		_ = config.SetConfigPath(oldConfigPath)
+	})
 	configfile.Install()
 	mount := rc.Calls.Get("mount/mount")
 	assert.NotNil(t, mount)

--- a/cmd/serve/rc.go
+++ b/cmd/serve/rc.go
@@ -17,6 +17,7 @@ import (
 	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/rc"
 	"github.com/rclone/rclone/lib/errcount"
+	"github.com/rclone/rclone/vfs"
 )
 
 // Handle describes what a server can do
@@ -35,9 +36,11 @@ type Handle interface {
 type server struct {
 	ID      string     `json:"id"`     // id of the server
 	Addr    string     `json:"addr"`   // address of the server
+	VfsID   string     `json:"vfsId"`  // id of the VFS used by the server
 	Params  rc.Params  `json:"params"` // Parameters used to start the server
 	h       Handle     `json:"-"`      // control the server
 	errChan chan error `json:"-"`      // receive errors from the server process
+	Vfses   []*vfs.VFS `json:"-"`      // VFSes used by the server
 }
 
 // Fn starts an rclone serve command
@@ -129,9 +132,21 @@ func startRc(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	newCtx = fs.CopyConfig(newCtx, ctx)
 	newCtx = filter.CopyConfig(newCtx, ctx)
 
+	var createdVFSes []*vfs.VFS
+	newCtx = vfs.WithTracker(newCtx, &createdVFSes)
+
+	vfsID, err := in.GetString("vfsId")
+	if err == nil && vfsID != "" {
+		newCtx = vfs.WithVFSID(newCtx, vfsID)
+		delete(in, "vfsId")
+	}
+
 	// Start the server
 	h, err := serveFn(newCtx, f, in)
 	if err != nil {
+		for _, v := range createdVFSes {
+			v.Shutdown()
+		}
 		return nil, fmt.Errorf("could not start serve %q: %w", serveType, err)
 	}
 
@@ -152,22 +167,32 @@ func startRc(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 		err = nil
 	}
 	if err != nil {
+		for _, v := range createdVFSes {
+			v.Shutdown()
+		}
 		return nil, fmt.Errorf("error when starting serve %q: %w", serveType, err)
 	}
 
 	// Store it for later
+	var resolvedVfsID string
+	if len(createdVFSes) > 0 {
+		resolvedVfsID = createdVFSes[0].ID
+	}
 	runningServer := server{
 		ID:      fmt.Sprintf("%s-%08x", serveType, rand.Uint32()),
 		Params:  in,
 		Addr:    h.Addr().String(),
+		VfsID:   resolvedVfsID,
 		h:       h,
 		errChan: errChan,
+		Vfses:   createdVFSes,
 	}
 	servers[runningServer.ID] = &runningServer
 
 	out = rc.Params{
-		"id":   runningServer.ID,
-		"addr": runningServer.Addr,
+		"id":    runningServer.ID,
+		"addr":  runningServer.Addr,
+		"vfsId": runningServer.VfsID,
 	}
 
 	fs.Debugf(f, "Started serve %s on %s", serveType, runningServer.Addr)
@@ -208,6 +233,9 @@ func stopRc(_ context.Context, in rc.Params) (out rc.Params, err error) {
 	}
 	err = s.h.Shutdown()
 	<-s.errChan // ignore server return error - likely is "use of closed network connection"
+	for _, v := range s.Vfses {
+		v.Shutdown()
+	}
 	delete(servers, id)
 	return nil, err
 }
@@ -344,6 +372,9 @@ func stopAll(_ context.Context, in rc.Params) (out rc.Params, err error) {
 	for id, s := range servers {
 		ec.Add(s.h.Shutdown())
 		<-s.errChan // ignore server return error - likely is "use of closed network connection"
+		for _, v := range s.Vfses {
+			v.Shutdown()
+		}
 		delete(servers, id)
 	}
 	return nil, ec.Err("error when stopping server")

--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -402,8 +402,8 @@ parameter.`,
 	})
 }
 
-// VfsInfo describes an active VFS instance
-type VfsInfo struct {
+// Info describes an active VFS instance
+type Info struct {
 	ID string `json:"id"`
 	Fs string `json:"fs"`
 }
@@ -412,7 +412,7 @@ func rcList(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	activeMu.Lock()
 	defer activeMu.Unlock()
 	var names = []string{}
-	var list = []VfsInfo{}
+	var list = []Info{}
 
 	for name, vfses := range active {
 		if len(vfses) == 1 {
@@ -423,7 +423,7 @@ func rcList(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 			}
 		}
 		for _, activeVFS := range vfses {
-			list = append(list, VfsInfo{
+			list = append(list, Info{
 				ID: activeVFS.ID,
 				Fs: name,
 			})
@@ -431,7 +431,7 @@ func rcList(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	}
 
 	// Sort list by ID for deterministic order
-	slices.SortFunc(list, func(a, b VfsInfo) int {
+	slices.SortFunc(list, func(a, b Info) int {
 		return cmp.Compare(a.ID, b.ID)
 	})
 

--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -1,9 +1,11 @@
 package vfs
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -42,10 +44,36 @@ func getVFS(in rc.Params) (vfs *VFS, err error) {
 	}
 	activeMu.Lock()
 	defer activeMu.Unlock()
+
+	// 1. Try to match by ID directly (e.g., "vfs-1")
+	for _, vfses := range active {
+		for _, activeVFS := range vfses {
+			if activeVFS.ID == fsString {
+				delete(in, "fs") // delete the fs parameter
+				return activeVFS, nil
+			}
+		}
+	}
+
+	// 2. Try to match by name with [ID] suffix (e.g., "Google Drive:[vfs-1]")
+	if strings.HasSuffix(fsString, "]") {
+		if openBracket := strings.LastIndex(fsString, "["); openBracket >= 0 {
+			idStr := fsString[openBracket+1 : len(fsString)-1]
+			for _, vfses := range active {
+				for _, activeVFS := range vfses {
+					if activeVFS.ID == idStr {
+						delete(in, "fs") // delete the fs parameter
+						return activeVFS, nil
+					}
+				}
+			}
+		}
+	}
+
 	fsString = cache.Canonicalize(fsString)
 	activeVFS := active[fsString]
 	if len(activeVFS) == 0 {
-		return nil, fmt.Errorf("no VFS found with name %q", fsString)
+		return nil, fmt.Errorf("no VFS found with name or ID %q", fsString)
 	} else if len(activeVFS) > 1 {
 		return nil, fmt.Errorf("more than one VFS active with name %q", fsString)
 	}
@@ -374,21 +402,42 @@ parameter.`,
 	})
 }
 
+// VfsInfo describes an active VFS instance
+type VfsInfo struct {
+	ID string `json:"id"`
+	Fs string `json:"fs"`
+}
+
 func rcList(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	activeMu.Lock()
 	defer activeMu.Unlock()
 	var names = []string{}
+	var list = []VfsInfo{}
+
 	for name, vfses := range active {
 		if len(vfses) == 1 {
 			names = append(names, name)
 		} else {
-			for i := range vfses {
-				names = append(names, fmt.Sprintf("%s[%d]", name, i))
+			for _, activeVFS := range vfses {
+				names = append(names, fmt.Sprintf("%s[%s]", name, activeVFS.ID))
 			}
 		}
+		for _, activeVFS := range vfses {
+			list = append(list, VfsInfo{
+				ID: activeVFS.ID,
+				Fs: name,
+			})
+		}
 	}
+
+	// Sort list by ID for deterministic order
+	slices.SortFunc(list, func(a, b VfsInfo) int {
+		return cmp.Compare(a.ID, b.ID)
+	})
+
 	out = rc.Params{}
 	out["vfses"] = names
+	out["list"] = list
 	return out, nil
 }
 

--- a/vfs/rc_test.go
+++ b/vfs/rc_test.go
@@ -40,10 +40,20 @@ func TestRcGetVFS(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, vfs == vfs2)
 
+	// Test direct ID lookup
+	vfs, err = getVFS(rc.Params{"fs": vfs2.ID})
+	require.NoError(t, err)
+	assert.True(t, vfs == vfs2)
+
+	// Test ID suffix lookup
+	vfs, err = getVFS(rc.Params{"fs": fs.ConfigString(r.Fremote) + "[" + vfs2.ID + "]"})
+	require.NoError(t, err)
+	assert.True(t, vfs == vfs2)
+
 	inWrong := rc.Params{"fs": fs.ConfigString(r.Fremote) + "notfound"}
 	vfs, err = getVFS(inWrong)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), "no VFS found with name")
+	assert.Contains(t, err.Error(), "no VFS found with name or ID")
 	assert.Nil(t, vfs)
 
 	opt := vfscommon.Opt
@@ -61,6 +71,19 @@ func TestRcGetVFS(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "more than one VFS active with name")
 	assert.Nil(t, vfs)
+
+	// Test lookups with multiple VFSes active
+	vfs, err = getVFS(rc.Params{"fs": vfs2.ID})
+	require.NoError(t, err)
+	assert.True(t, vfs == vfs2)
+
+	vfs, err = getVFS(rc.Params{"fs": vfs3.ID})
+	require.NoError(t, err)
+	assert.True(t, vfs == vfs3)
+
+	vfs, err = getVFS(rc.Params{"fs": fs.ConfigString(r.Fremote) + "[" + vfs3.ID + "]"})
+	require.NoError(t, err)
+	assert.True(t, vfs == vfs3)
 }
 
 func TestRcForget(t *testing.T) {
@@ -102,17 +125,33 @@ func TestRcPollInterval(t *testing.T) {
 }
 
 func TestRcList(t *testing.T) {
-	r, vfs, call := rcNewRun(t, "vfs/list")
-	_ = vfs
+	r, vfs2, call := rcNewRun(t, "vfs/list")
 
 	out, err := call.Fn(context.Background(), nil)
 	require.NoError(t, err)
 
-	assert.Equal(t, rc.Params{
-		"vfses": []string{
-			fs.ConfigString(r.Fremote),
-		},
-	}, out)
+	assert.Equal(t, []string{fs.ConfigString(r.Fremote)}, out["vfses"])
+	assert.Equal(t, []VfsInfo{
+		{ID: vfs2.ID, Fs: fs.ConfigString(r.Fremote)},
+	}, out["list"])
+
+	// Add a second VFS
+	opt := vfscommon.Opt
+	opt.NoModTime = true
+	vfs3 := New(context.Background(), r.Fremote, &opt)
+	defer vfs3.Shutdown()
+
+	out, err = call.Fn(context.Background(), nil)
+	require.NoError(t, err)
+
+	vfses := out["vfses"].([]string)
+	assert.Contains(t, vfses, fs.ConfigString(r.Fremote)+"["+vfs2.ID+"]")
+	assert.Contains(t, vfses, fs.ConfigString(r.Fremote)+"["+vfs3.ID+"]")
+
+	list := out["list"].([]VfsInfo)
+	assert.Len(t, list, 2)
+	assert.Contains(t, list, VfsInfo{ID: vfs2.ID, Fs: fs.ConfigString(r.Fremote)})
+	assert.Contains(t, list, VfsInfo{ID: vfs3.ID, Fs: fs.ConfigString(r.Fremote)})
 }
 
 func TestRcStats(t *testing.T) {

--- a/vfs/rc_test.go
+++ b/vfs/rc_test.go
@@ -131,7 +131,7 @@ func TestRcList(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, []string{fs.ConfigString(r.Fremote)}, out["vfses"])
-	assert.Equal(t, []VfsInfo{
+	assert.Equal(t, []Info{
 		{ID: vfs2.ID, Fs: fs.ConfigString(r.Fremote)},
 	}, out["list"])
 
@@ -148,10 +148,10 @@ func TestRcList(t *testing.T) {
 	assert.Contains(t, vfses, fs.ConfigString(r.Fremote)+"["+vfs2.ID+"]")
 	assert.Contains(t, vfses, fs.ConfigString(r.Fremote)+"["+vfs3.ID+"]")
 
-	list := out["list"].([]VfsInfo)
+	list := out["list"].([]Info)
 	assert.Len(t, list, 2)
-	assert.Contains(t, list, VfsInfo{ID: vfs2.ID, Fs: fs.ConfigString(r.Fremote)})
-	assert.Contains(t, list, VfsInfo{ID: vfs3.ID, Fs: fs.ConfigString(r.Fremote)})
+	assert.Contains(t, list, Info{ID: vfs2.ID, Fs: fs.ConfigString(r.Fremote)})
+	assert.Contains(t, list, Info{ID: vfs3.ID, Fs: fs.ConfigString(r.Fremote)})
 }
 
 func TestRcStats(t *testing.T) {

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -25,15 +25,15 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"os"
 	"path"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
-
-	"slices"
 
 	"github.com/go-git/go-billy/v5"
 	"github.com/rclone/rclone/fs"
@@ -188,6 +188,25 @@ type VFS struct {
 	usage       *fs.Usage
 	pollChan    chan time.Duration
 	inUse       atomic.Int32 // count of number of opens
+	ID          string       // unique ID of this VFS
+}
+
+type contextKeyType struct{}
+type vfsIDContextKeyType struct{}
+
+var (
+	contextKey      = contextKeyType{}
+	vfsIDContextKey = vfsIDContextKeyType{}
+)
+
+// WithTracker returns a new context that tracks created/reused VFSes in a slice pointer.
+func WithTracker(ctx context.Context, tracker *[]*VFS) context.Context {
+	return context.WithValue(ctx, contextKey, tracker)
+}
+
+// WithVFSID returns a new context that specifies a VFS ID to reuse.
+func WithVFSID(ctx context.Context, id string) context.Context {
+	return context.WithValue(ctx, vfsIDContextKey, id)
 }
 
 // Keep track of active VFS keyed on fs.ConfigString(f)
@@ -196,6 +215,21 @@ var (
 	active   = map[string][]*VFS{}
 )
 
+// GetVFSById finds a VFS in the active cache by its ID and increments its use count
+func GetVFSById(id string) (*VFS, error) {
+	activeMu.Lock()
+	defer activeMu.Unlock()
+	for _, vfses := range active {
+		for _, activeVFS := range vfses {
+			if activeVFS.ID == id {
+				activeVFS.inUse.Add(1)
+				return activeVFS, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no VFS found with ID %q", id)
+}
+
 // New creates a new VFS and root directory.  If opt is nil, then
 // DefaultOpt will be used.
 //
@@ -203,6 +237,7 @@ var (
 // the config in the context (if any) and filter config in the context
 // (if any).
 func New(ctx context.Context, f fs.Fs, opt *vfscommon.Options) *VFS {
+	originalCtx := ctx
 	fsDir := fs.NewDir("", time.Now())
 	// Strip the ctx of any cancellation but copy the config across
 	newCtx := context.Background()
@@ -213,6 +248,7 @@ func New(ctx context.Context, f fs.Fs, opt *vfscommon.Options) *VFS {
 		f:      f,
 		ctx:    ctx,
 		cancel: cancel,
+		ID:     fmt.Sprintf("vfs-%08x", rand.Uint32()),
 	}
 	vfs.inUse.Store(1)
 
@@ -230,16 +266,43 @@ func New(ctx context.Context, f fs.Fs, opt *vfscommon.Options) *VFS {
 	activeMu.Lock()
 	defer activeMu.Unlock()
 	configName := fs.ConfigString(f)
+
+	// 1. Try to match by VFS ID from context first
+	if id, ok := originalCtx.Value(vfsIDContextKey).(string); ok && id != "" {
+		for _, vfses := range active {
+			for _, activeVFS := range vfses {
+				if activeVFS.ID == id {
+					fs.Debugf(f, "Reusing VFS ID %s from active cache via context", id)
+					activeVFS.inUse.Add(1)
+					cancel()
+					if tracker, ok := originalCtx.Value(contextKey).(*[]*VFS); ok {
+						*tracker = append(*tracker, activeVFS)
+					}
+					return activeVFS
+				}
+			}
+		}
+	}
+
+	// 2. Try to match by name and options
 	for _, activeVFS := range active[configName] {
 		if vfs.Opt == activeVFS.Opt {
 			fs.Debugf(f, "Reusing VFS from active cache")
 			activeVFS.inUse.Add(1)
 			cancel()
+			if tracker, ok := originalCtx.Value(contextKey).(*[]*VFS); ok {
+				*tracker = append(*tracker, activeVFS)
+			}
 			return activeVFS
 		}
 	}
 	// Put the VFS into the active cache
 	active[configName] = append(active[configName], vfs)
+
+	tracker, ok := originalCtx.Value(contextKey).(*[]*VFS)
+	if ok {
+		*tracker = append(*tracker, vfs)
+	}
 
 	// Create root directory
 	vfs.root = newDir(vfs, f, nil, fsDir)
@@ -316,6 +379,7 @@ func (vfs *VFS) signalHandler(ctx context.Context) {
 // Stats returns info about the VFS
 func (vfs *VFS) Stats() (out rc.Params) {
 	out = make(rc.Params)
+	out["id"] = vfs.ID
 	out["fs"] = fs.ConfigString(vfs.f)
 	out["opt"] = vfs.Opt
 	out["inUse"] = vfs.inUse.Load()

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -215,8 +215,8 @@ var (
 	active   = map[string][]*VFS{}
 )
 
-// GetVFSById finds a VFS in the active cache by its ID and increments its use count
-func GetVFSById(id string) (*VFS, error) {
+// GetVFSByID finds a VFS in the active cache by its ID and increments its use count
+func GetVFSByID(id string) (*VFS, error) {
 	activeMu.Lock()
 	defer activeMu.Unlock()
 	for _, vfses := range active {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This PR partially fixes #9120 by introducing a unique VFS ID and ensuring active VFS instances are cleanly shut down and unpinned from the active cache upon mount or serve failures and shutdowns.

1. **VFS ID Integration**:
   - Added an `ID` field to the `VFS` struct generated with `vfs-%08x`.
   - Implemented `WithVFSID(ctx, id)` context wrapper and `GetVFSById(id)` to allow downstream callers to cleanly lookup, reuse, and reference-count active VFS caches.

2. **Mount Lifetime Cleanups (`cmd/mountlib`)**:
   - Calls `m.VFS.Shutdown()` on mount startup failures (`Mount()`), explicit unmounts (`Unmount()`), and external unmounts (`Wait()`). This prevents permanent memory and goroutine leaks in the `vfs.active` cache.
   - Updated the `mount/mount` RC command to accept `vfsId` to allow mounting on a pre-existing VFS.

3. **Serve Lifetime Cleanups (`cmd/serve`)**:
   - Tracks VFSes inside the `server` struct (`Vfses []*vfs.VFS`).
   - Cleanly calls `v.Shutdown()` when a server fails to start, exits prematurely within the 100ms startup window, or is stopped via `serve/stop` or `serve/stopall`.
   - Updated `serve/start` to accept `vfsId` to allow serving on an existing VFS instance.

4. **Testing Improvements**:
   - Patched `cmd/mountlib/rc_test.go` to use an in-memory configuration (`config.SetConfigPath("")`), resolving password prompt lockouts in headless test runners.

---

#### Was the change discussed in an issue or in the forum before?

Fixes #9120 (Partial Fix)

---

##### Manual Leak Comparison Logs

**Failed Serve Startup:**
* **Unmodified System `v1.74.2`**: Leaves the orphaned VFS in cache permanently after binding fails (Port 80):
  ```json
  $ rclone rc vfs/list
  { "vfses": [ ":local:/tmp/src" ] }  // LEAKED!
  ```
* **This PR**: Cleanly frees the VFS cache immediately:
  ```json
  $ rclone rc vfs/list
  { "list": [], "vfses": [] }  // Cleanly Cleaned Up!
  ```

**External OS-Level Unmount (`fusermount3 -u`):**
* **Unmodified System `v1.74.2`**: Leaves the VFS permanently leaked in memory:
  ```json
  $ rclone rc vfs/list
  { "vfses": [ ":local:/tmp/src" ] }  // PERMANENTLY LEAKED!
  ```
* **This PR**: Safely catches the exit and immediately terminates the VFS cache:
  ```json
  $ rclone rc vfs/list
  { "list": [], "vfses": [] }  // Cleanly Cleaned Up!
  ```

---

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)