### PR TITLE
vfs: add manual writeback mode

### DIFF
--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -11,6 +12,7 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/cache"
 	"github.com/rclone/rclone/fs/rc"
+	"github.com/rclone/rclone/vfs/vfscache"
 	"github.com/rclone/rclone/vfs/vfscache/writeback"
 )
 
@@ -556,4 +558,327 @@ func rcQueueSetExpiry(ctx context.Context, in rc.Params) (out rc.Params, err err
 	}
 	err = vfs.cache.QueueSetExpiry(writeback.Handle(id), refTime, time.Duration(float64(time.Second)*expiry))
 	return nil, err
+}
+
+type dirtySelector struct {
+	all   bool
+	files map[string]struct{}
+	dirs  []string
+}
+
+type manualResult struct {
+	Name  string `json:"name"`
+	Error string `json:"error,omitempty"`
+}
+
+func parseDirtySelector(in rc.Params, defaultAll, requireExplicit bool) (selector dirtySelector, err error) {
+	selector.files = map[string]struct{}{}
+
+	all, err := in.GetBool("all")
+	if err == nil {
+		selector.all = all
+		delete(in, "all")
+	} else if !rc.IsErrParamNotFound(err) {
+		return selector, err
+	}
+
+	for k, v := range in {
+		pathString, ok := v.(string)
+		if !ok {
+			return selector, fmt.Errorf("value must be string %q=%v", k, v)
+		}
+		pathString = strings.Trim(pathString, "/")
+		switch {
+		case strings.HasPrefix(k, "file"):
+			selector.files[pathString] = struct{}{}
+		case strings.HasPrefix(k, "dir"):
+			selector.dirs = append(selector.dirs, pathString)
+		default:
+			return selector, fmt.Errorf("unknown key %q", k)
+		}
+	}
+	if !selector.all && len(selector.files) == 0 && len(selector.dirs) == 0 {
+		if requireExplicit {
+			return selector, errors.New(`need at least one "file", "dir", or all=true parameter`)
+		}
+		selector.all = defaultAll
+	}
+	return selector, nil
+}
+
+func (selector dirtySelector) matches(name string) bool {
+	name = strings.Trim(name, "/")
+	if selector.all {
+		return true
+	}
+	if _, found := selector.files[name]; found {
+		return true
+	}
+	for _, dir := range selector.dirs {
+		if dir == "" || name == dir || strings.HasPrefix(name, dir+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+func selectedDirtyInfos(infos []vfscache.DirtyInfo, selector dirtySelector) []vfscache.DirtyInfo {
+	out := make([]vfscache.DirtyInfo, 0, len(infos))
+	for _, info := range infos {
+		if selector.matches(info.Name) {
+			out = append(out, info)
+		}
+	}
+	return out
+}
+
+func selectedDirtyNames(infos []vfscache.DirtyInfo, selector dirtySelector) []string {
+	seen := map[string]struct{}{}
+	for _, info := range infos {
+		if selector.matches(info.Name) {
+			seen[info.Name] = struct{}{}
+		}
+	}
+	for name := range selector.files {
+		seen[name] = struct{}{}
+	}
+	names := make([]string, 0, len(seen))
+	for name := range seen {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func dirtyInfoSummary(infos []vfscache.DirtyInfo) rc.Params {
+	var bytes int64
+	for _, info := range infos {
+		bytes += info.Size
+	}
+	return rc.Params{
+		"files": infos,
+		"count": len(infos),
+		"bytes": bytes,
+	}
+}
+
+func checkManualWriteBack(vfs *VFS) error {
+	if vfs.cache == nil {
+		return rc.NewErrParamInvalid(errors.New("can't call this unless using the VFS cache"))
+	}
+	if !vfs.Opt.ManualWriteBack {
+		return rc.NewErrParamInvalid(errors.New("can't call this unless --vfs-manual-writeback is enabled"))
+	}
+	return nil
+}
+
+func init() {
+	rc.Add(rc.Call{
+		Path:   "vfs/dirty",
+		NoAuth: true,
+		Title:  "List files staged for manual VFS writeback.",
+		Help: strings.ReplaceAll(`
+This returns files modified in the VFS cache when |--vfs-manual-writeback|
+is enabled.
+
+If no selectors are passed, all dirty files are returned. To restrict
+the result, pass files as |file=path|, |file2=path|, or recursive
+directory prefixes as |dir=path|, |dir2=path|.
+
+This returns:
+
+- |files| - an array of dirty files
+- |count| - the number of dirty files returned
+- |bytes| - the total size of dirty files returned
+
+Each file has |name|, |size|, |modTime|, |open|, and |remoteExists|.
+
+`, "|", "`") + getVFSHelp,
+		Fn: rcDirty,
+	})
+}
+
+func rcDirty(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+	vfs, err := getVFS(in)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkManualWriteBack(vfs); err != nil {
+		return nil, err
+	}
+	selector, err := parseDirtySelector(in, true, false)
+	if err != nil {
+		return nil, err
+	}
+	infos, err := vfs.cache.DirtyInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return dirtyInfoSummary(selectedDirtyInfos(infos, selector)), nil
+}
+
+func init() {
+	rc.Add(rc.Call{
+		Path:  "vfs/push",
+		Title: "Push files staged for manual VFS writeback.",
+		Help: strings.ReplaceAll(`
+This uploads files modified in the VFS cache when |--vfs-manual-writeback|
+is enabled. It waits for selected uploads to finish. To run it in the
+background, use the standard RC |_async=true| parameter.
+
+Select files with |file=path|, |file2=path|, recursive directory
+prefixes with |dir=path|, |dir2=path|, or all dirty files with
+|all=true|.
+
+This returns |pushed| and |failed| arrays.
+
+`, "|", "`") + getVFSHelp,
+		Fn: rcPush,
+	})
+}
+
+func rcPush(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+	vfs, err := getVFS(in)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkManualWriteBack(vfs); err != nil {
+		return nil, err
+	}
+	selector, err := parseDirtySelector(in, false, true)
+	if err != nil {
+		return nil, err
+	}
+	infos, err := vfs.cache.DirtyInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return vfs.rcPushOrRevert(ctx, selectedDirtyNames(infos, selector), true)
+}
+
+func init() {
+	rc.Add(rc.Call{
+		Path:  "vfs/revert",
+		Title: "Revert files staged for manual VFS writeback.",
+		Help: strings.ReplaceAll(`
+This discards files modified in the VFS cache when |--vfs-manual-writeback|
+is enabled without uploading them.
+
+Select files with |file=path|, |file2=path|, recursive directory
+prefixes with |dir=path|, |dir2=path|, or all dirty files with
+|all=true|.
+
+Existing remote files revert to the remote object. Files that only
+exist in the manual writeback cache are removed from the VFS view.
+
+This returns |reverted| and |failed| arrays.
+
+`, "|", "`") + getVFSHelp,
+		Fn: rcRevert,
+	})
+}
+
+func rcRevert(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+	vfs, err := getVFS(in)
+	if err != nil {
+		return nil, err
+	}
+	if err = checkManualWriteBack(vfs); err != nil {
+		return nil, err
+	}
+	selector, err := parseDirtySelector(in, false, true)
+	if err != nil {
+		return nil, err
+	}
+	infos, err := vfs.cache.DirtyInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return vfs.rcPushOrRevert(ctx, selectedDirtyNames(infos, selector), false)
+}
+
+func (vfs *VFS) rcPushOrRevert(ctx context.Context, names []string, push bool) (rc.Params, error) {
+	done := []manualResult{}
+	failed := []manualResult{}
+	for _, name := range names {
+		var err error
+		if push {
+			err = vfs.pushDirty(ctx, name)
+		} else {
+			err = vfs.revertDirty(ctx, name)
+		}
+		if err != nil {
+			failed = append(failed, manualResult{Name: name, Error: err.Error()})
+		} else {
+			done = append(done, manualResult{Name: name})
+		}
+	}
+	key := "reverted"
+	if push {
+		key = "pushed"
+	}
+	out := rc.Params{
+		key:      done,
+		"failed": failed,
+	}
+	if len(failed) > 0 {
+		return out, fmt.Errorf("%d file(s) failed", len(failed))
+	}
+	return out, nil
+}
+
+func (vfs *VFS) fileForPath(name string) *File {
+	node, err := vfs.Stat(name)
+	if err != nil {
+		return nil
+	}
+	file, ok := node.(*File)
+	if !ok {
+		return nil
+	}
+	return file
+}
+
+func (vfs *VFS) pushDirty(ctx context.Context, name string) error {
+	file := vfs.fileForPath(name)
+	return vfs.cache.Push(ctx, name, func(o fs.Object) {
+		if o == nil {
+			return
+		}
+		if file != nil {
+			file.setObject(o)
+			return
+		}
+		if err := vfs.AddVirtual(o.Remote(), o.Size(), false); err != nil {
+			fs.Errorf(o.Remote(), "Failed to add pushed object to VFS: %v", err)
+		}
+	})
+}
+
+func (vfs *VFS) revertDirty(ctx context.Context, name string) error {
+	var obj fs.Object
+	obj, err := vfs.f.NewObject(ctx, name)
+	if err != nil {
+		if !errors.Is(err, fs.ErrorObjectNotFound) {
+			return err
+		}
+		obj = nil
+	}
+	file := vfs.fileForPath(name)
+	err = vfs.cache.Revert(name)
+	if err != nil {
+		return err
+	}
+	if file == nil {
+		return nil
+	}
+	if obj != nil {
+		file.mu.Lock()
+		file.pendingModTime = time.Time{}
+		file.mu.Unlock()
+		file.setObject(obj)
+	} else {
+		file.Dir().delObject(file.Name())
+	}
+	return nil
 }

--- a/vfs/rc_test.go
+++ b/vfs/rc_test.go
@@ -2,11 +2,14 @@ package vfs
 
 import (
 	"context"
+	"errors"
+	"os"
 	"testing"
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/rc"
 	"github.com/rclone/rclone/fstest"
+	"github.com/rclone/rclone/vfs/vfscache"
 	"github.com/rclone/rclone/vfs/vfscommon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,6 +23,35 @@ func rcNewRun(t *testing.T, method string) (r *fstest.Run, vfs *VFS, call *rc.Ca
 	call = rc.Calls.Get(method)
 	assert.NotNil(t, call)
 	return r, vfs, call
+}
+
+func rcNewManualWriteBackRun(t *testing.T, method string) (r *fstest.Run, vfs *VFS, call *rc.Call) {
+	if *fstest.RemoteName != "" {
+		t.Skip("Skipping test on non local remote")
+	}
+	opt := vfscommon.Opt
+	opt.CacheMode = vfscommon.CacheModeWrites
+	opt.ManualWriteBack = true
+	opt.WriteBack = 0
+	opt.HandleCaching = 0
+	r, vfs = newTestVFSOpt(t, &opt)
+	call = rc.Calls.Get(method)
+	assert.NotNil(t, call)
+	return r, vfs, call
+}
+
+func rcWriteManualDirty(t *testing.T, vfs *VFS, name, contents string) {
+	h, err := vfs.OpenFile(name, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0777)
+	require.NoError(t, err)
+	n, err := h.Write([]byte(contents))
+	require.NoError(t, err)
+	assert.Equal(t, len(contents), n)
+	require.NoError(t, h.Close())
+	vfs.WaitForWriters(waitForWritersDelay)
+}
+
+func rcCheckRemoteItems(t *testing.T, r *fstest.Run, items ...fstest.Item) {
+	fstest.CheckListingWithPrecision(t, r.Fremote, items, nil, fs.ModTimeNotSupported)
 }
 
 func TestRcGetVFS(t *testing.T) {
@@ -124,4 +156,64 @@ func TestRcStats(t *testing.T) {
 	assert.Equal(t, 0, out["metadataCache"].(rc.Params)["files"])
 	assert.Equal(t, 1, out["metadataCache"].(rc.Params)["dirs"])
 	assert.Equal(t, vfs.Opt, out["opt"].(vfscommon.Options))
+}
+
+func TestRcDirtyAndPushManualWriteBack(t *testing.T) {
+	r, vfs, dirtyCall := rcNewManualWriteBackRun(t, "vfs/dirty")
+	pushCall := rc.Calls.Get("vfs/push")
+	require.NotNil(t, pushCall)
+
+	require.NoError(t, vfs.MkdirAll("dir", 0777))
+	rcWriteManualDirty(t, vfs, "dir/file1", "hello")
+	rcWriteManualDirty(t, vfs, "dir/file2", "bye")
+	rcCheckRemoteItems(t, r)
+
+	fsString := fs.ConfigString(r.Fremote)
+	out, err := dirtyCall.Fn(context.Background(), rc.Params{"fs": fsString, "dir": "dir"})
+	require.NoError(t, err)
+	assert.Equal(t, 2, out["count"])
+	assert.Equal(t, int64(8), out["bytes"])
+	infos := out["files"].([]vfscache.DirtyInfo)
+	require.Len(t, infos, 2)
+	assert.Equal(t, "dir/file1", infos[0].Name)
+	assert.Equal(t, "dir/file2", infos[1].Name)
+
+	_, err = pushCall.Fn(context.Background(), rc.Params{"fs": fsString})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "need at least one")
+
+	out, err = pushCall.Fn(context.Background(), rc.Params{"fs": fsString, "file": "dir/file1"})
+	require.NoError(t, err)
+	assert.Equal(t, []manualResult{{Name: "dir/file1"}}, out["pushed"])
+	assert.Equal(t, []manualResult{}, out["failed"])
+	rcCheckRemoteItems(t, r, fstest.NewItem("dir/file1", "hello", t1))
+
+	out, err = dirtyCall.Fn(context.Background(), rc.Params{"fs": fsString})
+	require.NoError(t, err)
+	infos = out["files"].([]vfscache.DirtyInfo)
+	require.Len(t, infos, 1)
+	assert.Equal(t, "dir/file2", infos[0].Name)
+}
+
+func TestRcRevertManualWriteBack(t *testing.T) {
+	r, vfs, revertCall := rcNewManualWriteBackRun(t, "vfs/revert")
+	old := r.WriteObject(context.Background(), "existing", "old", t1)
+	rcCheckRemoteItems(t, r, old)
+
+	rcWriteManualDirty(t, vfs, "existing", "new")
+	rcWriteManualDirty(t, vfs, "new", "staged")
+	rcCheckRemoteItems(t, r, old)
+
+	out, err := revertCall.Fn(context.Background(), rc.Params{"fs": fs.ConfigString(r.Fremote), "all": true})
+	require.NoError(t, err)
+	assert.Equal(t, []manualResult{{Name: "existing"}, {Name: "new"}}, out["reverted"])
+	assert.Equal(t, []manualResult{}, out["failed"])
+	rcCheckRemoteItems(t, r, old)
+
+	node, err := vfs.Stat("existing")
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), node.Size())
+
+	_, err = vfs.Stat("new")
+	assert.True(t, errors.Is(err, os.ErrNotExist))
 }

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -225,6 +225,10 @@ func New(ctx context.Context, f fs.Fs, opt *vfscommon.Options) *VFS {
 
 	// Fill out anything else
 	vfs.Opt.Init(ctx)
+	if vfs.Opt.ManualWriteBack && vfs.Opt.CacheMode < vfscommon.CacheModeWrites {
+		fs.Logf(f, "--vfs-manual-writeback requires --vfs-cache-mode writes or full - using writes")
+		vfs.Opt.CacheMode = vfscommon.CacheModeWrites
+	}
 
 	// Find a VFS with the same name and options and return it if possible
 	activeMu.Lock()
@@ -443,7 +447,11 @@ func (vfs *VFS) WaitForWriters(timeout time.Duration) {
 		writers := vfs.root.countActiveWriters()
 		cacheInUse := 0
 		if vfs.cache != nil {
-			cacheInUse = vfs.cache.TotalInUse()
+			if vfs.Opt.ManualWriteBack {
+				cacheInUse = vfs.cache.TotalActive()
+			} else {
+				cacheInUse = vfs.cache.TotalInUse()
+			}
 		}
 		if writers == 0 && cacheInUse == 0 {
 			return

--- a/vfs/vfs.md
+++ b/vfs/vfs.md
@@ -87,6 +87,7 @@ find that you need one or the other or both.
     --vfs-cache-max-size SizeSuffix        Max total size of objects in the cache (default off)
     --vfs-cache-min-free-space SizeSuffix  Target minimum free space on the disk containing the cache (default off)
     --vfs-cache-poll-interval duration     Interval to poll the cache for stale objects (default 1m0s)
+    --vfs-manual-writeback                 Disable automatic VFS cache writeback and require manual push
     --vfs-write-back duration              Time to writeback files after last use when using cache (default 5s)
 ```
 
@@ -104,6 +105,23 @@ closed and if they haven't been accessed for `--vfs-write-back`
 seconds. If rclone is quit or dies with files that haven't been
 uploaded, these will be uploaded next time rclone is run with the same
 flags.
+
+If `--vfs-manual-writeback` is set, changed files are kept dirty in
+the VFS cache after close and are not uploaded automatically, including
+after restarting rclone with the same cache. This requires
+`--vfs-cache-mode writes` or `--vfs-cache-mode full`; if a lower cache
+mode is configured, rclone promotes it to `writes`.
+
+Manual writeback is controlled through the RC API:
+
+- `vfs/dirty` lists files staged in the VFS cache.
+- `vfs/push file=path`, `vfs/push dir=path`, or `vfs/push all=true`
+  uploads staged files.
+- `vfs/revert file=path`, `vfs/revert dir=path`, or
+  `vfs/revert all=true` discards staged changes without uploading.
+
+`file`, `file2`, ... select exact files. `dir`, `dir2`, ... select
+recursive directory prefixes.
 
 If using `--vfs-cache-max-size` or `--vfs-cache-min-free-space` note
 that the cache may exceed these quotas for two reasons. Firstly

--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"sync"
@@ -186,6 +187,70 @@ func (c *Cache) Queue() (out rc.Params) {
 // otherwise the expiry of the item is used.
 func (c *Cache) QueueSetExpiry(id writeback.Handle, expiry time.Time, relative time.Duration) error {
 	return c.writeback.SetExpiry(id, expiry, relative)
+}
+
+// DirtyItems returns dirty cache items.
+func (c *Cache) DirtyItems() (items []*Item) {
+	c.mu.Lock()
+	for _, item := range c.item {
+		items = append(items, item)
+	}
+	c.mu.Unlock()
+
+	items = slices.DeleteFunc(items, func(item *Item) bool {
+		return !item.IsDirty()
+	})
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].GetName() < items[j].GetName()
+	})
+	return items
+}
+
+// DirtyInfo returns information about dirty cache items.
+func (c *Cache) DirtyInfo(ctx context.Context) (infos []DirtyInfo, err error) {
+	items := c.DirtyItems()
+	infos = make([]DirtyInfo, 0, len(items))
+	for _, item := range items {
+		info, infoErr := item.DirtyInfo(ctx)
+		if infoErr != nil {
+			if errors.Is(infoErr, ErrorNotDirty) {
+				continue
+			}
+			return infos, infoErr
+		}
+		infos = append(infos, info)
+	}
+	return infos, nil
+}
+
+// Push writes a dirty cache item back to the remote.
+func (c *Cache) Push(ctx context.Context, name string, storeFn StoreFn) error {
+	item := c.DirtyItem(name)
+	if item == nil {
+		return ErrorNotDirty
+	}
+	return item.Push(ctx, storeFn)
+}
+
+// Revert removes dirty cache data without writing it back.
+func (c *Cache) Revert(name string) error {
+	name = clean(name)
+	c.mu.Lock()
+	item := c.item[name]
+	c.mu.Unlock()
+	if item == nil || !item.IsDirty() {
+		return ErrorNotDirty
+	}
+	err := item.Revert("manual writeback reverted")
+	if err != nil {
+		return err
+	}
+	c.mu.Lock()
+	if c.item[name] == item {
+		delete(c.item, name)
+	}
+	c.mu.Unlock()
+	return nil
 }
 
 // createDir creates a directory path, along with any necessary parents
@@ -872,6 +937,18 @@ func (c *Cache) TotalInUse() (n int) {
 	defer c.mu.Unlock()
 	for _, item := range c.item {
 		if item.inUse() {
+			n++
+		}
+	}
+	return n
+}
+
+// TotalActive returns the number of items in the cache which are actively open.
+func (c *Cache) TotalActive() (n int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, item := range c.item {
+		if item.active() {
 			n++
 		}
 	}

--- a/vfs/vfscache/cache_test.go
+++ b/vfs/vfscache/cache_test.go
@@ -195,6 +195,60 @@ func TestCacheNew(t *testing.T) {
 	c.clean(false)
 }
 
+func TestCacheReloadManualWriteBack(t *testing.T) {
+	oldCacheDir := config.GetCacheDir()
+	require.NoError(t, config.SetCacheDir(t.TempDir()))
+	t.Cleanup(func() {
+		require.NoError(t, config.SetCacheDir(oldCacheDir))
+	})
+
+	opt := vfscommon.Opt
+	opt.CachePollInterval = 0
+	opt.WriteBack = 0
+	opt.HandleCaching = 0
+	opt.CacheMode = vfscommon.CacheModeWrites
+	opt.ManualWriteBack = true
+
+	r := fstest.NewRun(t)
+	ctx1, cancel1 := context.WithCancel(context.Background())
+	defer cancel1()
+
+	avInfos = nil
+	c1, err := New(ctx1, r.Fremote, &opt, addVirtual)
+	require.NoError(t, err)
+
+	item := c1.Item("potato")
+	require.NoError(t, item.Open(nil))
+	n, err := item.WriteAt([]byte("hello"), 0)
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+	require.NoError(t, item.Close(nil))
+	assert.True(t, item.IsDirty())
+	r.CheckRemoteItems(t)
+
+	cancel1()
+
+	ctx2, cancel2 := context.WithCancel(context.Background())
+	defer cancel2()
+
+	avInfos = nil
+	c2, err := New(ctx2, r.Fremote, &opt, addVirtual)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, c2.CleanUp())
+	})
+
+	infos, err := c2.DirtyInfo(context.Background())
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, "potato", infos[0].Name)
+	assert.Equal(t, int64(5), infos[0].Size)
+	assert.False(t, infos[0].Open)
+	assert.False(t, infos[0].RemoteExists)
+	assert.Equal(t, []avInfo{{Remote: "potato", Size: 5, IsDir: false}}, avInfos)
+	r.CheckRemoteItems(t)
+}
+
 func TestCacheOpens(t *testing.T) {
 	_, c := newTestCache(t)
 

--- a/vfs/vfscache/item.go
+++ b/vfs/vfscache/item.go
@@ -81,6 +81,21 @@ type Info struct {
 	Dirty       bool          // set if the backing file has been modified
 }
 
+// DirtyInfo is information about a dirty item in the cache.
+type DirtyInfo struct {
+	Name         string    `json:"name"`
+	Size         int64     `json:"size"`
+	ModTime      time.Time `json:"modTime"`
+	Open         bool      `json:"open"`
+	RemoteExists bool      `json:"remoteExists"`
+}
+
+// Errors returned by manual writeback operations.
+var (
+	ErrorNotDirty  = errors.New("cache item is not dirty")
+	ErrorItemInUse = errors.New("cache item is in use")
+)
+
 // Items are a slice of *Item ordered by ATime
 type Items []*Item
 
@@ -172,6 +187,13 @@ func (item *Item) inUse() bool {
 	item.mu.Lock()
 	defer item.mu.Unlock()
 	return item.opens != 0 || item.info.Dirty
+}
+
+// active returns true if the item is actively open.
+func (item *Item) active() bool {
+	item.mu.Lock()
+	defer item.mu.Unlock()
+	return item.opens != 0 || item.fd != nil
 }
 
 // getDiskSize returns the size on disk (approximately) of the item
@@ -462,6 +484,33 @@ func (item *Item) IsDirty() bool {
 	return item.info.Dirty
 }
 
+// DirtyInfo returns information about a dirty item.
+func (item *Item) DirtyInfo(ctx context.Context) (info DirtyInfo, err error) {
+	item.mu.Lock()
+	if !item.info.Dirty {
+		item.mu.Unlock()
+		return info, ErrorNotDirty
+	}
+	info = DirtyInfo{
+		Name:         item.name,
+		Size:         item.info.Size,
+		ModTime:      item.info.ModTime,
+		Open:         item.opens != 0,
+		RemoteExists: item.o != nil || item.info.Fingerprint != "",
+	}
+	name := item.name
+	item.mu.Unlock()
+	if !info.RemoteExists {
+		_, err = item.c.fremote.NewObject(ctx, name)
+		if err == nil {
+			info.RemoteExists = true
+		} else if errors.Is(err, fs.ErrorObjectNotFound) {
+			err = nil
+		}
+	}
+	return info, err
+}
+
 // Create the cache file and store the metadata on disk
 // Called with item.mu locked
 func (item *Item) _createFile(osPath string) (err error) {
@@ -672,10 +721,15 @@ func (item *Item) store(ctx context.Context, storeFn StoreFn) (err error) {
 
 // Close the cache file
 func (item *Item) Close(storeFn StoreFn) (err error) {
+	return item.close(storeFn, false)
+}
+
+// close the cache file, optionally forcing a synchronous writeback.
+func (item *Item) close(storeFn StoreFn, forceWriteBack bool) (err error) {
 	// defer log.Trace(item.o, "Item.Close")("err=%v", &err)
 	item.preAccess()
 	defer item.postAccess()
-	syncWriteBack := item.c.opt.WriteBack <= 0
+	syncWriteBack := forceWriteBack || (item.c.opt.WriteBack <= 0 && !item.c.opt.ManualWriteBack)
 	item.mu.Lock()
 	defer item.mu.Unlock()
 
@@ -791,11 +845,13 @@ func (item *Item) _actualClose(storeFn StoreFn, syncWriteBack bool) (err error) 
 
 	// upload the file to backing store if changed
 	if item.info.Dirty {
-		fs.Infof(item.name, "vfs cache: queuing for upload in %v", item.c.opt.WriteBack)
 		if syncWriteBack {
 			// do synchronous writeback
 			checkErr(item._store(item.c.ctx, storeFn))
+		} else if item.c.opt.ManualWriteBack {
+			fs.Infof(item.name, "vfs cache: staged for manual upload")
 		} else {
+			fs.Infof(item.name, "vfs cache: queuing for upload in %v", item.c.opt.WriteBack)
 			// asynchronous writeback
 			item.c.writeback.SetID(&item.writeBackID)
 			id := item.writeBackID
@@ -813,9 +869,38 @@ func (item *Item) _actualClose(storeFn StoreFn, syncWriteBack bool) (err error) 
 	return err
 }
 
+// Push writes a dirty cache item back to the remote immediately.
+func (item *Item) Push(ctx context.Context, storeFn StoreFn) error {
+	item.mu.Lock()
+	if !item.info.Dirty {
+		item.mu.Unlock()
+		return ErrorNotDirty
+	}
+	if item.opens != 0 || item.fd != nil {
+		item.mu.Unlock()
+		return ErrorItemInUse
+	}
+	name := item.name
+	item.mu.Unlock()
+
+	obj, err := item.c.fremote.NewObject(ctx, name)
+	if err != nil {
+		if !errors.Is(err, fs.ErrorObjectNotFound) {
+			return err
+		}
+		obj = nil
+	}
+	err = item.Open(obj)
+	if err != nil {
+		return err
+	}
+	return item.close(storeFn, true)
+}
+
 // reload is called with valid items recovered from a cache reload.
 //
-// If they are dirty then it makes sure they get uploaded.
+// If they are dirty then it makes sure they get uploaded unless manual
+// writeback is enabled.
 //
 // it is called before the cache has started so opens will be 0 and
 // metaDirty will be false.
@@ -824,6 +909,18 @@ func (item *Item) reload(ctx context.Context) error {
 	dirty := item.info.Dirty
 	item.mu.Unlock()
 	if !dirty {
+		return nil
+	}
+	if item.c.opt.ManualWriteBack {
+		size, err := item.GetSize()
+		if err != nil {
+			return fmt.Errorf("reload: failed to read size: %w", err)
+		}
+		err = item.c.AddVirtual(item.name, size, false)
+		if err != nil {
+			return fmt.Errorf("reload: failed to add virtual dir entry: %w", err)
+		}
+		fs.Infof(item.name, "vfs cache: staged for manual upload")
 		return nil
 	}
 	// see if the object still exists
@@ -839,7 +936,7 @@ func (item *Item) reload(ctx context.Context) error {
 		return err
 	}
 	// put the file into the directory listings
-	size, err := item._getSize()
+	size, err := item.GetSize()
 	if err != nil {
 		return fmt.Errorf("reload: failed to read size: %w", err)
 	}
@@ -966,6 +1063,20 @@ func (item *Item) remove(reason string) (wasWriting bool) {
 	item.mu.Lock()
 	defer item.mu.Unlock()
 	return item._remove(reason)
+}
+
+// Revert removes dirty cache data without writing it back.
+func (item *Item) Revert(reason string) error {
+	item.mu.Lock()
+	defer item.mu.Unlock()
+	if !item.info.Dirty {
+		return ErrorNotDirty
+	}
+	if item.opens != 0 || item.fd != nil {
+		return ErrorItemInUse
+	}
+	item._remove(reason)
+	return nil
 }
 
 // RemoveNotInUse is called to remove cache file that has not been accessed recently

--- a/vfs/vfscache/item_test.go
+++ b/vfs/vfscache/item_test.go
@@ -38,6 +38,24 @@ func newItemTestCache(t *testing.T) (r *fstest.Run, c *Cache) {
 	return newTestCacheOpt(t, opt)
 }
 
+func newItemManualWriteBackTestCache(t *testing.T) (r *fstest.Run, c *Cache) {
+	opt := vfscommon.Opt
+
+	// Disable the cache cleaner as it interferes with these tests
+	opt.CachePollInterval = 0
+
+	// Check manual writeback overrides synchronous close writeback
+	opt.WriteBack = 0
+
+	// Disable handle caching so existing tests get immediate close behavior
+	opt.HandleCaching = 0
+
+	opt.CacheMode = vfscommon.CacheModeWrites
+	opt.ManualWriteBack = true
+
+	return newTestCacheOpt(t, opt)
+}
+
 // Check the object has contents
 func checkObject(t *testing.T, r *fstest.Run, remote string, contents string) {
 	obj, err := r.Fremote.NewObject(context.Background(), remote)
@@ -119,6 +137,70 @@ func TestItemDirty(t *testing.T) {
 
 	assert.Equal(t, true, item.IsDirty())
 	checkObject(t, r, "potato", "hello")
+}
+
+func TestItemManualWriteBackPush(t *testing.T) {
+	r, c := newItemManualWriteBackTestCache(t)
+	item, _ := c.get("potato")
+	require.NoError(t, item.Open(nil))
+
+	n, err := item.WriteAt([]byte("hello"), 0)
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	require.NoError(t, item.Close(nil))
+	assert.True(t, item.IsDirty())
+	r.CheckRemoteItems(t)
+
+	infos, err := c.DirtyInfo(context.Background())
+	require.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, DirtyInfo{
+		Name:         "potato",
+		Size:         5,
+		ModTime:      infos[0].ModTime,
+		Open:         false,
+		RemoteExists: false,
+	}, infos[0])
+
+	callbackCalled := false
+	err = c.Push(context.Background(), "potato", func(o fs.Object) {
+		callbackCalled = true
+		assert.Equal(t, "potato", o.Remote())
+		assert.Equal(t, int64(5), o.Size())
+	})
+	require.NoError(t, err)
+	assert.True(t, callbackCalled)
+	assert.False(t, item.IsDirty())
+	checkObject(t, r, "potato", "hello")
+
+	infos, err = c.DirtyInfo(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, infos)
+}
+
+func TestItemManualWriteBackRevert(t *testing.T) {
+	r, c := newItemManualWriteBackTestCache(t)
+	item, _ := c.get("potato")
+	require.NoError(t, item.Open(nil))
+
+	n, err := item.WriteAt([]byte("hello"), 0)
+	require.NoError(t, err)
+	assert.Equal(t, 5, n)
+
+	require.NoError(t, item.Close(nil))
+	assert.True(t, item.IsDirty())
+	r.CheckRemoteItems(t)
+
+	require.NoError(t, c.Revert("potato"))
+	assert.False(t, item.IsDirty())
+
+	_, err = r.Fremote.NewObject(context.Background(), "potato")
+	assert.Equal(t, fs.ErrorObjectNotFound, err)
+
+	infos, err := c.DirtyInfo(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, infos)
 }
 
 func TestItemSync(t *testing.T) {

--- a/vfs/vfscommon/options.go
+++ b/vfs/vfscommon/options.go
@@ -131,6 +131,11 @@ var OptionsInfo = fs.Options{{
 	Help:    "Time to writeback files after last use when using cache",
 	Groups:  "VFS",
 }, {
+	Name:    "vfs_manual_writeback",
+	Default: false,
+	Help:    "Disable automatic VFS cache writeback and require manual push",
+	Groups:  "VFS",
+}, {
 	Name:    "vfs_read_ahead",
 	Default: 0 * fs.Mebi,
 	Help:    "Extra read ahead over --buffer-size when using cache-mode full",
@@ -210,6 +215,7 @@ type Options struct {
 	WriteWait          fs.Duration   `config:"vfs_write_wait"`       // time to wait for in-sequence write
 	ReadWait           fs.Duration   `config:"vfs_read_wait"`        // time to wait for in-sequence read
 	WriteBack          fs.Duration   `config:"vfs_write_back"`       // time to wait before writing back dirty files
+	ManualWriteBack    bool          `config:"vfs_manual_writeback"` // disable automatic writeback of dirty files
 	ReadAhead          fs.SizeSuffix `config:"vfs_read_ahead"`       // bytes to read ahead in cache mode "full"
 	UsedIsSize         bool          `config:"vfs_used_is_size"`     // if true, use the `rclone size` algorithm for Used size
 	FastFingerprint    bool          `config:"vfs_fast_fingerprint"` // if set use fast fingerprints


### PR DESCRIPTION
## Summary

This adds an explicit manual writeback mode for the VFS cache.

When `--vfs-manual-writeback` is enabled, dirty files are kept staged in the local VFS cache after close instead of being uploaded automatically through the normal writeback queue. The staged dirty state also survives restarting rclone with the same VFS cache.

The mode is controlled through RC:

- `vfs/dirty` lists staged dirty files.
- `vfs/push file=...`, `vfs/push dir=...`, or `vfs/push all=true` uploads selected staged files.
- `vfs/revert file=...`, `vfs/revert dir=...`, or `vfs/revert all=true` discards selected staged changes without uploading.

`file`, `file2`, ... select exact files and `dir`, `dir2`, ... select recursive directory prefixes. Push/revert require an explicit selector; dirty listing defaults to all staged files when no selector is supplied.

If manual writeback is enabled with a cache mode below `writes`, VFS promotes the mode to `writes` and logs that change.

## Motivation

This is useful for cloud AI agent workflows where agents edit files through a normal mounted filesystem, but the human user still needs to authorize what is uploaded back to the cloud source of truth.

For example, with a SharePoint or OneDrive-backed rclone mount, an AI coding/document agent can make changes locally through the VFS. The user can inspect the dirty set with `vfs/dirty`, approve selected files with `vfs/push`, or discard unwanted staged edits with `vfs/revert`. This creates an approval boundary between local agent work and remote cloud content.

Closes #9508.

## Tests

```sh
go test -count=1 ./vfs/...
```