### PR TITLE
fs: add --guess-mimetype option to get mime type from magic number

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/ncw/swift/v2"
+	"github.com/gabriel-vasile/mimetype"
 
 	"golang.org/x/net/http/httpguts"
 	"golang.org/x/sync/errgroup"
@@ -704,6 +705,11 @@ In this case, you might want to try disabling this option.
 			Advanced: true,
 			Default:  false,
 		}, {
+			Name:	  "guess_mimetype",
+			Help:     "Guess content-type from file's content",
+			Advanced: true,
+			Default:  false,
+		}, {
 			Name:     "sts_endpoint",
 			Help:     "Endpoint for STS (deprecated).\n\nLeave blank if using AWS to use the default endpoint for the region.",
 			Advanced: true,
@@ -1131,6 +1137,7 @@ type Options struct {
 	Decompress                  bool                 `config:"decompress"`
 	MightGzip                   fs.Tristate          `config:"might_gzip"`
 	UseAcceptEncodingGzip       fs.Tristate          `config:"use_accept_encoding_gzip"`
+	GuessMimetype	            bool		 `config:"guess_mimetype"`
 	NoSystemMetadata            bool                 `config:"no_system_metadata"`
 	UseAlreadyExists            fs.Tristate          `config:"use_already_exists"`
 	UseMultipartUploads         fs.Tristate          `config:"use_multipart_uploads"`
@@ -3166,7 +3173,7 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 		uploadOptions = append(uploadOptions, option)
 	}
 
-	ui, err := srcObj.prepareUpload(ctx, src, uploadOptions, true)
+	ui, err := srcObj.prepareUpload(ctx, src, uploadOptions, true, "")
 	if err != nil {
 		return nil, fmt.Errorf("failed to prepare upload: %w", err)
 	}
@@ -4149,8 +4156,20 @@ func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
 
 	// Copy the object to itself to update the metadata
 	bucket, bucketPath := o.split()
+	ctype := fs.MimeType(ctx, o)
+	if ctype == "application/octet-stream" {
+		rd, err := o.Open(context.Background())
+		if err == nil {
+			mimetype.SetLimit(1024*1024)
+			mtype, err := mimetype.DetectReader(rd)
+			if err == nil {
+				ctype = mtype.String()
+			}
+			rd.Close()
+		}
+	}
 	req := s3.CopyObjectInput{
-		ContentType:       aws.String(fs.MimeType(ctx, o)), // Guess the content type
+		ContentType:       aws.String(ctype), // Guess the content type
 		Metadata:          mapToS3Metadata(o.meta),
 		MetadataDirective: types.MetadataDirectiveReplace, // replace metadata with that passed in
 	}
@@ -4406,7 +4425,7 @@ func (f *Fs) OpenChunkWriter(ctx context.Context, remote string, src fs.ObjectIn
 		fs:     f,
 		remote: remote,
 	}
-	ui, err := o.prepareUpload(ctx, src, options, false)
+	ui, err := o.prepareUpload(ctx, src, options, false, "")
 	if err != nil {
 		return info, nil, fmt.Errorf("failed to prepare upload: %w", err)
 	}
@@ -4780,7 +4799,7 @@ type uploadInfo struct {
 // Prepare object for being uploaded
 //
 // If noHash is true the md5sum will not be calculated
-func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options []fs.OpenOption, noHash bool) (ui uploadInfo, err error) {
+func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options []fs.OpenOption, noHash bool, guess string) (ui uploadInfo, err error) {
 	bucket, bucketPath := o.split()
 	// Create parent dir/bucket if not saving directory marker
 	if !strings.HasSuffix(o.remote, "/") {
@@ -4900,6 +4919,9 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 	if ui.req.ContentType == nil {
 		ui.req.ContentType = aws.String(fs.MimeType(ctx, src))
 	}
+	if guess != "" {
+		ui.req.ContentType = aws.String(guess)
+	}
 	if size >= 0 {
 		ui.req.ContentLength = &size
 	}
@@ -4996,6 +5018,8 @@ func (o *Object) prepareUpload(ctx context.Context, src fs.ObjectInfo, options [
 
 // Update the Object from in with modTime and size
 func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
+	buf, _ := io.ReadAll(in)
+	ir := bytes.NewReader(buf)
 	if o.fs.opt.VersionAt.IsSet() {
 		return errNotWithVersionAt
 	}
@@ -5009,17 +5033,24 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	var err error
 	var ui uploadInfo
 	if multipart {
-		wantETag, gotETag, versionID, ui, err = o.uploadMultipart(ctx, src, in, options...)
+		wantETag, gotETag, versionID, ui, err = o.uploadMultipart(ctx, src, ir, options...)
 	} else {
-		ui, err = o.prepareUpload(ctx, src, options, false)
+		guess := ""
+		if o.fs.opt.GuessMimetype {
+                        mtype := mimetype.Detect(buf)
+                        if err == nil {
+				guess = mtype.String()
+                        }
+		}
+		ui, err = o.prepareUpload(ctx, src, options, false, guess)
 		if err != nil {
 			return fmt.Errorf("failed to prepare upload: %w", err)
 		}
 
 		if o.fs.opt.UsePresignedRequest {
-			gotETag, lastModified, versionID, err = o.uploadSinglepartPresignedRequest(ctx, ui.req, size, in)
+			gotETag, lastModified, versionID, err = o.uploadSinglepartPresignedRequest(ctx, ui.req, size, ir)
 		} else {
-			gotETag, lastModified, versionID, err = o.uploadSinglepartPutObject(ctx, ui.req, size, in)
+			gotETag, lastModified, versionID, err = o.uploadSinglepartPutObject(ctx, ui.req, size, ir)
 		}
 	}
 	if err != nil {

--- a/fs/config.go
+++ b/fs/config.go
@@ -566,6 +566,11 @@ var ConfigOptionsInfo = Options{{
 	Default: "",
 	Help:    "HTTP proxy URL.",
 	Groups:  "Networking",
+}, {
+	Name:    "guess_mimetype",
+	Default: false,
+	Help:    "Try to guess mime type of files with magic numbers",
+	Groups:  "Copy",
 }}
 
 // ConfigInfo is filesystem config options
@@ -680,6 +685,7 @@ type ConfigInfo struct {
 	MaxConnections             int               `config:"max_connections"`
 	NameTransform              []string          `config:"name_transform"`
 	HTTPProxy                  string            `config:"http_proxy"`
+	GuessMimetype              bool              `config:"guess_mimetype"`  
 }
 
 func init() {

--- a/fs/mimetype.go
+++ b/fs/mimetype.go
@@ -63,6 +63,7 @@ func MimeType(ctx context.Context, o DirEntry) (mimeType string) {
 			return mimeType
 		}
 	}
+
 	return MimeTypeFromName(o.Remote())
 }
 

--- a/fs/mimetype.go
+++ b/fs/mimetype.go
@@ -5,6 +5,7 @@ import (
 	"mime"
 	"path"
 	"strings"
+	"github.com/gabriel-vasile/mimetype"
 )
 
 // Add a minimal number of mime types to augment go's built in types
@@ -55,6 +56,20 @@ func MimeTypeFromName(remote string) (mimeType string) {
 // MimeType returns the MimeType from the object, either by calling
 // the MimeTyper interface or using MimeTypeFromName
 func MimeType(ctx context.Context, o DirEntry) (mimeType string) {
+	// Guess the MimeType from content if possible
+	ci := GetConfig(ctx)
+	if ci.GuessMimetype {
+		if ob, ok := o.(Object); ok {
+			ro, err := ob.Open(ctx)
+			if err == nil {
+				defer ro.Close()
+				if mtype, err := mimetype.DetectReader(ro); err == nil &&
+					mtype.String() != "application/octet-stream" {
+					return mtype.String()
+				}
+			}
+		}
+	}
 	// Read the MimeType from the optional interface if available
 	if do, ok := o.(MimeTyper); ok {
 		mimeType = do.MimeType(ctx)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Adds a CLI option (`--guess-mimetype`) that makes copy operations guess the mimetype of a file using magic numbers, if the backend requests for it.

#### Was the change discussed in an issue or in the forum before?

Not from what I've seen.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
