### PR TITLE
fix(webdav): handle mixed property statuses in multi-status responses

### DIFF
--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -98,21 +98,19 @@ func (p *Prop) Code() int {
 	return code
 }
 
+// Parse a status of the form "HTTP/1.1 200 OK" or "HTTP/1.1 200"
+var parseStatus2XX = regexp.MustCompile(`HTTP/[\d.]+\s+2\d{2}`)
+
 // StatusOK examines the Status and returns an OK flag
 func (p *Prop) StatusOK() bool {
-	// Fetch status code as int
-	c := p.Code()
-
 	// Assume OK if no statuses received
-	if c == -1 {
+	if len(p.Status) == 0 {
 		return true
 	}
-	if c == 0 {
-		return false
-	}
-	if c >= 200 && c < 300 {
-		return true
-
+	for _, statusStr := range p.Status {
+		if parseStatus2XX.MatchString(statusStr) {
+			return true
+		}
 	}
 	return false
 }

--- a/backend/webdav/api/types.go
+++ b/backend/webdav/api/types.go
@@ -98,10 +98,10 @@ func (p *Prop) Code() int {
 	return code
 }
 
-// Parse a status of the form "HTTP/1.1 200 OK" or "HTTP/1.1 200"
-var parseStatus2XX = regexp.MustCompile(`HTTP/[\d.]+\s+2\d{2}`)
+// Parse a status of the form "HTTP/1.1 2xx"
+var parseStatus2XX = regexp.MustCompile(`^HTTP/[\d.]+\s+2\d{2}`)
 
-// StatusOK examines the Status and returns an OK flag
+// StatusOK returns true if there is at least one 2XX response.
 func (p *Prop) StatusOK() bool {
 	// Assume OK if no statuses received
 	if len(p.Status) == 0 {

--- a/backend/webdav/api/types_test.go
+++ b/backend/webdav/api/types_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestPropStatusOK(t *testing.T) {
+	tests := []struct {
+		name   string
+		status []string
+		want   bool
+	}{
+		{"Empty status", []string{}, true},
+		{"Single 200 OK", []string{"HTTP/1.1 200 OK"}, true},
+		{"Single 404 Not Found", []string{"HTTP/1.1 404 Not Found"}, false},
+		{"Mixed status with 404 first", []string{"HTTP/1.1 404 Not Found", "HTTP/1.1 200 OK"}, true},
+		{"Mixed status with 200 first", []string{"HTTP/1.1 200 OK", "HTTP/1.1 404 Not Found"}, true},
+		{"Multiple non-2xx statuses", []string{"HTTP/1.1 404 Not Found", "HTTP/1.1 403 Forbidden"}, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &Prop{Status: tt.status}
+			if got := p.StatusOK(); got != tt.want {
+				t.Errorf("Prop.StatusOK() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

This PR fixes a bug in the WebDAV backend where directories or files could randomly "disappear" from listings due to strict and fragile multi-status code parsing.

##### The Problem
A regression was recently introduced when a new branch for explicit property fetching (`useStandardProps`) was added to the `PROPFIND` request body:

```go
// The recently added branch that triggered the issue:
if f.hasOCMD5 || f.hasOCSHA1 {
   opts.Body = bytes.NewBuffer(owncloudProps)
} else if f.useStandardProps {
   opts.Body = bytes.NewBuffer(standardProps) // 👈 This sends explicit XML props
}
```
When rclone queries multiple specific properties via `standardProps `(e.g., `displayname`, `getcontentlength`, `resourcetype`), `RFC 4918` fully allows standard-compliant WebDAV servers to return mixed statuses within a single item. For example, a directory does not have a content length, so the server legally returns `404 Not Found` for that specific property, alongside a `200 OK` for the resource type itself.

Since `RFC 4918` does not mandate the order of `<propstat>` XML elements, some standard-compliant servers return the `404 Not Found` block before the `200 OK` block.

Currently, `StatusOK()` relies on `p.Code()`, which blindly checks only the first element (`p.Status[0]`):
```Go

// Old fragile logic path inside p.Code()
match := parseStatus.FindStringSubmatch(p.Status[0])
```
If `404` happens to be the first status in the slice, `p.Code()` returns `0`, causing `StatusOK()` to return `false`. As a result, `listAll()` executes a continue and silently skips valid directories, causing them to randomly "disappear" from listings since the use_standard_props feature was introduced.
##### The Fix

To safely fix this without breaking other methods (like `readMetaDataForPath`) that rely on the original behavior of `p.Code()`, we decouple `StatusOK()` and update it to iterate through the entire `p.Status` slice:
Keep `p.Code()` intact to avoid breaking historical metadata checks (such as checking for `425` Too Early in 0-RTT scenarios).

Upgrade `StatusOK()` with a dedicated `2xx` regex pattern to scan all statuses. As long as any single status indicates success (`2xx`), the item is considered valid.

```Go

var parseStatus2XX = regexp.MustCompile(`HTTP/[\d.]+\s+2\d{2}`)

// StatusOK examines the Status and returns an OK flag
func (p *Prop) StatusOK() bool {
	// Assume OK if no statuses received
	if len(p.Status) == 0 {
		return true
	}
	for _, statusStr := range p.Status {
		if parseStatus2XX.MatchString(statusStr) {
			return true
		}
	}
	return false
}
```
#### Was the change discussed in an issue or in the forum before?

No, this was discovered during local integration testing with a standard-compliant WebDAV server that orders `404` property statuses before `200` statuses in the XML payload.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
