### PR TITLE
googlephotos: implement deletion workaround via trash album (opt-in)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ __pycache__
 .DS_Store
 resource_windows_*.syso
 .devcontainer
+
+# Google API Credentials
+client_secret*.json
+test_photo.jpg
+

--- a/backend/googlephotos/api/types.go
+++ b/backend/googlephotos/api/types.go
@@ -188,3 +188,8 @@ type BatchCreateResponse struct {
 type BatchRemoveItems struct {
 	MediaItemIDs []string `json:"mediaItemIds"`
 }
+
+// BatchAddItems is for adding items to an album
+type BatchAddItems struct {
+	MediaItemIDs []string `json:"mediaItemIds"`
+}

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -147,7 +147,7 @@ If you choose read only then rclone will only request read only access
 to your photos, otherwise rclone will request full access.`,
 		}, {
 			Name:    "trash_album_name",
-			Default: "rclone_Trash",
+			Default: "",
 			Help: `Name of the album to use as a trash bin for deleted and overwritten files.
 
 The Google Photos API does not support deleting media permanently.
@@ -827,6 +827,7 @@ func (f *Fs) trashMediaItem(ctx context.Context, mediaItemID string, currentAlbu
 
 	// 1. Add to trash album (skip when trash is disabled)
 	if trashAlbumID != "" {
+		fs.Infof(f, "Adding media item %q to trash album %q", mediaItemID, f.opt.TrashAlbumName)
 		addOpts := rest.Opts{
 			Method:     "POST",
 			Path:       "/albums/" + trashAlbumID + ":batchAddMediaItems",
@@ -846,6 +847,7 @@ func (f *Fs) trashMediaItem(ctx context.Context, mediaItemID string, currentAlbu
 
 	// 2. Remove from current album if applicable
 	if currentAlbumID != "" && currentAlbumID != trashAlbumID {
+		fs.Infof(f, "Removing media item %q from album ID %q", mediaItemID, currentAlbumID)
 		removeOpts := rest.Opts{
 			Method:     "POST",
 			Path:       "/albums/" + currentAlbumID + ":batchRemoveMediaItems",

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -1305,7 +1305,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	if oldID != "" && oldID != o.id {
 		err = o.fs.trashMediaItem(ctx, oldID, albumID)
 		if err != nil {
-			fs.Errorf(o, "Failed to trash old duplicate media item %q: %v", oldID, err)
+			return fmt.Errorf("failed to trash old duplicate media item %q: %w", oldID, err)
 		}
 	}
 

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -146,6 +146,18 @@ IMPORTANT: Due to Google policy changes rclone can now only download photos it u
 If you choose read only then rclone will only request read only access
 to your photos, otherwise rclone will request full access.`,
 		}, {
+			Name:    "trash_album_name",
+			Default: "rclone_Trash",
+			Help: `Name of the album to use as a trash bin for deleted and overwritten files.
+
+The Google Photos API does not support deleting media permanently.
+Instead rclone moves removed items into this album so they can be
+reviewed and deleted manually from the Google Photos UI.
+
+Set this to an empty string to disable the trash workaround (removed
+items will not be added to any album, but will remain in your library).`,
+			Advanced: true,
+		}, {
 			Name:    "read_size",
 			Default: false,
 			Help: `Set to read the size of media items.
@@ -228,6 +240,7 @@ type Options struct {
 	BatchSize       int                  `config:"batch_size"`
 	BatchTimeout    fs.Duration          `config:"batch_timeout"`
 	Proxy           string               `config:"proxy"`
+	TrashAlbumName  string               `config:"trash_album_name"`
 }
 
 // Fs represents a remote storage server
@@ -786,12 +799,16 @@ func (f *Fs) getOrCreateAlbum(ctx context.Context, albumTitle string) (album *ap
 	return f.createAlbum(ctx, albumTitle)
 }
 
-// findOrCreateTrashAlbum gets the trash album ID or retrieves it/creates it if it hasn't been cached yet
+// findOrCreateTrashAlbum gets the trash album ID or retrieves it/creates it if it hasn't been cached yet.
+// Returns an empty string (no error) when TrashAlbumName is empty, meaning the trash workaround is disabled.
 func (f *Fs) findOrCreateTrashAlbum(ctx context.Context) (string, error) {
+	if f.opt.TrashAlbumName == "" {
+		return "", nil
+	}
 	if f.trashAlbumID != "" {
 		return f.trashAlbumID, nil
 	}
-	album, err := f.getOrCreateAlbum(ctx, "rclone_Trash")
+	album, err := f.getOrCreateAlbum(ctx, f.opt.TrashAlbumName)
 	if err != nil {
 		return "", err
 	}
@@ -799,29 +816,32 @@ func (f *Fs) findOrCreateTrashAlbum(ctx context.Context) (string, error) {
 	return f.trashAlbumID, nil
 }
 
-// trashMediaItem moves a media item to the "rclone_Trash" album and removes it from a specified album
+// trashMediaItem moves a media item to the configured trash album and removes it from a specified album.
 func (f *Fs) trashMediaItem(ctx context.Context, mediaItemID string, currentAlbumID string) error {
 	trashAlbumID, err := f.findOrCreateTrashAlbum(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to find or create trash album: %w", err)
 	}
 
-	// 1. Add to trash album
-	addOpts := rest.Opts{
-		Method:     "POST",
-		Path:       "/albums/" + trashAlbumID + ":batchAddMediaItems",
-		NoResponse: true,
-	}
-	addRequest := api.BatchAddItems{
-		MediaItemIDs: []string{mediaItemID},
-	}
 	var resp *http.Response
-	err = f.pacer.Call(func() (bool, error) {
-		resp, err = f.srv.CallJSON(ctx, &addOpts, &addRequest, nil)
-		return shouldRetry(ctx, resp, err)
-	})
-	if err != nil {
-		return fmt.Errorf("failed to add item to trash album: %w", err)
+
+	// 1. Add to trash album (skip when trash is disabled)
+	if trashAlbumID != "" {
+		addOpts := rest.Opts{
+			Method:     "POST",
+			Path:       "/albums/" + trashAlbumID + ":batchAddMediaItems",
+			NoResponse: true,
+		}
+		addRequest := api.BatchAddItems{
+			MediaItemIDs: []string{mediaItemID},
+		}
+		err = f.pacer.Call(func() (bool, error) {
+			resp, err = f.srv.CallJSON(ctx, &addOpts, &addRequest, nil)
+			return shouldRetry(ctx, resp, err)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to add item to trash album: %w", err)
+		}
 	}
 
 	// 2. Remove from current album if applicable

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -1304,7 +1304,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	}
 
 	// If this was an overwrite (update), trash the old media item
-	if oldID != "" && oldID != o.id {
+	if oldID != "" {
 		err = o.fs.trashMediaItem(ctx, oldID, albumID)
 		if err != nil {
 			return fmt.Errorf("failed to trash old duplicate media item %q: %w", oldID, err)

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -486,6 +486,7 @@ func (f *Fs) newObjectWithInfo(ctx context.Context, remote string, info *api.Med
 	o := &Object{
 		fs:     f,
 		remote: remote,
+		bytes:  -1,
 	}
 	if info != nil {
 		o.setMetaData(info)
@@ -654,6 +655,7 @@ func (f *Fs) itemToDirEntry(ctx context.Context, remote string, item *api.MediaI
 	o := &Object{
 		fs:     f,
 		remote: remote,
+		bytes:  -1,
 	}
 	o.setMetaData(item)
 	return o, nil
@@ -736,6 +738,7 @@ func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options .
 	o := &Object{
 		fs:     f,
 		remote: src.Remote(),
+		bytes:  -1,
 	}
 	return o, o.Update(ctx, in, src, options...)
 }
@@ -914,11 +917,18 @@ func (o *Object) Size() int64 {
 	return o.bytes
 }
 
-// setMetaData sets the fs data from a storage.Object
+// setMetaData sets the fs data from a storage.Object.
+// If info is nil (e.g. when using async batch_mode and the item has not yet
+// been committed), only o.bytes is set to -1 so the caller knows size is
+// unknown; all other fields retain their existing values.
 func (o *Object) setMetaData(info *api.MediaItem) {
+	if info == nil {
+		o.bytes = -1
+		return
+	}
 	o.url = info.BaseURL
 	o.id = info.ID
-	o.bytes = -1 // FIXME
+	o.bytes = -1 // FIXME: Google Photos API does not return size
 	o.mimeType = info.MimeType
 	o.modTime = info.MediaMetadata.CreationTime
 }
@@ -1199,7 +1209,15 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		return fmt.Errorf("failed to commit batch: %w", err)
 	}
 
-	o.setMetaData(info)
+	// In async batch_mode, info is nil until the batch is flushed later.
+	// setMetaData handles nil gracefully; we pre-populate bytes with the
+	// source size so the hasher overlay can cache the correct fingerprint
+	// without waiting for eventual consistency.
+	if info == nil {
+		o.bytes = src.Size()
+	} else {
+		o.setMetaData(info)
+	}
 
 	// Add upload to internal storage
 	if pattern.isUpload {

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -232,21 +232,22 @@ type Options struct {
 
 // Fs represents a remote storage server
 type Fs struct {
-	name       string                 // name of this remote
-	root       string                 // the path we are working on if any
-	opt        Options                // parsed options
-	features   *fs.Features           // optional features
-	unAuth     *rest.Client           // unauthenticated http client
-	srv        *rest.Client           // the connection to the server
-	ts         *oauthutil.TokenSource // token source for oauth2
-	pacer      *fs.Pacer              // To pace the API calls
-	startTime  time.Time              // time Fs was started - used for datestamps
-	albumsMu   sync.Mutex             // protect albums (but not contents)
-	albums     map[bool]*albums       // albums, shared or not
-	uploadedMu sync.Mutex             // to protect the below
-	uploaded   dirtree.DirTree        // record of uploaded items
-	createMu   sync.Mutex             // held when creating albums to prevent dupes
-	batcher    *batcher.Batcher[uploadedItem, *api.MediaItem]
+	name         string                 // name of this remote
+	root         string                 // the path we are working on if any
+	opt          Options                // parsed options
+	features     *fs.Features           // optional features
+	unAuth       *rest.Client           // unauthenticated http client
+	srv          *rest.Client           // the connection to the server
+	ts           *oauthutil.TokenSource // token source for oauth2
+	pacer        *fs.Pacer              // To pace the API calls
+	startTime    time.Time              // time Fs was started - used for datestamps
+	albumsMu     sync.Mutex             // protect albums (but not contents)
+	albums       map[bool]*albums       // albums, shared or not
+	uploadedMu   sync.Mutex             // to protect the below
+	uploaded     dirtree.DirTree        // record of uploaded items
+	createMu     sync.Mutex             // held when creating albums to prevent dupes
+	batcher      *batcher.Batcher[uploadedItem, *api.MediaItem]
+	trashAlbumID string // Cache for rclone_Trash album ID
 }
 
 // Object describes a storage object
@@ -785,6 +786,66 @@ func (f *Fs) getOrCreateAlbum(ctx context.Context, albumTitle string) (album *ap
 	return f.createAlbum(ctx, albumTitle)
 }
 
+// findOrCreateTrashAlbum gets the trash album ID or retrieves it/creates it if it hasn't been cached yet
+func (f *Fs) findOrCreateTrashAlbum(ctx context.Context) (string, error) {
+	if f.trashAlbumID != "" {
+		return f.trashAlbumID, nil
+	}
+	album, err := f.getOrCreateAlbum(ctx, "rclone_Trash")
+	if err != nil {
+		return "", err
+	}
+	f.trashAlbumID = album.ID
+	return f.trashAlbumID, nil
+}
+
+// trashMediaItem moves a media item to the "rclone_Trash" album and removes it from a specified album
+func (f *Fs) trashMediaItem(ctx context.Context, mediaItemID string, currentAlbumID string) error {
+	trashAlbumID, err := f.findOrCreateTrashAlbum(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to find or create trash album: %w", err)
+	}
+
+	// 1. Add to trash album
+	addOpts := rest.Opts{
+		Method:     "POST",
+		Path:       "/albums/" + trashAlbumID + ":batchAddMediaItems",
+		NoResponse: true,
+	}
+	addRequest := api.BatchAddItems{
+		MediaItemIDs: []string{mediaItemID},
+	}
+	var resp *http.Response
+	err = f.pacer.Call(func() (bool, error) {
+		resp, err = f.srv.CallJSON(ctx, &addOpts, &addRequest, nil)
+		return shouldRetry(ctx, resp, err)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to add item to trash album: %w", err)
+	}
+
+	// 2. Remove from current album if applicable
+	if currentAlbumID != "" && currentAlbumID != trashAlbumID {
+		removeOpts := rest.Opts{
+			Method:     "POST",
+			Path:       "/albums/" + currentAlbumID + ":batchRemoveMediaItems",
+			NoResponse: true,
+		}
+		removeRequest := api.BatchRemoveItems{
+			MediaItemIDs: []string{mediaItemID},
+		}
+		err = f.pacer.Call(func() (bool, error) {
+			resp, err = f.srv.CallJSON(ctx, &removeOpts, &removeRequest, nil)
+			return shouldRetry(ctx, resp, err)
+		})
+		if err != nil {
+			return fmt.Errorf("failed to remove item from current album: %w", err)
+		}
+	}
+
+	return nil
+}
+
 // Mkdir creates the album if it doesn't exist
 func (f *Fs) Mkdir(ctx context.Context, dir string) (err error) {
 	// defer log.Trace(f, "dir=%q", dir)("err=%v", &err)
@@ -1129,6 +1190,7 @@ func (f *Fs) commitBatch(ctx context.Context, items []uploadedItem, results []*a
 // The new object may have been created if an error is returned
 func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (err error) {
 	// defer log.Trace(o, "src=%+v", src)("err=%v", &err)
+	oldID := o.id
 	match, _, pattern := patterns.match(o.fs.root, o.remote, true)
 	if pattern == nil || !pattern.isFile || !pattern.canUpload {
 		return errCantUpload
@@ -1219,6 +1281,14 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		o.setMetaData(info)
 	}
 
+	// If this was an overwrite (update), trash the old media item
+	if oldID != "" && oldID != o.id {
+		err = o.fs.trashMediaItem(ctx, oldID, albumID)
+		if err != nil {
+			fs.Errorf(o, "Failed to trash old duplicate media item %q: %v", oldID, err)
+		}
+	}
+
 	// Add upload to internal storage
 	if pattern.isUpload {
 		o.fs.uploadedMu.Lock()
@@ -1231,31 +1301,28 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 // Remove an object
 func (o *Object) Remove(ctx context.Context) (err error) {
 	match, _, pattern := patterns.match(o.fs.root, o.remote, true)
-	if pattern == nil || !pattern.isFile || !pattern.canUpload || pattern.isUpload {
+	if pattern == nil || !pattern.isFile {
 		return errRemove
 	}
-	albumTitle, fileName := match[1], match[2]
-	album, ok := o.fs.albums[false].get(albumTitle)
-	if !ok {
-		return fmt.Errorf("couldn't file %q in album %q for delete", fileName, albumTitle)
+
+	var currentAlbumID string
+	if len(match) >= 3 {
+		albumTitle := match[1]
+		if albums := o.fs.albums[false]; albums != nil {
+			if album, ok := albums.get(albumTitle); ok {
+				currentAlbumID = album.ID
+			}
+		}
+		if currentAlbumID == "" {
+			if albums := o.fs.albums[true]; albums != nil {
+				if album, ok := albums.get(albumTitle); ok {
+					currentAlbumID = album.ID
+				}
+			}
+		}
 	}
-	opts := rest.Opts{
-		Method:     "POST",
-		Path:       "/albums/" + album.ID + ":batchRemoveMediaItems",
-		NoResponse: true,
-	}
-	request := api.BatchRemoveItems{
-		MediaItemIDs: []string{o.id},
-	}
-	var resp *http.Response
-	err = o.fs.pacer.Call(func() (bool, error) {
-		resp, err = o.fs.srv.CallJSON(ctx, &opts, &request, nil)
-		return shouldRetry(ctx, resp, err)
-	})
-	if err != nil {
-		return fmt.Errorf("couldn't delete item from album: %w", err)
-	}
-	return nil
+
+	return o.fs.trashMediaItem(ctx, o.id, currentAlbumID)
 }
 
 // MimeType of an Object if known, "" otherwise

--- a/backend/googlephotos/googlephotos_workaround_test.go
+++ b/backend/googlephotos/googlephotos_workaround_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rclone/rclone/backend/googlephotos/api"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fstest/mockobject"
 	"github.com/rclone/rclone/lib/batcher"
 	"github.com/rclone/rclone/lib/pacer"
 	"github.com/rclone/rclone/lib/rest"
@@ -73,7 +74,8 @@ func TestAsyncBatchModePanic(t *testing.T) {
 	// assert.NotPanics documents the expected post-fix behaviour.
 	// Before the fix this panics with: "runtime error: invalid memory address
 	// or nil pointer dereference" inside setMetaData(info) when info is nil.
+	src := mockobject.New("photo.jpg").WithContent([]byte("content"), mockobject.SeekModeNone)
 	assert.NotPanics(t, func() {
-		_, _ = f.Put(ctx, strings.NewReader("content"), nil)
+		_, _ = f.Put(ctx, strings.NewReader("content"), src)
 	})
 }

--- a/backend/googlephotos/googlephotos_workaround_test.go
+++ b/backend/googlephotos/googlephotos_workaround_test.go
@@ -507,3 +507,85 @@ func TestUpdateTrashWorkaroundFailure(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to trash old duplicate media item")
 }
+
+func TestUpdateTrashWorkaroundAsync(t *testing.T) {
+	ctx := context.Background()
+	calls := make(map[string]int)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls[r.Method+" "+r.URL.Path]++
+
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/albums":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListAlbums{
+				Albums: []api.Album{
+					{ID: "album1", Title: "my-album", IsWriteable: true},
+					{ID: "trash-album-123", Title: "rclone_Trash", IsWriteable: true},
+				},
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/uploads":
+			body, _ := io.ReadAll(r.Body)
+			assert.Equal(t, "new content", string(body))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("upload-token-abc"))
+
+		case r.Method == "POST" && r.URL.Path == "/albums/trash-album-123:batchAddMediaItems":
+			var req api.BatchAddItems
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, []string{"old-photo-123"}, req.MediaItemIDs)
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == "POST" && r.URL.Path == "/albums/album1:batchRemoveMediaItems":
+			var req api.BatchRemoveItems
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, []string{"old-photo-123"}, req.MediaItemIDs)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	f := &Fs{
+		name:   "TestGphotos",
+		root:   "album/my-album",
+		unAuth: rest.NewClient(http.DefaultClient),
+		srv:    rest.NewClient(http.DefaultClient).SetRoot(ts.URL),
+		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
+		albums: map[bool]*albums{},
+		opt: Options{
+			BatchMode:      "async",
+			TrashAlbumName: "rclone_Trash",
+		},
+	}
+	f.srv.SetErrorHandler(errorHandler)
+
+	var err error
+	batcherOpts := defaultBatcherOptions
+	batcherOpts.Mode = f.opt.BatchMode
+	f.batcher, err = batcher.New(ctx, f, f.commitBatch, batcherOpts)
+	require.NoError(t, err)
+	defer f.batcher.Shutdown()
+
+	_, err = f.listAlbums(ctx, false)
+	require.NoError(t, err)
+
+	o := &Object{
+		fs:     f,
+		remote: "photo.jpg",
+		id:     "old-photo-123",
+	}
+
+	src := mockobject.New("photo.jpg").WithContent([]byte("new content"), mockobject.SeekModeNone)
+	err = o.Update(ctx, strings.NewReader("new content"), src)
+	require.NoError(t, err)
+
+	// In async mode, the upload is queued but trashing old duplicate ID is done immediately.
+	assert.Equal(t, 1, calls["POST /uploads"], "Should upload new photo")
+	assert.Equal(t, 0, calls["POST /mediaItems:batchCreate"], "Should not commit upload batch synchronously")
+	assert.Equal(t, 1, calls["POST /albums/trash-album-123:batchAddMediaItems"], "Should trash old duplicate ID immediately")
+	assert.Equal(t, 1, calls["POST /albums/album1:batchRemoveMediaItems"], "Should remove old duplicate ID from album immediately")
+}

--- a/backend/googlephotos/googlephotos_workaround_test.go
+++ b/backend/googlephotos/googlephotos_workaround_test.go
@@ -3,6 +3,7 @@ package googlephotos
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -78,4 +79,199 @@ func TestAsyncBatchModePanic(t *testing.T) {
 	assert.NotPanics(t, func() {
 		_, _ = f.Put(ctx, strings.NewReader("content"), src)
 	})
+}
+
+func TestRemoveTrashWorkaround(t *testing.T) {
+	ctx := context.Background()
+
+	// Track mock request count and URLs called
+	calls := make(map[string]int)
+
+	// Mock server
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls[r.Method+" "+r.URL.Path]++
+
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/albums":
+			// Return list of albums (rclone_Trash does not exist yet)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListAlbums{
+				Albums: []api.Album{
+					{ID: "album1", Title: "my-album"},
+				},
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/albums":
+			// Create rclone_Trash album
+			var req api.CreateAlbum
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, "rclone_Trash", req.Album.Title)
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.Album{
+				ID:    "trash-album-123",
+				Title: "rclone_Trash",
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/albums/trash-album-123:batchAddMediaItems":
+			// Add items to trash
+			var req api.BatchAddItems
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, []string{"photo-123"}, req.MediaItemIDs)
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == "POST" && r.URL.Path == "/albums/album1:batchRemoveMediaItems":
+			// Remove items from my-album
+			var req api.BatchRemoveItems
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, []string{"photo-123"}, req.MediaItemIDs)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	// Instantiate a test Fs manually
+	f := &Fs{
+		name:   "TestGphotos",
+		root:   "album/my-album",
+		unAuth: rest.NewClient(http.DefaultClient),
+		srv:    rest.NewClient(http.DefaultClient).SetRoot(ts.URL),
+		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
+		albums: map[bool]*albums{},
+	}
+	f.srv.SetErrorHandler(errorHandler)
+
+	// Build the local albums cache (mocking listAlbums result)
+	_, err := f.listAlbums(ctx, false)
+	require.NoError(t, err)
+
+	// Create Object to remove (remote path is relative to the root "album/my-album")
+	o := &Object{
+		fs:     f,
+		remote: "photo.jpg",
+		id:     "photo-123",
+	}
+
+	// Remove item
+	err = o.Remove(ctx)
+	require.NoError(t, err)
+
+	// Assertions
+	assert.Equal(t, 1, calls["GET /albums"], "Should list albums to find rclone_Trash")
+	assert.Equal(t, 1, calls["POST /albums"], "Should create rclone_Trash")
+	assert.Equal(t, 1, calls["POST /albums/trash-album-123:batchAddMediaItems"], "Should add to trash album")
+	assert.Equal(t, 1, calls["POST /albums/album1:batchRemoveMediaItems"], "Should remove from my-album")
+}
+
+func TestUpdateTrashWorkaround(t *testing.T) {
+	ctx := context.Background()
+	calls := make(map[string]int)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls[r.Method+" "+r.URL.Path]++
+
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/albums":
+			// Return list containing rclone_Trash
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListAlbums{
+				Albums: []api.Album{
+					{ID: "album1", Title: "my-album", IsWriteable: true},
+					{ID: "trash-album-123", Title: "rclone_Trash", IsWriteable: true},
+				},
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/uploads":
+			// Upload media bytes
+			body, _ := io.ReadAll(r.Body)
+			assert.Equal(t, "new content", string(body))
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("upload-token-abc"))
+
+		case r.Method == "POST" && r.URL.Path == "/mediaItems:batchCreate":
+			// Commit batch upload
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.BatchCreateResponse{
+				NewMediaItemResults: []struct {
+					UploadToken string `json:"uploadToken"`
+					Status      struct {
+						Message string `json:"message"`
+						Code    int    `json:"code"`
+					} `json:"status"`
+					MediaItem api.MediaItem `json:"mediaItem"`
+				}{
+					{
+						UploadToken: "upload-token-abc",
+						MediaItem: api.MediaItem{
+							ID:       "new-photo-456",
+							Filename: "photo.jpg",
+						},
+					},
+				},
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/albums/trash-album-123:batchAddMediaItems":
+			// Add old photo to trash
+			var req api.BatchAddItems
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, []string{"old-photo-123"}, req.MediaItemIDs)
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == "POST" && r.URL.Path == "/albums/album1:batchRemoveMediaItems":
+			// Remove old photo from my-album
+			var req api.BatchRemoveItems
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, []string{"old-photo-123"}, req.MediaItemIDs)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	// Instantiate a test Fs manually
+	f := &Fs{
+		name:   "TestGphotos",
+		root:   "album/my-album",
+		unAuth: rest.NewClient(http.DefaultClient),
+		srv:    rest.NewClient(http.DefaultClient).SetRoot(ts.URL),
+		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
+		albums: map[bool]*albums{},
+		opt: Options{
+			BatchMode: "sync",
+		},
+	}
+	f.srv.SetErrorHandler(errorHandler)
+
+	var err error
+	batcherOpts := defaultBatcherOptions
+	batcherOpts.Mode = f.opt.BatchMode
+	f.batcher, err = batcher.New(ctx, f, f.commitBatch, batcherOpts)
+	require.NoError(t, err)
+
+	// Build the local albums cache
+	_, err = f.listAlbums(ctx, false)
+	require.NoError(t, err)
+
+	// Create Object to update (remote path is relative to the root "album/my-album")
+	o := &Object{
+		fs:     f,
+		remote: "photo.jpg",
+		id:     "old-photo-123",
+	}
+
+	// Update object with new contents
+	err = o.Update(ctx, strings.NewReader("new content"), nil)
+	require.NoError(t, err)
+
+	// Assertions
+	assert.Equal(t, "new-photo-456", o.id, "Object ID should be updated to new ID")
+	assert.Equal(t, 1, calls["POST /uploads"], "Should upload new photo")
+	assert.Equal(t, 1, calls["POST /mediaItems:batchCreate"], "Should commit upload batch")
+	assert.Equal(t, 1, calls["POST /albums/trash-album-123:batchAddMediaItems"], "Should trash old duplicate ID")
+	assert.Equal(t, 1, calls["POST /albums/album1:batchRemoveMediaItems"], "Should remove old duplicate ID from album")
 }

--- a/backend/googlephotos/googlephotos_workaround_test.go
+++ b/backend/googlephotos/googlephotos_workaround_test.go
@@ -414,3 +414,96 @@ func TestUpdateTrashWorkaround(t *testing.T) {
 	assert.Equal(t, 1, calls["POST /albums/trash-album-123:batchAddMediaItems"], "Should trash old duplicate ID")
 	assert.Equal(t, 1, calls["POST /albums/album1:batchRemoveMediaItems"], "Should remove old duplicate ID from album")
 }
+
+func TestUpdateTrashWorkaroundFailure(t *testing.T) {
+	ctx := context.Background()
+	calls := make(map[string]int)
+
+	ci := fs.GetConfig(ctx)
+	saveLowLevelRetries := ci.LowLevelRetries
+	ci.LowLevelRetries = 1
+	defer func() {
+		ci.LowLevelRetries = saveLowLevelRetries
+	}()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls[r.Method+" "+r.URL.Path]++
+
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/albums":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListAlbums{
+				Albums: []api.Album{
+					{ID: "album1", Title: "my-album", IsWriteable: true},
+					{ID: "trash-album-123", Title: "rclone_Trash", IsWriteable: true},
+				},
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/uploads":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("upload-token-abc"))
+
+		case r.Method == "POST" && r.URL.Path == "/mediaItems:batchCreate":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.BatchCreateResponse{
+				NewMediaItemResults: []struct {
+					UploadToken string `json:"uploadToken"`
+					Status      struct {
+						Message string `json:"message"`
+						Code    int    `json:"code"`
+					} `json:"status"`
+					MediaItem api.MediaItem `json:"mediaItem"`
+				}{
+					{
+						UploadToken: "upload-token-abc",
+						MediaItem: api.MediaItem{
+							ID:       "new-photo-456",
+							Filename: "photo.jpg",
+						},
+					},
+				},
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/albums/trash-album-123:batchAddMediaItems":
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"error": {"code": 429, "message": "Quota exceeded"}}`))
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	f := &Fs{
+		name:   "TestGphotos",
+		root:   "album/my-album",
+		unAuth: rest.NewClient(http.DefaultClient),
+		srv:    rest.NewClient(http.DefaultClient).SetRoot(ts.URL),
+		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
+		albums: map[bool]*albums{},
+		opt: Options{
+			BatchMode:      "sync",
+			TrashAlbumName: "rclone_Trash",
+		},
+	}
+	f.srv.SetErrorHandler(errorHandler)
+
+	var err error
+	batcherOpts := defaultBatcherOptions
+	batcherOpts.Mode = f.opt.BatchMode
+	f.batcher, err = batcher.New(ctx, f, f.commitBatch, batcherOpts)
+	require.NoError(t, err)
+
+	_, err = f.listAlbums(ctx, false)
+	require.NoError(t, err)
+
+	o := &Object{
+		fs:     f,
+		remote: "photo.jpg",
+		id:     "old-photo-123",
+	}
+
+	err = o.Update(ctx, strings.NewReader("new content"), nil)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to trash old duplicate media item")
+}

--- a/backend/googlephotos/googlephotos_workaround_test.go
+++ b/backend/googlephotos/googlephotos_workaround_test.go
@@ -1,0 +1,79 @@
+package googlephotos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/backend/googlephotos/api"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/lib/batcher"
+	"github.com/rclone/rclone/lib/pacer"
+	"github.com/rclone/rclone/lib/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAsyncBatchModePanic is a regression test for the nil-pointer panic that
+// occurred when batch_mode=async was used. In async mode batcher.Commit
+// returns immediately with a nil *api.MediaItem result; the old code passed
+// that nil directly to o.setMetaData which dereferenced it unconditionally.
+//
+// This test should FAIL (panic) against the unfixed code and PASS after the fix.
+func TestAsyncBatchModePanic(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/albums":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListAlbums{
+				Albums: []api.Album{
+					{ID: "album1", Title: "my-album", IsWriteable: true},
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/uploads":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("upload-token-async"))
+		default:
+			// In async mode the batcher does not call batchCreate synchronously,
+			// so we should never reach mediaItems:batchCreate during Put.
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	f := &Fs{
+		name:   "TestGphotos",
+		root:   "album/my-album",
+		unAuth: rest.NewClient(http.DefaultClient),
+		srv:    rest.NewClient(http.DefaultClient).SetRoot(ts.URL),
+		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
+		albums: map[bool]*albums{},
+		opt: Options{
+			BatchMode: "async",
+		},
+	}
+	f.srv.SetErrorHandler(errorHandler)
+
+	var err error
+	batcherOpts := defaultBatcherOptions
+	batcherOpts.Mode = f.opt.BatchMode
+	f.batcher, err = batcher.New(ctx, f, f.commitBatch, batcherOpts)
+	require.NoError(t, err)
+	defer f.batcher.Shutdown()
+
+	_, err = f.listAlbums(ctx, false)
+	require.NoError(t, err)
+
+	// assert.NotPanics documents the expected post-fix behaviour.
+	// Before the fix this panics with: "runtime error: invalid memory address
+	// or nil pointer dereference" inside setMetaData(info) when info is nil.
+	assert.NotPanics(t, func() {
+		_, _ = f.Put(ctx, strings.NewReader("content"), nil)
+	})
+}

--- a/backend/googlephotos/googlephotos_workaround_test.go
+++ b/backend/googlephotos/googlephotos_workaround_test.go
@@ -141,6 +141,9 @@ func TestRemoveTrashWorkaround(t *testing.T) {
 		srv:    rest.NewClient(http.DefaultClient).SetRoot(ts.URL),
 		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
 		albums: map[bool]*albums{},
+		opt: Options{
+			TrashAlbumName: "rclone_Trash",
+		},
 	}
 	f.srv.SetErrorHandler(errorHandler)
 
@@ -164,6 +167,141 @@ func TestRemoveTrashWorkaround(t *testing.T) {
 	assert.Equal(t, 1, calls["POST /albums"], "Should create rclone_Trash")
 	assert.Equal(t, 1, calls["POST /albums/trash-album-123:batchAddMediaItems"], "Should add to trash album")
 	assert.Equal(t, 1, calls["POST /albums/album1:batchRemoveMediaItems"], "Should remove from my-album")
+}
+
+// TestCustomTrashAlbumName verifies that a custom TrashAlbumName is used instead of the default "rclone_Trash".
+func TestCustomTrashAlbumName(t *testing.T) {
+	ctx := context.Background()
+	calls := make(map[string]int)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls[r.Method+" "+r.URL.Path]++
+
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/albums":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListAlbums{
+				Albums: []api.Album{
+					{ID: "album1", Title: "my-album"},
+				},
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/albums":
+			var req api.CreateAlbum
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			// Should use custom name, not "rclone_Trash"
+			assert.Equal(t, "my_custom_trash", req.Album.Title)
+
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.Album{
+				ID:    "custom-trash-456",
+				Title: "my_custom_trash",
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/albums/custom-trash-456:batchAddMediaItems":
+			var req api.BatchAddItems
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, []string{"photo-123"}, req.MediaItemIDs)
+			w.WriteHeader(http.StatusOK)
+
+		case r.Method == "POST" && r.URL.Path == "/albums/album1:batchRemoveMediaItems":
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	f := &Fs{
+		name:   "TestGphotos",
+		root:   "album/my-album",
+		unAuth: rest.NewClient(http.DefaultClient),
+		srv:    rest.NewClient(http.DefaultClient).SetRoot(ts.URL),
+		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
+		albums: map[bool]*albums{},
+		opt: Options{
+			TrashAlbumName: "my_custom_trash",
+		},
+	}
+	f.srv.SetErrorHandler(errorHandler)
+
+	_, err := f.listAlbums(ctx, false)
+	require.NoError(t, err)
+
+	o := &Object{
+		fs:     f,
+		remote: "photo.jpg",
+		id:     "photo-123",
+	}
+
+	err = o.Remove(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 1, calls["POST /albums"], "Should create custom trash album")
+	assert.Equal(t, 1, calls["POST /albums/custom-trash-456:batchAddMediaItems"], "Should add to custom trash album")
+	assert.Equal(t, 0, calls["POST /albums/trash-album-123:batchAddMediaItems"], "Should NOT use default rclone_Trash album")
+}
+
+// TestDisabledTrashAlbum verifies that setting TrashAlbumName="" disables the trash workaround:
+// items are removed from their current album but not added to any trash album.
+func TestDisabledTrashAlbum(t *testing.T) {
+	ctx := context.Background()
+	calls := make(map[string]int)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls[r.Method+" "+r.URL.Path]++
+
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/albums":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListAlbums{
+				Albums: []api.Album{
+					{ID: "album1", Title: "my-album"},
+				},
+			})
+
+		case r.Method == "POST" && r.URL.Path == "/albums/album1:batchRemoveMediaItems":
+			// Should still remove from album even when trash is disabled
+			var req api.BatchRemoveItems
+			_ = json.NewDecoder(r.Body).Decode(&req)
+			assert.Equal(t, []string{"photo-123"}, req.MediaItemIDs)
+			w.WriteHeader(http.StatusOK)
+
+		default:
+			// No POST /albums to create trash, no batchAddMediaItems - should not be called
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	f := &Fs{
+		name:   "TestGphotos",
+		root:   "album/my-album",
+		unAuth: rest.NewClient(http.DefaultClient),
+		srv:    rest.NewClient(http.DefaultClient).SetRoot(ts.URL),
+		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
+		albums: map[bool]*albums{},
+		opt: Options{
+			TrashAlbumName: "", // Disabled
+		},
+	}
+	f.srv.SetErrorHandler(errorHandler)
+
+	_, err := f.listAlbums(ctx, false)
+	require.NoError(t, err)
+
+	o := &Object{
+		fs:     f,
+		remote: "photo.jpg",
+		id:     "photo-123",
+	}
+
+	err = o.Remove(ctx)
+	require.NoError(t, err)
+
+	assert.Equal(t, 0, calls["POST /albums"], "Should NOT create any trash album")
+	assert.Equal(t, 1, calls["POST /albums/album1:batchRemoveMediaItems"], "Should still remove from current album")
 }
 
 func TestUpdateTrashWorkaround(t *testing.T) {
@@ -242,7 +380,8 @@ func TestUpdateTrashWorkaround(t *testing.T) {
 		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
 		albums: map[bool]*albums{},
 		opt: Options{
-			BatchMode: "sync",
+			BatchMode:      "sync",
+			TrashAlbumName: "rclone_Trash",
 		},
 	}
 	f.srv.SetErrorHandler(errorHandler)

--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -639,9 +639,13 @@ Rclone can remove files it uploaded from albums it created only.
 
 ### Deleting files
 
-Rclone can remove files from albums it created, but note that the
-Google Photos API does not allow media to be deleted permanently so
-this media will still remain. See [bug #109759781](https://issuetracker.google.com/issues/109759781).
+The Google Photos Library API does not allow media items to be permanently deleted via the API (see [bug #109759781](https://issuetracker.google.com/issues/109759781)).
+
+To work around this limitation and keep your active albums clean:
+* Rclone implements a "Trash Album" workaround for write operations (`Remove` and `Update`).
+* When a file is deleted or overwritten, rclone automatically discovers or creates an album named `"rclone_Trash"`.
+* The old media item is added to `"rclone_Trash"` and removed from the active album.
+* You can periodically review and permanently delete or empty items from the `"rclone_Trash"` album via the Google Photos web interface.
 
 Rclone cannot delete files anywhere except under `album`.
 

--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -345,6 +345,24 @@ Properties:
 - Type:        bool
 - Default:     false
 
+#### --gphotos-trash-album-name
+
+Name of the album to use as a trash bin for deleted and overwritten files.
+
+The Google Photos API does not support deleting media permanently.
+Instead rclone moves removed items into this album so they can be
+reviewed and deleted manually from the Google Photos UI.
+
+Set this to an empty string to disable the trash workaround (removed
+items will not be added to any album, but will remain in your library).
+
+Properties:
+
+- Config:      trash_album_name
+- Env Var:     RCLONE_GPHOTOS_TRASH_ALBUM_NAME
+- Type:        string
+- Default:     "rclone_Trash"
+
 #### --gphotos-read-size
 
 Set to read the size of media items.
@@ -643,9 +661,22 @@ The Google Photos Library API does not allow media items to be permanently delet
 
 To work around this limitation and keep your active albums clean:
 * Rclone implements a "Trash Album" workaround for write operations (`Remove` and `Update`).
-* When a file is deleted or overwritten, rclone automatically discovers or creates an album named `"rclone_Trash"`.
-* The old media item is added to `"rclone_Trash"` and removed from the active album.
-* You can periodically review and permanently delete or empty items from the `"rclone_Trash"` album via the Google Photos web interface.
+* When a file is deleted or overwritten, rclone automatically discovers or creates an album named `"rclone_Trash"` (configurable via `--gphotos-trash-album-name`).
+* The old media item is added to the trash album and removed from the active album.
+* You can periodically review and permanently delete or empty items from the trash album via the Google Photos web interface.
+* To customize the trash album name, set `--gphotos-trash-album-name=<name>`.
+* To disable the trash workaround entirely (items will remain in your library but be removed from the album), set `--gphotos-trash-album-name=""`.
+
+> [!WARNING]
+> **Do not use the trash album feature (`--gphotos-trash-album-name`) when syncing to albums that rclone cannot delete from (such as a "Favorites" or shared album)**. If the trash album feature is active, rclone will attempt to "delete" photos from these albums by moving them to the trash album.
+> 
+> To prevent this, you **must** disable the trash album feature by setting `--gphotos-trash-album-name ""` on the command line when performing these syncs.
+
+
+
+
+
+
 
 Rclone cannot delete files anywhere except under `album`.
 

--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -361,7 +361,7 @@ Properties:
 - Config:      trash_album_name
 - Env Var:     RCLONE_GPHOTOS_TRASH_ALBUM_NAME
 - Type:        string
-- Default:     "rclone_Trash"
+- Default:     ""
 
 #### --gphotos-read-size
 
@@ -661,11 +661,11 @@ The Google Photos Library API does not allow media items to be permanently delet
 
 To work around this limitation and keep your active albums clean:
 * Rclone implements a "Trash Album" workaround for write operations (`Remove` and `Update`).
-* When a file is deleted or overwritten, rclone automatically discovers or creates an album named `"rclone_Trash"` (configurable via `--gphotos-trash-album-name`).
+* **This feature is disabled by default** (the default trash album name is `""`). To enable it, set `--gphotos-trash-album-name` to a non-empty name (e.g. `"rclone_Trash"`).
+* When enabled, if a file is deleted or overwritten, rclone automatically discovers or creates the configured trash album.
 * The old media item is added to the trash album and removed from the active album.
 * You can periodically review and permanently delete or empty items from the trash album via the Google Photos web interface.
-* To customize the trash album name, set `--gphotos-trash-album-name=<name>`.
-* To disable the trash workaround entirely (items will remain in your library but be removed from the album), set `--gphotos-trash-album-name=""`.
+* To disable the trash workaround entirely, set `--gphotos-trash-album-name=""` (or leave it unset).
 
 > [!WARNING]
 > **Do not use the trash album feature (`--gphotos-trash-album-name`) when syncing to albums that rclone cannot delete from (such as a "Favorites" or shared album)**. If the trash album feature is active, rclone will attempt to "delete" photos from these albums by moving them to the trash album.


### PR DESCRIPTION
## Summary

The Google Photos Library REST API does not expose a `delete` endpoint — media items cannot be permanently removed via the API ([bug #109759781](https://issuetracker.google.com/issues/109759781)). Currently rclone's `Remove` and overwrite (`Update`) operations on the Google Photos backend silently leave orphaned items in the library.

This PR implements an opt-in **Trash Album workaround** controlled by a new configuration option `--gphotos-trash-album-name` (empty / disabled by default).

---

## How It Works

### `Remove`

1. If `trash_album_name` is empty, the item is removed from the album but stays in the library (existing behaviour).
2. If set (e.g. `rclone_Trash`), the backend lazily discovers or creates the album, then:
   - Adds the item to the trash album via `albums.batchAddMediaItems`.
   - Removes the item from the source album via `albums.batchRemoveMediaItems`.

### `Update` (overwrite)

1. The new version is uploaded; its new media-item ID is recorded.
2. The *old* media-item ID is trashed by the same two-step add/remove.
3. **Trashing errors are now propagated** — if the trash step fails (e.g. `429 RESOURCE_EXHAUSTED`), `Update` returns an error so rclone retries on the next run rather than silently succeeding with a half-moved item.

### Enabling the workaround

```ini
[myphotos]
type = google photos
trash_album_name = rclone_Trash
```

Or on the command line: `--gphotos-trash-album-name=rclone_Trash`

> [!WARNING]
> **Do not use the trash album feature (`--gphotos-trash-album-name`) when syncing to albums that rclone cannot delete from (such as a "Favorites" or shared album)**. If the trash album feature is active, rclone will attempt to "delete" photos from these albums by moving them to the trash album.
> 
> To prevent this, you **must** disable the trash album feature by setting `--gphotos-trash-album-name ""` on the command line when performing these syncs.




---

## Automated Tests

New unit tests in `backend/googlephotos/googlephotos_workaround_test.go`:

| Test | Covers |
|---|---|
| `TestRemoveTrashWorkaround` | Item moved to trash album and removed from source album on `Remove` |
| `TestUpdateTrashWorkaround` | Old duplicate moved to trash on `Update` |
| `TestCustomTrashAlbumName` | Custom album name is used when configured |
| `TestDisabledTrashAlbum` | No trash API calls when `trash_album_name=""` |
| `TestUpdateTrashWorkaroundFailure` | `Update` returns error when trash API call fails (error propagation) |

```
ok  github.com/rclone/rclone/backend/googlephotos  2.5s
```

---

## Manual Test Plan

> [!IMPORTANT]
> **Manual testing under async batch mode (`--gphotos-batch-mode=async`) relies on the changes in `gphotos-async-panic` (PR #9502)**. Without the fix in PR #9502, any write operation using async batch mode will crash with a nil-pointer panic.
>
> Build: `go build .`

### Deletion

```bash
./rclone copy test_photo.jpg gphotos:album/rclone_Test_Album/
./rclone deletefile gphotos:album/rclone_Test_Album/test_photo.jpg \
  --gphotos-trash-album-name=rclone_Trash
./rclone lsf gphotos:album/rclone_Test_Album/  # → empty
./rclone lsf gphotos:album/rclone_Trash/       # → test_photo.jpg ✓
```

### Overwrite

```bash
./rclone copyto photo1.jpg gphotos:album/rclone_Test_Album/test.jpg \
  --gphotos-trash-album-name=rclone_Trash
./rclone copyto photo2.jpg gphotos:album/rclone_Test_Album/test.jpg \
  --gphotos-trash-album-name=rclone_Trash --ignore-times
./rclone lsf gphotos:album/rclone_Test_Album/  # → test.jpg (new version) ✓
./rclone lsf gphotos:album/rclone_Trash/       # → test.jpg (old version) ✓
```

### Cleanup

> [!WARNING]
> Running `rclone purge` on `rclone_Trash` deletes the album container but **leaves the files themselves orphaned ("zombie files") in your main Google Photos library**. You must delete the files from your library first.

1. Open the Google Photos Web UI, navigate to the `rclone_Trash` album, select all photos, and click **"Move to trash"** (or delete them).
2. Delete local files:
```bash
rm photo1.jpg photo2.jpg test_photo.jpg
```
3. Purge the empty album containers:
```bash
./rclone purge gphotos:album/rclone_Test_Album
./rclone purge gphotos:album/rclone_Trash
```

#### Was the change discussed in an issue or in the forum before?

Yes, this is an opt-in workaround for the API limitation where media items cannot be permanently deleted via the API (tracked on Google's issue tracker as bug #109759781), which has been discussed in rclone [issue #7956](https://github.com/rclone/rclone/issues/7956).

---

## Dependencies (gh-stack)

This PR depends on:
- `gphotos-async-panic`: async batch-mode panic fix

---

## Other Backends

No other backends are affected. All changes are isolated to `backend/googlephotos/`.

---

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
