### PR TITLE
iclouddrive: support folders shared by another Apple ID (read + write) - fixes #9477

### DIFF
--- a/backend/iclouddrive/api/clouddocs.go
+++ b/backend/iclouddrive/api/clouddocs.go
@@ -1,0 +1,275 @@
+package api
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/rclone/rclone/lib/rest"
+)
+
+// CloudDocs is a thin CloudKit (ckdatabasews) client for the com.apple.clouddocs
+// container, shared database. It is used for operations that the drivews/docws
+// endpoints cannot perform — most importantly placing a document inside a folder
+// shared by another Apple ID (a FOLDER_IN_SHARED_FOLDER), which is only reachable
+// through the owner's CloudKit zone.
+//
+// The drivews/docws layer returns HTTP 400 for any write whose parent is a
+// FOLDER_IN_SHARED_FOLDER. The workaround implemented here is:
+//
+//  1. upload the document into the share ROOT the normal way (drivews performs the
+//     Protected Cloud Storage chaining server-side, because the share root is an
+//     addressable SHARED_FOLDER);
+//  2. re-parent the resulting record into the target sub-folder via a CloudKit
+//     records/modify "update". The server re-chains PCS itself, because the record
+//     already carries its own PCS key — so no client-side PCS crypto is required.
+type CloudDocs struct {
+	icloud *Client
+	url    string
+	zone   *CKZoneID
+}
+
+// CKZoneID identifies a CloudKit zone.
+type CKZoneID struct {
+	ZoneName        string `json:"zoneName"`
+	OwnerRecordName string `json:"ownerRecordName"`
+	ZoneType        string `json:"zoneType"`
+}
+
+// CloudDocsService returns a CloudDocs client, or nil if the account has no
+// ckdatabasews web service (in which case shared-subfolder writes are unsupported).
+func (c *Client) CloudDocsService() *CloudDocs {
+	ws := c.Session.AccountInfo.Webservices["ckdatabasews"]
+	if ws == nil || ws.URL == "" {
+		return nil
+	}
+	return &CloudDocs{icloud: c, url: ws.URL}
+}
+
+func (cd *CloudDocs) request(ctx context.Context, sub string, body, response any) (*http.Response, error) {
+	rootURL := fmt.Sprintf("%s/database/1/com.apple.clouddocs/production/shared/%s?remapEnums=true&getCurrentSyncToken=true", cd.url, sub)
+	reader, err := IntoReader(body)
+	if err != nil {
+		return nil, err
+	}
+	opts := rest.Opts{
+		Method:       "POST",
+		RootURL:      rootURL,
+		ExtraHeaders: cd.icloud.Session.GetHeaders(map[string]string{"Content-Type": "text/plain"}),
+		Body:         reader,
+	}
+	return cd.icloud.Request(ctx, opts, nil, response)
+}
+
+// Zone returns the (single) shared CloudDocs zone, discovering and caching it on
+// first use via zones/list.
+func (cd *CloudDocs) Zone(ctx context.Context) (*CKZoneID, error) {
+	if cd.zone != nil {
+		return cd.zone, nil
+	}
+	var out struct {
+		Zones []struct {
+			ZoneID CKZoneID `json:"zoneID"`
+		} `json:"zones"`
+	}
+	if _, err := cd.request(ctx, "zones/list", map[string]any{}, &out); err != nil {
+		return nil, err
+	}
+	for i := range out.Zones {
+		if out.Zones[i].ZoneID.ZoneName == defaultZone {
+			cd.zone = &out.Zones[i].ZoneID
+			return cd.zone, nil
+		}
+	}
+	if len(out.Zones) > 0 {
+		cd.zone = &out.Zones[0].ZoneID
+		return cd.zone, nil
+	}
+	return nil, fmt.Errorf("no shared clouddocs zone found")
+}
+
+// ckRecord is the subset of a CloudKit record we read back.
+type ckRecord struct {
+	RecordName      string `json:"recordName"`
+	RecordChangeTag string `json:"recordChangeTag"`
+	Reason          string `json:"reason"`
+	ServerErrorCode string `json:"serverErrorCode"`
+	Deleted         bool   `json:"deleted"`
+}
+
+func (cd *CloudDocs) lookup(ctx context.Context, recordNames ...string) ([]ckRecord, error) {
+	zone, err := cd.Zone(ctx)
+	if err != nil {
+		return nil, err
+	}
+	recs := make([]map[string]any, 0, len(recordNames))
+	for _, rn := range recordNames {
+		recs = append(recs, map[string]any{"recordName": rn})
+	}
+	var out struct {
+		Records []ckRecord `json:"records"`
+	}
+	if _, err := cd.request(ctx, "records/lookup", map[string]any{"zoneID": zone, "records": recs}, &out); err != nil {
+		return nil, err
+	}
+	return out.Records, nil
+}
+
+// ReparentStructure moves the documentStructure/<uuid> record under a new parent
+// directory/<targetDirUUID>, within the shared zone. The matching
+// documentContent/<uuid> follows automatically (its parent is the structure).
+//
+// uuid is the bare record UUID (e.g. the docwsid of the just-uploaded file, which
+// CloudDocs reuses as the structure/content record name). The current
+// recordChangeTag is fetched automatically.
+func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID string) error {
+	zone, err := cd.Zone(ctx)
+	if err != nil {
+		return err
+	}
+	structRec := "documentStructure/" + strings.ToUpper(uuid)
+	recs, err := cd.lookup(ctx, structRec)
+	if err != nil {
+		return err
+	}
+	if len(recs) == 0 || recs[0].RecordChangeTag == "" {
+		reason := "not found"
+		if len(recs) > 0 && recs[0].Reason != "" {
+			reason = recs[0].Reason
+		}
+		return fmt.Errorf("clouddocs: could not look up %s: %s", structRec, reason)
+	}
+	dirRef := map[string]any{
+		"recordName": "directory/" + strings.ToUpper(targetDirUUID),
+		"action":     "VALIDATE",
+		"zoneID":     zone,
+	}
+	record := map[string]any{
+		"recordName":      structRec,
+		"recordType":      "structure",
+		"recordChangeTag": recs[0].RecordChangeTag,
+		"fields": map[string]any{
+			"parent": map[string]any{"value": dirRef, "type": "REFERENCE"},
+		},
+		"parent": map[string]any{"recordName": "directory/" + strings.ToUpper(targetDirUUID)},
+	}
+	body := map[string]any{
+		"atomic":     true,
+		"zoneID":     zone,
+		"operations": []any{map[string]any{"operationType": "update", "record": record}},
+	}
+	var out struct {
+		Records []ckRecord `json:"records"`
+	}
+	if _, err := cd.request(ctx, "records/modify", body, &out); err != nil {
+		return err
+	}
+	for _, r := range out.Records {
+		if r.ServerErrorCode != "" {
+			return fmt.Errorf("clouddocs re-parent failed for %s: %s (%s)", r.RecordName, r.Reason, r.ServerErrorCode)
+		}
+	}
+	return nil
+}
+
+// DeleteFile deletes the documentStructure/documentContent pair for the given
+// record UUID from the shared zone. Used to remove or overwrite files that live
+// inside a shared sub-folder, which the drivews trash endpoint cannot touch.
+func (cd *CloudDocs) DeleteFile(ctx context.Context, uuid string) error {
+	zone, err := cd.Zone(ctx)
+	if err != nil {
+		return err
+	}
+	uuid = strings.ToUpper(uuid)
+	contentRec := "documentContent/" + uuid
+	structRec := "documentStructure/" + uuid
+	recs, err := cd.lookup(ctx, contentRec, structRec)
+	if err != nil {
+		return err
+	}
+	tags := map[string]string{}
+	for _, r := range recs {
+		tags[r.RecordName] = r.RecordChangeTag
+	}
+	ops := []any{}
+	for _, rn := range []string{contentRec, structRec} {
+		rec := map[string]any{"recordName": rn}
+		if t := tags[rn]; t != "" {
+			rec["recordChangeTag"] = t
+		}
+		ops = append(ops, map[string]any{"operationType": "delete", "record": rec})
+	}
+	var out struct {
+		Records []ckRecord `json:"records"`
+	}
+	_, err = cd.request(ctx, "records/modify", map[string]any{"atomic": false, "zoneID": zone, "operations": ops}, &out)
+	return err
+}
+
+// FindFileUUID looks up the record UUID of the file named leaf inside the shared
+// directory directory/<dirUUID>. CloudDocs record types are not query-indexable, so
+// it enumerates the zone (changes/zone) and matches a documentStructure whose parent
+// is that directory and whose basehash equals SHA256(basename-without-ext). Returns
+// "" if not found.
+func (cd *CloudDocs) FindFileUUID(ctx context.Context, dirUUID, leaf string) (string, error) {
+	zone, err := cd.Zone(ctx)
+	if err != nil {
+		return "", err
+	}
+	basename := leaf
+	if i := strings.LastIndexByte(leaf, '.'); i > 0 {
+		basename = leaf[:i]
+	}
+	sum := sha256.Sum256([]byte(basename))
+	wantHash := base64.StdEncoding.EncodeToString(sum[:])
+	wantParent := "directory/" + strings.ToUpper(dirUUID)
+
+	syncToken := ""
+	for {
+		zoneReq := map[string]any{"zoneID": zone}
+		if syncToken != "" {
+			zoneReq["syncToken"] = syncToken
+		}
+		var out struct {
+			Zones []struct {
+				Records []struct {
+					RecordName string `json:"recordName"`
+					RecordType string `json:"recordType"`
+					Fields     map[string]struct {
+						Value any `json:"value"`
+					} `json:"fields"`
+				} `json:"records"`
+				SyncToken  string `json:"syncToken"`
+				MoreComing bool   `json:"moreComing"`
+			} `json:"zones"`
+		}
+		if _, err := cd.request(ctx, "changes/zone", map[string]any{"zones": []any{zoneReq}}, &out); err != nil {
+			return "", err
+		}
+		if len(out.Zones) == 0 {
+			return "", nil
+		}
+		z := out.Zones[0]
+		for _, r := range z.Records {
+			if r.RecordType != "structure" || !strings.HasPrefix(r.RecordName, "documentStructure/") {
+				continue
+			}
+			bh, _ := r.Fields["basehash"].Value.(string)
+			if bh != wantHash {
+				continue
+			}
+			if pv, ok := r.Fields["parent"].Value.(map[string]any); ok {
+				if rn, _ := pv["recordName"].(string); rn == wantParent {
+					return strings.TrimPrefix(r.RecordName, "documentStructure/"), nil
+				}
+			}
+		}
+		if !z.MoreComing {
+			return "", nil
+		}
+		syncToken = z.SyncToken
+	}
+}

--- a/backend/iclouddrive/api/clouddocs.go
+++ b/backend/iclouddrive/api/clouddocs.go
@@ -264,12 +264,7 @@ func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID 
 	if err := cd.request(ctx, "records/modify", body, &out); err != nil {
 		return err
 	}
-	for _, r := range out.Records {
-		if r.ServerErrorCode != "" {
-			return fmt.Errorf("clouddocs re-parent failed for %s: %s (%s)", r.RecordName, r.Reason, r.ServerErrorCode)
-		}
-	}
-	return nil
+	return checkRecordErrors("clouddocs re-parent", out.Records)
 }
 
 // documentRecordNames returns the documentContent and documentStructure record
@@ -278,6 +273,11 @@ func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID 
 func documentRecordNames(uuid string) (content, structure string) {
 	uuid = strings.ToUpper(uuid)
 	return "documentContent/" + uuid, "documentStructure/" + uuid
+}
+
+// directoryRecordName returns the directory record name for a bare folder UUID.
+func directoryRecordName(uuid string) string {
+	return "directory/" + strings.ToUpper(uuid)
 }
 
 // deleteRecordOperations builds the records/modify "delete" operations for a
@@ -294,6 +294,30 @@ func deleteRecordOperations(contentRec, structRec string, tags map[string]string
 	return ops
 }
 
+func deleteDirectoryRecordOperation(directoryRec string, tags map[string]string) []ckOperation {
+	return []ckOperation{{
+		OperationType: "delete",
+		Record:        ckRecordModify{RecordName: directoryRec, RecordChangeTag: tags[directoryRec]},
+	}}
+}
+
+func lookupRecordTags(records []ckRecord) map[string]string {
+	tags := map[string]string{}
+	for _, r := range records {
+		tags[r.RecordName] = r.RecordChangeTag
+	}
+	return tags
+}
+
+func checkRecordErrors(operation string, records []ckRecord) error {
+	for _, r := range records {
+		if r.ServerErrorCode != "" {
+			return fmt.Errorf("%s failed for %s: %s (%s)", operation, r.RecordName, r.Reason, r.ServerErrorCode)
+		}
+	}
+	return nil
+}
+
 // DeleteFile deletes the documentStructure/documentContent pair for the given
 // record UUID from the shared zone. Used to remove or overwrite files that live
 // inside a shared sub-folder, which the drivews trash endpoint cannot touch.
@@ -307,13 +331,33 @@ func (cd *CloudDocs) DeleteFile(ctx context.Context, uuid string) error {
 	if err != nil {
 		return err
 	}
-	tags := map[string]string{}
-	for _, r := range recs {
-		tags[r.RecordName] = r.RecordChangeTag
-	}
-	ops := deleteRecordOperations(contentRec, structRec, tags)
+	ops := deleteRecordOperations(contentRec, structRec, lookupRecordTags(recs))
 	var out ckRecordsResponse
-	return cd.request(ctx, "records/modify", ckModifyRequest{Atomic: false, ZoneID: zone, Operations: ops}, &out)
+	if err := cd.request(ctx, "records/modify", ckModifyRequest{Atomic: false, ZoneID: zone, Operations: ops}, &out); err != nil {
+		return err
+	}
+	return checkRecordErrors("clouddocs delete file", out.Records)
+}
+
+// DeleteDirectory deletes an empty directory/<uuid> record from the shared zone.
+// It is used for rmdir of shared sub-directories; callers must verify emptiness
+// first because this is not a recursive purge operation.
+func (cd *CloudDocs) DeleteDirectory(ctx context.Context, uuid string) error {
+	zone, err := cd.Zone(ctx)
+	if err != nil {
+		return err
+	}
+	dirRec := directoryRecordName(uuid)
+	recs, err := cd.lookup(ctx, dirRec)
+	if err != nil {
+		return err
+	}
+	ops := deleteDirectoryRecordOperation(dirRec, lookupRecordTags(recs))
+	var out ckRecordsResponse
+	if err := cd.request(ctx, "records/modify", ckModifyRequest{Atomic: false, ZoneID: zone, Operations: ops}, &out); err != nil {
+		return err
+	}
+	return checkRecordErrors("clouddocs delete directory", out.Records)
 }
 
 // ckZoneChangesRequestZone names a zone (and an optional resume token) in a

--- a/backend/iclouddrive/api/clouddocs.go
+++ b/backend/iclouddrive/api/clouddocs.go
@@ -221,12 +221,31 @@ type ckModifyRequest struct {
 // CloudDocs reuses as the structure/content record name). The current
 // recordChangeTag is fetched automatically.
 func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID, leaf string) error {
+	return cd.reparent(ctx, "documentStructure/"+strings.ToUpper(uuid), targetDirUUID, documentNameFields(leaf))
+}
+
+// ReparentDirectory moves the directory/<uuid> record under a new parent
+// directory/<targetDirUUID>, within the shared zone, and sets its visible leaf
+// name. It is the folder counterpart of ReparentStructure: a fresh directory
+// record cannot be created inside a shared sub-folder (the server rejects it for
+// lacking a PCS key), so a folder is first placed in the share root the normal way
+// which gives it a PCS key, and then re-parented here. The server re-chains PCS
+// itself because the record already carries its own key.
+func (cd *CloudDocs) ReparentDirectory(ctx context.Context, uuid, targetDirUUID, leaf string) error {
+	return cd.reparent(ctx, directoryRecordName(uuid), targetDirUUID, directoryNameFields(leaf))
+}
+
+// reparent issues the records/modify "update" that moves recordName under
+// directory/<targetDirUUID> and sets its name fields. The record must already
+// carry a PCS key (i.e. already live in the owner's zone); the server re-chains
+// PCS to the new parent. Both document-structure and directory records are
+// CloudKit recordType "structure".
+func (cd *CloudDocs) reparent(ctx context.Context, recordName, targetDirUUID string, fields map[string]ckField) error {
 	zone, err := cd.Zone(ctx)
 	if err != nil {
 		return err
 	}
-	structRec := "documentStructure/" + strings.ToUpper(uuid)
-	recs, err := cd.lookup(ctx, structRec)
+	recs, err := cd.lookup(ctx, recordName)
 	if err != nil {
 		return err
 	}
@@ -235,10 +254,9 @@ func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID,
 		if len(recs) > 0 && recs[0].Reason != "" {
 			reason = recs[0].Reason
 		}
-		return fmt.Errorf("clouddocs: could not look up %s: %s", structRec, reason)
+		return fmt.Errorf("clouddocs: could not look up %s: %s", recordName, reason)
 	}
