### PR TITLE
s3: fix objects with consecutive slashes in keys being silently skipped

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2468,6 +2468,9 @@ func (f *Fs) list(ctx context.Context, opt listOpt, fn listFn) error {
 					continue
 				}
 				remote = remote[len(opt.prefix):]
+				// Trim leading slashes which can occur with object
+				// keys containing consecutive slashes (e.g. "dir//file")
+				remote = strings.TrimLeft(remote, "/")
 				// Trim one slash off the remote name
 				remote, _ = strings.CutSuffix(remote, "/")
 				if remote == "" || bucket.IsAllSlashes(remote) {
@@ -2512,6 +2515,9 @@ func (f *Fs) list(ctx context.Context, opt listOpt, fn listFn) error {
 				}
 			}
 			remote = remote[len(opt.prefix):]
+			// Trim leading slashes which can occur with object
+			// keys containing consecutive slashes (e.g. "dir//file")
+			remote = strings.TrimLeft(remote, "/")
 			if isDirectory {
 				// process directory markers as directories
 				remote, _ = strings.CutSuffix(remote, "/")


### PR DESCRIPTION
## What

When S3 object keys contain consecutive slashes (e.g. `2026/1//1d8c54b6416447b99897ab846100f7f6`), the S3 listing backend strips the prefix but leaves a leading slash in the relative path (e.g. `/1d8c54b6416447b99897ab846100f7f6`). This causes `filterDir` in `fs/list/list.go` to reject the entry with:

```
Entry doesn't belong in directory "2026/1/" (too short) - ignoring
```

The objects are silently skipped during `copy`/`sync` operations, resulting in **data loss** without a non-zero exit code.

Fixes #9383

## Root cause

In `backend/s3/s3.go`'s `list()` function, after stripping the prefix from the S3 key, consecutive slashes in the key leave a leading `/` in the relative path:

- S3 key: `2026/1//1d8c54b6416447b99897ab846100f7f6`
- Prefix: `2026/1/`
- After strip: `/1d8c54b6416447b99897ab846100f7f6` (leading `/`)
- Expected: `1d8c54b6416447b99897ab846100f7f6`

The leading `/` causes `strings.HasPrefix(remote, prefix)` to fail in `filterDir`.

## Fix

Trim leading slashes after prefix stripping in both the CommonPrefixes and Contents listing paths in `backend/s3/s3.go`.

## Testing

- Verified existing `fs/list` tests pass
- Verified `backend/s3` builds successfully
- The fix handles edge cases: normal keys (unchanged), double-slash keys (corrected), root-level double-slash keys (corrected)