### PR TITLE
build: enable support for linux/riscv64

### DIFF
--- a/bin/cross-compile.go
+++ b/bin/cross-compile.go
@@ -58,6 +58,7 @@ var osarches = []string{
 	"linux/arm64",
 	"linux/mips",
 	"linux/mipsle",
+	"linux/riscv64",
 	"freebsd/386",
 	"freebsd/amd64",
 	"freebsd/arm",

--- a/docs/content/downloads.md
+++ b/docs/content/downloads.md
@@ -40,6 +40,7 @@ in the Go Wiki.
 | ARM - 64 Bit | {{< download windows arm64 >}} | {{< download osx arm64 >}} | {{< download linux arm64 >}} | {{< download linux arm64 deb >}} | {{< download linux arm64 rpm >}} | - | - | - | - | - |
 | MIPS - Big Endian | - | - | {{< download linux mips >}} | {{< download linux mips deb >}} | {{< download linux mips rpm >}} | - | - | - | - | - |
 | MIPS - Little Endian | - | - | {{< download linux mipsle >}} | {{< download linux mipsle deb >}} | {{< download linux mipsle rpm >}} | - | - | - | - | - |
+| RISC-V 64-bit | - | - | {{< download linux riscv64 >}} | {{< download linux riscv64 deb >}} | {{< download linux riscv64 rpm >}} | - | - | - | - | - |
 
 <!-- markdownlint-disable-next-line no-bare-urls line-length -->
 You can also find a [mirror of the downloads on GitHub](https://github.com/rclone/rclone/releases/tag/{{< version >}}).
@@ -129,6 +130,7 @@ script) from a URL which doesn't change then you can use these links.
 | ARM - 64 Bit | {{< cdownload windows arm64 >}} | {{< cdownload osx arm64 >}} | {{< cdownload linux arm64 >}} | {{< cdownload linux arm64 deb >}} | {{< cdownload linux arm64 rpm >}} | - | - | - | - | - |
 | MIPS - Big Endian | - | - | {{< cdownload linux mips >}} | {{< cdownload linux mips deb >}} | {{< cdownload linux mips rpm >}} | - | - | - | - | - |
 | MIPS - Little Endian | - | - | {{< cdownload linux mipsle >}} | {{< cdownload linux mipsle deb >}} | {{< cdownload linux mipsle rpm >}} | - | - | - | - | - |
+| RISC-V 64-bit | - | - | {{< cdownload linux riscv64 >}} | {{< cdownload linux riscv64 deb >}} | {{< cdownload linux riscv64 rpm >}} | - | - | - | - | - |
 
 ## Older Downloads
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Adds linux/riscv64 builds to CI. This architecture does not require any special flags, it just works cross-compiling with Go.

#### Was the change discussed in an issue or in the forum before?

Fixes #8592

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

Tested CI with temporarily disabled jobs other than Linux and hacked Makefile to do cross-compiling without uploads (hence without the need for a correct config secret): https://github.com/MichaIng/rclone/actions/runs/26724805773

I will test builds from CI once available on local riscv64 hardware, but native builds just work, and with Go, there is really no reason to doubt cross-compiled builds do the same.