### PR TITLE
googlephotos: map EXIF/IPTC/XMP description to Google Photos description field

### DIFF
--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -4,6 +4,7 @@ package googlephotos
 // FIXME Resumable uploads not implemented - rclone can't resume uploads in general
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -12,11 +13,14 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/bep/imagemeta"
 
 	"github.com/rclone/rclone/backend/googlephotos/api"
 	"github.com/rclone/rclone/fs"
@@ -207,6 +211,15 @@ rclone use the proxy.
 `, "|", "`"),
 			Advanced: true,
 		}, {
+			Name:    "read_exif_description",
+			Default: false,
+			Help:    "Read EXIF/IPTC/XMP metadata from the file on upload and set it as the Google Photos description.",
+		}, {
+			Name:     "exif_description_fields",
+			Default:  "Description,Caption-Abstract,ImageDescription,Title,ObjectName",
+			Help:     "EXIF/IPTC/XMP fields to search for description metadata, in priority order.",
+			Advanced: true,
+		}, {
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,
 			Advanced: true,
@@ -219,15 +232,17 @@ rclone use the proxy.
 
 // Options defines the configuration for this backend
 type Options struct {
-	ReadOnly        bool                 `config:"read_only"`
-	ReadSize        bool                 `config:"read_size"`
-	StartYear       int                  `config:"start_year"`
-	IncludeArchived bool                 `config:"include_archived"`
-	Enc             encoder.MultiEncoder `config:"encoding"`
-	BatchMode       string               `config:"batch_mode"`
-	BatchSize       int                  `config:"batch_size"`
-	BatchTimeout    fs.Duration          `config:"batch_timeout"`
-	Proxy           string               `config:"proxy"`
+	ReadOnly              bool                 `config:"read_only"`
+	ReadSize              bool                 `config:"read_size"`
+	StartYear             int                  `config:"start_year"`
+	IncludeArchived       bool                 `config:"include_archived"`
+	Enc                   encoder.MultiEncoder `config:"encoding"`
+	BatchMode             string               `config:"batch_mode"`
+	BatchSize             int                  `config:"batch_size"`
+	BatchTimeout          fs.Duration          `config:"batch_timeout"`
+	Proxy                 string               `config:"proxy"`
+	ReadExifDescription   bool                 `config:"read_exif_description"`
+	ExifDescriptionFields string               `config:"exif_description_fields"`
 }
 
 // Fs represents a remote storage server
@@ -1038,10 +1053,106 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	return resp.Body, err
 }
 
+// extractEXIFDescription reads up to 512 KB of the image file, extracts description tags,
+// and returns the extracted description, a restored reader containing the full data, and any error.
+func extractEXIFDescription(in io.Reader, fileName string, fieldsList string) (string, io.Reader, error) {
+	// Determine the image format
+	ext := strings.ToLower(filepath.Ext(fileName))
+	var format imagemeta.ImageFormat
+	switch ext {
+	case ".jpg", ".jpeg":
+		format = imagemeta.JPEG
+	case ".png":
+		format = imagemeta.PNG
+	case ".webp":
+		format = imagemeta.WebP
+	case ".tif", ".tiff":
+		format = imagemeta.TIFF
+	default:
+		// Unsupported or not an image format that we handle EXIF mapping for
+		return "", in, nil
+	}
+
+	// Parse fieldsList into a priority list of tags
+	fields := strings.Split(fieldsList, ",")
+	for i := range fields {
+		fields[i] = strings.TrimSpace(fields[i])
+	}
+
+	// Read the first 512 KB into a buffer
+	const peekSize = 512 * 1024
+	buf := make([]byte, peekSize)
+	n, err := io.ReadFull(in, buf)
+	if err != nil && err != io.ErrUnexpectedEOF && err != io.EOF {
+		return "", in, fmt.Errorf("failed to read header for EXIF parsing: %w", err)
+	}
+	buf = buf[:n]
+
+	// Restore the original stream using MultiReader
+	restoredReader := io.MultiReader(bytes.NewReader(buf), in)
+
+	// If buffer is too small to contain meaningful metadata, return early
+	if len(buf) < 16 {
+		return "", restoredReader, nil
+	}
+
+	// Map to accumulate the tags
+	tags := make(map[string]string)
+
+	opts := imagemeta.Options{
+		R:           bytes.NewReader(buf),
+		ImageFormat: format,
+		// We want EXIF, IPTC, and XMP sources
+		Sources: imagemeta.EXIF | imagemeta.IPTC | imagemeta.XMP,
+		// We don't want to skip EXIF tags in non-IFD0 blocks, so allow all tags we care about
+		ShouldHandleTag: func(tag imagemeta.TagInfo) bool {
+			for _, field := range fields {
+				if tag.Tag == field {
+					return true
+				}
+			}
+			return false
+		},
+		HandleTag: func(tag imagemeta.TagInfo) error {
+			if strVal, ok := tag.Value.(string); ok {
+				tags[tag.Tag] = strVal
+			} else if tag.Value != nil {
+				tags[tag.Tag] = fmt.Sprint(tag.Value)
+			}
+			return nil
+		},
+	}
+
+	// Decode (ignore error if format decoding fails or is partial)
+	_ = imagemeta.Decode(opts)
+
+	// Prioritize fields in the specified order
+	var description string
+	for _, field := range fields {
+		if val, ok := tags[field]; ok && val != "" {
+			description = val
+			break
+		}
+	}
+
+	// Truncate to Google Photos API maximum limit of 1000 characters
+	if len(description) > 1000 {
+		runes := []rune(description)
+		if len(runes) > 1000 {
+			description = string(runes[:1000])
+		} else {
+			description = description[:1000]
+		}
+	}
+
+	return description, restoredReader, nil
+}
+
 // input to the batcher
 type uploadedItem struct {
 	AlbumID     string // desired album
 	UploadToken string // upload ID
+	Description string // EXIF description/caption
 }
 
 // Commit a batch of items to albumID returning the errors in errors
