### PR TITLE
Fix DeleteFile backup-dir handling

### DIFF
--- a/cmd/deletefile/deletefile.go
+++ b/cmd/deletefile/deletefile.go
@@ -36,7 +36,8 @@ specified file exists, it will always be removed.`,
 			if err != nil {
 				return err
 			}
-			return operations.DeleteFile(context.Background(), fileObj)
+			backupDir := operations.GetBackupDir(context.Background(), f)
+			return operations.DeleteFileWithBackupDir(context.Background(), fileObj, backupDir)
 		})
 	},
 }

--- a/cmd/ncdu/ncdu.go
+++ b/cmd/ncdu/ncdu.go
@@ -578,7 +578,8 @@ func (u *UI) deleteSingle() {
 			if o != 1 {
 				return "Aborted!", nil
 			}
-			err := operations.DeleteFile(ctx, obj)
+			backupDir := operations.GetBackupDir(ctx, f)
+			err := operations.DeleteFileWithBackupDir(ctx, obj, backupDir)
 			if err != nil {
 				return "", err
 			}
@@ -633,7 +634,8 @@ func (u *UI) deleteSelected() {
 			var err error
 
 			if obj, isFile := dirEntry.(fs.Object); isFile {
-				err = operations.DeleteFile(ctx, obj)
+				backupDir := operations.GetBackupDir(ctx, f)
+				err = operations.DeleteFileWithBackupDir(ctx, obj, backupDir)
 			} else {
 				err = operations.Purge(ctx, f, dirEntry.String())
 			}

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -546,7 +546,11 @@ func SuffixName(ctx context.Context, remote string) string {
 // and accumulating stats and errors.
 //
 // If backupDir is set then it moves the file to there instead of
-// deleting
+// deleting.
+//
+// Note that BackupDir is expensive because it needs to create the
+// directory structure for the backup. This should be called outside
+// loops if possible.
 func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs) (err error) {
 	tr := accounting.Stats(ctx).NewCheckingTransfer(dst, "deleting")
 	defer func() {
@@ -579,8 +583,8 @@ func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs
 
 // DeleteFile deletes a single file respecting --dry-run and accumulating stats and errors.
 //
-// If useBackupDir is set and --backup-dir is in effect then it moves
-// the file to there instead of deleting
+// Note that this does NOT use the --backup-dir flag. If you want to
+// use --backup-dir then call DeleteFileWithBackupDir instead.
 func DeleteFile(ctx context.Context, dst fs.Object) (err error) {
 	return DeleteFileWithBackupDir(ctx, dst, nil)
 }
@@ -1911,6 +1915,23 @@ func CopyURLToWriter(ctx context.Context, url string, out io.Writer) (err error)
 		_, err = io.Copy(out, in)
 		return err
 	})
+}
+
+// GetBackupDir returns a backupDir fs if --backup-dir or --suffix is
+// configured, otherwise nil. Errors are logged and nil is returned.
+// This is a convenience wrapper for callers that want to conditionally
+// use backup.
+func GetBackupDir(ctx context.Context, f fs.Fs) fs.Fs {
+	ci := fs.GetConfig(ctx)
+	if ci.BackupDir == "" && ci.Suffix == "" {
+		return nil
+	}
+	backupDir, err := BackupDir(ctx, f, f, "")
+	if err != nil {
+		fs.Errorf(f, "Failed to create backup dir: %v", err)
+		return nil
+	}
+	return backupDir
 }
 
 // BackupDir returns the correctly configured --backup-dir

--- a/fs/operations/rc.go
+++ b/fs/operations/rc.go
@@ -268,7 +268,8 @@ func rcSingleCommand(ctx context.Context, in rc.Params, name string, noRemote bo
 		if err != nil {
 			return nil, err
 		}
-		return nil, DeleteFile(ctx, o)
+		backupDir := GetBackupDir(ctx, f)
+		return nil, DeleteFileWithBackupDir(ctx, o, backupDir)
 	case "copyurl":
 		url, err := in.GetString("url")
 		if err != nil {


### PR DESCRIPTION
Fixes #7566

- Corrects DeleteFile comment to accurately state it does not use --backup-dir
- Adds doc note that BackupDir is expensive, call outside loops
- Adds GetBackupDir convenience wrapper for callers
- Updates callers that should use DeleteFileWithBackupDir: cmd/deletefile, cmd/ncdu, operations/rc (deletefile rpc)