### PR TITLE
fs/hash: fix xxh128 hasher size

### DIFF
--- a/fs/hash/hash.go
+++ b/fs/hash/hash.go
@@ -114,6 +114,11 @@ func (h *xxh128Hasher) Sum(b []byte) []byte {
 	return buf[:]
 }
 
+// Size returns the number of bytes Sum will return.
+func (h *xxh128Hasher) Size() int {
+	return 16
+}
+
 func init() {
 	MD5 = RegisterHash("md5", "MD5", 32, md5.New)
 	SHA1 = RegisterHash("sha1", "SHA-1", 40, sha1.New)


### PR DESCRIPTION
The 128-bit wrapper overrides Sum to return a 16-byte digest, but it still inherited Size from the embedded 64-bit implementation. That made the interface contract inconsistent: Size reported 8 while Sum returned 16 bytes.

This adds the matching Size method and covers it with a small internal test.

Tested with:

    go test ./fs/hash
