### PR TITLE
docs(googlephotos): document read-only limitation of feature/favorites

### DIFF
--- a/docs/content/googlephotos.md
+++ b/docs/content/googlephotos.md
@@ -201,6 +201,9 @@ into albums.
 There are two writable parts of the tree, the `upload` directory and
 sub directories of the `album` directory.
 
+The `feature/favorites` directory allows you to view and download
+your starred/favorited photos, but it is read-only.
+
 The `upload` directory is for uploading files you don't want to put
 into albums. This will be empty to start with and will contain the
 files you've uploaded for one rclone session only, becoming empty
@@ -588,6 +591,13 @@ web interface. This is covered by [bug #113672044](https://issuetracker.google.c
 
 **NB** you **can** use the [--gphotos-proxy](#gphotos-proxy) flag to use a
 headless browser to download images in full resolution.
+
+### Marking Favorites
+
+The Google Photos API does not allow third-party applications to mark
+photos as favorites (star them) or write to the `feature/favorites`
+directory. This is an API limitation and is covered by
+[issue #264602929](https://issuetracker.google.com/issues/264602929).
 
 ### Duplicates
 


### PR DESCRIPTION
## Summary

This PR adds documentation explaining that the virtual `feature/favorites` directory is read-only. Due to Google Photos API limitations, third-party applications cannot mark photos as favorites or write to this directory.

---

## Changes

### docs/content/googlephotos.md

- Added a brief note in the **Directory Structure** section stating that `feature/favorites` is read-only.
- Added a dedicated **Marking Favorites** subsection under the **Limitations** block with a reference to Google's issue tracker (bug #264602929).

---

#### Was the change discussed in an issue or in the forum before?

As far as I know, this was not discussed previously. This documents an upstream Google Photos API limitation tracked on Google's issue tracker as [bug #264602929](https://issuetracker.google.com/issues/264602929).

## Dependencies (gh-stack)

This PR is independent and has no dependencies.

---

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)