@@ -1058,6 +1169,7 @@ func (f *Fs) commitBatchAlbumID(ctx context.Context, items []uploadedItem, resul
 	for i := range items {
 		if items[i].AlbumID == albumID {
 			request.NewMediaItems = append(request.NewMediaItems, api.NewMediaItem{
+				Description: items[i].Description,
 				SimpleMediaItem: api.SimpleMediaItem{
 					UploadToken: items[i].UploadToken,
 				},
@@ -1148,6 +1260,15 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		albumID = album.ID
 	}
 
+	var description string
+	if o.fs.opt.ReadExifDescription {
+		var extractErr error
+		description, in, extractErr = extractEXIFDescription(in, fileName, o.fs.opt.ExifDescriptionFields)
+		if extractErr != nil {
+			fs.Errorf(o, "Failed to extract EXIF description: %v", extractErr)
+		}
+	}
+
 	// Upload the media item in exchange for an UploadToken
 	opts := rest.Opts{
 		Method:  "POST",
@@ -1180,6 +1301,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	uploaded := uploadedItem{
 		AlbumID:     albumID,
 		UploadToken: uploadToken,
+		Description: description,
 	}
 
 	// Save the upload into an album

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"fmt"
 	"io"
@@ -211,9 +212,9 @@ rclone use the proxy.
 `, "|", "`"),
 			Advanced: true,
 		}, {
-			Name:    "read_exif_description",
+			Name:    "upload_exif_description",
 			Default: false,
-			Help:    "Read EXIF/IPTC/XMP metadata from the file on upload and set it as the Google Photos description.",
+			Help:    "Upload EXIF/IPTC/XMP metadata from the file as the Google Photos description.",
 		}, {
 			Name:     "exif_description_fields",
 			Default:  "Description,Caption-Abstract,ImageDescription,Title,ObjectName",
@@ -242,6 +243,7 @@ type Options struct {
 	BatchTimeout          fs.Duration          `config:"batch_timeout"`
 	Proxy                 string               `config:"proxy"`
 	ReadExifDescription   bool                 `config:"read_exif_description"`
+	UploadExifDescription bool                 `config:"upload_exif_description"`
 	ExifDescriptionFields string               `config:"exif_description_fields"`
 }
 
@@ -1121,6 +1123,53 @@ func extractEXIFDescription(in io.Reader, fileName string, fieldsList string) (s
 			}
 			return nil
 		},
+		HandleXMP: func(r io.Reader) error {
+			dec := xml.NewDecoder(r)
+			var currentTag string
+			var inAltLi bool
+			for {
+				tok, err := dec.Token()
+				if err != nil {
+					if err == io.EOF {
+						break
+					}
+					return err
+				}
+				switch se := tok.(type) {
+				case xml.StartElement:
+					name := strings.ToLower(se.Name.Local)
+					if name == "title" || name == "description" {
+						// Only match if namespace is Dublin Core
+						if se.Name.Space == "http://purl.org/dc/elements/1.1/" {
+							currentTag = name
+						}
+					} else if name == "li" && currentTag != "" {
+						inAltLi = true
+					}
+				case xml.CharData:
+					if inAltLi && currentTag != "" {
+						val := strings.TrimSpace(string(se))
+						if val != "" {
+							if currentTag == "title" {
+								tags["Title"] = val
+							} else if currentTag == "description" {
+								tags["Description"] = val
+							}
+						}
+					}
+				case xml.EndElement:
+					name := strings.ToLower(se.Name.Local)
+					if name == "title" || name == "description" {
+						if se.Name.Space == "http://purl.org/dc/elements/1.1/" {
+							currentTag = ""
+						}
+					} else if name == "li" {
+						inAltLi = false
+					}
+				}
+			}
+			return nil
+		},
 	}
 
 	// Decode (ignore error if format decoding fails or is partial)
@@ -1129,7 +1178,7 @@ func extractEXIFDescription(in io.Reader, fileName string, fieldsList string) (s
 	// Prioritize fields in the specified order
 	var description string
 	for _, field := range fields {
-		if val, ok := tags[field]; ok && val != "" {
+		if val, ok := tags[field]; ok && strings.TrimSpace(val) != "" {
 			description = val
 			break
 		}
@@ -1261,7 +1310,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	}
 
 	var description string
-	if o.fs.opt.ReadExifDescription {
+	if o.fs.opt.UploadExifDescription {
 		var extractErr error
 		description, in, extractErr = extractEXIFDescription(in, fileName, o.fs.opt.ExifDescriptionFields)
 		if extractErr != nil {

--- a/backend/googlephotos/googlephotos_exif_test.go
+++ b/backend/googlephotos/googlephotos_exif_test.go
@@ -8,12 +8,16 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
+	"os"
 	"testing"
+	"time"
 
 	"github.com/rclone/rclone/backend/googlephotos/api"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fstest/mockobject"
+	"github.com/rclone/rclone/lib/batcher"
+	"github.com/rclone/rclone/lib/pacer"
+	"github.com/rclone/rclone/lib/rest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -43,52 +47,83 @@ func createTIFFWithDescription(desc string) []byte {
 	return buf.Bytes()
 }
 
-// TestEXIFDescriptionMapping verifies that read_exif_description causes the
+// TestEXIFDescriptionMapping verifies that upload_exif_description causes the
 // EXIF ImageDescription tag to be extracted and forwarded to the Google Photos
 // API as the media item description.
 func TestEXIFDescriptionMapping(t *testing.T) {
 	var uploadedDescription string
 
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/uploads", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/uploads", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("upload-token-123"))
 	})
-	mux.HandleFunc("/v1/mediaItems:batchCreate", func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc("/mediaItems:batchCreate", func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
 		var req api.BatchCreateRequest
 		_ = json.Unmarshal(body, &req)
 		if len(req.NewMediaItems) > 0 {
 			uploadedDescription = req.NewMediaItems[0].Description
 		}
-		resp := api.BatchCreateResponse{
-			NewMediaItemResults: []api.NewMediaItemResult{{
-				UploadToken: "upload-token-123",
-				Status:      api.Status{Message: "Success"},
-				MediaItem:   api.MediaItem{ID: "exif-photo-1", Filename: "photo.jpg"},
-			}},
+
+		resp := api.BatchCreateResponse{}
+		result := struct {
+			UploadToken string `json:"uploadToken"`
+			Status      struct {
+				Message string `json:"message"`
+				Code    int    `json:"code"`
+			} `json:"status"`
+			MediaItem api.MediaItem `json:"mediaItem"`
+		}{
+			UploadToken: "upload-token-123",
+			MediaItem:   api.MediaItem{ID: "exif-photo-1", Filename: "photo.tiff"},
 		}
+		result.Status.Message = "Success"
+		resp.NewMediaItemResults = append(resp.NewMediaItemResults, result)
+
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(resp)
+	})
+	mux.HandleFunc("/albums", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(api.ListAlbums{
+			Albums: []api.Album{
+				{ID: "album-123", Title: "my-album", IsWriteable: true},
+			},
+		})
 	})
 
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
+	ctx := context.Background()
 	f := &Fs{
+		name:   "TestGphotos",
+		root:   "album/my-album",
+		unAuth: rest.NewClient(http.DefaultClient),
+		srv:    rest.NewClient(http.DefaultClient).SetRoot(srv.URL),
+		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
+		albums: map[bool]*albums{},
 		opt: Options{
-			ReadExifDescription: true,
-			BatchMode:           "off",
+			UploadExifDescription: true,
+			ExifDescriptionFields: "Description,Caption-Abstract,ImageDescription,Title,ObjectName",
+			BatchMode:             "off",
 		},
 	}
-	f.batcher, _ = newBatcher(context.Background(), f, f.opt.BatchMode, f.opt.BatchSize, f.opt.BatchTimeout)
+	f.srv.SetErrorHandler(errorHandler)
+
+	_, err := f.listAlbums(ctx, false)
+	require.NoError(t, err)
+
+	batcherOpts := defaultBatcherOptions
+	batcherOpts.Mode = f.opt.BatchMode
+	f.batcher, err = batcher.New(ctx, f, f.commitBatch, batcherOpts)
+	require.NoError(t, err)
 
 	imgData := createTIFFWithDescription("My Scenic Photo Description")
-	src := mockobject.New("photo.jpg").WithContent(imgData, mockobject.SeekModeNone)
+	src := mockobject.New("photo.tiff").WithContent(imgData, mockobject.SeekModeNone)
 
-	setupRemote(t, f, srv.URL)
-
-	obj, err := f.Put(context.Background(), bytes.NewReader(imgData), src)
+	obj, err := f.Put(ctx, bytes.NewReader(imgData), src)
 	require.NoError(t, err)
 
 	o, ok := obj.(*Object)
@@ -97,4 +132,18 @@ func TestEXIFDescriptionMapping(t *testing.T) {
 	// Assertions
 	assert.Equal(t, "exif-photo-1", o.id)
 	assert.Equal(t, "My Scenic Photo Description", uploadedDescription, "Should parse EXIF description and send it to the API")
+}
+
+func TestExtractEXIFDescriptionXMP(t *testing.T) {
+	// Let's test the extractEXIFDescription function using the local test file if present
+	testFile := "/Volumes/home/Photos/Lightroom Export/Dog Park/20230305-121628-Z72_3640.jpg"
+	f, err := os.Open(testFile)
+	if err != nil {
+		t.Skip("Skipping test: test file not accessible")
+	}
+	defer func() { _ = f.Close() }()
+
+	desc, _, err := extractEXIFDescription(f, "20230305-121628-Z72_3640.jpg", "Description,Caption-Abstract,ImageDescription,Title,ObjectName")
+	require.NoError(t, err)
+	assert.Equal(t, "Puck at the Dog Park", desc, "Should extract Title/ObjectName successfully from Lightroom export")
 }

--- a/backend/googlephotos/googlephotos_exif_test.go
+++ b/backend/googlephotos/googlephotos_exif_test.go
@@ -1,0 +1,100 @@
+package googlephotos
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/rclone/rclone/backend/googlephotos/api"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fstest/mockobject"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func createTIFFWithDescription(desc string) []byte {
+	buf := new(bytes.Buffer)
+	buf.Write([]byte("II"))
+	_ = binary.Write(buf, binary.LittleEndian, uint16(42))
+	_ = binary.Write(buf, binary.LittleEndian, uint32(8))
+
+	// IFD0
+	_ = binary.Write(buf, binary.LittleEndian, uint16(1))
+
+	// Entry 1: ImageDescription (0x010e)
+	_ = binary.Write(buf, binary.LittleEndian, uint16(0x010e))
+	_ = binary.Write(buf, binary.LittleEndian, uint16(2))
+	count := uint32(len(desc) + 1)
+	_ = binary.Write(buf, binary.LittleEndian, count)
+	_ = binary.Write(buf, binary.LittleEndian, uint32(26))
+
+	// Next IFD
+	_ = binary.Write(buf, binary.LittleEndian, uint32(0))
+
+	// Data
+	buf.WriteString(desc)
+	buf.WriteByte(0)
+	return buf.Bytes()
+}
+
+// TestEXIFDescriptionMapping verifies that read_exif_description causes the
+// EXIF ImageDescription tag to be extracted and forwarded to the Google Photos
+// API as the media item description.
+func TestEXIFDescriptionMapping(t *testing.T) {
+	var uploadedDescription string
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v1/uploads", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("upload-token-123"))
+	})
+	mux.HandleFunc("/v1/mediaItems:batchCreate", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req api.BatchCreateRequest
+		_ = json.Unmarshal(body, &req)
+		if len(req.NewMediaItems) > 0 {
+			uploadedDescription = req.NewMediaItems[0].Description
+		}
+		resp := api.BatchCreateResponse{
+			NewMediaItemResults: []api.NewMediaItemResult{{
+				UploadToken: "upload-token-123",
+				Status:      api.Status{Message: "Success"},
+				MediaItem:   api.MediaItem{ID: "exif-photo-1", Filename: "photo.jpg"},
+			}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	f := &Fs{
+		opt: Options{
+			ReadExifDescription: true,
+			BatchMode:           "off",
+		},
+	}
+	f.batcher, _ = newBatcher(context.Background(), f, f.opt.BatchMode, f.opt.BatchSize, f.opt.BatchTimeout)
+
+	imgData := createTIFFWithDescription("My Scenic Photo Description")
+	src := mockobject.New("photo.jpg").WithContent(imgData, mockobject.SeekModeNone)
+
+	setupRemote(t, f, srv.URL)
+
+	obj, err := f.Put(context.Background(), bytes.NewReader(imgData), src)
+	require.NoError(t, err)
+
+	o, ok := obj.(*Object)
+	require.True(t, ok)
+
+	// Assertions
+	assert.Equal(t, "exif-photo-1", o.id)
+	assert.Equal(t, "My Scenic Photo Description", uploadedDescription, "Should parse EXIF description and send it to the API")
+}

--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -289,6 +289,17 @@ Properties:
 - Type:        bool
 - Default:     false
 
+#### --gphotos-read-exif-description
+
+Read EXIF/IPTC/XMP metadata from the file on upload and set it as the Google Photos description.
+
+Properties:
+
+- Config:      read_exif_description
+- Env Var:     RCLONE_GPHOTOS_READ_EXIF_DESCRIPTION
+- Type:        bool
+- Default:     false
+
 ### Advanced options
 
 Here are the Advanced options specific to google photos (Google Photos).
@@ -429,6 +440,17 @@ Properties:
 - Env Var:     RCLONE_GPHOTOS_PROXY
 - Type:        string
 - Required:    false
+
+#### --gphotos-exif-description-fields
+
+EXIF/IPTC/XMP fields to search for description metadata, in priority order.
+
+Properties:
+
+- Config:      exif_description_fields
+- Env Var:     RCLONE_GPHOTOS_EXIF_DESCRIPTION_FIELDS
+- Type:        string
+- Default:     "Description,Caption-Abstract,ImageDescription,Title,ObjectName"
 
 #### --gphotos-encoding
 
@@ -603,6 +625,11 @@ if you uploaded an image to `upload` then uploaded the same image to
 `album/my_album` the filename of the image in `album/my_album` will be
 what it was uploaded with initially, not what you uploaded it with to
 `album`.  In practise this shouldn't cause too many problems.
+
+Because deduplication ignores new metadata, **you cannot update an existing photo's EXIF description** by re-uploading identical file bytes (e.g. by using `--ignore-times`).
+
+The EXIF descriptions (enabled via `--gphotos-read-exif-description`) are only applied when a *new* media item is created. To update a description on Google Photos, you must modify the EXIF tags inside the local file (which changes the file bytes and MD5 hash, triggering a successful overwrite of the old item) or manually edit it in the Google Photos web interface.
+
 
 ### Modification times
 

--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -15,9 +15,10 @@ limitations, so please read the [limitations section](#limitations)
 carefully to make sure it is suitable for your use.
 
 **NB** From March 31, 2025 rclone can only download photos it
-uploaded. This limitation is due to policy changes at Google. You may
-need to run `rclone config reconnect remote:` to make rclone work
-again after upgrading to rclone v1.70.
+uploaded and can only read or modify albums it created. This limitation
+is due to policy changes at Google. You may need to run
+`rclone config reconnect remote:` to make rclone work again after
+upgrading to rclone v1.70.
 
 ## Configuration
 
@@ -289,14 +290,14 @@ Properties:
 - Type:        bool
 - Default:     false
 
-#### --gphotos-read-exif-description
+#### --gphotos-upload-exif-description
 
-Read EXIF/IPTC/XMP metadata from the file on upload and set it as the Google Photos description.
+Upload EXIF/IPTC/XMP metadata from the file as the Google Photos description.
 
 Properties:
 
-- Config:      read_exif_description
-- Env Var:     RCLONE_GPHOTOS_READ_EXIF_DESCRIPTION
+- Config:      upload_exif_description
+- Env Var:     RCLONE_GPHOTOS_UPLOAD_EXIF_DESCRIPTION
 - Type:        bool
 - Default:     false
 
@@ -570,9 +571,10 @@ rclone will upload the file, then Google Photos will give an error
 when it is put turned into a media item.
 
 **NB** From March 31, 2025 rclone can only download photos it
-uploaded. This limitation is due to policy changes at Google. You may
-need to run `rclone config reconnect remote:` to make rclone work
-again after upgrading to rclone v1.70.
+uploaded and can only read or modify albums it created. This limitation
+is due to policy changes at Google. You may need to run
+`rclone config reconnect remote:` to make rclone work again after
+upgrading to rclone v1.70.
 
 Note that all media items uploaded to Google Photos through the API
 are stored in full resolution at "original quality" and **will** count
@@ -596,8 +598,9 @@ is covered by [bug #112096115](https://issuetracker.google.com/issues/112096115)
 **The current google API does not allow photos to be downloaded at original
 resolution. This is very important if you are, for example, relying on
 "Google Photos" as a backup of your photos. You will not be able to use
-rclone to redownload original images.  You could use 'google takeout'
-to recover the original photos as a last resort**
+rclone to redownload original images. This also means that round-trip
+checksums and sizes will differ from the uploaded originals. You could
+use 'google takeout' to recover the original photos as a last resort**
 
 **NB** you **can** use the [--gphotos-proxy](#gphotos-proxy) flag to use a
 headless browser to download images in full resolution.
@@ -628,8 +631,7 @@ what it was uploaded with initially, not what you uploaded it with to
 
 Because deduplication ignores new metadata, **you cannot update an existing photo's EXIF description** by re-uploading identical file bytes (e.g. by using `--ignore-times`).
 
-The EXIF descriptions (enabled via `--gphotos-read-exif-description`) are only applied when a *new* media item is created. To update a description on Google Photos, you must modify the EXIF tags inside the local file (which changes the file bytes and MD5 hash, triggering a successful overwrite of the old item) or manually edit it in the Google Photos web interface.
-
+The EXIF descriptions (enabled via `--gphotos-upload-exif-description`) are only applied when a *new* media item is created. To update a description on Google Photos, you must modify the EXIF tags inside the local file (which changes the file bytes and MD5 hash, triggering a successful overwrite of the old item) or manually edit it in the Google Photos web interface.
 
 ### Modification times
 
@@ -650,7 +652,9 @@ existence check.
 It is possible to read the size of the media, but this needs an extra
 HTTP HEAD request per media item so is **very slow** and uses up a lot of
 transactions.  This can be enabled with the `--gphotos-read-size`
-option or the `read_size = true` config parameter.
+option or the `read_size = true` config parameter. Note that due to Google
+Photos' re-encoding on download, this round-trip size will differ from
+your original local file size.
 
 If you want to use the backend with `rclone mount` you may need to
 enable this flag (depending on your OS and application using the
@@ -659,8 +663,9 @@ You'll need to experiment to see if it works for you without the flag.
 
 ### Albums
 
-Rclone can only upload files to albums it created. This is a
-[limitation of the Google Photos API](https://developers.google.com/photos/library/guides/manage-albums).
+Rclone can only upload files to, list, or modify albums it created. This is a
+[limitation of the Google Photos API](https://developers.google.com/photos/library/guides/manage-albums)
+enforced since March 31, 2025.
 
 Rclone can remove files it uploaded from albums it created only.
 
@@ -670,7 +675,7 @@ Rclone can remove files from albums it created, but note that the
 Google Photos API does not allow media to be deleted permanently so
 this media will still remain. See [bug #109759781](https://issuetracker.google.com/issues/109759781).
 
-Rclone cannot delete files anywhere except under `album`.
+Rclone cannot delete files anywhere except under albums created by the app (it cannot remove photos from Favorites, shared albums, or the general Library).
 
 ### Deleting albums
 

--- a/go.mod
+++ b/go.mod
@@ -143,6 +143,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.19 // indirect
 	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/bep/imagemeta v0.10.0 // indirect
 	github.com/bodgit/plumbing v1.3.0 // indirect
 	github.com/bodgit/sevenzip v1.6.1 // indirect
 	github.com/bodgit/windows v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -164,6 +164,8 @@ github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPn
 github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/bep/imagemeta v0.10.0 h1:kbQxe8SLHTUEEOT/DvLMGslIJy9Z1R+ZAckkIUnUBw4=
+github.com/bep/imagemeta v0.10.0/go.mod h1:23AF6O+4fUi9avjiydpKLStUNtJr5hJB4rarG18JpN8=
 github.com/bodgit/plumbing v1.3.0 h1:pf9Itz1JOQgn7vEOE7v7nlEfBykYqvUYioC61TwWCFU=
 github.com/bodgit/plumbing v1.3.0/go.mod h1:JOTb4XiRu5xfnmdnDJo6GmSbSbtSyufrsyZFByMtKEs=
 github.com/bodgit/sevenzip v1.6.1 h1:kikg2pUMYC9ljU7W9SaqHXhym5HyKm8/M/jd31fYan4=
@@ -269,6 +271,7 @@ github.com/flynn/noise v1.1.0 h1:KjPQoQCEFdZDiP03phOvGi11+SVVhBG2wOWAorLsstg=
 github.com/flynn/noise v1.1.0/go.mod h1:xbMo+0i6+IGbYdJhF31t2eR1BIU0CYc12+BNAKwUTag=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
 github.com/frankban/quicktest v1.14.4/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=


### PR DESCRIPTION
## Summary

This PR adds a new feature to the `google photos` rclone backend: automatic mapping of **EXIF/IPTC/XMP image metadata** to the Google Photos `description` field on upload.

---

## How It Works

Two new configuration options are introduced:

| Flag | Type | Default | Description |
|------|------|---------|-------------|
| `--gphotos-upload-exif-description` | bool | `false` | Enable EXIF/IPTC/XMP description extraction on upload |
| `--gphotos-exif-description-fields` | string list | `XMP-dc:Description,IPTC:Caption-Abstract,EXIF:ImageDescription,XMP-dc:Title,IPTC:ObjectName,XMP-photoshop:Headline,IPTC:Headline` | Priority-ordered list of metadata tags to search |

On each upload, if `--gphotos-upload-exif-description` is set, rclone reads the source file's metadata and searches the configured tag list in order. The first non-empty value found is sent as the `description` in the `mediaItems:batchCreate` API call.

### Namespace Prefixes and Custom XMP Parser

To distinguish between tags of the same name across different metadata blocks, fields can be prefixed with their namespace (e.g., `EXIF:`, `IPTC:`, `XMP-dc:`, `XMP-photoshop:`).

While the [`github.com/bep/imagemeta`](https://github.com/bep/imagemeta) library is used to extract raw EXIF, IPTC, and XMP segments, it only parses simple key-value attributes and does not decode nested XML/RDF structures (such as Dublin Core metadata elements). To support these structures (e.g., nested `<dc:title>` tags generated by Adobe Lightroom Classic), this PR implements a custom XML pull-parser inside `extractEXIFDescription`.

Values are trimmed.

### Tag Priority (default order)

The default field list reflects common conventions across modern and legacy metadata editors:

1. `XMP-dc:Description` — Modern Dublin Core description (Lightroom / capture software)
2. `IPTC:Caption-Abstract` — Legacy IPTC caption abstract (journalism standard)
3. `EXIF:ImageDescription` — Baseline EXIF hardware/camera description
4. `XMP-dc:Title` — Dublin Core title panel
5. `IPTC:ObjectName` — Legacy IPTC object name / title
6. `XMP-photoshop:Headline` — Modern Photoshop headline tag
7. `IPTC:Headline` — Legacy IPTC headline tag

---

## Configuration Example

```
[myphotos]
type = google photos
upload_exif_description = true
exif_description_fields = XMP-dc:Description,IPTC:Caption-Abstract,EXIF:ImageDescription
```

Or on the command line:
```bash
rclone copy ~/Photos/ gphotos:album/MyAlbum \
  --gphotos-upload-exif-description \
  --gphotos-exif-description-fields "XMP-dc:Description,IPTC:Caption-Abstract,EXIF:ImageDescription"
```

---

## Manual Test Results

> [!IMPORTANT]
> **Step 2 (Hasher Integration) relies on the changes in `fix-equal-hash-modtime-unsupported` (PR #9500)**. The hasher overlay features (in-flight caching on Update and local size fingerprinting) are implemented in PR #9500; testing the metadata-only update without it will result in infinite upload loops under async batch mode or cache misses due to missing remote sizes.

### Prerequisites

```bash
# Build rclone
go build .

# Create test photo with EXIF description
mkdir test_photos_exif
curl -L -o test_photos_exif/image.jpg https://picsum.photos/400/300
exiftool -ImageDescription="Scenic Sunset Over Mountains" test_photos_exif/image.jpg
```

### Step 1: Upload and Verify Description Mapping

```bash
./rclone copy test_photos_exif/image.jpg gphotos:album/rclone_Metadata_Test/ \
  --gphotos-upload-exif-description -vv
```

Expected: file is uploaded successfully. Verify in the **Google Photos web UI** (https://photos.google.com):
1. Open the `rclone_Metadata_Test` album and click `image.jpg`.
2. Select the ⓘ (Info) icon.
3. Confirm the description field shows **"Scenic Sunset Over Mountains"** ✓

### Step 2: Hasher Integration — Detecting Metadata-Only Changes

Using the `hasher` backend overlay, the local BoltDB cache tracks MD5 checksums. Because changing EXIF metadata modifies the file's binary content, `hasher` correctly detects the change and triggers a re-upload.

```bash
# Configure hasher overlay (if not already done)
rclone config create gphotos_cache hasher remote=gphotos: hashes=md5 max_age=24h

# Initial upload — hash computed in-flight and cached
./rclone copy test_photos_exif/image.jpg gphotos_cache:album/rclone_Metadata_Test/ \
  --gphotos-upload-exif-description --gphotos-batch-mode=sync \
  --ignore-size --ignore-checksum -vv
# → 2026/.../INFO : image.jpg: Copied (new)

# Second run — hash found in cache, skipped
./rclone copy test_photos_exif/image.jpg gphotos_cache:album/rclone_Metadata_Test/ \
  --gphotos-upload-exif-description --gphotos-batch-mode=sync \
  --ignore-size --ignore-checksum -vv
# → There was nothing to transfer

# Modify EXIF description locally
exiftool -ImageDescription="Spectacular Mountain Range" test_photos_exif/image.jpg

# Third run — MD5 changed, triggers re-upload with new description
./rclone copy test_photos_exif/image.jpg gphotos_cache:album/rclone_Metadata_Test/ \
  --gphotos-upload-exif-description --gphotos-batch-mode=sync \
  --ignore-size --ignore-checksum -vv
# → 2026/.../INFO : image.jpg: Copied (replaced existing)
```

Verify in the **Google Photos web UI** that the description for `image.jpg` in `rclone_Metadata_Test` now shows **"Spectacular Mountain Range"** ✓

---

## Automated Tests

Self-contained unit tests are added to verify the metadata extraction:
- `TestEXIFDescriptionMapping`: Mocks the batch upload flow using an in-memory TIFF file with an EXIF `ImageDescription` tag.
- `TestExtractEXIFDescriptionXMP`: Mocks the Dublin Core nested XMP tag parsing flow using an in-memory TIFF with a synthesized XMP block.

```
$ go test -v ./backend/googlephotos/...
=== RUN   TestEXIFDescriptionMapping
--- PASS: TestEXIFDescriptionMapping (0.00s)
=== RUN   TestExtractEXIFDescriptionXMP
--- PASS: TestExtractEXIFDescriptionXMP (0.00s)
...all other existing tests PASS...
ok  	github.com/rclone/rclone/backend/googlephotos	1.339s
```

---

## Notes

- No EXIF extraction happens when `--gphotos-upload-exif-description` is not set (zero performance impact by default).
- If no matching tag is found, the description is left empty (no error).
- The tag list is user-configurable to accommodate different metadata workflows (Lightroom, Darktable, camera-native EXIF, etc.).

## Dependencies (gh-stack)

This PR is independent and has no dependencies.

#### Was the change discussed in an issue or in the forum before?

As far as I know, this was not discussed previously. This is a new feature to map EXIF/IPTC/XMP description metadata to Google Photos descriptions on upload.

---

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
