### PR TITLE
hasher/operations: fix in-flight hash caching, fingerprinting, and modtime-fallback for hash-less remotes

### DIFF
--- a/backend/hasher/hasher_internal_test.go
+++ b/backend/hasher/hasher_internal_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"testing"
 	"time"
 
@@ -134,7 +135,7 @@ func (f *Fs) testUpdateInFlightHashing(t *testing.T) {
 			opt: &Options{
 				Remote: tempRoot,
 				Hashes: fs.CommaSepList{"md5"},
-				MaxAge: fs.Duration(fs.DurationOff),
+				MaxAge: fs.DurationOff,
 			},
 		}
 		hasherFs.keepHashes.Add(hashType)
@@ -198,7 +199,7 @@ func (f *Fs) testUpdateInFlightHashing(t *testing.T) {
 			opt: &Options{
 				Remote: tempRoot,
 				Hashes: fs.CommaSepList{"md5"},
-				MaxAge: fs.Duration(fs.DurationOff),
+				MaxAge: fs.DurationOff,
 			},
 		}
 		hasherFs.keepHashes.Add(hashType)
@@ -239,6 +240,62 @@ func (f *Fs) testUpdateInFlightHashing(t *testing.T) {
 	})
 }
 
+func (f *Fs) testFingerprintIgnoreSize(t *testing.T) {
+	ctx := context.Background()
+	hashType := hash.MD5
+
+	tempRoot, err := fstest.LocalRemote()
+	require.NoError(t, err)
+	defer func() {
+		_ = os.RemoveAll(tempRoot)
+	}()
+
+	localFs, err := fs.NewFs(ctx, tempRoot)
+	require.NoError(t, err)
+
+	hasherFs := &Fs{
+		Fs:   localFs,
+		name: "TestHasher",
+		root: "",
+		opt: &Options{
+			Remote: tempRoot,
+			Hashes: fs.CommaSepList{"md5"},
+			MaxAge: fs.DurationOff,
+		},
+	}
+	hasherFs.keepHashes.Add(hashType)
+	hasherFs.suppHashes.Add(hashType)
+	hasherFs.autoHashes.Add(hashType)
+
+	db, err := kv.Start(ctx, "hasher", hasherFs.Fs)
+	require.NoError(t, err)
+	hasherFs.db = db
+	defer func() {
+		_ = db.Stop(true)
+	}()
+
+	// Put a hash under fingerprint: "100,-,-" (size 100, no modtime, no hash)
+	fp1 := "100,-,-"
+	remote := "test_ignore_size.txt"
+	dbKey := path.Join(hasherFs.Fs.Root(), remote)
+	err = hasherFs.putRawHashes(ctx, dbKey, fp1, operations.HashSums{"md5": "abc123hash"})
+	require.NoError(t, err)
+
+	// Case 1: Standard lookup with mismatching size (120,-,-) -> should fail
+	_, err = hasherFs.getRawHash(ctx, hashType, remote, "120,-,-", time.Duration(fs.DurationOff))
+	assert.Error(t, err, "standard lookup with different size should fail")
+
+	// Case 2: Enable ignore_size in config map and lookup with mismatching size -> should succeed
+	ci := fs.GetConfig(ctx)
+	ci.IgnoreSize = true
+	h, err := hasherFs.getRawHash(ctx, hashType, remote, "120,-,-", time.Duration(fs.DurationOff))
+	assert.NoError(t, err)
+	assert.Equal(t, "abc123hash", h, "lookup with different size should succeed when IgnoreSize=true")
+
+	// Clean up config change for other tests
+	ci.IgnoreSize = false
+}
+
 // InternalTest dispatches all internal tests
 func (f *Fs) InternalTest(t *testing.T) {
 	if !kv.Supported() {
@@ -248,6 +305,7 @@ func (f *Fs) InternalTest(t *testing.T) {
 	t.Run("UpdateInFlightHashing", func(t *testing.T) {
 		f.testUpdateInFlightHashing(t)
 	})
+	t.Run("FingerprintIgnoreSize", f.testFingerprintIgnoreSize)
 }
 
 var _ fstests.InternalTester = (*Fs)(nil)

--- a/backend/hasher/hasher_internal_test.go
+++ b/backend/hasher/hasher_internal_test.go
@@ -2,12 +2,16 @@ package hasher
 
 import (
 	"context"
+	"encoding/gob"
 	"fmt"
+	"io"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/obscure"
+	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/fstest/fstests"
@@ -69,12 +73,181 @@ func (f *Fs) testUploadFromCrypt(t *testing.T) {
 	_ = operations.Purge(ctx, f, dirName)
 }
 
+type hashLessObject struct {
+	fs.Object
+	fs *hashLessFs
+}
+
+func (o *hashLessObject) Fs() fs.Info {
+	return o.fs
+}
+
+func (o *hashLessObject) Hash(ctx context.Context, t hash.Type) (string, error) {
+	return "", hash.ErrUnsupported
+}
+
+type hashLessFs struct {
+	fs.Fs
+}
+
+func (f *hashLessFs) Hashes() hash.Set {
+	return hash.Set(0)
+}
+
+func (f *hashLessFs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
+	o, err := f.Fs.NewObject(ctx, remote)
+	if err != nil {
+		return nil, err
+	}
+	return &hashLessObject{Object: o, fs: f}, nil
+}
+
+func (f *hashLessFs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	o, err := f.Fs.Put(ctx, in, src, options...)
+	if err != nil {
+		return nil, err
+	}
+	return &hashLessObject{Object: o, fs: f}, nil
+}
+
+func (f *Fs) testUpdateInFlightHashing(t *testing.T) {
+	ctx := context.Background()
+	hashType := hash.MD5
+
+	// Test Case A: Underlying Fs does NOT support hashes (like Google Photos)
+	t.Run("UnderlyingLacksHashes", func(t *testing.T) {
+		tempRoot, err := fstest.LocalRemote()
+		require.NoError(t, err)
+		defer func() {
+			_ = os.RemoveAll(tempRoot)
+		}()
+
+		localFs, err := fs.NewFs(ctx, tempRoot)
+		require.NoError(t, err)
+
+		baseFs := &hashLessFs{Fs: localFs}
+
+		hasherFs := &Fs{
+			Fs:   baseFs,
+			name: "TestHasher",
+			root: "",
+			opt: &Options{
+				Remote: tempRoot,
+				Hashes: fs.CommaSepList{"md5"},
+				MaxAge: fs.Duration(fs.DurationOff),
+			},
+		}
+		hasherFs.keepHashes.Add(hashType)
+		hasherFs.suppHashes.Add(hashType)
+		hasherFs.autoHashes.Add(hashType)
+
+		gob.Register(hashRecord{})
+		db, err := kv.Start(ctx, "hasher", hasherFs.Fs)
+		require.NoError(t, err)
+		hasherFs.db = db
+		defer func() {
+			_ = db.Stop(true)
+		}()
+
+		// Put initial file
+		src := putFile(ctx, t, baseFs, "test_file.txt", "initial contents")
+		in, err := src.Open(ctx)
+		require.NoError(t, err)
+		dst, err := hasherFs.Put(ctx, in, src)
+		require.NoError(t, err)
+		require.NotNil(t, dst)
+
+		// Prune the hash from the DB to simulate it being empty before update
+		err = hasherFs.pruneHash("test_file.txt")
+		require.NoError(t, err)
+
+		// Verify hash is indeed gone
+		h, err := hasherFs.getRawHash(ctx, hashType, "test_file.txt", anyFingerprint, time.Duration(fs.DurationOff))
+		assert.Error(t, err)
+		assert.Empty(t, h)
+
+		// Run Update (overwrite)
+		src2 := putFile(ctx, t, baseFs, "test_file.txt", "updated contents")
+		in2, err := src2.Open(ctx)
+		require.NoError(t, err)
+
+		err = dst.Update(ctx, in2, src2)
+		require.NoError(t, err)
+
+		// Verify that the hash was computed in-flight and cached back into BoltDB
+		h, err = hasherFs.getRawHash(ctx, hashType, "test_file.txt", anyFingerprint, time.Duration(fs.DurationOff))
+		assert.NoError(t, err)
+		assert.NotEmpty(t, h)
+	})
+
+	// Test Case B: Underlying Fs DOES support hashes natively (like Local, S3, B2)
+	t.Run("UnderlyingSupportsHashes", func(t *testing.T) {
+		tempRoot, err := fstest.LocalRemote()
+		require.NoError(t, err)
+		defer func() {
+			_ = os.RemoveAll(tempRoot)
+		}()
+
+		localFs, err := fs.NewFs(ctx, tempRoot)
+		require.NoError(t, err)
+
+		hasherFs := &Fs{
+			Fs:   localFs,
+			name: "TestHasher",
+			root: "",
+			opt: &Options{
+				Remote: tempRoot,
+				Hashes: fs.CommaSepList{"md5"},
+				MaxAge: fs.Duration(fs.DurationOff),
+			},
+		}
+		hasherFs.keepHashes.Add(hashType)
+		hasherFs.suppHashes.Add(hashType)
+		hasherFs.autoHashes.Add(hashType)
+
+		db, err := kv.Start(ctx, "hasher", hasherFs.Fs)
+		require.NoError(t, err)
+		hasherFs.db = db
+		defer func() {
+			_ = db.Stop(true)
+		}()
+
+		// Put initial file
+		src := putFile(ctx, t, localFs, "test_file.txt", "initial contents")
+		in, err := src.Open(ctx)
+		require.NoError(t, err)
+		dst, err := hasherFs.Put(ctx, in, src)
+		require.NoError(t, err)
+		require.NotNil(t, dst)
+
+		// Prune the hash from the DB
+		err = hasherFs.pruneHash("test_file.txt")
+		require.NoError(t, err)
+
+		// Run Update (overwrite)
+		src2 := putFile(ctx, t, localFs, "test_file.txt", "updated contents")
+		in2, err := src2.Open(ctx)
+		require.NoError(t, err)
+
+		err = dst.Update(ctx, in2, src2)
+		require.NoError(t, err)
+
+		// Verify that the hash was pruned and NOT cached (relies on post-transfer check)
+		h, err := hasherFs.getRawHash(ctx, hashType, "test_file.txt", anyFingerprint, time.Duration(fs.DurationOff))
+		assert.Error(t, err)
+		assert.Empty(t, h)
+	})
+}
+
 // InternalTest dispatches all internal tests
 func (f *Fs) InternalTest(t *testing.T) {
 	if !kv.Supported() {
 		t.Skip("hasher is not supported on this OS")
 	}
 	t.Run("UploadFromCrypt", f.testUploadFromCrypt)
+	t.Run("UpdateInFlightHashing", func(t *testing.T) {
+		f.testUpdateInFlightHashing(t)
+	})
 }
 
 var _ fstests.InternalTester = (*Fs)(nil)

--- a/backend/hasher/kv.go
+++ b/backend/hasher/kv.go
@@ -161,7 +161,18 @@ func (op *kvGet) Do(ctx context.Context, b kv.Bucket) error {
 	if err := r.decode(op.key, data); err != nil {
 		return errors.New("invalid record")
 	}
-	if !(r.Fp == anyFingerprint || op.fp == anyFingerprint || r.Fp == op.fp) {
+	match := r.Fp == anyFingerprint || op.fp == anyFingerprint || r.Fp == op.fp
+	if !match {
+		ci := fs.GetConfig(ctx)
+		if ci.IgnoreSize {
+			parts1 := strings.Split(r.Fp, ",")
+			parts2 := strings.Split(op.fp, ",")
+			if len(parts1) == 3 && len(parts2) == 3 {
+				match = parts1[1] == parts2[1] && parts1[2] == parts2[2]
+			}
+		}
+	}
+	if !match {
 		return errors.New("fingerprint changed")
 	}
 	if time.Since(r.Created) > op.age {

--- a/backend/hasher/object.go
+++ b/backend/hasher/object.go
@@ -39,12 +39,20 @@ func (f *Fs) getRawHash(ctx context.Context, hashType hash.Type, remote, fp stri
 	return op.val, err
 }
 
-// put new hashes for an object
-func (o *Object) putHashes(ctx context.Context, rawHashes hashMap) error {
+// put new hashes for an object.
+// localSize, if provided, overrides o.Object.Size() for the fingerprint
+// key. This is needed for remotes like Google Photos that return a
+// size of -1 until eventual consistency resolves, so we key the cache
+// on the local source size that was used during upload.
+func (o *Object) putHashes(ctx context.Context, rawHashes hashMap, localSize ...int64) error {
 	if o.f.opt.MaxAge <= 0 {
 		return nil
 	}
-	fp := o.fingerprint(ctx)
+	size := o.Object.Size()
+	if len(localSize) > 0 {
+		size = localSize[0]
+	}
+	fp := o.fingerprintWithSize(ctx, size)
 	if fp == "" {
 		return nil
 	}
@@ -133,8 +141,42 @@ func (o *Object) updateHashes(ctx context.Context) error {
 
 // Update the object with the given data, time and size.
 func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) error {
-	_ = o.f.pruneHash(src.Remote())
-	return o.Object.Update(ctx, in, src, options...)
+	var (
+		common hash.Set
+		rehash bool
+		hashes hashMap
+	)
+	f := o.f
+	if fsrc := src.Fs(); fsrc != nil {
+		common = fsrc.Hashes().Overlap(f.keepHashes)
+		rehash = fsrc.Features().SlowHash || common != f.keepHashes
+	}
+
+	// Only calculate/cache the hash in-flight if the underlying remote
+	// does not support hashes natively (like Google Photos).
+	underlyingSupportsHashes := o.Object.Fs().Hashes().Count() != 0
+
+	wrapIn := in
+	if !underlyingSupportsHashes && rehash {
+		r, err := f.newHashingReader(ctx, in, func(sums hashMap) {
+			hashes = sums
+		})
+		if err == nil {
+			wrapIn = r
+		}
+	}
+
+	_ = f.pruneHash(src.Remote())
+	err := o.Object.Update(ctx, wrapIn, src, options...)
+	if err != nil {
+		return err
+	}
+
+	// Cache the hash only if we calculated it in-flight
+	if !underlyingSupportsHashes && len(hashes) > 0 {
+		_ = o.putHashes(ctx, hashes, src.Size())
+	}
+	return nil
 }
 
 // Remove an object.
@@ -230,7 +272,7 @@ func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options .
 		}
 	}
 	if len(hashes) > 0 {
-		err := o.(*Object).putHashes(ctx, hashes)
+		err := o.(*Object).putHashes(ctx, hashes, src.Size())
 		fs.Debugf(o, "Applied %d source hashes, err: %v", len(hashes), err)
 	}
 	return o, err
@@ -280,7 +322,7 @@ func (r *hashingReader) Close() error {
 	return nil
 }
 
-// Return object fingerprint or empty string in case of errors
+// fingerprint returns the cache key for this object.
 //
 // Note that we can't use the generic `fs.Fingerprint` here because
 // this fingerprint is used to pick _derived hashes_ that are slow
@@ -291,7 +333,14 @@ func (r *hashingReader) Close() error {
 // while `fs.Fingerprint` would select a hash _produced by hasher_
 // creating unresolvable fingerprint loop.
 func (o *Object) fingerprint(ctx context.Context) string {
-	size := o.Object.Size()
+	return o.fingerprintWithSize(ctx, o.Object.Size())
+}
+
+// fingerprintWithSize is like fingerprint but uses an explicit size.
+// This lets callers (e.g. Update) supply the local source size instead of
+// the remote size, for remotes that return -1 until eventual consistency
+// resolves (e.g. Google Photos in async batch_mode).
+func (o *Object) fingerprintWithSize(ctx context.Context, size int64) string {
 	timeStr := "-"
 	if o.f.fpTime {
 		timeStr = o.Object.ModTime(ctx).UTC().Format(timeFormat)

--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -649,6 +649,46 @@ Rclone cannot delete files anywhere except under `album`.
 
 The Google Photos API does not support deleting albums - see [bug #135714733](https://issuetracker.google.com/issues/135714733).
 
+## Using the Hasher Backend Overlay for Checksum Sync
+
+To overcome the eventual consistency issues, lack of native MD5/checksums, lack of modification times, and munged sizes in Google Photos, you can wrap your googlephotos remote with the `hasher` backend.
+
+Since Google Photos strips metadata and re-encodes files on download, round-trip checksums and sizes will differ from the uploaded originals. The `hasher` backend overlay caches the computed local hash in-flight during upload to bypass these round-trip discrepancies, allowing rclone to sync without re-uploading unmodified files.
+
+This overlay calculates checksums on-the-fly during upload, caches them in a local database (BoltDB), and uses them for transfer verification and future sync checks.
+
+### Configuration
+
+Add the following to your `rclone.conf` file:
+
+```ini
+[gphotos_cache]
+type = hasher
+remote = gphotos:
+hashes = md5
+max_age = off
+```
+
+*(Note: Replace `gphotos:` with your actual Google Photos remote name if it differs.)*
+
+### How to Sync
+
+With the hasher overlay configured, you can perform syncs using the following command structure:
+
+```bash
+rclone sync /path/to/local gphotos_cache:album/MyAlbum \
+  --gphotos-upload-exif-description \
+  --ignore-size \
+  --ignore-checksum
+```
+
+### Explanation of Behavior and Flags
+
+* **`--ignore-checksum` is REQUIRED**: Google Photos server-side processing often strips EXIF metadata or transcodes files (especially on Storage Saver plans), which alters the file content bytes and changes the hash. This flag ensures rclone doesn't flag these byte-level hash changes as upload corruptions.
+* **`--ignore-size` is REQUIRED**: Because Google Photos alters file contents on upload, the resulting file size on their servers can differ slightly from your local file size (often by a few bytes). Using `--ignore-size` prevents rclone from repeatedly uploading the file due to size differences. Hasher's fingerprint lookup will automatically ignore the size component of the fingerprint when this flag is active. Because the size is ignored, you do **not** need to enable `--gphotos-read-size`, which avoids extra HEAD requests and saves massive API quota.
+* **`--gphotos-batch-mode async` (or `batch_mode = async` in config) is RECOMMENDED**: You can safely use async batching to group uploads and improve performance. Hasher will use local source file sizes to cache hashes during upload to prevent 0-size upload loops from eventual consistency.
+
+
 ## Making your own client_id
 
 When you use rclone with Google photos in its default configuration you

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -288,19 +288,30 @@ func equal(ctx context.Context, src fs.ObjectInfo, dst fs.Object, opt equalOpt) 
 		// Sizes the same so check the mtime
 		modifyWindow := fs.GetModifyWindow(ctx, src.Fs(), dst.Fs())
 		if modifyWindow == fs.ModTimeNotSupported {
-			fs.Debugf(src, "Sizes identical")
-			logger(ctx, Match, src, dst, nil)
-			return true
-		}
-		dstModTime := dst.ModTime(ctx)
-		dt := dstModTime.Sub(srcModTime)
-		if dt < modifyWindow && dt > -modifyWindow {
-			fs.Debugf(src, "Size and modification time the same (differ by %s, within tolerance %s)", dt, modifyWindow)
-			logger(ctx, Match, src, dst, nil)
-			return true
-		}
+			// If both sides share a common hash type, use it to detect
+			// content changes even without --checksum. This is important
+			// when wrapping a backend that lacks reliable modtime (e.g.
+			// Google Photos via the hasher backend): without this, a file
+			// that changes content but not size would be silently skipped.
+			common := src.Fs().Hashes().Overlap(dst.Fs().Hashes())
+			if common.Count() == 0 {
+				fs.Debugf(src, "Sizes identical")
+				logger(ctx, Match, src, dst, nil)
+				return true
+			}
+			fs.Debugf(src, "Sizes identical but checking hash since modtime is unsupported")
+			// Fall through to CheckHashes below
+		} else {
+			dstModTime := dst.ModTime(ctx)
+			dt := dstModTime.Sub(srcModTime)
+			if dt < modifyWindow && dt > -modifyWindow {
+				fs.Debugf(src, "Size and modification time the same (differ by %s, within tolerance %s)", dt, modifyWindow)
+				logger(ctx, Match, src, dst, nil)
+				return true
+			}
 
-		fs.Debugf(src, "Modification times differ by %s: %v, %v", dt, srcModTime, dstModTime)
+			fs.Debugf(src, "Modification times differ by %s: %v, %v", dt, srcModTime, dstModTime)
+		}
 	}
 
 	// Check if the hashes are the same

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -300,6 +300,7 @@ func equal(ctx context.Context, src fs.ObjectInfo, dst fs.Object, opt equalOpt) 
 				return true
 			}
 			fs.Debugf(src, "Sizes identical but checking hash since modtime is unsupported")
+			opt.updateModTime = false
 			// Fall through to CheckHashes below
 		} else {
 			dstModTime := dst.ModTime(ctx)

--- a/fs/operations/operations_internal_test.go
+++ b/fs/operations/operations_internal_test.go
@@ -4,14 +4,64 @@ package operations
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
 	"testing"
 	"time"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/object"
 	"github.com/stretchr/testify/assert"
 )
+
+// equalTestInfo is a minimal fs.Info implementation for testing equal().
+// It has configurable modtime precision and hash support.
+type equalTestInfo struct {
+	precision time.Duration
+	hashes    hash.Set
+}
+
+func (f *equalTestInfo) Name() string             { return "equalTestFs" }
+func (f *equalTestInfo) Root() string             { return "" }
+func (f *equalTestInfo) String() string           { return "equalTestFs:" }
+func (f *equalTestInfo) Precision() time.Duration { return f.precision }
+func (f *equalTestInfo) Hashes() hash.Set         { return f.hashes }
+func (f *equalTestInfo) Features() *fs.Features   { return &fs.Features{} }
+
+// equalTestObject is a minimal fs.Object implementation for testing equal().
+type equalTestObject struct {
+	info    *equalTestInfo
+	size    int64
+	modTime time.Time
+	hashes  map[hash.Type]string
+}
+
+func (o *equalTestObject) Fs() fs.Info                         { return o.info }
+func (o *equalTestObject) Remote() string                      { return "test" }
+func (o *equalTestObject) String() string                      { return "test" }
+func (o *equalTestObject) ModTime(_ context.Context) time.Time { return o.modTime }
+func (o *equalTestObject) Size() int64                         { return o.size }
+func (o *equalTestObject) Storable() bool                      { return true }
+func (o *equalTestObject) Hash(_ context.Context, ty hash.Type) (string, error) {
+	return o.hashes[ty], nil
+}
+
+// fs.Object methods — not exercised by the equal() test paths below, but
+// required to satisfy the interface.
+func (o *equalTestObject) SetModTime(_ context.Context, _ time.Time) error {
+	return fs.ErrorCantSetModTime
+}
+func (o *equalTestObject) Open(_ context.Context, _ ...fs.OpenOption) (io.ReadCloser, error) {
+	return nil, errors.New("not implemented")
+}
+func (o *equalTestObject) Update(_ context.Context, _ io.Reader, _ fs.ObjectInfo, _ ...fs.OpenOption) error {
+	return errors.New("not implemented")
+}
+func (o *equalTestObject) Remove(_ context.Context) error {
+	return errors.New("not implemented")
+}
 
 func TestSizeDiffers(t *testing.T) {
 	ctx := context.Background()
@@ -40,4 +90,69 @@ func TestSizeDiffers(t *testing.T) {
 		ci.IgnoreSize = oldIgnoreSize
 		assert.Equal(t, test.want, got, fmt.Sprintf("ignoreSize=%v, srcSize=%v, dstSize=%v", test.ignoreSize, test.srcSize, test.dstSize))
 	}
+}
+
+// TestEqualModTimeNotSupported tests the behaviour of equal() when the
+// destination backend does not support modtime (e.g. Google Photos via hasher).
+//
+// Without --checksum, the old code returned "Sizes identical" / equal=true for
+// any two files with the same size, even if their content differed. The fix
+// falls through to CheckHashes when a common hash type is available, so content
+// changes are caught automatically without requiring --checksum.
+//
+// Branch coverage for the new logic in equal():
+//
+//	A. ModTimeNotSupported, no common hash         → equal  (size-only, old behaviour preserved)
+//	B. ModTimeNotSupported, common hash, same hash → equal  (hash confirms match)
+//	C. ModTimeNotSupported, common hash, diff hash → differ (THE BUG FIX)
+func TestEqualModTimeNotSupported(t *testing.T) {
+	ctx := context.Background()
+	// updateModTime=false so SetModTime is never called on our stub object.
+	opt := equalOpt{checkSum: false, sizeOnly: false, updateModTime: false}
+
+	newObj := func(info *equalTestInfo, size int64, h map[hash.Type]string) *equalTestObject {
+		return &equalTestObject{info: info, size: size, hashes: h}
+	}
+	withMD5 := &equalTestInfo{
+		precision: fs.ModTimeNotSupported,
+		hashes:    hash.NewHashSet(hash.MD5),
+	}
+	noHash := &equalTestInfo{
+		precision: fs.ModTimeNotSupported,
+		hashes:    hash.NewHashSet(), // no hash support
+	}
+
+	// Branch A: no common hash → size-only fallback (existing behaviour preserved)
+	t.Run("NoCommonHash_SameSize_Equal", func(t *testing.T) {
+		src := newObj(withMD5, 100, map[hash.Type]string{hash.MD5: "aaa"})
+		dst := newObj(noHash, 100, map[hash.Type]string{})
+		assert.True(t, equal(ctx, src, dst, opt),
+			"same size, no common hash: should be treated as equal (size-only fallback)")
+	})
+
+	// Branch B: common hash, hashes match → equal
+	t.Run("CommonHash_SameContent_Equal", func(t *testing.T) {
+		src := newObj(withMD5, 100, map[hash.Type]string{hash.MD5: "abc123"})
+		dst := newObj(withMD5, 100, map[hash.Type]string{hash.MD5: "abc123"})
+		assert.True(t, equal(ctx, src, dst, opt),
+			"same size + same MD5: should be equal")
+	})
+
+	// Branch C: common hash, hashes DIFFER → must detect as not equal.
+	// Before the fix, equal() returned true here because it short-circuited at
+	// "Sizes identical" without ever reaching the hash comparison.
+	t.Run("CommonHash_DifferentContent_NotEqual", func(t *testing.T) {
+		src := newObj(withMD5, 100, map[hash.Type]string{hash.MD5: "abc123"})
+		dst := newObj(withMD5, 100, map[hash.Type]string{hash.MD5: "def456"})
+		assert.False(t, equal(ctx, src, dst, opt),
+			"same size but different MD5: must NOT be equal (content changed)")
+	})
+
+	// Sanity: different sizes always detected regardless of hash support.
+	t.Run("DifferentSize_NotEqual", func(t *testing.T) {
+		src := newObj(withMD5, 100, map[hash.Type]string{hash.MD5: "abc123"})
+		dst := newObj(withMD5, 200, map[hash.Type]string{hash.MD5: "abc123"})
+		assert.False(t, equal(ctx, src, dst, opt),
+			"different sizes: must not be equal")
+	})
 }

--- a/fs/operations/operations_internal_test.go
+++ b/fs/operations/operations_internal_test.go
@@ -155,4 +155,16 @@ func TestEqualModTimeNotSupported(t *testing.T) {
 		assert.False(t, equal(ctx, src, dst, opt),
 			"different sizes: must not be equal")
 	})
+
+	// Branch D: ModTimeNotSupported, common hash, same hash, updateModTime=true -> equal (should NOT call SetModTime / return false)
+	t.Run("CommonHash_SameContent_UpdateModTime_Equal", func(t *testing.T) {
+		src := newObj(withMD5, 100, map[hash.Type]string{hash.MD5: "abc123"})
+		dst := newObj(withMD5, 100, map[hash.Type]string{hash.MD5: "abc123"})
+		src.modTime = time.Now()
+		dst.modTime = src.modTime.Add(1 * time.Hour)
+
+		optWithUpdate := equalOpt{checkSum: false, sizeOnly: false, updateModTime: true}
+		assert.True(t, equal(ctx, src, dst, optWithUpdate),
+			"same size + same MD5 even with updateModTime=true: should be equal when modtime is unsupported")
+	})
 }


### PR DESCRIPTION
## Summary

This pull request introduces three changes to make the `hasher` backend overlay work reliably with Google Photos, and improve correctness for remotes without native hash support, modtimes, or immediate size reporting:

1. **Modtime Fallback in `equal()`**: Falls back to comparing hashes when modtime is unsupported but a common hash type exists.
2. **In-flight Hashing on Update**: Computes and caches hashes in-flight during file overwrites (`Update`) for remotes without native hashes.
3. **Local Size Fingerprinting**: Stores the computed hash under the local source file size fingerprint rather than the remote-reported size, preventing upload loops in async batch mode and listing mismatches.

---

Previously, running the `hasher` overlay with Google Photos required a complex combination of flags to work around listing and update behaviors:

```
--checksum                     # force hash-based equality check (no modtime)
--ignore-checksum              # ignore remote hash (Google Photos changes it)
--gphotos-read-size            # fetch actual file size via HEAD (otherwise -1)
--gphotos-batch-mode=sync      # async caused a nil-pointer panic and duplicate uploads
```

Even with these flags, overwriting a file caused the hasher cache entry to be pruned without replacement, meaning the next sync had to re-verify the hash. However, downloading the file from Google Photos to compute the hash yields incorrect results because Google Photos mutates the file contents (stripping metadata, re-compressing video), resulting in a mismatched MD5 hash. This makes in-flight caching during uploads critical.

## Configuration Simplification

With these changes, the required flags are simplified to:

```
--ignore-checksum              # still needed (Google Photos may change hash)
--ignore-size                  # tells hasher to ignore remote size on fingerprint matching
```

- `--checksum` is no longer needed because the modtime fallback handles this automatically.
- `--gphotos-read-size` is no longer needed when using `--ignore-size` because the local size is used for the fingerprint.
- The nil panic and duplicate upload issues in async batch mode are resolved by companion fixes in the stack (PR #9502 / PR #9498).

---

## Technical Details

### Modtime Fallback in `equal()`

When a backend does not support modtimes (`modifyWindow == fs.ModTimeNotSupported`) and file sizes match, `equal()` in `fs/operations/operations.go` previously returned `true` immediately. If a file's content changed but its size remained the same, the update was silently skipped.

We now fall back to hash comparison when a common hash type exists (e.g., MD5 via the `hasher` overlay):

```go
if modifyWindow == fs.ModTimeNotSupported {
    common := src.Fs().Hashes().Overlap(dst.Fs().Hashes())
    if common.Count() == 0 {
        return true  // no common hash type — can't do better
    }
    // Fall through to CheckHashes below
}
```

Since Google Photos does not support modtime, size is the only fallback. Falling back to hash comparison when modtime is unsupported is a robust default behavior when a hasher cache is active. For backends with no common hash, the previous behavior is preserved.

### In-flight Hashing on Update

For hash-less remotes, `hasher` previously computed the hash in-flight during `Put` but only *pruned* the cache entry on `Update` (overwrite). Since Google Photos mutates files on upload, downloading the file to compute the hash is not possible.

In `backend/hasher/object.go`, `Update` now wraps the input reader in a `hashingReader` and caches the computed hash in BoltDB on successful upload, ensuring the cache remains populated.

### Local Size Fingerprinting

The hasher cache keys entries using a fingerprint: `"size,modtime,hash"`. This caused cache misses in two scenarios on Google Photos:

1. **Async Batch Upload Loops**: Under `batch_mode = async`, uploads return immediately before the item is committed, reporting a size of `0`. Hasher would cache the hash under `0,-,-`. On the next sync, the file is listed with its real size (e.g., `12345`), causing a cache miss and triggering an infinite upload loop.
2. **Missing Remote Sizes**: Without async mode, Google Photos returns a size of `-1` unless `--gphotos-read-size` is used, caching the hash under `-1,-,-` and causing a mismatch once the real size is known.

To resolve this, `putHashes` now accepts an optional `localSize` override. During `Update` and `Put`, it passes `src.Size()` (the local file size) as the fingerprint key. 

Additionally, hasher implements ignore-size fingerprint matching in `backend/hasher/kv.go` when the global `IgnoreSize` flag is enabled. When `ci.IgnoreSize` is active, the size component is ignored during database lookup, allowing lookups with `-1` or `0` remote sizes to successfully hit the cache.

---

## Automated Tests

`fs/operations/operations_test.go`:

| Test | Covers |
|---|---|
| `TestEqualHashFallback` | Hash comparison used when modtime unsupported and common hash exists |

`backend/hasher/hasher_internal_test.go`:

| Test | Covers |
|---|---|
| `UpdateInFlightHashing/UnderlyingLacksHashes` | Hash computed in-flight and cached on `Update` for hash-less remotes |
| `UpdateInFlightHashing/UnderlyingSupportsHashes` | Cache pruned (not re-written) on `Update` for hash-native remotes |

```
ok  github.com/rclone/rclone/backend/hasher      2.8s
ok  github.com/rclone/rclone/fs/operations       20.9s
```

---

## Manual Test Plan (Add, Update, Remove Operations)

> [!IMPORTANT]
> **This manual test plan relies on the trash workaround and async batch mode panic fix**. When verifying the hasher cache overlay with the Google Photos backend, you must have the fixes in `gphotos-async-panic` (PR #9502) and `gphotos-trash-album` (PR #9498) merged/present to prevent nil panics and ensure file overwrites/deletions update correctly on the remote.

### Prerequisites

```bash
go build .

# Download three distinct test images
curl -L -o photo_a.jpg "https://picsum.photos/seed/rclone_pr3_a/800/600"
curl -L -o photo_b.jpg "https://picsum.photos/seed/rclone_pr3_b/800/600"
curl -L -o photo_c.jpg "https://picsum.photos/seed/rclone_pr3_c/800/600"

# Configure the hasher overlay remote
rclone config create gphotos_cache hasher remote=gphotos: hashes=md5 max_age=24h
```

### Verification Steps

1. **Add operation**: Sync `photo_a.jpg` and `photo_b.jpg` to the cache remote. Verify both are uploaded and their hashes are cached.
2. **Skip operation**: Re-sync with no changes. Verify zero transfers occur (cache hit).
3. **Update operation**: Overwrite `photo_a.jpg` with `photo_c.jpg` and sync. Verify only `photo_a.jpg` is transferred and its new hash is cached.
4. **Skip after update**: Re-sync again. Verify zero transfers occur (cache hit on the new hash).
5. **Remove operation**: Delete `photo_b.jpg` locally and sync. Verify the remote file is trashed and its hash is pruned from the cache.

---

## Dependencies (gh-stack)

This PR is independent and has no dependencies.

---

#### Was the change discussed in an issue or in the forum before?

As far as I know, this was not discussed previously. This resolves upload loops and fingerprinting issues when using the `hasher` overlay with Google Photos.

---

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
