### PR TITLE
googlephotos: fix nil panic in Update when using async batch_mode

### DIFF
--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -486,6 +486,7 @@ func (f *Fs) newObjectWithInfo(ctx context.Context, remote string, info *api.Med
 	o := &Object{
 		fs:     f,
 		remote: remote,
+		bytes:  -1,
 	}
 	if info != nil {
 		o.setMetaData(info)
@@ -654,6 +655,7 @@ func (f *Fs) itemToDirEntry(ctx context.Context, remote string, item *api.MediaI
 	o := &Object{
 		fs:     f,
 		remote: remote,
+		bytes:  -1,
 	}
 	o.setMetaData(item)
 	return o, nil
@@ -736,6 +738,7 @@ func (f *Fs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options .
 	o := &Object{
 		fs:     f,
 		remote: src.Remote(),
+		bytes:  -1,
 	}
 	return o, o.Update(ctx, in, src, options...)
 }
@@ -914,11 +917,18 @@ func (o *Object) Size() int64 {
 	return o.bytes
 }
 
-// setMetaData sets the fs data from a storage.Object
+// setMetaData sets the fs data from a storage.Object.
+// If info is nil (e.g. when using async batch_mode and the item has not yet
+// been committed), only o.bytes is set to -1 so the caller knows size is
+// unknown; all other fields retain their existing values.
 func (o *Object) setMetaData(info *api.MediaItem) {
+	if info == nil {
+		o.bytes = -1
+		return
+	}
 	o.url = info.BaseURL
 	o.id = info.ID
-	o.bytes = -1 // FIXME
+	o.bytes = -1 // FIXME: Google Photos API does not return size
 	o.mimeType = info.MimeType
 	o.modTime = info.MediaMetadata.CreationTime
 }
@@ -1199,7 +1209,15 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		return fmt.Errorf("failed to commit batch: %w", err)
 	}
 
-	o.setMetaData(info)
+	// In async batch_mode, info is nil until the batch is flushed later.
+	// setMetaData handles nil gracefully; we pre-populate bytes with the
+	// source size so the hasher overlay can cache the correct fingerprint
+	// without waiting for eventual consistency.
+	if info == nil {
+		o.bytes = src.Size()
+	} else {
+		o.setMetaData(info)
+	}
 
 	// Add upload to internal storage
 	if pattern.isUpload {

--- a/backend/googlephotos/googlephotos_workaround_test.go
+++ b/backend/googlephotos/googlephotos_workaround_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rclone/rclone/backend/googlephotos/api"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fstest/mockobject"
 	"github.com/rclone/rclone/lib/batcher"
 	"github.com/rclone/rclone/lib/pacer"
 	"github.com/rclone/rclone/lib/rest"
@@ -73,7 +74,8 @@ func TestAsyncBatchModePanic(t *testing.T) {
 	// assert.NotPanics documents the expected post-fix behaviour.
 	// Before the fix this panics with: "runtime error: invalid memory address
 	// or nil pointer dereference" inside setMetaData(info) when info is nil.
+	src := mockobject.New("photo.jpg").WithContent([]byte("content"), mockobject.SeekModeNone)
 	assert.NotPanics(t, func() {
-		_, _ = f.Put(ctx, strings.NewReader("content"), nil)
+		_, _ = f.Put(ctx, strings.NewReader("content"), src)
 	})
 }

--- a/backend/googlephotos/googlephotos_workaround_test.go
+++ b/backend/googlephotos/googlephotos_workaround_test.go
@@ -1,0 +1,79 @@
+package googlephotos
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/backend/googlephotos/api"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/lib/batcher"
+	"github.com/rclone/rclone/lib/pacer"
+	"github.com/rclone/rclone/lib/rest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestAsyncBatchModePanic is a regression test for the nil-pointer panic that
+// occurred when batch_mode=async was used. In async mode batcher.Commit
+// returns immediately with a nil *api.MediaItem result; the old code passed
+// that nil directly to o.setMetaData which dereferenced it unconditionally.
+//
+// This test should FAIL (panic) against the unfixed code and PASS after the fix.
+func TestAsyncBatchModePanic(t *testing.T) {
+	ctx := context.Background()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/albums":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(api.ListAlbums{
+				Albums: []api.Album{
+					{ID: "album1", Title: "my-album", IsWriteable: true},
+				},
+			})
+		case r.Method == "POST" && r.URL.Path == "/uploads":
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("upload-token-async"))
+		default:
+			// In async mode the batcher does not call batchCreate synchronously,
+			// so we should never reach mediaItems:batchCreate during Put.
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer ts.Close()
+
+	f := &Fs{
+		name:   "TestGphotos",
+		root:   "album/my-album",
+		unAuth: rest.NewClient(http.DefaultClient),
+		srv:    rest.NewClient(http.DefaultClient).SetRoot(ts.URL),
+		pacer:  fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(10*time.Millisecond))),
+		albums: map[bool]*albums{},
+		opt: Options{
+			BatchMode: "async",
+		},
+	}
+	f.srv.SetErrorHandler(errorHandler)
+
+	var err error
+	batcherOpts := defaultBatcherOptions
+	batcherOpts.Mode = f.opt.BatchMode
+	f.batcher, err = batcher.New(ctx, f, f.commitBatch, batcherOpts)
+	require.NoError(t, err)
+	defer f.batcher.Shutdown()
+
+	_, err = f.listAlbums(ctx, false)
+	require.NoError(t, err)
+
+	// assert.NotPanics documents the expected post-fix behaviour.
+	// Before the fix this panics with: "runtime error: invalid memory address
+	// or nil pointer dereference" inside setMetaData(info) when info is nil.
+	assert.NotPanics(t, func() {
+		_, _ = f.Put(ctx, strings.NewReader("content"), nil)
+	})
+}


### PR DESCRIPTION
## Summary

When `batch_mode=async` is configured, `batcher.Commit` returns immediately with a `nil` `*api.MediaItem` result (the actual commit happens later in a background goroutine). The old code passed this `nil` directly to `o.setMetaData(info)`, which dereferenced it and panicked:

```
runtime error: invalid memory address or nil pointer dereference
```

This PR adds a defensive nil guard to `setMetaData` and updates `Update` to use the local size when the API response is deferred, preventing the crash.

---

## Technical Details

- Adds a nil guard in `setMetaData(info)` to handle deferred results from async batcher commits.
- Uses `src.Size()` for `o.bytes` in `Update` when `info == nil` (so caching layers like the `hasher` overlay can immediately record the correct fingerprint).

---

## Automated Tests

Adds the `TestAsyncBatchModePanic` regression test in `backend/googlephotos/googlephotos_workaround_test.go` verifying the fix under async mode.

---

## Manual Verification

Run an upload/overwrite in async mode:
```bash
./rclone copy test_photo.jpg gphotos:album/rclone_PR4_Test \
  --gphotos-batch-mode=async --gphotos-batch-size=1 -v
```

Before the fix, this crashed immediately. After the fix, it succeeds without panic.

---

## Dependencies (gh-stack)

This PR is independent and has no dependencies.

---

#### Was the change discussed in an issue or in the forum before?

As far as I know, this was not discussed previously.

---

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