-	dirRecordName := "directory/" + strings.ToUpper(targetDirUUID)
-	fields := documentNameFields(leaf)
+	dirRecordName := directoryRecordName(targetDirUUID)
 	fields["parent"] = ckField{
 		Type: "REFERENCE",
 		Value: ckReference{
@@ -253,7 +271,7 @@ func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID,
 		Operations: []ckOperation{{
 			OperationType: "update",
 			Record: ckRecordModify{
-				RecordName:      structRec,
+				RecordName:      recordName,
 				RecordType:      "structure",
 				RecordChangeTag: recs[0].RecordChangeTag,
 				Fields:          fields,
@@ -393,7 +411,15 @@ type ckZoneChangesResponse struct {
 // documentStructure records the file's name, and how FindFileUUID matches it.
 func documentBaseHash(leaf string) string {
 	basename, _ := documentNameParts(leaf)
-	sum := sha256.Sum256([]byte(basename))
+	return nameBaseHash(basename)
+}
+
+func directoryBaseHash(leaf string) string {
+	return nameBaseHash(leaf)
+}
+
+func nameBaseHash(name string) string {
+	sum := sha256.Sum256([]byte(name))
 	return base64.StdEncoding.EncodeToString(sum[:])
 }
 
@@ -425,6 +451,19 @@ func documentNameFields(leaf string) map[string]ckField {
 	}
 }
 
+func directoryNameFields(leaf string) map[string]ckField {
+	return map[string]ckField{
+		"basehash": {
+			Value: directoryBaseHash(leaf),
+			Type:  "BYTES",
+		},
+		"encryptedBasename": {
+			Value: base64.StdEncoding.EncodeToString([]byte(leaf)),
+			Type:  "ENCRYPTED_BYTES",
+		},
+	}
+}
+
 // FindFileUUID looks up the record UUID of the file named leaf inside the shared
 // directory directory/<dirUUID>. CloudDocs record types are not query-indexable, so
 // it enumerates the zone (changes/zone) and matches a documentStructure whose parent
@@ -447,6 +486,9 @@ func (cd *CloudDocs) findChildStructureUUID(ctx context.Context, dirUUID, leaf, 
 		return "", err
 	}
 	wantHash := documentBaseHash(leaf)
+	if recordPrefix == "directory/" {
+		wantHash = directoryBaseHash(leaf)
+	}
 	wantParent := "directory/" + strings.ToUpper(dirUUID)
 
 	syncToken := ""

--- a/backend/iclouddrive/api/clouddocs.go
+++ b/backend/iclouddrive/api/clouddocs.go
@@ -272,6 +272,28 @@ func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID 
 	return nil
 }
 
+// documentRecordNames returns the documentContent and documentStructure record
+// names for a bare file UUID. CloudDocs reuses the same UUID (upper-cased) for both
+// halves of a document.
+func documentRecordNames(uuid string) (content, structure string) {
+	uuid = strings.ToUpper(uuid)
+	return "documentContent/" + uuid, "documentStructure/" + uuid
+}
+
+// deleteRecordOperations builds the records/modify "delete" operations for a
+// document's content and structure records, attaching each record's current change
+// tag (a missing tag is sent empty, which the server tolerates for a delete).
+func deleteRecordOperations(contentRec, structRec string, tags map[string]string) []ckOperation {
+	ops := make([]ckOperation, 0, 2)
+	for _, rn := range []string{contentRec, structRec} {
+		ops = append(ops, ckOperation{
+			OperationType: "delete",
+			Record:        ckRecordModify{RecordName: rn, RecordChangeTag: tags[rn]},
+		})
+	}
+	return ops
+}
+
 // DeleteFile deletes the documentStructure/documentContent pair for the given
 // record UUID from the shared zone. Used to remove or overwrite files that live
 // inside a shared sub-folder, which the drivews trash endpoint cannot touch.
@@ -280,9 +302,7 @@ func (cd *CloudDocs) DeleteFile(ctx context.Context, uuid string) error {
 	if err != nil {
 		return err
 	}
-	uuid = strings.ToUpper(uuid)
-	contentRec := "documentContent/" + uuid
-	structRec := "documentStructure/" + uuid
+	contentRec, structRec := documentRecordNames(uuid)
 	recs, err := cd.lookup(ctx, contentRec, structRec)
 	if err != nil {
 		return err
@@ -291,13 +311,7 @@ func (cd *CloudDocs) DeleteFile(ctx context.Context, uuid string) error {
 	for _, r := range recs {
 		tags[r.RecordName] = r.RecordChangeTag
 	}
-	ops := make([]ckOperation, 0, 2)
-	for _, rn := range []string{contentRec, structRec} {
-		ops = append(ops, ckOperation{
-			OperationType: "delete",
-			Record:        ckRecordModify{RecordName: rn, RecordChangeTag: tags[rn]},
-		})
-	}
+	ops := deleteRecordOperations(contentRec, structRec, tags)
 	var out ckRecordsResponse
 	return cd.request(ctx, "records/modify", ckModifyRequest{Atomic: false, ZoneID: zone, Operations: ops}, &out)
 }
@@ -329,6 +343,18 @@ type ckZoneChangesResponse struct {
 	} `json:"zones"`
 }
 
+// documentBaseHash returns the CloudKit "basehash" field value for a file: the
+// base64 of SHA256 over the basename with its extension stripped. This is how a
+// documentStructure records the file's name, and how FindFileUUID matches it.
+func documentBaseHash(leaf string) string {
+	basename := leaf
+	if i := strings.LastIndexByte(leaf, '.'); i > 0 {
+		basename = leaf[:i]
+	}
+	sum := sha256.Sum256([]byte(basename))
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
 // FindFileUUID looks up the record UUID of the file named leaf inside the shared
 // directory directory/<dirUUID>. CloudDocs record types are not query-indexable, so
 // it enumerates the zone (changes/zone) and matches a documentStructure whose parent
@@ -339,12 +365,7 @@ func (cd *CloudDocs) FindFileUUID(ctx context.Context, dirUUID, leaf string) (st
 	if err != nil {
 		return "", err
 	}
-	basename := leaf
-	if i := strings.LastIndexByte(leaf, '.'); i > 0 {
-		basename = leaf[:i]
-	}
-	sum := sha256.Sum256([]byte(basename))
-	wantHash := base64.StdEncoding.EncodeToString(sum[:])
+	wantHash := documentBaseHash(leaf)
 	wantParent := "directory/" + strings.ToUpper(dirUUID)
 
 	syncToken := ""

--- a/backend/iclouddrive/api/clouddocs.go
+++ b/backend/iclouddrive/api/clouddocs.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base64"
+	"errors"
 	"fmt"
-	"net/http"
 	"strings"
 
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/lib/rest"
 )
 
@@ -26,10 +27,15 @@ import (
 //  2. re-parent the resulting record into the target sub-folder via a CloudKit
 //     records/modify "update". The server re-chains PCS itself, because the record
 //     already carries its own PCS key — so no client-side PCS crypto is required.
+//
+// Every request goes through the backend pacer (rate-limit / retry), and re-auths
+// on a 401/421/423 once, exactly like the rest of the api package.
 type CloudDocs struct {
-	icloud *Client
-	url    string
-	zone   *CKZoneID
+	icloud      *Client
+	url         string
+	zone        *CKZoneID
+	pacer       *fs.Pacer
+	shouldRetry ShouldRetryFunc
 }
 
 // CKZoneID identifies a CloudKit zone.
@@ -41,41 +47,70 @@ type CKZoneID struct {
 
 // CloudDocsService returns a CloudDocs client, or nil if the account has no
 // ckdatabasews web service (in which case shared-subfolder writes are unsupported).
-func (c *Client) CloudDocsService() *CloudDocs {
+// The pacer and shouldRetry are threaded through so every ckdatabasews request is
+// rate-limited and retried like the rest of the package.
+func (c *Client) CloudDocsService(pacer *fs.Pacer, shouldRetry ShouldRetryFunc) *CloudDocs {
 	ws := c.Session.AccountInfo.Webservices["ckdatabasews"]
 	if ws == nil || ws.URL == "" {
 		return nil
 	}
-	return &CloudDocs{icloud: c, url: ws.URL}
+	return &CloudDocs{icloud: c, url: ws.URL, pacer: pacer, shouldRetry: shouldRetry}
 }
 
-func (cd *CloudDocs) request(ctx context.Context, sub string, body, response any) (*http.Response, error) {
+// request POSTs body to the shared ckdatabasews endpoint sub (e.g. "records/modify")
+// and decodes the JSON reply into response. The call is rate-limited and retried by
+// the pacer, and re-authenticates once on a 401/421/423.
+func (cd *CloudDocs) request(ctx context.Context, sub string, body, response any) error {
 	rootURL := fmt.Sprintf("%s/database/1/com.apple.clouddocs/production/shared/%s?remapEnums=true&getCurrentSyncToken=true", cd.url, sub)
-	reader, err := IntoReader(body)
-	if err != nil {
-		return nil, err
-	}
-	opts := rest.Opts{
-		Method:       "POST",
-		RootURL:      rootURL,
-		ExtraHeaders: cd.icloud.Session.GetHeaders(map[string]string{"Content-Type": "text/plain"}),
-		Body:         reader,
-	}
-	return cd.icloud.Request(ctx, opts, nil, response)
+	reauthDone := false
+	return cd.pacer.Call(func() (bool, error) {
+		// The body reader is consumed on each attempt, so rebuild it every time.
+		reader, err := IntoReader(body)
+		if err != nil {
+			return false, err
+		}
+		opts := rest.Opts{
+			Method:       "POST",
+			RootURL:      rootURL,
+			ExtraHeaders: cd.icloud.Session.GetHeaders(map[string]string{"Content-Type": "text/plain"}),
+			Body:         reader,
+		}
+		resp, err := cd.icloud.Session.Request(ctx, opts, nil, response)
+		if !reauthDone && err != nil && resp != nil && (resp.StatusCode == 401 || resp.StatusCode == 421 || resp.StatusCode == 423) {
+			reauthDone = true
+			if authErr := cd.icloud.Authenticate(ctx); authErr != nil {
+				return false, authErr
+			}
+			if cd.icloud.Session.Requires2FA() {
+				return false, errors.New("trust token expired, please reauth")
+			}
+			if reader, err = IntoReader(body); err != nil {
+				return false, err
+			}
+			opts.Body = reader
+			resp, err = cd.icloud.Session.Request(ctx, opts, nil, response)
+		}
+		return cd.shouldRetry(ctx, resp, err)
+	})
 }
 
-// Zone returns the (single) shared CloudDocs zone, discovering and caching it on
-// first use via zones/list.
+// ckZonesListResponse is the reply to zones/list.
+type ckZonesListResponse struct {
+	Zones []struct {
+		ZoneID CKZoneID `json:"zoneID"`
+	} `json:"zones"`
+}
+
+// Zone returns the shared CloudDocs zone, discovering and caching it on first use
+// via zones/list. It prefers the zone named defaultZone; if the account
+// participates in several shared zones and none carries that name, it falls back to
+// the first and logs the ambiguity.
 func (cd *CloudDocs) Zone(ctx context.Context) (*CKZoneID, error) {
 	if cd.zone != nil {
 		return cd.zone, nil
 	}
-	var out struct {
-		Zones []struct {
-			ZoneID CKZoneID `json:"zoneID"`
-		} `json:"zones"`
-	}
-	if _, err := cd.request(ctx, "zones/list", map[string]any{}, &out); err != nil {
+	var out ckZonesListResponse
+	if err := cd.request(ctx, "zones/list", struct{}{}, &out); err != nil {
 		return nil, err
 	}
 	for i := range out.Zones {
@@ -84,11 +119,30 @@ func (cd *CloudDocs) Zone(ctx context.Context) (*CKZoneID, error) {
 			return cd.zone, nil
 		}
 	}
-	if len(out.Zones) > 0 {
-		cd.zone = &out.Zones[0].ZoneID
-		return cd.zone, nil
+	if len(out.Zones) == 0 {
+		return nil, errors.New("no shared clouddocs zone found")
 	}
-	return nil, fmt.Errorf("no shared clouddocs zone found")
+	if len(out.Zones) > 1 {
+		names := make([]string, len(out.Zones))
+		for i := range out.Zones {
+			names[i] = out.Zones[i].ZoneID.ZoneName
+		}
+		fs.Logf(nil, "iclouddrive: %d shared CloudDocs zones %v and none named %q; using first (%q)",
+			len(out.Zones), names, defaultZone, out.Zones[0].ZoneID.ZoneName)
+	}
+	cd.zone = &out.Zones[0].ZoneID
+	return cd.zone, nil
+}
+
+// ckRecordRef names a single record, for records/lookup.
+type ckRecordRef struct {
+	RecordName string `json:"recordName"`
+}
+
+// ckLookupRequest is the body of a records/lookup request.
+type ckLookupRequest struct {
+	ZoneID  *CKZoneID     `json:"zoneID"`
+	Records []ckRecordRef `json:"records"`
 }
 
 // ckRecord is the subset of a CloudKit record we read back.
@@ -100,22 +154,62 @@ type ckRecord struct {
 	Deleted         bool   `json:"deleted"`
 }
 
+// ckRecordsResponse is the reply to records/lookup and records/modify.
+type ckRecordsResponse struct {
+	Records []ckRecord `json:"records"`
+}
+
 func (cd *CloudDocs) lookup(ctx context.Context, recordNames ...string) ([]ckRecord, error) {
 	zone, err := cd.Zone(ctx)
 	if err != nil {
 		return nil, err
 	}
-	recs := make([]map[string]any, 0, len(recordNames))
+	refs := make([]ckRecordRef, 0, len(recordNames))
 	for _, rn := range recordNames {
-		recs = append(recs, map[string]any{"recordName": rn})
+		refs = append(refs, ckRecordRef{RecordName: rn})
 	}
-	var out struct {
-		Records []ckRecord `json:"records"`
-	}
-	if _, err := cd.request(ctx, "records/lookup", map[string]any{"zoneID": zone, "records": recs}, &out); err != nil {
+	var out ckRecordsResponse
+	if err := cd.request(ctx, "records/lookup", ckLookupRequest{ZoneID: zone, Records: refs}, &out); err != nil {
 		return nil, err
 	}
 	return out.Records, nil
+}
+
+// ckReference is a CloudKit record reference, used both as a field value (with an
+// action) and as a record's parent pointer (recordName only).
+type ckReference struct {
+	RecordName string    `json:"recordName"`
+	Action     string    `json:"action,omitempty"`
+	ZoneID     *CKZoneID `json:"zoneID,omitempty"`
+}
+
+// ckField is a typed CloudKit field value.
+type ckField struct {
+	Value any    `json:"value"`
+	Type  string `json:"type,omitempty"`
+}
+
+// ckRecordModify is a record carried by a records/modify operation. Only the fields
+// relevant to the operation are populated (delete needs just the name + change tag).
+type ckRecordModify struct {
+	RecordName      string             `json:"recordName"`
+	RecordType      string             `json:"recordType,omitempty"`
+	RecordChangeTag string             `json:"recordChangeTag,omitempty"`
+	Fields          map[string]ckField `json:"fields,omitempty"`
+	Parent          *ckReference       `json:"parent,omitempty"`
+}
+
+// ckOperation is a single operation within a records/modify request.
+type ckOperation struct {
+	OperationType string         `json:"operationType"`
+	Record        ckRecordModify `json:"record"`
+}
+
+// ckModifyRequest is the body of a records/modify request.
+type ckModifyRequest struct {
+	Atomic     bool          `json:"atomic"`
+	ZoneID     *CKZoneID     `json:"zoneID"`
+	Operations []ckOperation `json:"operations"`
 }
 
 // ReparentStructure moves the documentStructure/<uuid> record under a new parent
@@ -142,29 +236,32 @@ func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID 
 		}
 		return fmt.Errorf("clouddocs: could not look up %s: %s", structRec, reason)
 	}
-	dirRef := map[string]any{
-		"recordName": "directory/" + strings.ToUpper(targetDirUUID),
-		"action":     "VALIDATE",
-		"zoneID":     zone,
+	dirRecordName := "directory/" + strings.ToUpper(targetDirUUID)
+	body := ckModifyRequest{
+		Atomic: true,
+		ZoneID: zone,
+		Operations: []ckOperation{{
+			OperationType: "update",
+			Record: ckRecordModify{
+				RecordName:      structRec,
+				RecordType:      "structure",
+				RecordChangeTag: recs[0].RecordChangeTag,
+				Fields: map[string]ckField{
+					"parent": {
+						Type: "REFERENCE",
+						Value: ckReference{
+							RecordName: dirRecordName,
+							Action:     "VALIDATE",
+							ZoneID:     zone,
+						},
+					},
+				},
+				Parent: &ckReference{RecordName: dirRecordName},
+			},
+		}},
 	}
-	record := map[string]any{
-		"recordName":      structRec,
-		"recordType":      "structure",
-		"recordChangeTag": recs[0].RecordChangeTag,
-		"fields": map[string]any{
-			"parent": map[string]any{"value": dirRef, "type": "REFERENCE"},
-		},
-		"parent": map[string]any{"recordName": "directory/" + strings.ToUpper(targetDirUUID)},
-	}
-	body := map[string]any{
-		"atomic":     true,
-		"zoneID":     zone,
-		"operations": []any{map[string]any{"operationType": "update", "record": record}},
-	}
-	var out struct {
-		Records []ckRecord `json:"records"`
-	}
-	if _, err := cd.request(ctx, "records/modify", body, &out); err != nil {
+	var out ckRecordsResponse
+	if err := cd.request(ctx, "records/modify", body, &out); err != nil {
 		return err
 	}
 	for _, r := range out.Records {
@@ -194,19 +291,42 @@ func (cd *CloudDocs) DeleteFile(ctx context.Context, uuid string) error {
 	for _, r := range recs {
 		tags[r.RecordName] = r.RecordChangeTag
 	}
-	ops := []any{}
+	ops := make([]ckOperation, 0, 2)
 	for _, rn := range []string{contentRec, structRec} {
-		rec := map[string]any{"recordName": rn}
-		if t := tags[rn]; t != "" {
-			rec["recordChangeTag"] = t
-		}
-		ops = append(ops, map[string]any{"operationType": "delete", "record": rec})
+		ops = append(ops, ckOperation{
+			OperationType: "delete",
+			Record:        ckRecordModify{RecordName: rn, RecordChangeTag: tags[rn]},
+		})
 	}
-	var out struct {
-		Records []ckRecord `json:"records"`
-	}
-	_, err = cd.request(ctx, "records/modify", map[string]any{"atomic": false, "zoneID": zone, "operations": ops}, &out)
-	return err
+	var out ckRecordsResponse
+	return cd.request(ctx, "records/modify", ckModifyRequest{Atomic: false, ZoneID: zone, Operations: ops}, &out)
+}
+
+// ckZoneChangesRequestZone names a zone (and an optional resume token) in a
+// changes/zone request.
+type ckZoneChangesRequestZone struct {
+	ZoneID    *CKZoneID `json:"zoneID"`
+	SyncToken string    `json:"syncToken,omitempty"`
+}
+
+// ckZoneChangesRequest is the body of a changes/zone request.
+type ckZoneChangesRequest struct {
+	Zones []ckZoneChangesRequestZone `json:"zones"`
+}
+
+// ckZoneChangesResponse is the reply to changes/zone.
+type ckZoneChangesResponse struct {
+	Zones []struct {
+		Records []struct {
+			RecordName string `json:"recordName"`
+			RecordType string `json:"recordType"`
+			Fields     map[string]struct {
+				Value any `json:"value"`
+			} `json:"fields"`
+		} `json:"records"`
+		SyncToken  string `json:"syncToken"`
+		MoreComing bool   `json:"moreComing"`
+	} `json:"zones"`
 }
 
 // FindFileUUID looks up the record UUID of the file named leaf inside the shared
@@ -229,24 +349,9 @@ func (cd *CloudDocs) FindFileUUID(ctx context.Context, dirUUID, leaf string) (st
 
 	syncToken := ""
 	for {
-		zoneReq := map[string]any{"zoneID": zone}
-		if syncToken != "" {
-			zoneReq["syncToken"] = syncToken
-		}
-		var out struct {
-			Zones []struct {
-				Records []struct {
-					RecordName string `json:"recordName"`
-					RecordType string `json:"recordType"`
-					Fields     map[string]struct {
-						Value any `json:"value"`
-					} `json:"fields"`
-				} `json:"records"`
-				SyncToken  string `json:"syncToken"`
-				MoreComing bool   `json:"moreComing"`
-			} `json:"zones"`
-		}
-		if _, err := cd.request(ctx, "changes/zone", map[string]any{"zones": []any{zoneReq}}, &out); err != nil {
+		zoneReq := ckZoneChangesRequestZone{ZoneID: zone, SyncToken: syncToken}
+		var out ckZoneChangesResponse
+		if err := cd.request(ctx, "changes/zone", ckZoneChangesRequest{Zones: []ckZoneChangesRequestZone{zoneReq}}, &out); err != nil {
 			return "", err
 		}
 		if len(out.Zones) == 0 {
@@ -267,7 +372,14 @@ func (cd *CloudDocs) FindFileUUID(ctx context.Context, dirUUID, leaf string) (st
 				}
 			}
 		}
+		// Stop when the server says there is nothing more, or when it claims more is
+		// coming but the resume token did not advance (empty or unchanged) — otherwise
+		// we would re-request the same page forever.
 		if !z.MoreComing {
+			return "", nil
+		}
+		if z.SyncToken == "" || z.SyncToken == syncToken {
+			fs.Debugf(nil, "iclouddrive: clouddocs changes/zone set moreComing but syncToken did not advance; stopping enumeration")
 			return "", nil
 		}
 		syncToken = z.SyncToken

--- a/backend/iclouddrive/api/clouddocs.go
+++ b/backend/iclouddrive/api/clouddocs.go
@@ -213,13 +213,14 @@ type ckModifyRequest struct {
 }
 
 // ReparentStructure moves the documentStructure/<uuid> record under a new parent
-// directory/<targetDirUUID>, within the shared zone. The matching
-// documentContent/<uuid> follows automatically (its parent is the structure).
+// directory/<targetDirUUID>, within the shared zone, and sets its visible leaf
+// name. The matching documentContent/<uuid> follows automatically (its parent is
+// the structure).
 //
 // uuid is the bare record UUID (e.g. the docwsid of the just-uploaded file, which
 // CloudDocs reuses as the structure/content record name). The current
 // recordChangeTag is fetched automatically.
-func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID string) error {
+func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID, leaf string) error {
 	zone, err := cd.Zone(ctx)
 	if err != nil {
 		return err
@@ -237,6 +238,15 @@ func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID 
 		return fmt.Errorf("clouddocs: could not look up %s: %s", structRec, reason)
 	}
 	dirRecordName := "directory/" + strings.ToUpper(targetDirUUID)
+	fields := documentNameFields(leaf)
+	fields["parent"] = ckField{
+		Type: "REFERENCE",
+		Value: ckReference{
+			RecordName: dirRecordName,
+			Action:     "VALIDATE",
+			ZoneID:     zone,
+		},
+	}
 	body := ckModifyRequest{
 		Atomic: true,
 		ZoneID: zone,
@@ -246,17 +256,8 @@ func (cd *CloudDocs) ReparentStructure(ctx context.Context, uuid, targetDirUUID 
 				RecordName:      structRec,
 				RecordType:      "structure",
 				RecordChangeTag: recs[0].RecordChangeTag,
-				Fields: map[string]ckField{
-					"parent": {
-						Type: "REFERENCE",
-						Value: ckReference{
-							RecordName: dirRecordName,
-							Action:     "VALIDATE",
-							ZoneID:     zone,
-						},
-					},
-				},
-				Parent: &ckReference{RecordName: dirRecordName},
+				Fields:          fields,
+				Parent:          &ckReference{RecordName: dirRecordName},
 			},
 		}},
 	}
@@ -391,12 +392,37 @@ type ckZoneChangesResponse struct {
 // base64 of SHA256 over the basename with its extension stripped. This is how a
 // documentStructure records the file's name, and how FindFileUUID matches it.
 func documentBaseHash(leaf string) string {
-	basename := leaf
-	if i := strings.LastIndexByte(leaf, '.'); i > 0 {
-		basename = leaf[:i]
-	}
+	basename, _ := documentNameParts(leaf)
 	sum := sha256.Sum256([]byte(basename))
 	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func documentNameParts(leaf string) (basename, extension string) {
+	if strings.HasSuffix(leaf, ".") {
+		return leaf, ""
+	}
+	if i := strings.LastIndexByte(leaf, '.'); i > 0 {
+		return leaf[:i], leaf[i+1:]
+	}
+	return leaf, ""
+}
+
+func documentNameFields(leaf string) map[string]ckField {
+	basename, extension := documentNameParts(leaf)
+	return map[string]ckField{
+		"basehash": {
+			Value: documentBaseHash(leaf),
+			Type:  "BYTES",
+		},
+		"encryptedBasename": {
+			Value: base64.StdEncoding.EncodeToString([]byte(basename)),
+			Type:  "ENCRYPTED_BYTES",
+		},
+		"extension": {
+			Value: extension,
+			Type:  "STRING",
+		},
+	}
 }
 
 // FindFileUUID looks up the record UUID of the file named leaf inside the shared
@@ -405,6 +431,17 @@ func documentBaseHash(leaf string) string {
 // is that directory and whose basehash equals SHA256(basename-without-ext). Returns
 // "" if not found.
 func (cd *CloudDocs) FindFileUUID(ctx context.Context, dirUUID, leaf string) (string, error) {
+	return cd.findChildStructureUUID(ctx, dirUUID, leaf, "documentStructure/", "structure")
+}
+
+// FindDirectoryUUID looks up the record UUID of the directory named leaf inside
+// the shared directory directory/<dirUUID>. It is needed for nested shared
+// directories returned by docws enumerate without a drivewsid.
+func (cd *CloudDocs) FindDirectoryUUID(ctx context.Context, dirUUID, leaf string) (string, error) {
+	return cd.findChildStructureUUID(ctx, dirUUID, leaf, "directory/", "")
+}
+
+func (cd *CloudDocs) findChildStructureUUID(ctx context.Context, dirUUID, leaf, recordPrefix, recordType string) (string, error) {
 	zone, err := cd.Zone(ctx)
 	if err != nil {
 		return "", err
@@ -424,7 +461,10 @@ func (cd *CloudDocs) FindFileUUID(ctx context.Context, dirUUID, leaf string) (st
 		}
 		z := out.Zones[0]
 		for _, r := range z.Records {
-			if r.RecordType != "structure" || !strings.HasPrefix(r.RecordName, "documentStructure/") {
+			if recordType != "" && r.RecordType != recordType {
+				continue
+			}
+			if !strings.HasPrefix(r.RecordName, recordPrefix) {
 				continue
 			}
 			bh, _ := r.Fields["basehash"].Value.(string)
@@ -433,7 +473,7 @@ func (cd *CloudDocs) FindFileUUID(ctx context.Context, dirUUID, leaf string) (st
 			}
 			if pv, ok := r.Fields["parent"].Value.(map[string]any); ok {
 				if rn, _ := pv["recordName"].(string); rn == wantParent {
-					return strings.TrimPrefix(r.RecordName, "documentStructure/"), nil
+					return strings.TrimPrefix(r.RecordName, recordPrefix), nil
 				}
 			}
 		}

--- a/backend/iclouddrive/api/clouddocs_test.go
+++ b/backend/iclouddrive/api/clouddocs_test.go
@@ -194,3 +194,36 @@ func TestDocumentBaseHashEdgeCases(t *testing.T) {
 	// full name and differs from the same text without the leading dot.
 	assert.NotEqual(t, documentBaseHash(".hidden"), documentBaseHash("hidden"))
 }
+
+// TestDocumentNameParts checks the name splitting used when rewriting a
+// temporary shared-root upload to its final CloudDocs name.
+func TestDocumentNameParts(t *testing.T) {
+	for _, tc := range []struct {
+		leaf, base, ext string
+	}{
+		{"report.txt", "report", "txt"},
+		{"archive.tar.gz", "archive.tar", "gz"},
+		{"noext", "noext", ""},
+		{"trailingdot.", "trailingdot.", ""},
+		{".hidden", ".hidden", ""},
+	} {
+		t.Run(tc.leaf, func(t *testing.T) {
+			base, ext := documentNameParts(tc.leaf)
+			assert.Equal(t, tc.base, base)
+			assert.Equal(t, tc.ext, ext)
+		})
+	}
+}
+
+// TestDocumentNameFields checks the CloudDocs structure fields used to rename a
+// temporary shared-root upload during re-parenting.
+func TestDocumentNameFields(t *testing.T) {
+	fields := documentNameFields("report.txt")
+
+	assert.Equal(t, "hF6RgxMZ6JxNZWvbgMJ4rAmnIw1h5d/S4bH7tDasiRc=", fields["basehash"].Value)
+	assert.Equal(t, "BYTES", fields["basehash"].Type)
+	assert.Equal(t, "cmVwb3J0", fields["encryptedBasename"].Value)
+	assert.Equal(t, "ENCRYPTED_BYTES", fields["encryptedBasename"].Type)
+	assert.Equal(t, "txt", fields["extension"].Value)
+	assert.Equal(t, "STRING", fields["extension"].Type)
+}

--- a/backend/iclouddrive/api/clouddocs_test.go
+++ b/backend/iclouddrive/api/clouddocs_test.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestDocumentRecordNames checks that a bare file UUID maps to the upper-cased
+// documentContent/documentStructure record names CloudDocs uses for both halves of
+// a document.
+func TestDocumentRecordNames(t *testing.T) {
+	content, structure := documentRecordNames("abc-123")
+	assert.Equal(t, "documentContent/ABC-123", content)
+	assert.Equal(t, "documentStructure/ABC-123", structure)
+
+	// Already upper-case input is left unchanged.
+	content, structure = documentRecordNames("DEF-456")
+	assert.Equal(t, "documentContent/DEF-456", content)
+	assert.Equal(t, "documentStructure/DEF-456", structure)
+}
+
+// TestDeleteRecordOperations checks the records/modify delete operations: one per
+// record, in content-then-structure order, each carrying its current change tag (an
+// unknown tag is sent empty).
+func TestDeleteRecordOperations(t *testing.T) {
+	content, structure := documentRecordNames("abc-123")
+	tags := map[string]string{
+		content:   "tag-content",
+		structure: "tag-structure",
+	}
+	ops := deleteRecordOperations(content, structure, tags)
+
+	require.Len(t, ops, 2)
+	assert.Equal(t, "delete", ops[0].OperationType)
+	assert.Equal(t, content, ops[0].Record.RecordName)
+	assert.Equal(t, "tag-content", ops[0].Record.RecordChangeTag)
+	assert.Equal(t, "delete", ops[1].OperationType)
+	assert.Equal(t, structure, ops[1].Record.RecordName)
+	assert.Equal(t, "tag-structure", ops[1].Record.RecordChangeTag)
+}
+
+// TestDeleteRecordOperationsMissingTag verifies a record with no looked-up change
+// tag gets an empty tag rather than panicking on the map lookup.
+func TestDeleteRecordOperationsMissingTag(t *testing.T) {
+	content, structure := documentRecordNames("abc-123")
+	ops := deleteRecordOperations(content, structure, map[string]string{content: "only-content"})
+
+	require.Len(t, ops, 2)
+	assert.Equal(t, "only-content", ops[0].Record.RecordChangeTag)
+	assert.Equal(t, "", ops[1].Record.RecordChangeTag)
+}
+
+// TestDeleteRequestJSON locks the wire format of a shared-zone delete: a
+// non-atomic records/modify with two delete operations and the bare record names.
+func TestDeleteRequestJSON(t *testing.T) {
+	content, structure := documentRecordNames("abc-123")
+	zone := &CKZoneID{ZoneName: "com.apple.CloudDocs", OwnerRecordName: "_owner", ZoneType: "REGULAR_CUSTOM_ZONE"}
+	body := ckModifyRequest{
+		Atomic:     false,
+		ZoneID:     zone,
+		Operations: deleteRecordOperations(content, structure, map[string]string{content: "t1", structure: "t2"}),
+	}
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	assert.Equal(t, false, got["atomic"])
+	ops, ok := got["operations"].([]any)
+	require.True(t, ok)
+	require.Len(t, ops, 2)
+
+	op0 := ops[0].(map[string]any)
+	assert.Equal(t, "delete", op0["operationType"])
+	rec0 := op0["record"].(map[string]any)
+	assert.Equal(t, "documentContent/ABC-123", rec0["recordName"])
+	assert.Equal(t, "t1", rec0["recordChangeTag"])
+	// A delete carries only the record name + change tag; no fields/parent are emitted.
+	_, hasFields := rec0["fields"]
+	assert.False(t, hasFields)
+	_, hasParent := rec0["parent"]
+	assert.False(t, hasParent)
+}
+
+// TestDocumentBaseHash checks the basehash used to locate a document by name inside
+// a shared folder: base64(SHA256(basename)) with the extension stripped.
+func TestDocumentBaseHash(t *testing.T) {
+	// base64(sha256("report")), computed independently.
+	const reportHash = "hF6RgxMZ6JxNZWvbgMJ4rAmnIw1h5d/S4bH7tDasiRc="
+	assert.Equal(t, reportHash, documentBaseHash("report"))
+	// The (single) extension is stripped before hashing, so "report" and
+	// "report.<ext>" collide.
+	assert.Equal(t, reportHash, documentBaseHash("report.txt"))
+	assert.Equal(t, reportHash, documentBaseHash("report.pdf"))
+	assert.Equal(t, reportHash, documentBaseHash("report.tar"))
+
+	// Only the FINAL extension is stripped (matches strings.LastIndexByte), so
+	// "report.tar.gz" hashes "report.tar", not "report".
+	assert.NotEqual(t, reportHash, documentBaseHash("report.tar.gz"))
+}
+
+// TestDocumentBaseHashEdgeCases documents the dot-handling: a leading dot is part of
+// the name (LastIndexByte must be > 0 to strip), and a name with no dot is hashed
+// whole.
+func TestDocumentBaseHashEdgeCases(t *testing.T) {
+	// base64(sha256("noext")), computed independently.
+	const noextHash = "yEfweOKyUPB5TsC6TUTlFvSAkkD+MQJM3r9XArkpbTk="
+	// No dot: the name is hashed whole.
+	assert.Equal(t, noextHash, documentBaseHash("noext"))
+	// Stripping the trailing extension makes "noext.txt" collide with "noext".
+	assert.Equal(t, noextHash, documentBaseHash("noext.txt"))
+	// A leading dot is NOT stripped (index 0 is not > 0), so a dotfile keeps its
+	// full name and differs from the same text without the leading dot.
+	assert.NotEqual(t, documentBaseHash(".hidden"), documentBaseHash("hidden"))
+}

--- a/backend/iclouddrive/api/clouddocs_test.go
+++ b/backend/iclouddrive/api/clouddocs_test.go
@@ -22,6 +22,13 @@ func TestDocumentRecordNames(t *testing.T) {
 	assert.Equal(t, "documentStructure/DEF-456", structure)
 }
 
+// TestDirectoryRecordName checks that a bare folder UUID maps to the upper-cased
+// directory record name CloudDocs uses for shared-folder child directories.
+func TestDirectoryRecordName(t *testing.T) {
+	assert.Equal(t, "directory/ABC-123", directoryRecordName("abc-123"))
+	assert.Equal(t, "directory/DEF-456", directoryRecordName("DEF-456"))
+}
+
 // TestDeleteRecordOperations checks the records/modify delete operations: one per
 // record, in content-then-structure order, each carrying its current change tag (an
 // unknown tag is sent empty).
@@ -51,6 +58,18 @@ func TestDeleteRecordOperationsMissingTag(t *testing.T) {
 	require.Len(t, ops, 2)
 	assert.Equal(t, "only-content", ops[0].Record.RecordChangeTag)
 	assert.Equal(t, "", ops[1].Record.RecordChangeTag)
+}
+
+// TestDeleteDirectoryRecordOperation checks the single records/modify delete
+// operation used for rmdir of an empty shared sub-directory.
+func TestDeleteDirectoryRecordOperation(t *testing.T) {
+	dir := directoryRecordName("abc-123")
+	ops := deleteDirectoryRecordOperation(dir, map[string]string{dir: "tag-dir"})
+
+	require.Len(t, ops, 1)
+	assert.Equal(t, "delete", ops[0].OperationType)
+	assert.Equal(t, dir, ops[0].Record.RecordName)
+	assert.Equal(t, "tag-dir", ops[0].Record.RecordChangeTag)
 }
 
 // TestDeleteRequestJSON locks the wire format of a shared-zone delete: a
@@ -85,6 +104,63 @@ func TestDeleteRequestJSON(t *testing.T) {
 	assert.False(t, hasFields)
 	_, hasParent := rec0["parent"]
 	assert.False(t, hasParent)
+}
+
+// TestDeleteDirectoryRequestJSON locks the wire format for shared-directory
+// rmdir: a non-atomic records/modify with one delete operation for directory/<uuid>.
+func TestDeleteDirectoryRequestJSON(t *testing.T) {
+	dir := directoryRecordName("abc-123")
+	zone := &CKZoneID{ZoneName: "com.apple.CloudDocs", OwnerRecordName: "_owner", ZoneType: "REGULAR_CUSTOM_ZONE"}
+	body := ckModifyRequest{
+		Atomic:     false,
+		ZoneID:     zone,
+		Operations: deleteDirectoryRecordOperation(dir, map[string]string{dir: "td"}),
+	}
+
+	raw, err := json.Marshal(body)
+	require.NoError(t, err)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(raw, &got))
+
+	assert.Equal(t, false, got["atomic"])
+	ops, ok := got["operations"].([]any)
+	require.True(t, ok)
+	require.Len(t, ops, 1)
+
+	op0 := ops[0].(map[string]any)
+	assert.Equal(t, "delete", op0["operationType"])
+	rec0 := op0["record"].(map[string]any)
+	assert.Equal(t, "directory/ABC-123", rec0["recordName"])
+	assert.Equal(t, "td", rec0["recordChangeTag"])
+	_, hasFields := rec0["fields"]
+	assert.False(t, hasFields)
+	_, hasParent := rec0["parent"]
+	assert.False(t, hasParent)
+}
+
+// TestLookupRecordTags extracts current change tags from lookup results before a
+// delete request. It intentionally keeps unknown records out of the map.
+func TestLookupRecordTags(t *testing.T) {
+	tags := lookupRecordTags([]ckRecord{
+		{RecordName: "directory/A", RecordChangeTag: "ta"},
+		{RecordName: "documentStructure/B", RecordChangeTag: "tb"},
+	})
+	assert.Equal(t, map[string]string{"directory/A": "ta", "documentStructure/B": "tb"}, tags)
+}
+
+// TestCheckRecordErrors documents how CloudKit per-record failures are surfaced
+// from records/modify responses.
+func TestCheckRecordErrors(t *testing.T) {
+	require.NoError(t, checkRecordErrors("op", []ckRecord{{RecordName: "directory/A"}}))
+
+	err := checkRecordErrors("op", []ckRecord{{
+		RecordName:      "directory/A",
+		Reason:          "not allowed",
+		ServerErrorCode: "ACCESS_DENIED",
+	}})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "op failed for directory/A: not allowed (ACCESS_DENIED)")
 }
 
 // TestDocumentBaseHash checks the basehash used to locate a document by name inside

--- a/backend/iclouddrive/api/clouddocs_test.go
+++ b/backend/iclouddrive/api/clouddocs_test.go
@@ -227,3 +227,17 @@ func TestDocumentNameFields(t *testing.T) {
 	assert.Equal(t, "txt", fields["extension"].Value)
 	assert.Equal(t, "STRING", fields["extension"].Type)
 }
+
+// TestDirectoryNameFields checks the CloudDocs structure fields used to rename a
+// directory record. Directories store the full leaf as encryptedBasename and do
+// not split an extension from dotted names.
+func TestDirectoryNameFields(t *testing.T) {
+	fields := directoryNameFields("folder.with.dots")
+
+	assert.Equal(t, "bGIwGmiW/8Lo4S6RFBn4jVMGnKD/ML/SVJ1bQrpDI8Y=", fields["basehash"].Value)
+	assert.Equal(t, "BYTES", fields["basehash"].Type)
+	assert.Equal(t, "Zm9sZGVyLndpdGguZG90cw==", fields["encryptedBasename"].Value)
+	assert.Equal(t, "ENCRYPTED_BYTES", fields["encryptedBasename"].Type)
+	_, ok := fields["extension"]
+	assert.False(t, ok)
+}

--- a/backend/iclouddrive/api/drive.go
+++ b/backend/iclouddrive/api/drive.go
@@ -892,6 +892,26 @@ func DeconstructDriveID(id string) (docType, zone, docid string) {
 	return split[0], split[1], split[2]
 }
 
+// IsSharedFolderChildID reports whether the given drivewsid refers to an item that
+// lives inside a folder shared by another Apple ID (a "participant" share).
+//
+// Such items have a drivewsid of the form FOLDER_IN_SHARED_FOLDER::zone::docwsid (or
+// FILE_IN_SHARED_FOLDER::...) and cannot be addressed by the drivews endpoints
+// (retrieveItemDetailsInFolders etc.), which only operate within the caller's own
+// zone. They must instead be addressed through the docws item endpoints by item_id.
+//
+// An empty drivewsid also counts as a shared child: items discovered via the docws
+// enumerate endpoint only carry an item_id (no drivewsid), so descendants deeper than
+// one level below the share root reach here with an empty drivewsid.
+func IsSharedFolderChildID(drivewsid string) bool {
+	if drivewsid == "" {
+		return true
+	}
+	docType, _, _ := DeconstructDriveID(drivewsid)
+	return strings.HasPrefix(docType, "FOLDER_IN_SHARED_FOLDER") ||
+		strings.HasPrefix(docType, "FILE_IN_SHARED_FOLDER")
+}
+
 // ConstructDriveID constructs a drive ID from the given components.
 func ConstructDriveID(id string, zone string, t string) string {
 	return strings.Join([]string{t, zone, id}, "::")

--- a/backend/iclouddrive/api/drive.go
+++ b/backend/iclouddrive/api/drive.go
@@ -828,6 +828,14 @@ type CreateFoldersResponse struct {
 	Folders []*DriveItem `json:"folders"`
 }
 
+// ShareID identifies a shared CloudDocs root record returned by drivews for
+// SHARED_FOLDER and FILE_IN_SHARED_FOLDER items.
+type ShareID struct {
+	ShareName  string   `json:"shareName"`
+	RecordName string   `json:"recordName"`
+	ZoneID     CKZoneID `json:"zoneID"`
+}
+
 // DriveItem represents an item on iCloud.
 type DriveItem struct {
 	DateCreated         time.Time    `json:"dateCreated"`
@@ -844,6 +852,7 @@ type DriveItem struct {
 	FileCount           int64        `json:"fileCount"`
 	ShareCount          int64        `json:"shareCount"`
 	ShareAliasCount     int64        `json:"shareAliasCount"`
+	ShareID             *ShareID     `json:"shareID"`
 	DirectChildrenCount int64        `json:"directChildrenCount"`
 	Items               []*DriveItem `json:"items"`
 	NumberOfItems       int64        `json:"numberOfItems"`

--- a/backend/iclouddrive/api/shared_folder_test.go
+++ b/backend/iclouddrive/api/shared_folder_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -137,4 +138,26 @@ func TestDocumentDriveID(t *testing.T) {
 
 	noZone := &Document{Type: "FILE", DocumentID: "D2"}
 	assert.Equal(t, "FILE::com.apple.CloudDocs::D2", noZone.DriveID())
+}
+
+// TestDriveItemShareID checks that drivews shared-root metadata preserves the
+// CloudDocs share record name needed to address files directly in a shared root.
+func TestDriveItemShareID(t *testing.T) {
+	var item DriveItem
+	err := json.Unmarshal([]byte(`{
+		"drivewsid": "SHARED_FOLDER::com.apple.CloudDocs::D1",
+		"shareID": {
+			"shareName": "SHARE-1",
+			"recordName": "SHARE-1",
+			"zoneID": {
+				"zoneName": "com.apple.CloudDocs",
+				"ownerRecordName": "_owner",
+				"zoneType": "REGULAR_CUSTOM_ZONE"
+			}
+		}
+	}`), &item)
+	assert.NoError(t, err)
+	assert.NotNil(t, item.ShareID)
+	assert.Equal(t, "SHARE-1", item.ShareID.RecordName)
+	assert.Equal(t, "_owner", item.ShareID.ZoneID.OwnerRecordName)
 }

--- a/backend/iclouddrive/api/shared_folder_test.go
+++ b/backend/iclouddrive/api/shared_folder_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestIsSharedFolderChildID covers the classification used to decide whether an
+// item lives inside a folder shared by another Apple ID and therefore must be
+// addressed through the docws endpoints by item_id rather than by drivewsid.
+func TestIsSharedFolderChildID(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		drivewsid string
+		want      bool
+	}{
+		{"empty is a shared child (docws-only item)", "", true},
+		{"folder in shared folder", "FOLDER_IN_SHARED_FOLDER::com.apple.CloudDocs::ABC-123", true},
+		{"file in shared folder", "FILE_IN_SHARED_FOLDER::com.apple.CloudDocs::ABC-123", true},
+		{"own-zone folder", "FOLDER::com.apple.CloudDocs::ABC-123", false},
+		{"own-zone file", "FILE::com.apple.CloudDocs::ABC-123", false},
+		{"share root folder is addressable", "SHARED_FOLDER::com.apple.CloudDocs::ABC-123", false},
+		{"garbage without separators", "garbage", false},
+		// HasPrefix matches the docType only after DeconstructDriveID has confirmed
+		// there are three "::"-separated components; a bare prefix without the zone
+		// and doc id deconstructs to an empty docType and is therefore not a child.
+		{"prefix without full triple", "FOLDER_IN_SHARED_FOLDER::zone", false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, IsSharedFolderChildID(tc.drivewsid))
+		})
+	}
+}
+
+// TestDriveIDRoundTrip checks Construct/Deconstruct/GetDocIDFromDriveID agree.
+func TestDriveIDRoundTrip(t *testing.T) {
+	for _, tc := range []struct {
+		docType, zone, docid string
+	}{
+		{"FOLDER", "com.apple.CloudDocs", "ABC-123"},
+		{"FILE", "com.apple.CloudDocs", "doc-with-dashes-456"},
+		{"FOLDER_IN_SHARED_FOLDER", "com.apple.CloudDocs", "789"},
+	} {
+		t.Run(tc.docType, func(t *testing.T) {
+			id := ConstructDriveID(tc.docid, tc.zone, tc.docType)
+			gotType, gotZone, gotDoc := DeconstructDriveID(id)
+			assert.Equal(t, tc.docType, gotType)
+			assert.Equal(t, tc.zone, gotZone)
+			assert.Equal(t, tc.docid, gotDoc)
+			assert.Equal(t, tc.docid, GetDocIDFromDriveID(id))
+		})
+	}
+}
+
+// TestDeconstructDriveIDShort documents the fallback for malformed IDs: fewer
+// than three components yields empty type/zone and the whole string as the docid.
+func TestDeconstructDriveIDShort(t *testing.T) {
+	docType, zone, docid := DeconstructDriveID("not-a-drive-id")
+	assert.Equal(t, "", docType)
+	assert.Equal(t, "", zone)
+	assert.Equal(t, "not-a-drive-id", docid)
+
+	// GetDocIDFromDriveID always returns the trailing component.
+	assert.Equal(t, "not-a-drive-id", GetDocIDFromDriveID("not-a-drive-id"))
+}
+
+// TestSplitName covers the name/extension splitting used when converting raw
+// docws enumerate items into DriveItems.
+func TestSplitName(t *testing.T) {
+	for _, tc := range []struct {
+		in, name, ext string
+	}{
+		{"report.txt", "report", "txt"},
+		{"archive.tar.gz", "archive.tar", "gz"},
+		{"noext", "noext", ""},
+		{"trailingdot.", "trailingdot.", ""},
+		{".hidden", "", "hidden"},
+		{"", "", ""},
+	} {
+		t.Run(tc.in, func(t *testing.T) {
+			d := &DriveItemRaw{ItemInfo: &DriveItemRawInfo{Name: tc.in}}
+			name, ext := d.SplitName()
+			assert.Equal(t, tc.name, name)
+			assert.Equal(t, tc.ext, ext)
+		})
+	}
+}
+
+// TestIntoDriveItem checks the deterministic DriveItemRaw -> DriveItem conversion
+// (as used for items listed via the docws enumerate endpoint).
+func TestIntoDriveItem(t *testing.T) {
+	raw := &DriveItemRaw{
+		ItemID: "ITEM-1",
+		ItemInfo: &DriveItemRawInfo{
+			Name:       "photo.jpeg",
+			Type:       "FILE",
+			Version:    "etag-v2",
+			Size:       4096,
+			ModifiedAt: "1700000000000",
+			CreatedAt:  "1600000000000",
+		},
+	}
+	raw.ItemInfo.Urls.URLDownload = "https://example.invalid/download"
+
+	item := raw.IntoDriveItem()
+	assert.Equal(t, "ITEM-1", item.Itemid)
+	assert.Equal(t, "photo", item.Name)
+	assert.Equal(t, "jpeg", item.Extension)
+	assert.Equal(t, "photo.jpeg", item.FullName())
+	assert.Equal(t, "FILE", item.Type)
+	assert.Equal(t, "etag-v2", item.Etag)
+	assert.Equal(t, int64(4096), item.Size)
+	assert.Equal(t, "https://example.invalid/download", item.DownloadURL())
+	assert.False(t, item.IsFolder())
+	assert.Equal(t, time.UnixMilli(1700000000000), item.DateModified)
+	assert.Equal(t, time.UnixMilli(1600000000000), item.DateCreated)
+}
+
+// TestIntoDriveItemBadTimes verifies unparseable timestamps degrade to the zero time.
+func TestIntoDriveItemBadTimes(t *testing.T) {
+	raw := &DriveItemRaw{
+		ItemID:   "ITEM-2",
+		ItemInfo: &DriveItemRawInfo{Name: "dir", Type: "FOLDER", ModifiedAt: "", CreatedAt: "nope"},
+	}
+	item := raw.IntoDriveItem()
+	assert.True(t, item.DateModified.IsZero())
+	assert.True(t, item.DateCreated.IsZero())
+	assert.True(t, item.IsFolder())
+}
+
+// TestDocumentDriveID checks the zone defaulting in Document.DriveID.
+func TestDocumentDriveID(t *testing.T) {
+	withZone := &Document{Type: "FILE", Zone: "owner.zone", DocumentID: "D1"}
+	assert.Equal(t, "FILE::owner.zone::D1", withZone.DriveID())
+
+	noZone := &Document{Type: "FILE", DocumentID: "D2"}
+	assert.Equal(t, "FILE::com.apple.CloudDocs::D2", noZone.DriveID())
+}

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -9,9 +9,11 @@ import (
 	"path"
 
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/rclone/rclone/fs"
@@ -59,16 +61,24 @@ type Options struct {
 
 // Fs represents a remote icloud drive
 type Fs struct {
-	name     string // name of this remote
-	root     string // the path we are working on.
-	rootID   string
-	opt      Options            // parsed config options
-	m        configmap.Mapper   // config map for persisting auth state
-	features *fs.Features       // optional features
-	dirCache *dircache.DirCache // Map of directory path to directory id
-	icloud   *api.Client
-	service  *api.DriveService
-	pacer    *fs.Pacer // pacer for API calls
+	name       string // name of this remote
+	root       string // the path we are working on.
+	rootID     string
+	opt        Options            // parsed config options
+	m          configmap.Mapper   // config map for persisting auth state
+	features   *fs.Features       // optional features
+	dirCache   *dircache.DirCache // Map of directory path to directory id
+	icloud     *api.Client
+	service    *api.DriveService
+	pacer      *fs.Pacer       // pacer for API calls
+	shareRoots *shareRootCache // cached drivewsids of top-level shared-folder roots (stable)
+}
+
+// shareRootCache memoises the (stable) drivewsid of each top-level shared-folder
+// root by name, so a shared write does not re-list the drive root every time.
+type shareRootCache struct {
+	mu  sync.Mutex
+	ids map[string]string
 }
 
 // Object describes an icloud drive object
@@ -729,13 +739,14 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	root = strings.Trim(root, "/")
 
 	f := &Fs{
-		name:   name,
-		root:   root,
-		icloud: icloud,
-		rootID: "FOLDER::com.apple.CloudDocs::root",
-		opt:    *opt,
-		m:      m,
-		pacer:  fs.NewPacer(ctx, pacer.NewDefault(pacer.MinSleep(minSleep), pacer.MaxSleep(maxSleep), pacer.DecayConstant(decayConstant))),
+		name:       name,
+		root:       root,
+		icloud:     icloud,
+		rootID:     "FOLDER::com.apple.CloudDocs::root",
+		opt:        *opt,
+		m:          m,
+		pacer:      fs.NewPacer(ctx, pacer.NewDefault(pacer.MinSleep(minSleep), pacer.MaxSleep(maxSleep), pacer.DecayConstant(decayConstant))),
+		shareRoots: &shareRootCache{ids: map[string]string{}},
 	}
 	f.features = (&fs.Features{
 		CanHaveEmptyDirectories: true,
@@ -899,33 +910,81 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadClo
 		return io.NopCloser(bytes.NewBufferString("")), nil
 	}
 
+	// Files inside a folder shared by another Apple ID have no usable drivewsid
+	// (they are addressed by item_id via the docws endpoints), so the by_id download
+	// lookup is not available — the enumerate/item response gives a direct download
+	// URL instead. That URL is short-lived, but an Object can live a long time (e.g.
+	// in a VFS mount cache), so the cached URL may have gone stale: refresh it from
+	// the item lookup and retry on a download failure.
+	shared := o.driveID == ""
+
+	url, err := o.resolveDownloadURL(ctx, shared, false)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := o.downloadURLBody(ctx, url, options)
+	if err != nil && shared {
+		fs.Debugf(o, "iclouddrive: shared download failed (%v), refreshing download URL and retrying", err)
+		var fresh string
+		if fresh, err = o.resolveDownloadURL(ctx, shared, true); err == nil {
+			resp, err = o.downloadURLBody(ctx, fresh, options)
+		}
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return resp.Body, nil
+}
+
+// resolveDownloadURL returns the download URL for the object. For own-zone items it
+// resolves via the by-id lookup. For files inside a folder shared by another Apple
+// ID it returns the cached URL, re-resolving it via the item lookup when the cache
+// is empty or a refresh is forced (the shared URL is short-lived).
+func (o *Object) resolveDownloadURL(ctx context.Context, shared, refresh bool) (string, error) {
+	if !shared {
+		var url string
+		var resp *http.Response
+		var err error
+		if err = o.fs.pacer.Call(func() (bool, error) {
+			url, resp, err = o.fs.service.GetDownloadURLByDriveID(ctx, o.driveID)
+			return shouldRetry(ctx, resp, err)
+		}); err != nil {
+			return "", err
+		}
+		return url, nil
+	}
+	if o.downloadURL != "" && !refresh {
+		return o.downloadURL, nil
+	}
+	var item *api.DriveItemRaw
 	var resp *http.Response
 	var err error
-
 	if err = o.fs.pacer.Call(func() (bool, error) {
-		var url string
+		item, resp, err = o.fs.service.GetItemRawByItemID(ctx, o.itemID)
+		return shouldRetry(ctx, resp, err)
+	}); err != nil {
+		return "", err
+	}
+	if item == nil || item.ItemInfo == nil || item.ItemInfo.Urls.URLDownload == "" {
+		return "", fmt.Errorf("iclouddrive: could not resolve download URL for %q", o.remote)
+	}
+	o.downloadURL = item.ItemInfo.Urls.URLDownload
+	return o.downloadURL, nil
+}
 
-		// Files inside a folder shared by another Apple ID have no usable drivewsid
-		// (they are addressed by item_id via the docws endpoints), so the by_id
-		// download lookup is not available. The enumerate response gives us a direct
-		// download URL, so use it.
-		if o.driveID == "" && o.downloadURL != "" {
-			url = o.downloadURL
-		} else {
-			// Can not get the download url on a item to work, so do it the hard way.
-			url, _, err = o.fs.service.GetDownloadURLByDriveID(ctx, o.driveID)
-			if err != nil {
-				return shouldRetry(ctx, resp, err)
-			}
-		}
-
+// downloadURLBody fetches the given URL through the pacer and returns the response.
+func (o *Object) downloadURLBody(ctx context.Context, url string, options []fs.OpenOption) (*http.Response, error) {
+	var resp *http.Response
+	var err error
+	if err = o.fs.pacer.Call(func() (bool, error) {
 		resp, err = o.fs.service.DownloadFile(ctx, url, options)
 		return shouldRetry(ctx, resp, err)
 	}); err != nil {
 		return nil, err
 	}
-
-	return resp.Body, err
+	return resp, nil
 }
 
 // Remote implements fs.Object.
@@ -1070,6 +1129,18 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 // shareName (a SHARED_FOLDER at the drive root). This is the destination a document
 // is moved into so it enters the owner's zone with PCS chaining applied.
 func (f *Fs) lookupSharedFolderRoot(ctx context.Context, shareName string) (string, error) {
+	// The share-root drivewsid is stable, so cache it per name to avoid listing the
+	// drive root on every shared write.
+	cache := f.shareRoots
+	if cache != nil {
+		cache.mu.Lock()
+		id, ok := cache.ids[shareName]
+		cache.mu.Unlock()
+		if ok {
+			return id, nil
+		}
+	}
+
 	var root *api.DriveItem
 	var resp *http.Response
 	var err error
@@ -1083,10 +1154,15 @@ func (f *Fs) lookupSharedFolderRoot(ctx context.Context, shareName string) (stri
 	for _, it := range root.Items {
 		name := norm.NFC.String(f.opt.Enc.ToStandardName(it.Name))
 		if strings.EqualFold(name, want) && strings.HasPrefix(it.Drivewsid, "SHARED_FOLDER::") {
+			if cache != nil {
+				cache.mu.Lock()
+				cache.ids[shareName] = it.Drivewsid
+				cache.mu.Unlock()
+			}
 			return it.Drivewsid, nil
 		}
 	}
-	return "", errors.New("iclouddrive: could not find shared-folder root " + shareName)
+	return "", fmt.Errorf("iclouddrive: could not find shared-folder root %q", shareName)
 }
 
 // updateViaCloudDocs writes a document into a folder shared by another Apple ID.
@@ -1096,7 +1172,7 @@ func (f *Fs) lookupSharedFolderRoot(ctx context.Context, shareName string) (stri
 // into the target sub-folder via the CloudKit shared database. See api.CloudDocs.
 func (o *Object) updateViaCloudDocs(ctx context.Context, in io.Reader, src fs.ObjectInfo, leaf, dirID string, modTime time.Time, size int64) error {
 	f := o.fs
-	cd := f.icloud.CloudDocsService()
+	cd := f.icloud.CloudDocsService(f.pacer, shouldRetry)
 	if cd == nil {
 		return errors.New("iclouddrive: cannot write into a shared sub-folder: account has no ckdatabasews service")
 	}
@@ -1166,18 +1242,26 @@ func (o *Object) updateViaCloudDocs(ctx context.Context, in io.Reader, src fs.Ob
 	uuid := api.GetDocIDFromDriveID(moved.Drivewsid)
 
 	// Overwrite: if a file with the same name already exists in the target folder,
-	// remove its record so we don't leave a duplicate (best-effort).
+	// remove its record so we don't leave a duplicate (best-effort). The lookup is
+	// not query-indexable, so a miss is possible; log it so a resulting duplicate is
+	// diagnosable.
 	if o.itemID != "" {
-		if oldUUID, qerr := cd.FindFileUUID(ctx, targetDirUUID, leaf); qerr == nil && oldUUID != "" && !strings.EqualFold(oldUUID, uuid) {
-			_ = cd.DeleteFile(ctx, oldUUID)
+		oldUUID, qerr := cd.FindFileUUID(ctx, targetDirUUID, leaf)
+		switch {
+		case qerr != nil:
+			fs.Debugf(o, "iclouddrive: could not look up existing %q in shared folder to overwrite: %v", leaf, qerr)
+		case oldUUID == "":
+			fs.Debugf(o, "iclouddrive: existing copy of %q not found in shared folder before overwrite; a duplicate may result", leaf)
+		case !strings.EqualFold(oldUUID, uuid):
+			if derr := cd.DeleteFile(ctx, oldUUID); derr != nil {
+				fs.Debugf(o, "iclouddrive: could not delete previous copy of %q (%s): %v", leaf, oldUUID, derr)
+			}
 		}
 	}
 
-	// (3) Re-parent the record into the target shared sub-folder.
-	if err = f.pacer.Call(func() (bool, error) {
-		err = cd.ReparentStructure(ctx, uuid, targetDirUUID)
-		return shouldRetry(ctx, nil, err)
-	}); err != nil {
+	// (3) Re-parent the record into the target shared sub-folder. The CloudDocs
+	// request layer already paces and retries each call, so no extra pacer here.
+	if err = cd.ReparentStructure(ctx, uuid, targetDirUUID); err != nil {
 		return err
 	}
 

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -543,21 +543,21 @@ func (f *Fs) cloudDocsDirectoryRecordID(ctx context.Context, cd *api.CloudDocs, 
 }
 
 func (f *Fs) cloudDocsDirectoryRecordIDAbs(ctx context.Context, cd *api.CloudDocs, absDir, dirID string) (string, error) {
-	if api.IsSharedFolderChildID(dirID) {
-		if dirID == "" {
-			parent, leaf := dircache.SplitPath(absDir)
-			dc := dircache.New("", f.rootID, f)
-			parentJID, err := dc.FindDir(ctx, parent, false)
-			if err != nil {
-				return "", err
-			}
-			parentID, _ := f.parseNormalizedID(parentJID)
-			parentRecordID, err := f.cloudDocsDirectoryRecordIDAbs(ctx, cd, parent, parentID)
-			if err != nil {
-				return "", err
-			}
-			return cd.FindDirectoryUUID(ctx, parentRecordID, leaf)
+	if dirID == "" {
+		parent, leaf := dircache.SplitPath(absDir)
+		dc := dircache.New("", f.rootID, f)
+		parentJID, err := dc.FindDir(ctx, parent, false)
+		if err != nil {
+			return "", err
 		}
+		parentID, _ := f.parseNormalizedID(parentJID)
+		parentRecordID, err := f.cloudDocsDirectoryRecordIDAbs(ctx, cd, parent, parentID)
+		if err != nil {
+			return "", err
+		}
+		return cd.FindDirectoryUUID(ctx, parentRecordID, leaf)
+	}
+	if api.IsSharedFolderChildID(dirID) {
 		return api.GetDocIDFromDriveID(dirID), nil
 	}
 	if isSharedFolderRootID(dirID) {
@@ -664,6 +664,14 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 
 	srcDirectoryID, srcEtag := f.parseNormalizedID(jsrcDirectoryID)
 	dstDirectoryID, _ := f.parseNormalizedID(jdstDirectoryID)
+	if f.isSharedWriteJID(srcID) || f.isSharedWriteJID(jsrcDirectoryID) || f.isSharedWriteJID(jdstDirectoryID) {
+		if err := f.dirMoveViaCloudDocs(ctx, srcFs, srcID, jdstDirectoryID, dstLeaf, srcRemote, dstRemote); err != nil {
+			return err
+		}
+		srcFs.dirCache.FlushDir(srcRemote)
+		f.dirCache.FlushDir(dstRemote)
+		return nil
+	}
 
 	_, err = f.move(ctx, srcID, srcDirectoryID, srcLeaf, srcEtag, dstDirectoryID, dstLeaf)
 	if err != nil {
@@ -673,6 +681,47 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 	srcFs.dirCache.FlushDir(srcRemote)
 
 	return nil
+}
+
+// dirMoveViaCloudDocs moves or renames an existing directory inside a folder shared
+// by another Apple ID. The drivews directory move endpoint cannot address the
+// owner's shared zone, but the directory record can be re-parented/renamed through
+// the shared CloudDocs database.
+func (f *Fs) dirMoveViaCloudDocs(ctx context.Context, srcFs *Fs, srcJID, dstParentJID, dstLeaf, srcRemote, dstRemote string) error {
+	srcID, _ := f.parseNormalizedID(srcJID)
+	if !api.IsSharedFolderChildID(srcID) && f.parseSharedItemID(srcJID) == "" {
+		return fs.ErrorCantDirMove
+	}
+	dstParentID, _ := f.parseNormalizedID(dstParentJID)
+
+	cd := f.icloud.CloudDocsService(f.pacer, shouldRetry)
+	if cd == nil {
+		return errors.New("iclouddrive: cannot move a directory in a shared folder: account has no ckdatabasews service")
+	}
+
+	srcAbs := path.Join(srcFs.root, srcRemote)
+	srcUUID, err := srcFs.cloudDocsDirectoryRecordIDAbs(ctx, cd, srcAbs, srcID)
+	if err != nil {
+		return err
+	}
+	if srcUUID == "" {
+		return fmt.Errorf("iclouddrive: cannot move shared directory %q: missing source CloudDocs directory ID", srcAbs)
+	}
+
+	dstAbs := path.Join(f.root, dstRemote)
+	dstParentAbs := path.Dir(path.Clean(dstAbs))
+	if dstParentAbs == "." {
+		dstParentAbs = ""
+	}
+	dstParentUUID, err := f.cloudDocsDirectoryRecordIDAbs(ctx, cd, dstParentAbs, dstParentID)
+	if err != nil {
+		return err
+	}
+	if dstParentUUID == "" {
+		return fmt.Errorf("iclouddrive: cannot move shared directory %q: missing target CloudDocs directory ID", dstAbs)
+	}
+
+	return cd.ReparentDirectory(ctx, srcUUID, dstParentUUID, f.opt.Enc.FromStandardName(dstLeaf))
 }
 
 func (f *Fs) move(ctx context.Context, ID, srcDirectoryID, srcLeaf, srcEtag, dstDirectoryID, dstLeaf string) (*api.DriveItem, error) {

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -599,6 +599,13 @@ func (f *Fs) String() string {
 // This should be implemented by the backend and will be called by the
 // dircache package when appropriate.
 func (f *Fs) CreateDir(ctx context.Context, pathID, leaf string) (string, error) {
+	// A folder cannot be created directly inside a folder shared by another Apple
+	// ID: drivews/docws return HTTP 400 for the share root and every sub-folder.
+	// Route those through the CloudDocs workaround (see createDirViaCloudDocs).
+	if f.isSharedWriteJID(pathID) {
+		return f.createDirViaCloudDocs(ctx, pathID, leaf)
+	}
+
 	var item *api.DriveItem
 	var err error
 	var found bool
@@ -1245,8 +1252,14 @@ func sharedUploadTempName(leaf, token string) string {
 // may be inside the share, so don't assume the first relative path component is
 // the shared folder.
 func (f *Fs) findSharedFolderRoot(ctx context.Context, remote string) (string, error) {
-	absPath := path.Join(f.root, remote)
-	dir := path.Dir(path.Clean(absPath))
+	return f.findSharedFolderRootAbs(ctx, path.Join(f.root, remote))
+}
+
+// findSharedFolderRootAbs is findSharedFolderRoot for an absolute path (relative to
+// the drive root, not to f.root). It walks up from the item's parent looking for the
+// nearest SHARED_FOLDER ancestor.
+func (f *Fs) findSharedFolderRootAbs(ctx context.Context, absItemPath string) (string, error) {
+	dir := path.Dir(path.Clean(absItemPath))
 	if dir == "." {
 		dir = ""
 	}
@@ -1269,7 +1282,136 @@ func (f *Fs) findSharedFolderRoot(ctx context.Context, remote string) (string, e
 		}
 	}
 
-	return "", fmt.Errorf("iclouddrive: could not find shared-folder root for %q", remote)
+	return "", fmt.Errorf("iclouddrive: could not find shared-folder root for %q", absItemPath)
+}
+
+// isSharedWriteJID reports whether a normalized directory-cache id refers to a
+// folder shared by another Apple ID (the share root or any sub-folder). Sub-folders
+// deep enough to lack a drivewsid are still recognised by the embedded item_id.
+func (f *Fs) isSharedWriteJID(jid string) bool {
+	id, _ := f.parseNormalizedID(jid)
+	return isSharedWriteDirID(id) || f.parseSharedItemID(jid) != ""
+}
+
+// sharedDirTempName returns a unique, collision-free folder name used while a new
+// shared sub-directory is staged in the caller's own zone root before being moved
+// into the owner's zone. The final name is applied afterwards via CloudDocs.
+func sharedDirTempName(token string) string {
+	return ".rclone-dir-" + token
+}
+
+// createDirViaCloudDocs creates a directory inside a folder shared by another Apple
+// ID. drivews/docws cannot do this directly (HTTP 400), so it mirrors the document
+// write path (see updateViaCloudDocs):
+//
+//  1. create the folder under a temporary name in the caller's own zone root;
+//  2. move it into the share root, which lands it in the owner's zone with PCS
+//     chaining done server-side (this alone is enough for the share root itself);
+//  3. if the target is a sub-folder, re-parent and rename the record into it via the
+//     CloudKit shared database; the server re-chains PCS because the record now
+//     carries its own key.
+//
+// It returns the new directory's normalized cache id.
+func (f *Fs) createDirViaCloudDocs(ctx context.Context, parentJID, leaf string) (string, error) {
+	parentID, _ := f.parseNormalizedID(parentJID)
+
+	// Resolve the parent's absolute path (relative to the drive root). CreateDir can
+	// run while the directory cache is still locating its own root (e.g. for
+	// "mkdir remote:Share/new", where the Fs root is the not-yet-existent new dir),
+	// in which case cached paths are drive-root-absolute; once the root is found they
+	// are relative to f.root. Normalise to absolute so the helpers below work in
+	// either state.
+	parentRemote, ok := f.dirCache.GetInv(parentJID)
+	if !ok {
+		return "", fmt.Errorf("iclouddrive: cannot create shared directory %q: parent path unknown", leaf)
+	}
+	// Decide whether the cached parent path is drive-root-absolute or relative to
+	// f.root. CreateDir is invoked by the dircache while it holds its internal mutex,
+	// so we must NOT call any DirCache method that re-locks that mutex (FoundRoot,
+	// FindDir, etc.) because that self-deadlocks. Get/GetInv use a separate mutex
+	// and are safe.
+	//
+	// The cache entry that maps to "" is the cache's current frame root: while the
+	// root is still being located it is the true drive root (f.rootID) and all cached
+	// paths are drive-root-absolute; once the root is found the cache is re-based and
+	// that entry becomes f.root's id, with cached paths relative to f.root. So we only
+	// prepend f.root when the frame root is no longer the true drive root.
+	frameRootID, ok := f.dirCache.Get("")
+	parentAbs := parentRemote
+	if ok && frameRootID != f.rootID {
+		parentAbs = path.Join(f.root, parentRemote)
+	}
+	newAbs := path.Join(parentAbs, leaf)
+
+	cd := f.icloud.CloudDocsService(f.pacer, shouldRetry)
+	if cd == nil {
+		return "", errors.New("iclouddrive: cannot create a directory in a shared folder: account has no ckdatabasews service")
+	}
+
+	// The share root is the only addressable ancestor in the owner's zone.
+	shareRootID, err := f.findSharedFolderRootAbs(ctx, newAbs)
+	if err != nil {
+		return "", err
+	}
+
+	// (1) Create under a temporary name in the caller's own zone root. The final
+	// name is applied later, after the record has moved into the owner's zone,
+	// so a clashing name in the own root or share root cannot cause a "name 2"
+	// rename of the user-visible folder.
+	tempName := f.opt.Enc.FromStandardName(sharedDirTempName(uuid.NewString()))
+	var ownItem *api.DriveItem
+	var resp *http.Response
+	if err = f.pacer.Call(func() (bool, error) {
+		ownItem, resp, err = f.service.CreateNewFolderByDriveID(ctx, f.rootID, tempName)
+		return ignoreResultUnknown(ctx, resp, err)
+	}); err != nil {
+		return "", err
+	}
+
+	// (2) Move it into the share root (lands in the owner's zone, PCS applied).
+	var moved *api.DriveItem
+	if err = f.pacer.Call(func() (bool, error) {
+		moved, resp, err = f.service.MoveItemByDriveID(ctx, ownItem.Drivewsid, ownItem.Etag, shareRootID, true)
+		return ignoreResultUnknown(ctx, resp, err)
+	}); err != nil {
+		return "", err
+	}
+	uuid := api.GetDocIDFromDriveID(moved.Drivewsid)
+	name := f.opt.Enc.FromStandardName(leaf)
+	cleanupMovedDir := func() {
+		_ = cd.DeleteDirectory(ctx, uuid)
+	}
+
+	// (3) Re-parent into the target. The CloudDocs directory record of the target
+	// is the share root itself when the parent is the share root, or the sub-folder
+	// otherwise; either way ReparentDirectory sets the final name and (for a deeper
+	// target) re-chains PCS.
+	targetDirUUID, err := f.cloudDocsDirectoryRecordIDAbs(ctx, cd, parentAbs, parentID)
+	if err != nil {
+		cleanupMovedDir()
+		return "", err
+	}
+	if targetDirUUID == "" {
+		cleanupMovedDir()
+		return "", fmt.Errorf("iclouddrive: cannot create directory in shared folder %q: missing CloudDocs directory ID", parentAbs)
+	}
+	if err = cd.ReparentDirectory(ctx, uuid, targetDirUUID, name); err != nil {
+		cleanupMovedDir()
+		return "", err
+	}
+
+	// The moved/re-parented folder's drivewsid and item_id are not reported back by
+	// the CloudDocs response, so re-resolve it through the parent listing (which lists
+	// by ID, uncached) to build a correct cache id; deeper shared folders are
+	// addressed by item_id, not drivewsid.
+	item, found, err := f.findLeafItem(ctx, parentJID, leaf)
+	if err != nil {
+		return "", err
+	}
+	if !found || item == nil {
+		return "", fmt.Errorf("iclouddrive: created shared directory %q but could not re-read it", newAbs)
+	}
+	return f.folderID(item), nil
 }
 
 // updateViaCloudDocs writes a document into a folder shared by another Apple ID.

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -162,9 +162,36 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 		return errors.New("can't purge root directory")
 	}
 
-	directoryID, etag, err := f.FindDir(ctx, dir, false)
+	jDirectoryID, err := f.dirCache.FindDir(ctx, dir, false)
 	if err != nil {
 		return err
+	}
+	directoryID, etag := f.parseNormalizedID(jDirectoryID)
+
+	if api.IsSharedFolderChildID(directoryID) {
+		if !check {
+			return fs.ErrorCantPurge
+		}
+		items, err := f.listAll(ctx, jDirectoryID)
+		if err != nil {
+			return err
+		}
+		if len(items) > 0 {
+			return fs.ErrorDirectoryNotEmpty
+		}
+		dirUUID := api.GetDocIDFromDriveID(directoryID)
+		if dirUUID == "" {
+			return fmt.Errorf("iclouddrive: cannot remove shared directory %q: missing CloudDocs directory ID", dir)
+		}
+		cd := f.icloud.CloudDocsService(f.pacer, shouldRetry)
+		if cd == nil {
+			return errors.New("iclouddrive: cannot remove shared directory: account has no ckdatabasews service")
+		}
+		if err := cd.DeleteDirectory(ctx, dirUUID); err != nil {
+			return err
+		}
+		f.dirCache.FlushDir(dir)
+		return nil
 	}
 
 	if check {

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -133,7 +133,7 @@ func (f *Fs) FindLeaf(ctx context.Context, pathID string, leaf string) (pathIDOu
 		return "", false, fs.ErrorIsFile
 	}
 
-	return f.IDJoin(item.Drivewsid, item.Etag), true, nil
+	return f.folderID(item), true, nil
 }
 
 // Features implements fs.Fs.
@@ -197,18 +197,37 @@ func (f *Fs) Purge(ctx context.Context, dir string) error {
 }
 
 func (f *Fs) listAll(ctx context.Context, dirID string) (items []*api.DriveItem, err error) {
-	var item *api.DriveItem
 	var resp *http.Response
 
-	if err = f.pacer.Call(func() (bool, error) {
-		id, _ := f.parseNormalizedID(dirID)
-		item, resp, err = f.service.GetItemByDriveID(ctx, id, true)
-		return shouldRetry(ctx, resp, err)
-	}); err != nil {
-		return nil, err
-	}
+	id, _ := f.parseNormalizedID(dirID)
+	itemID := f.parseSharedItemID(dirID)
 
-	items = item.Items
+	// Items inside a folder shared by another Apple ID cannot be listed through the
+	// drivews retrieveItemDetailsInFolders endpoint (it only operates within the
+	// caller's own zone and returns HTTP 400). Use the docws enumerate-by-item_id
+	// endpoint instead. See api.IsSharedFolderChildID.
+	if itemID != "" && api.IsSharedFolderChildID(id) {
+		var raws []*api.DriveItemRaw
+		if err = f.pacer.Call(func() (bool, error) {
+			raws, resp, err = f.service.GetItemsInFolder(ctx, itemID, 5000)
+			return shouldRetry(ctx, resp, err)
+		}); err != nil {
+			return nil, err
+		}
+		items = make([]*api.DriveItem, 0, len(raws))
+		for _, raw := range raws {
+			items = append(items, raw.IntoDriveItem())
+		}
+	} else {
+		var item *api.DriveItem
+		if err = f.pacer.Call(func() (bool, error) {
+			item, resp, err = f.service.GetItemByDriveID(ctx, id, true)
+			return shouldRetry(ctx, resp, err)
+		}); err != nil {
+			return nil, err
+		}
+		items = item.Items
+	}
 
 	for i, item := range items {
 		item.Name = f.opt.Enc.ToStandardName(item.Name)
@@ -234,11 +253,10 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 	}
 
 	for _, item := range items {
-		id := item.Drivewsid
 		name := item.FullName()
 		remote := path.Join(dir, name)
 		if item.IsFolder() {
-			jid := f.putFolderCache(id, item.Etag, remote)
+			jid := f.putFolderCache(item, remote)
 			d := fs.NewDir(remote, item.DateModified).SetID(jid).SetSize(item.AssetQuota)
 			entries = append(entries, d)
 		} else {
@@ -422,6 +440,32 @@ func (f *Fs) parseNormalizedID(rid string) (id string, etag string) {
 	return split[0], split[1]
 }
 
+// parseSharedItemID returns the item_id embedded in a normalized ID, if present.
+//
+// For items that live inside a folder shared by another Apple ID we cache the id as
+// `drivewsid#etag#itemID`, because such items can only be addressed through the docws
+// endpoints by item_id (the drivewsid is unusable, and may even be empty). Normal
+// (own-zone) items are cached as `drivewsid#etag` and this returns "".
+func (f *Fs) parseSharedItemID(rid string) string {
+	split := strings.Split(rid, "#")
+	if len(split) >= 3 {
+		return split[2]
+	}
+	return ""
+}
+
+// folderID builds the normalized directory cache id for a DriveItem. For items inside
+// a folder shared by another Apple ID it additionally embeds the item_id (see
+// parseSharedItemID); for normal items it is identical to IDJoin so behaviour is
+// unchanged.
+func (f *Fs) folderID(item *api.DriveItem) string {
+	base := f.IDJoin(item.Drivewsid, item.Etag)
+	if item.Itemid != "" && api.IsSharedFolderChildID(item.Drivewsid) {
+		base += "#" + item.Itemid
+	}
+	return base
+}
+
 // FindPath finds the leaf and directoryID from a normalized path
 func (f *Fs) FindPath(ctx context.Context, remote string, create bool) (leaf, directoryID, etag string, err error) {
 	leaf, jDirectoryID, err := f.dirCache.FindPath(ctx, remote, create)
@@ -453,9 +497,9 @@ func (f *Fs) IDJoin(id string, etag string) string {
 	return strings.Join([]string{id, etag}, "#")
 }
 
-func (f *Fs) putFolderCache(id, etag, remote string) string {
-	jid := f.IDJoin(id, etag)
-	f.dirCache.Put(remote, f.IDJoin(id, etag))
+func (f *Fs) putFolderCache(item *api.DriveItem, remote string) string {
+	jid := f.folderID(item)
+	f.dirCache.Put(remote, jid)
 	return jid
 }
 
@@ -512,7 +556,7 @@ func (f *Fs) CreateDir(ctx context.Context, pathID, leaf string) (string, error)
 		return "", err
 	}
 
-	return f.IDJoin(item.Drivewsid, item.Etag), err
+	return f.folderID(item), err
 }
 
 // DirMove moves src, srcRemote to this remote at dstRemote
@@ -785,7 +829,11 @@ func (f *Fs) NewObjectFromDriveItem(ctx context.Context, remote string, item *ap
 }
 
 func (f *Fs) readMetaData(ctx context.Context, path string) (item *api.DriveItem, err error) {
-	leaf, ID, _, err := f.FindPath(ctx, path, false)
+	// Use the full normalized directory ID (which, for items inside a shared folder,
+	// carries the item_id needed to list the folder via the docws endpoint). Going
+	// through f.FindPath here would strip it down to drivewsid#etag - see folderID
+	// and parseSharedItemID.
+	leaf, directoryID, err := f.dirCache.FindPath(ctx, path, false)
 
 	if err != nil {
 		if err == fs.ErrorDirNotFound {
@@ -794,7 +842,7 @@ func (f *Fs) readMetaData(ctx context.Context, path string) (item *api.DriveItem
 		return nil, err
 	}
 
-	item, found, err := f.findLeafItem(ctx, ID, leaf)
+	item, found, err := f.findLeafItem(ctx, directoryID, leaf)
 
 	if err != nil {
 		return nil, err
@@ -857,13 +905,19 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadClo
 	if err = o.fs.pacer.Call(func() (bool, error) {
 		var url string
 
-		//var doc *api.Document
-		//if o.docID == "" {
-		//doc, resp, err = o.fs.service.GetDocByItemID(ctx, o.itemID)
-		//}
-
-		// Can not get the download url on a item to work, so do it the hard way.
-		url, _, err = o.fs.service.GetDownloadURLByDriveID(ctx, o.driveID)
+		// Files inside a folder shared by another Apple ID have no usable drivewsid
+		// (they are addressed by item_id via the docws endpoints), so the by_id
+		// download lookup is not available. The enumerate response gives us a direct
+		// download URL, so use it.
+		if o.driveID == "" && o.downloadURL != "" {
+			url = o.downloadURL
+		} else {
+			// Can not get the download url on a item to work, so do it the hard way.
+			url, _, err = o.fs.service.GetDownloadURLByDriveID(ctx, o.driveID)
+			if err != nil {
+				return shouldRetry(ctx, resp, err)
+			}
+		}
 
 		resp, err = o.fs.service.DownloadFile(ctx, url, options)
 		return shouldRetry(ctx, resp, err)

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -989,6 +989,13 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		return err
 	}
 
+	// Items whose parent is a folder shared by another Apple ID cannot be written
+	// through the drivews/docws upload endpoints (they only operate in the caller's
+	// own zone and return HTTP 400). Route those through CloudKit instead.
+	if api.IsSharedFolderChildID(dirID) {
+		return o.updateViaCloudDocs(ctx, in, src, leaf, dirID, modTime, size)
+	}
+
 	// Move current file to trash
 	if o.driveID != "" {
 		err = o.Remove(ctx)
@@ -1056,6 +1063,134 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	o.modTime = modTime
 	o.size = src.Size()
 
+	return nil
+}
+
+// lookupSharedFolderRoot returns the drivewsid of the top-level shared folder named
+// shareName (a SHARED_FOLDER at the drive root). This is the destination a document
+// is moved into so it enters the owner's zone with PCS chaining applied.
+func (f *Fs) lookupSharedFolderRoot(ctx context.Context, shareName string) (string, error) {
+	var root *api.DriveItem
+	var resp *http.Response
+	var err error
+	if err = f.pacer.Call(func() (bool, error) {
+		root, resp, err = f.service.GetItemByDriveID(ctx, f.rootID, true)
+		return shouldRetry(ctx, resp, err)
+	}); err != nil {
+		return "", err
+	}
+	want := norm.NFC.String(shareName)
+	for _, it := range root.Items {
+		name := norm.NFC.String(f.opt.Enc.ToStandardName(it.Name))
+		if strings.EqualFold(name, want) && strings.HasPrefix(it.Drivewsid, "SHARED_FOLDER::") {
+			return it.Drivewsid, nil
+		}
+	}
+	return "", errors.New("iclouddrive: could not find shared-folder root " + shareName)
+}
+
+// updateViaCloudDocs writes a document into a folder shared by another Apple ID.
+// drivews/docws cannot do this directly, so it: (1) uploads the document into the
+// caller's own zone root, (2) moves it into the share root (which puts it in the
+// owner's zone with PCS chaining done server-side), then (3) re-parents the record
+// into the target sub-folder via the CloudKit shared database. See api.CloudDocs.
+func (o *Object) updateViaCloudDocs(ctx context.Context, in io.Reader, src fs.ObjectInfo, leaf, dirID string, modTime time.Time, size int64) error {
+	f := o.fs
+	cd := f.icloud.CloudDocsService()
+	if cd == nil {
+		return errors.New("iclouddrive: cannot write into a shared sub-folder: account has no ckdatabasews service")
+	}
+
+	remote := o.Remote()
+	dirRemote := path.Dir(path.Clean(remote))
+	targetDirUUID := api.GetDocIDFromDriveID(dirID)
+
+	// The file must first land in the owner's zone via the share root (an addressable
+	// SHARED_FOLDER at the top of the drive). The share root is the first component of
+	// the absolute path; resolve its drivewsid from the drive root listing.
+	absPath := path.Join(f.root, remote)
+	shareName := absPath
+	if i := strings.IndexByte(absPath, '/'); i >= 0 {
+		shareName = absPath[:i]
+	}
+	shareRootID, err := f.lookupSharedFolderRoot(ctx, shareName)
+	if err != nil {
+		return err
+	}
+
+	name := f.opt.Enc.FromStandardName(leaf)
+	var resp *http.Response
+
+	// (1) Upload into the caller's own zone root.
+	var uploadInfo *api.UploadResponse
+	if err = f.pacer.Call(func() (bool, error) {
+		uploadInfo, resp, err = f.service.CreateUpload(ctx, size, name)
+		return ignoreResultUnknown(ctx, resp, err)
+	}); err != nil {
+		return err
+	}
+	var upload *api.SingleFileResponse
+	if err = f.pacer.Call(func() (bool, error) {
+		upload, resp, err = f.service.Upload(ctx, in, size, name, uploadInfo.URL)
+		return ignoreResultUnknown(ctx, resp, err)
+	}); err != nil {
+		return err
+	}
+	r := api.NewUpdateFileInfo()
+	r.DocumentID = uploadInfo.DocumentID
+	r.Path.Path = name
+	r.Path.StartingDocumentID = api.GetDocIDFromDriveID(f.rootID) // own zone root
+	r.Data.Receipt = upload.SingleFile.Receipt
+	r.Data.Signature = upload.SingleFile.Signature
+	r.Data.ReferenceSignature = upload.SingleFile.ReferenceSignature
+	r.Data.WrappingKey = upload.SingleFile.WrappingKey
+	r.Data.Size = upload.SingleFile.Size
+	r.Mtime = modTime.Unix() * 1000
+	r.Btime = modTime.Unix() * 1000
+	var ownItem *api.DriveItem
+	if err = f.pacer.Call(func() (bool, error) {
+		ownItem, resp, err = f.service.UpdateFile(ctx, &r)
+		return ignoreResultUnknown(ctx, resp, err)
+	}); err != nil {
+		return err
+	}
+
+	// (2) Move it into the share root (lands in the owner's zone, PCS applied).
+	var moved *api.DriveItem
+	if err = f.pacer.Call(func() (bool, error) {
+		moved, resp, err = f.service.MoveItemByDriveID(ctx, ownItem.Drivewsid, ownItem.Etag, shareRootID, true)
+		return ignoreResultUnknown(ctx, resp, err)
+	}); err != nil {
+		return err
+	}
+	uuid := api.GetDocIDFromDriveID(moved.Drivewsid)
+
+	// Overwrite: if a file with the same name already exists in the target folder,
+	// remove its record so we don't leave a duplicate (best-effort).
+	if o.itemID != "" {
+		if oldUUID, qerr := cd.FindFileUUID(ctx, targetDirUUID, leaf); qerr == nil && oldUUID != "" && !strings.EqualFold(oldUUID, uuid) {
+			_ = cd.DeleteFile(ctx, oldUUID)
+		}
+	}
+
+	// (3) Re-parent the record into the target shared sub-folder.
+	if err = f.pacer.Call(func() (bool, error) {
+		err = cd.ReparentStructure(ctx, uuid, targetDirUUID)
+		return shouldRetry(ctx, nil, err)
+	}); err != nil {
+		return err
+	}
+
+	o.size = size
+	o.modTime = modTime
+	o.docID = uuid
+	// Best-effort: refresh metadata (item_id etc.) from the now-placed file.
+	f.dirCache.FlushDir(dirRemote)
+	if item, merr := f.readMetaData(ctx, remote); merr == nil {
+		_ = o.setMetaData(item)
+		o.modTime = modTime
+		o.size = size
+	}
 	return nil
 }
 

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -13,9 +13,9 @@ import (
 	"io"
 	"net/http"
 	"strings"
-	"sync"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/fserrors"
@@ -61,24 +61,16 @@ type Options struct {
 
 // Fs represents a remote icloud drive
 type Fs struct {
-	name       string // name of this remote
-	root       string // the path we are working on.
-	rootID     string
-	opt        Options            // parsed config options
-	m          configmap.Mapper   // config map for persisting auth state
-	features   *fs.Features       // optional features
-	dirCache   *dircache.DirCache // Map of directory path to directory id
-	icloud     *api.Client
-	service    *api.DriveService
-	pacer      *fs.Pacer       // pacer for API calls
-	shareRoots *shareRootCache // cached drivewsids of top-level shared-folder roots (stable)
-}
-
-// shareRootCache memoises the (stable) drivewsid of each top-level shared-folder
-// root by name, so a shared write does not re-list the drive root every time.
-type shareRootCache struct {
-	mu  sync.Mutex
-	ids map[string]string
+	name     string // name of this remote
+	root     string // the path we are working on.
+	rootID   string
+	opt      Options            // parsed config options
+	m        configmap.Mapper   // config map for persisting auth state
+	features *fs.Features       // optional features
+	dirCache *dircache.DirCache // Map of directory path to directory id
+	icloud   *api.Client
+	service  *api.DriveService
+	pacer    *fs.Pacer // pacer for API calls
 }
 
 // Object describes an icloud drive object
@@ -179,13 +171,16 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 		if len(items) > 0 {
 			return fs.ErrorDirectoryNotEmpty
 		}
-		dirUUID := api.GetDocIDFromDriveID(directoryID)
-		if dirUUID == "" {
-			return fmt.Errorf("iclouddrive: cannot remove shared directory %q: missing CloudDocs directory ID", dir)
-		}
 		cd := f.icloud.CloudDocsService(f.pacer, shouldRetry)
 		if cd == nil {
 			return errors.New("iclouddrive: cannot remove shared directory: account has no ckdatabasews service")
+		}
+		dirUUID, err := f.cloudDocsDirectoryRecordID(ctx, cd, dir, directoryID)
+		if err != nil {
+			return err
+		}
+		if dirUUID == "" {
+			return fmt.Errorf("iclouddrive: cannot remove shared directory %q: missing CloudDocs directory ID", dir)
 		}
 		if err := cd.DeleteDirectory(ctx, dirUUID); err != nil {
 			return err
@@ -540,6 +535,50 @@ func (f *Fs) putFolderCache(item *api.DriveItem, remote string) string {
 	return jid
 }
 
+func (f *Fs) cloudDocsDirectoryRecordID(ctx context.Context, cd *api.CloudDocs, dirRemote, dirID string) (string, error) {
+	if dirRemote == "." {
+		dirRemote = ""
+	}
+	return f.cloudDocsDirectoryRecordIDAbs(ctx, cd, path.Join(f.root, dirRemote), dirID)
+}
+
+func (f *Fs) cloudDocsDirectoryRecordIDAbs(ctx context.Context, cd *api.CloudDocs, absDir, dirID string) (string, error) {
+	if api.IsSharedFolderChildID(dirID) {
+		if dirID == "" {
+			parent, leaf := dircache.SplitPath(absDir)
+			dc := dircache.New("", f.rootID, f)
+			parentJID, err := dc.FindDir(ctx, parent, false)
+			if err != nil {
+				return "", err
+			}
+			parentID, _ := f.parseNormalizedID(parentJID)
+			parentRecordID, err := f.cloudDocsDirectoryRecordIDAbs(ctx, cd, parent, parentID)
+			if err != nil {
+				return "", err
+			}
+			return cd.FindDirectoryUUID(ctx, parentRecordID, leaf)
+		}
+		return api.GetDocIDFromDriveID(dirID), nil
+	}
+	if isSharedFolderRootID(dirID) {
+		parent, leaf := dircache.SplitPath(absDir)
+		dc := dircache.New("", f.rootID, f)
+		parentID, err := dc.FindDir(ctx, parent, false)
+		if err != nil {
+			return "", err
+		}
+		item, found, err := f.findLeafItem(ctx, parentID, leaf)
+		if err != nil {
+			return "", err
+		}
+		if !found || item == nil || item.ShareID == nil || item.ShareID.RecordName == "" {
+			return "", fmt.Errorf("iclouddrive: shared root %q has no CloudDocs shareID", dirID)
+		}
+		return item.ShareID.RecordName, nil
+	}
+	return "", fmt.Errorf("iclouddrive: directory %q is not in a shared folder", dirID)
+}
+
 // Rmdir implements fs.Fs.
 func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 	return f.purgeCheck(ctx, dir, true)
@@ -770,14 +809,13 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	root = strings.Trim(root, "/")
 
 	f := &Fs{
-		name:       name,
-		root:       root,
-		icloud:     icloud,
-		rootID:     "FOLDER::com.apple.CloudDocs::root",
-		opt:        *opt,
-		m:          m,
-		pacer:      fs.NewPacer(ctx, pacer.NewDefault(pacer.MinSleep(minSleep), pacer.MaxSleep(maxSleep), pacer.DecayConstant(decayConstant))),
-		shareRoots: &shareRootCache{ids: map[string]string{}},
+		name:   name,
+		root:   root,
+		icloud: icloud,
+		rootID: "FOLDER::com.apple.CloudDocs::root",
+		opt:    *opt,
+		m:      m,
+		pacer:  fs.NewPacer(ctx, pacer.NewDefault(pacer.MinSleep(minSleep), pacer.MaxSleep(maxSleep), pacer.DecayConstant(decayConstant))),
 	}
 	f.features = (&fs.Features{
 		CanHaveEmptyDirectories: true,
@@ -1032,12 +1070,16 @@ func (o *Object) Remove(ctx context.Context) error {
 	leaf, dirID, err := o.fs.dirCache.FindPath(ctx, o.remote, false)
 	if err == nil {
 		id, _ := o.fs.parseNormalizedID(dirID)
-		if api.IsSharedFolderChildID(id) || o.driveID == "" {
+		if api.IsSharedFolderChildID(id) || api.IsSharedFolderChildID(o.driveID) || o.driveID == "" {
 			cd := o.fs.icloud.CloudDocsService(o.fs.pacer, shouldRetry)
 			if cd == nil {
 				return errors.New("iclouddrive: cannot remove shared file: account has no ckdatabasews service")
 			}
-			uuid, err := cd.FindFileUUID(ctx, api.GetDocIDFromDriveID(id), leaf)
+			dirRecordID, err := o.fs.cloudDocsDirectoryRecordID(ctx, cd, path.Dir(path.Clean(o.remote)), id)
+			if err != nil {
+				return err
+			}
+			uuid, err := cd.FindFileUUID(ctx, dirRecordID, leaf)
 			if err != nil {
 				return err
 			}
@@ -1180,51 +1222,58 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	return nil
 }
 
-// lookupSharedFolderRoot returns the drivewsid of the top-level shared folder named
-// shareName (a SHARED_FOLDER at the drive root). This is the destination a document
-// is moved into so it enters the owner's zone with PCS chaining applied.
-func (f *Fs) lookupSharedFolderRoot(ctx context.Context, shareName string) (string, error) {
-	// The share-root drivewsid is stable, so cache it per name to avoid listing the
-	// drive root on every shared write.
-	cache := f.shareRoots
-	if cache != nil {
-		cache.mu.Lock()
-		id, ok := cache.ids[shareName]
-		cache.mu.Unlock()
-		if ok {
+func isSharedFolderRootID(id string) bool {
+	return strings.HasPrefix(id, "SHARED_FOLDER::")
+}
+
+func sharedUploadTempName(leaf, token string) string {
+	ext := ""
+	if !strings.HasSuffix(leaf, ".") {
+		if i := strings.LastIndexByte(leaf, '.'); i > 0 {
+			ext = leaf[i:]
+		}
+	}
+	return ".rclone-upload-" + token + ext
+}
+
+// findSharedFolderRoot returns the drivewsid of the nearest SHARED_FOLDER ancestor
+// of remote. The share may be nested below the drive root, or the Fs root itself
+// may be inside the share, so don't assume the first relative path component is
+// the shared folder.
+func (f *Fs) findSharedFolderRoot(ctx context.Context, remote string) (string, error) {
+	absPath := path.Join(f.root, remote)
+	dir := path.Dir(path.Clean(absPath))
+	if dir == "." {
+		dir = ""
+	}
+	dc := dircache.New("", f.rootID, f)
+	for {
+		jid, err := dc.FindDir(ctx, dir, false)
+		if err != nil {
+			return "", err
+		}
+		id, _ := f.parseNormalizedID(jid)
+		if isSharedFolderRootID(id) {
 			return id, nil
+		}
+		if dir == "" {
+			break
+		}
+		dir = path.Dir(dir)
+		if dir == "." {
+			dir = ""
 		}
 	}
 
-	var root *api.DriveItem
-	var resp *http.Response
-	var err error
-	if err = f.pacer.Call(func() (bool, error) {
-		root, resp, err = f.service.GetItemByDriveID(ctx, f.rootID, true)
-		return shouldRetry(ctx, resp, err)
-	}); err != nil {
-		return "", err
-	}
-	want := norm.NFC.String(shareName)
-	for _, it := range root.Items {
-		name := norm.NFC.String(f.opt.Enc.ToStandardName(it.Name))
-		if strings.EqualFold(name, want) && strings.HasPrefix(it.Drivewsid, "SHARED_FOLDER::") {
-			if cache != nil {
-				cache.mu.Lock()
-				cache.ids[shareName] = it.Drivewsid
-				cache.mu.Unlock()
-			}
-			return it.Drivewsid, nil
-		}
-	}
-	return "", fmt.Errorf("iclouddrive: could not find shared-folder root %q", shareName)
+	return "", fmt.Errorf("iclouddrive: could not find shared-folder root for %q", remote)
 }
 
 // updateViaCloudDocs writes a document into a folder shared by another Apple ID.
-// drivews/docws cannot do this directly, so it: (1) uploads the document into the
-// caller's own zone root, (2) moves it into the share root (which puts it in the
-// owner's zone with PCS chaining done server-side), then (3) re-parents the record
-// into the target sub-folder via the CloudKit shared database. See api.CloudDocs.
+// drivews/docws cannot do this directly, so it: (1) uploads the document under a
+// temporary collision-free name into the caller's own zone root, (2) moves it into
+// the share root (which puts it in the owner's zone with PCS chaining done
+// server-side), then (3) re-parents and renames the record into the target
+// sub-folder via the CloudKit shared database. See api.CloudDocs.
 func (o *Object) updateViaCloudDocs(ctx context.Context, in io.Reader, src fs.ObjectInfo, leaf, dirID string, modTime time.Time, size int64) error {
 	f := o.fs
 	cd := f.icloud.CloudDocsService(f.pacer, shouldRetry)
@@ -1234,42 +1283,46 @@ func (o *Object) updateViaCloudDocs(ctx context.Context, in io.Reader, src fs.Ob
 
 	remote := o.Remote()
 	dirRemote := path.Dir(path.Clean(remote))
-	targetDirUUID := api.GetDocIDFromDriveID(dirID)
-
-	// The file must first land in the owner's zone via the share root (an addressable
-	// SHARED_FOLDER at the top of the drive). The share root is the first component of
-	// the absolute path; resolve its drivewsid from the drive root listing.
-	absPath := path.Join(f.root, remote)
-	shareName := absPath
-	if i := strings.IndexByte(absPath, '/'); i >= 0 {
-		shareName = absPath[:i]
+	targetDirUUID, err := f.cloudDocsDirectoryRecordID(ctx, cd, dirRemote, dirID)
+	if err != nil {
+		return err
 	}
-	shareRootID, err := f.lookupSharedFolderRoot(ctx, shareName)
+	if targetDirUUID == "" {
+		return fmt.Errorf("iclouddrive: cannot write into shared directory %q: missing CloudDocs directory ID", dirRemote)
+	}
+
+	// The file must first land in the owner's zone via an addressable SHARED_FOLDER
+	// ancestor. Find that ancestor from the directory cache instead of assuming
+	// shared folders are direct children of the drive root.
+	shareRootID, err := f.findSharedFolderRoot(ctx, remote)
 	if err != nil {
 		return err
 	}
 
 	name := f.opt.Enc.FromStandardName(leaf)
+	tempName := f.opt.Enc.FromStandardName(sharedUploadTempName(leaf, uuid.NewString()))
 	var resp *http.Response
 
-	// (1) Upload into the caller's own zone root.
+	// (1) Upload into the caller's own zone root under a temporary name. The final
+	// name is applied in CloudDocs after the record has moved into the owner's zone,
+	// avoiding "name 2" suffixes if the share root already contains the same leaf.
 	var uploadInfo *api.UploadResponse
 	if err = f.pacer.Call(func() (bool, error) {
-		uploadInfo, resp, err = f.service.CreateUpload(ctx, size, name)
+		uploadInfo, resp, err = f.service.CreateUpload(ctx, size, tempName)
 		return ignoreResultUnknown(ctx, resp, err)
 	}); err != nil {
 		return err
 	}
 	var upload *api.SingleFileResponse
 	if err = f.pacer.Call(func() (bool, error) {
-		upload, resp, err = f.service.Upload(ctx, in, size, name, uploadInfo.URL)
+		upload, resp, err = f.service.Upload(ctx, in, size, tempName, uploadInfo.URL)
 		return ignoreResultUnknown(ctx, resp, err)
 	}); err != nil {
 		return err
 	}
 	r := api.NewUpdateFileInfo()
 	r.DocumentID = uploadInfo.DocumentID
-	r.Path.Path = name
+	r.Path.Path = tempName
 	r.Path.StartingDocumentID = api.GetDocIDFromDriveID(f.rootID) // own zone root
 	r.Data.Receipt = upload.SingleFile.Receipt
 	r.Data.Signature = upload.SingleFile.Signature
@@ -1314,9 +1367,10 @@ func (o *Object) updateViaCloudDocs(ctx context.Context, in io.Reader, src fs.Ob
 		}
 	}
 
-	// (3) Re-parent the record into the target shared sub-folder. The CloudDocs
-	// request layer already paces and retries each call, so no extra pacer here.
-	if err = cd.ReparentStructure(ctx, uuid, targetDirUUID); err != nil {
+	// (3) Re-parent the record into the target shared sub-folder and set the final
+	// name. The CloudDocs request layer already paces and retries each call, so no
+	// extra pacer here.
+	if err = cd.ReparentStructure(ctx, uuid, targetDirUUID, name); err != nil {
 		return err
 	}
 

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -652,6 +652,10 @@ func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object,
 		return nil, err
 	}
 
+	if api.IsSharedFolderChildID(srcDirectoryID) || api.IsSharedFolderChildID(dstDirectoryID) || srcObj.driveID == "" {
+		return nil, fs.ErrorCantMove
+	}
+
 	item, err := f.move(ctx, srcObj.driveID, srcDirectoryID, srcLeaf, srcObj.etag, dstDirectoryID, dstLeaf)
 	if err != nil {
 		return src, err
@@ -998,8 +1002,32 @@ func (o *Object) Remove(ctx context.Context) error {
 		return nil
 	}
 
+	leaf, dirID, err := o.fs.dirCache.FindPath(ctx, o.remote, false)
+	if err == nil {
+		id, _ := o.fs.parseNormalizedID(dirID)
+		if api.IsSharedFolderChildID(id) || o.driveID == "" {
+			cd := o.fs.icloud.CloudDocsService(o.fs.pacer, shouldRetry)
+			if cd == nil {
+				return errors.New("iclouddrive: cannot remove shared file: account has no ckdatabasews service")
+			}
+			uuid, err := cd.FindFileUUID(ctx, api.GetDocIDFromDriveID(id), leaf)
+			if err != nil {
+				return err
+			}
+			if uuid == "" {
+				return fs.ErrorObjectNotFound
+			}
+			if err := cd.DeleteFile(ctx, uuid); err != nil {
+				return err
+			}
+			o.fs.dirCache.FlushDir(path.Dir(o.remote))
+			return nil
+		}
+	} else if err != fs.ErrorDirNotFound {
+		return err
+	}
+
 	var resp *http.Response
-	var err error
 	if err = o.fs.pacer.Call(func() (bool, error) {
 		_, resp, err = o.fs.service.MoveItemToTrashByID(ctx, o.driveID, o.etag, true)
 		return retryResultUnknown(ctx, resp, err)

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -718,7 +718,7 @@ func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object,
 		return nil, err
 	}
 
-	if api.IsSharedFolderChildID(srcDirectoryID) || api.IsSharedFolderChildID(dstDirectoryID) || srcObj.driveID == "" {
+	if isSharedWriteDirID(srcDirectoryID) || isSharedWriteDirID(dstDirectoryID) || api.IsSharedFolderChildID(srcObj.driveID) {
 		return nil, fs.ErrorCantMove
 	}
 
@@ -985,7 +985,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadClo
 	// URL instead. That URL is short-lived, but an Object can live a long time (e.g.
 	// in a VFS mount cache), so the cached URL may have gone stale: refresh it from
 	// the item lookup and retry on a download failure.
-	shared := o.driveID == ""
+	shared := api.IsSharedFolderChildID(o.driveID)
 
 	url, err := o.resolveDownloadURL(ctx, shared, false)
 	if err != nil {
@@ -1148,7 +1148,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	// Items whose parent is a folder shared by another Apple ID cannot be written
 	// through the drivews/docws upload endpoints (they only operate in the caller's
 	// own zone and return HTTP 400). Route those through CloudKit instead.
-	if api.IsSharedFolderChildID(dirID) {
+	if isSharedWriteDirID(dirID) {
 		return o.updateViaCloudDocs(ctx, in, src, leaf, dirID, modTime, size)
 	}
 
@@ -1224,6 +1224,10 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 
 func isSharedFolderRootID(id string) bool {
 	return strings.HasPrefix(id, "SHARED_FOLDER::")
+}
+
+func isSharedWriteDirID(id string) bool {
+	return isSharedFolderRootID(id) || api.IsSharedFolderChildID(id)
 }
 
 func sharedUploadTempName(leaf, token string) string {

--- a/backend/iclouddrive/shared_folder_id_test.go
+++ b/backend/iclouddrive/shared_folder_id_test.go
@@ -1,0 +1,109 @@
+//go:build !plan9 && !solaris
+
+package iclouddrive
+
+import (
+	"testing"
+
+	"github.com/rclone/rclone/backend/iclouddrive/api"
+	"github.com/stretchr/testify/assert"
+)
+
+// The directory-cache ID helpers below are pure: they never touch the network or
+// any Fs configuration, so an empty *Fs is enough to exercise them.
+
+// TestParseSharedItemID checks extraction of the embedded item_id. Own-zone IDs
+// are stored as `drivewsid#etag` and yield ""; shared-folder children are stored
+// as `drivewsid#etag#itemID`.
+func TestParseSharedItemID(t *testing.T) {
+	f := &Fs{}
+	for _, tc := range []struct {
+		name, rid, want string
+	}{
+		{"own-zone id has no item_id", "FOLDER::z::doc#etag", ""},
+		{"shared child carries item_id", "FOLDER_IN_SHARED_FOLDER::z::doc#etag#ITEM-9", "ITEM-9"},
+		{"bare id", "FOLDER::z::doc", ""},
+		{"empty drivewsid with item_id", "#etag#ITEM-7", "ITEM-7"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, f.parseSharedItemID(tc.rid))
+		})
+	}
+}
+
+// TestParseNormalizedID checks the drivewsid/etag split, including the 3-part
+// shared-child form where only the first two components are returned.
+func TestParseNormalizedID(t *testing.T) {
+	f := &Fs{}
+	for _, tc := range []struct {
+		rid, wantID, wantEtag string
+	}{
+		{"FOLDER::z::doc#etag", "FOLDER::z::doc", "etag"},
+		{"FOLDER::z::doc", "FOLDER::z::doc", ""},
+		{"FOLDER_IN_SHARED_FOLDER::z::doc#etag#ITEM-9", "FOLDER_IN_SHARED_FOLDER::z::doc", "etag"},
+	} {
+		t.Run(tc.rid, func(t *testing.T) {
+			id, etag := f.parseNormalizedID(tc.rid)
+			assert.Equal(t, tc.wantID, id)
+			assert.Equal(t, tc.wantEtag, etag)
+		})
+	}
+}
+
+// TestIDJoin checks joining and the replace-existing-etag behaviour.
+func TestIDJoin(t *testing.T) {
+	f := &Fs{}
+	assert.Equal(t, "FOLDER::z::doc#etag", f.IDJoin("FOLDER::z::doc", "etag"))
+	// An ID that already carries an etag has it replaced, not appended.
+	assert.Equal(t, "FOLDER::z::doc#new", f.IDJoin("FOLDER::z::doc#old", "new"))
+}
+
+// TestFolderID checks that the normalized cache ID embeds the item_id only for
+// shared-folder children, and is identical to IDJoin for own-zone items.
+func TestFolderID(t *testing.T) {
+	f := &Fs{}
+	for _, tc := range []struct {
+		name string
+		item *api.DriveItem
+		want string
+	}{
+		{
+			"own-zone folder is unchanged (no item_id appended)",
+			&api.DriveItem{Drivewsid: "FOLDER::z::doc", Etag: "e1", Itemid: "ITEM-1"},
+			"FOLDER::z::doc#e1",
+		},
+		{
+			"shared child embeds item_id",
+			&api.DriveItem{Drivewsid: "FOLDER_IN_SHARED_FOLDER::z::doc", Etag: "e2", Itemid: "ITEM-2"},
+			"FOLDER_IN_SHARED_FOLDER::z::doc#e2#ITEM-2",
+		},
+		{
+			"shared child without item_id stays as drivewsid#etag",
+			&api.DriveItem{Drivewsid: "FOLDER_IN_SHARED_FOLDER::z::doc", Etag: "e3", Itemid: ""},
+			"FOLDER_IN_SHARED_FOLDER::z::doc#e3",
+		},
+		{
+			"empty drivewsid (docws-only) embeds item_id",
+			&api.DriveItem{Drivewsid: "", Etag: "e4", Itemid: "ITEM-4"},
+			"#e4#ITEM-4",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := f.folderID(tc.item)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+// TestFolderIDRoundTrip checks the cache ID built by folderID is parsed back into
+// its components by the parse helpers consistently.
+func TestFolderIDRoundTrip(t *testing.T) {
+	f := &Fs{}
+	item := &api.DriveItem{Drivewsid: "FOLDER_IN_SHARED_FOLDER::z::doc", Etag: "etag", Itemid: "ITEM-5"}
+	jid := f.folderID(item)
+
+	id, etag := f.parseNormalizedID(jid)
+	assert.Equal(t, item.Drivewsid, id)
+	assert.Equal(t, item.Etag, etag)
+	assert.Equal(t, item.Itemid, f.parseSharedItemID(jid))
+}

--- a/backend/iclouddrive/shared_folder_id_test.go
+++ b/backend/iclouddrive/shared_folder_id_test.go
@@ -117,6 +117,15 @@ func TestIsSharedFolderRootID(t *testing.T) {
 	assert.False(t, isSharedFolderRootID(""))
 }
 
+// TestIsSharedWriteDirID checks the directory classifier used to route writes
+// either into a shared root or below a shared root through CloudDocs.
+func TestIsSharedWriteDirID(t *testing.T) {
+	assert.True(t, isSharedWriteDirID("SHARED_FOLDER::z::share-root"))
+	assert.True(t, isSharedWriteDirID("FOLDER_IN_SHARED_FOLDER::z::child"))
+	assert.True(t, isSharedWriteDirID(""))
+	assert.False(t, isSharedWriteDirID("FOLDER::z::own"))
+}
+
 // TestSharedUploadTempName verifies that temporary upload names are collision-free
 // at the share root while preserving the final extension for content type handling.
 func TestSharedUploadTempName(t *testing.T) {

--- a/backend/iclouddrive/shared_folder_id_test.go
+++ b/backend/iclouddrive/shared_folder_id_test.go
@@ -107,3 +107,22 @@ func TestFolderIDRoundTrip(t *testing.T) {
 	assert.Equal(t, item.Etag, etag)
 	assert.Equal(t, item.Itemid, f.parseSharedItemID(jid))
 }
+
+// TestIsSharedFolderRootID checks the shared-root classifier used when selecting
+// where a temporary shared-subfolder upload should first land.
+func TestIsSharedFolderRootID(t *testing.T) {
+	assert.True(t, isSharedFolderRootID("SHARED_FOLDER::z::share-root"))
+	assert.False(t, isSharedFolderRootID("FOLDER_IN_SHARED_FOLDER::z::child"))
+	assert.False(t, isSharedFolderRootID("FOLDER::z::own"))
+	assert.False(t, isSharedFolderRootID(""))
+}
+
+// TestSharedUploadTempName verifies that temporary upload names are collision-free
+// at the share root while preserving the final extension for content type handling.
+func TestSharedUploadTempName(t *testing.T) {
+	assert.Equal(t, ".rclone-upload-token.txt", sharedUploadTempName("report.txt", "token"))
+	assert.Equal(t, ".rclone-upload-token.gz", sharedUploadTempName("archive.tar.gz", "token"))
+	assert.Equal(t, ".rclone-upload-token", sharedUploadTempName("noext", "token"))
+	assert.Equal(t, ".rclone-upload-token", sharedUploadTempName("trailingdot.", "token"))
+	assert.Equal(t, ".rclone-upload-token", sharedUploadTempName(".hidden", "token"))
+}


### PR DESCRIPTION
#### What is the purpose of this change?

Make a folder shared by another Apple ID (current account is a non-owner participant with edit access) usable through the `iclouddrive` backend. Previously operations below or at the share root frequently returned HTTP 400/404/412 because shared-folder items live in the owner's CloudDocs zone, while many `drivews` endpoints operate only in the caller's own zone (#9477).

Main pieces:

1. **Read / navigate** — listing/downloading one or more levels below the share root returned HTTP 400/404. The CloudKit zone string is `com.apple.CloudDocs` for every item; the real cause is that items inside a shared folder have `SHARED_FOLDER`, `FOLDER_IN_SHARED_FOLDER`, or `FILE_IN_SHARED_FOLDER` identifiers and live in the *owner's* zone, which the `drivews` endpoints (caller's own zone only) cannot address. Fixed by routing shared items through the `docws` item-id endpoints where needed, threading item IDs through the dir cache, and using shared download URLs for shared files.

2. **File writes / rename / delete** — writing into a shared subfolder failed (HTTP 400 on the `drivews` move; HTTP 412 PCS-chaining error on a direct create, because a new record has no Protected Cloud Storage key). Rather than reimplement Apple's client-side PCS key-wrapping, this lets the **server** do the crypto: upload the file into the caller's own root under a unique temporary name, move it into the share root (the server performs PCS chaining there, in the owner's zone), then re-parent and rename the resulting record into the target folder via the `ckdatabasews` CloudKit shared database. File rename uses rclone's copy+delete fallback. File delete removes the shared-zone CloudDocs records.

3. **Directory create / rename / delete** — direct `drivews` directory creation/move/trash also fails for shared folders. New shared directories are staged in the caller's own root, moved into the share root so the server assigns the needed PCS state, then re-parented/renamed as `directory/<uuid>` records through the shared CloudDocs database. Existing shared directories are renamed/moved by re-parenting/renaming their `directory/<uuid>` records. Empty shared directories are removed via CloudDocs record delete.

All shared-only code paths are gated on `SHARED_FOLDER` / `FOLDER_IN_SHARED_FOLDER` / `FILE_IN_SHARED_FOLDER`, so own-zone and unrelated non-shared behaviour is unchanged.

Verified live against a real shared folder:

- shared root: direct file upload/read/rename/delete, directory `mkdir`/`rmdir`, and empty/non-empty directory rename
- nested shared subfolders, including paths such as `<shared-root>/<base>/level1/level2`: `lsf`, `cat`, `copyto`, overwrite, file rename/delete, directory `mkdir`/`rmdir`, and non-empty directory rename

#### Was the change discussed in an issue or in the forum before?

Yes — #9477.

#### Known limitations

- Unit tests are included for the pure ID/zone/CloudDocs payload helpers; full integration tests would need a `TestICloud` remote backed by a folder shared from another Apple ID — happy to add if you can advise on the fixture.
- ~~During a write the file briefly lands in the share root before being re-parented; a unique temporary name during that hop would remove a small collision window.~~ Fixed: shared writes now use collision-resistant temporary names before the CloudDocs re-parent/rename step.
- Overwrite and some directory resolution paths enumerate the shared CloudDocs zone to locate the existing record (O(zone)); first writes do not enumerate.
- ~~`Mkdir` of new shared subfolders and nesting more than one level below the share root are not implemented here (out of scope).~~ Fixed: `mkdir`/`rmdir` now work at the shared root and in nested shared subfolders.
- `Purge` for shared directories is still not implemented. CloudDocs directory deletion is non-recursive and is used only for empty-directory `rmdir`.

#### Checklist

- [x] I have read the contribution guidelines.
- [x] I have added unit tests for the new pure helpers (offline; integration tests pending a shared-folder test fixture — see above).
- [ ] I have updated the docs (happy to add an iclouddrive docs note if desired).
- [x] I have used a parseable commit message in the form `iclouddrive: <summary>`.
