### PR TITLE
vfs: prevent duplicate file when renaming onto a symlink - fixes #8245

### DIFF
--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -1174,6 +1174,26 @@ func (d *Dir) RemoveName(name string) error {
 	return node.Remove()
 }
 
+// nodeKind classifies a Node as a regular file, a symlink or a directory
+type nodeKind byte
+
+const (
+	nodeKindFile    nodeKind = iota // regular file
+	nodeKindSymlink                 // symbolic link
+	nodeKindDir                     // directory
+)
+
+// kindOf returns the nodeKind of n
+func kindOf(n Node) nodeKind {
+	if n.IsDir() {
+		return nodeKindDir
+	}
+	if f, ok := n.(*File); ok && f.IsSymlink() {
+		return nodeKindSymlink
+	}
+	return nodeKindFile
+}
+
 // Rename the file
 func (d *Dir) Rename(oldName, newName string, destDir *Dir) error {
 	// fs.Debugf(d, "BEFORE\n%s", d.dump())
@@ -1186,6 +1206,21 @@ func (d *Dir) Rename(oldName, newName string, destDir *Dir) error {
 	oldNode, err := d.stat(oldName)
 	if err != nil {
 		fs.Errorf(oldPath, "Dir.Rename error: %v", err)
+		return err
+	}
+	// Reject a cross-kind file/symlink collision that would duplicate on the remote, see #8245
+	newNode, err := destDir.stat(newName)
+	switch err {
+	case ENOENT:
+		// not found, carry on
+	case nil:
+		// found so check what it is
+		if kindOf(newNode) != kindOf(oldNode) {
+			return EEXIST
+		}
+	default:
+		// a different error - report
+		fs.Errorf(newPath, "Dir.Rename stat failed: %v", err)
 		return err
 	}
 	switch x := oldNode.DirEntry().(type) {

--- a/vfs/vfs.md
+++ b/vfs/vfs.md
@@ -364,11 +364,6 @@ The VFS will correctly resolve `linked-dir` but not
 `linked-dir/file.txt`. This is not a problem for the tested commands
 but may be for other commands.
 
-**Note** that there is an outstanding issue with symlink support
-[issue #8245](https://github.com/rclone/rclone/issues/8245) with duplicate
-files being created when symlinks are moved into directories where
-there is a file of the same name (or vice versa).
-
 ### VFS Case Sensitivity
 
 Linux file systems are case-sensitive: two files can differ only

--- a/vfs/vfstest/file.go
+++ b/vfs/vfstest/file.go
@@ -234,7 +234,6 @@ func TestSymlinks(t *testing.T) {
 
 	// Move symlink -> regular file
 	t.Run("MoveSymlinkToFile", func(t *testing.T) {
-		t.Skip("FIXME not implemented")
 		link1Name := "link1.txt"
 
 		run.symlink(t, ".", link1Name)
@@ -251,7 +250,6 @@ func TestSymlinks(t *testing.T) {
 
 	// Move regular file -> symlink
 	t.Run("MoveFileToSymlink", func(t *testing.T) {
-		t.Skip("FIXME not implemented")
 		link1Name := "link1.txt"
 
 		run.createFile(t, link1Name, "")
@@ -268,7 +266,6 @@ func TestSymlinks(t *testing.T) {
 
 	// Move symlink -> directory
 	t.Run("MoveSymlinkToDirectory", func(t *testing.T) {
-		t.Skip("FIXME not implemented")
 		link1Name := "link1"
 
 		run.symlink(t, ".", link1Name)
@@ -285,7 +282,6 @@ func TestSymlinks(t *testing.T) {
 
 	// Move directory -> symlink
 	t.Run("MoveDirectoryToSymlink", func(t *testing.T) {
-		t.Skip("FIXME not implemented")
 		link1Name := "dir1/link1"
 
 		run.mkdir(t, "link1")
@@ -296,6 +292,23 @@ func TestSymlinks(t *testing.T) {
 		assert.Error(t, err)
 
 		run.rm(t, "link1")
+		run.rm(t, link1Name)
+		checkBaseState()
+	})
+
+	// Move regular file -> symlink, same directory (issue #8245 demo)
+	t.Run("MoveFileToSymlinkSameDir", func(t *testing.T) {
+		link1Name := "link1.txt"
+		file1Name := "file3.txt"
+
+		run.symlink(t, ".", link1Name)
+		run.createFile(t, file1Name, "")
+		run.checkDir(t, baseState+"|file3.txt 0|link1.txt 1")
+
+		err := run.os.Rename(run.path(file1Name), run.path(link1Name))
+		assert.Error(t, err)
+
+		run.rm(t, file1Name)
 		run.rm(t, link1Name)
 		checkBaseState()
 	})


### PR DESCRIPTION
#### What is the purpose of this change?

When `--vfs-links` is enabled the VFS keys items by the logical leaf with `.rclonelink` stripped, so renaming a file onto an existing symlink (or vice versa) left both `name` and `name.rclonelink` on the remote with one node visible in the mount.

`Dir.Rename` now stats the destination first. If a node of a different kind already exists there, it returns `EEXIST`. The shape mirrors the existing collision check in `Dir.Create` and `Dir.Mkdir`. Four skipped tests in `vfs/vfstest/file.go` are enabled, plus one same-directory case covering the issue body's exact demo. All five pass.

The per-command docs and MANUAL are generated at release.

#### Was the change discussed in an issue or in the forum before?

https://github.com/rclone/rclone/issues/8245

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
