### PR TITLE
docs: Add padding to footer card

### DIFF
--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -61,7 +61,7 @@
       <footer>
         <div class="row">
           <div class="col-footer{{ if not (and (gt .WordCount 200) (not (.Params.notoc))) }} col-footer-notoc{{ end }}">
-            <div class="card card-body">
+            <div class="card card-body card-body-padded">
               <p style="font-size: 90%;">
                 &copy; <a href="https://www.craig-wood.com/nick/" target="blank">Nick Craig-Wood</a> 2014-{{ now.Format "2006" }}<br>
                 {{ if .File}}{{ with $path := strings.TrimPrefix "/" .File.Path }}Source file <a href="https://github.com/rclone/rclone/blob/master/docs/content/{{ $path }}" target="blank">{{ $path }}</a>{{ end }}


### PR DESCRIPTION
### Before
<img width="1116" height="254" alt="image" src="https://github.com/user-attachments/assets/9c18688e-9df8-4b55-bcde-d807e4cd5e39" />
<img width="1116" height="254" alt="image" src="https://github.com/user-attachments/assets/b65caf49-91f0-487b-8ce1-fca4388770f9" />

### After 
<img width="1116" height="304" alt="image" src="https://github.com/user-attachments/assets/461c750b-6269-4fe0-b9eb-de8bdb608b49" />


<img width="1116" height="304" alt="image" src="https://github.com/user-attachments/assets/6ceb08bc-8e78-4905-b5e5-80dac33afa33" />

The reason that the background color also changed is because of this css 
in `rclone.css`
```css
@media (prefers-color-scheme: dark) {
  .card-body:not(.card-body-padded) { background: #f8f9fb; }
  .sponsor-logo { background: #f8f9fb; }
}
```
Still I belive it looks better, since the focus of the page should probably not be the footer. And with the footer being white it was to much contrast.

#### Checklist
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
