### PR TITLE
protondrive: add browser login authentication

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -44,6 +44,9 @@ const (
 	maxSleep      = 2 * time.Second
 	decayConstant = 2 // bigger for slower decay, exponential
 
+	authMethodPassword = "password"
+	authMethodWeb      = "web"
+
 	clientUIDKey           = "client_uid"
 	clientAccessTokenKey   = "client_access_token"
 	clientRefreshTokenKey  = "client_refresh_token"
@@ -67,13 +70,26 @@ func init() {
 		Description: "Proton Drive",
 		NewFs:       NewFs,
 		Options: []fs.Option{{
-			Name:     "username",
-			Help:     `The username of your proton account`,
-			Required: true,
+			Name: "auth_method",
+			Help: `Choose how rclone authenticates with Proton Drive.
+
+Use "password" for the existing username/password login flow.
+Use "web" for Proton browser login via session fork. This is experimental
+and avoids direct password login, which can trigger Proton anti-bot checks.`,
+			Default: "password",
+			Examples: []fs.OptionExample{{
+				Value: authMethodPassword,
+				Help:  "Use username/password login",
+			}, {
+				Value: authMethodWeb,
+				Help:  "Use Proton browser login",
+			}},
+		}, {
+			Name: "username",
+			Help: `The username of your proton account`,
 		}, {
 			Name:       "password",
 			Help:       "The password of your proton account.",
-			Required:   true,
 			IsPassword: true,
 		}, {
 			Name: "mailbox_password",
@@ -206,6 +222,7 @@ then we might have a problem with caching the stale data.`,
 
 // Options defines the configuration for this backend
 type Options struct {
+	AuthMethod      string `config:"auth_method"`
 	Username        string `config:"username"`
 	Password        string `config:"password"`
 	MailboxPassword string `config:"mailbox_password"`
@@ -357,6 +374,22 @@ func deAuthHandler() {
 	clearConfigMap(_mapper)
 }
 
+func validateProtonAuthMethod(authMethod string) error {
+	switch authMethod {
+	case "", authMethodPassword, authMethodWeb:
+		return nil
+	default:
+		return fmt.Errorf("unknown auth_method %q; expected %q or %q", authMethod, authMethodPassword, authMethodWeb)
+	}
+}
+
+func normalizeProtonAuthMethod(authMethod string) string {
+	if authMethod == "" {
+		return authMethodPassword
+	}
+	return authMethod
+}
+
 func protonDriveAppVersionFromRcloneVersion(version string) string {
 	const fallback = "external-drive-rclone@1.0.0-stable"
 
@@ -475,6 +508,11 @@ func newProtonDrive(ctx context.Context, f *Fs, opt *Options, m configmap.Mapper
 	config.ReplaceExistingDraft = opt.ReplaceExistingDraft
 	config.EnableCaching = opt.EnableCaching
 
+	if err := validateProtonAuthMethod(opt.AuthMethod); err != nil {
+		return nil, err
+	}
+	opt.AuthMethod = normalizeProtonAuthMethod(opt.AuthMethod)
+
 	// let's see if we have the cached access credential
 	uid, accessToken, refreshToken, saltedKeyPass, hasUseReusableLoginCredentials := getConfigMap(m)
 	_saltedKeyPass = saltedKeyPass
@@ -503,8 +541,35 @@ func newProtonDrive(ctx context.Context, f *Fs, opt *Options, m configmap.Mapper
 		}
 	}
 
+	if opt.AuthMethod == authMethodWeb {
+		fs.Logf(f, "No working cached Proton Drive session found; starting browser login")
+		credential, err := protonDriveAuthViaWeb(ctx, f, config.AppVersion, config.UserAgent, config.Transport)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't authenticate with Proton browser login: %w", err)
+		}
+
+		config.UseReusableLogin = true
+		config.ReusableCredential.UID = credential.UID
+		config.ReusableCredential.AccessToken = credential.AccessToken
+		config.ReusableCredential.RefreshToken = credential.RefreshToken
+		config.ReusableCredential.SaltedKeyPass = credential.SaltedKeyPass
+
+		protonDrive, _, err := protonDriveAPI.NewProtonDrive(ctx, config, authHandler, deAuthHandler)
+		if err != nil {
+			clearConfigMap(m)
+			return nil, fmt.Errorf("couldn't initialize a new proton drive instance using browser login credentials: %w", err)
+		}
+
+		fs.Debugf(f, "Used Proton browser login to initialize the ProtonDrive API")
+		setConfigMap(m, credential.UID, credential.AccessToken, credential.RefreshToken, credential.SaltedKeyPass)
+		return protonDrive, nil
+	}
+
 	// if not, let's try to log the user in using username and password (and 2FA if required)
 	fs.Debugf(f, "Using username and password to log in")
+	if opt.Username == "" || opt.Password == "" {
+		return nil, errors.New("username and password are required when auth_method=password")
+	}
 	config.UseReusableLogin = false
 	config.FirstLoginCredential.Username = opt.Username
 	config.FirstLoginCredential.Password = opt.Password

--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -44,6 +44,9 @@ const (
 	maxSleep      = 2 * time.Second
 	decayConstant = 2 // bigger for slower decay, exponential
 
+	authMethodPassword = "password"
+	authMethodWeb      = "web"
+
 	clientUIDKey           = "client_uid"
 	clientAccessTokenKey   = "client_access_token"
 	clientRefreshTokenKey  = "client_refresh_token"
@@ -67,13 +70,26 @@ func init() {
 		Description: "Proton Drive",
 		NewFs:       NewFs,
 		Options: []fs.Option{{
-			Name:     "username",
-			Help:     `The username of your proton account`,
-			Required: true,
+			Name: "auth_method",
+			Help: `Choose how rclone authenticates with Proton Drive.
+
+Use "password" for the existing username/password login flow.
+Use "web" for Proton browser login via session fork. This is experimental
+and avoids direct password login, which can trigger Proton anti-bot checks.`,
+			Default: "password",
+			Examples: []fs.OptionExample{{
+				Value: authMethodPassword,
+				Help:  "Use username/password login",
+			}, {
+				Value: authMethodWeb,
+				Help:  "Use Proton browser login",
+			}},
+		}, {
+			Name: "username",
+			Help: `The username of your proton account`,
 		}, {
 			Name:       "password",
 			Help:       "The password of your proton account.",
-			Required:   true,
 			IsPassword: true,
 		}, {
 			Name: "mailbox_password",
@@ -206,6 +222,7 @@ then we might have a problem with caching the stale data.`,
 
 // Options defines the configuration for this backend
 type Options struct {
+	AuthMethod      string `config:"auth_method"`
 	Username        string `config:"username"`
 	Password        string `config:"password"`
 	MailboxPassword string `config:"mailbox_password"`
@@ -361,6 +378,22 @@ func deAuthHandler() {
 	clearConfigMap(_mapper)
 }
 
+func validateProtonAuthMethod(authMethod string) error {
+	switch authMethod {
+	case "", authMethodPassword, authMethodWeb:
+		return nil
+	default:
+		return fmt.Errorf("unknown auth_method %q; expected %q or %q", authMethod, authMethodPassword, authMethodWeb)
+	}
+}
+
+func normalizeProtonAuthMethod(authMethod string) string {
+	if authMethod == "" {
+		return authMethodPassword
+	}
+	return authMethod
+}
+
 func protonDriveAppVersionFromRcloneVersion(version string) string {
 	const fallback = "external-drive-rclone@1.0.0-stable"
 
@@ -479,6 +512,11 @@ func newProtonDrive(ctx context.Context, f *Fs, opt *Options, m configmap.Mapper
 	config.ReplaceExistingDraft = opt.ReplaceExistingDraft
 	config.EnableCaching = opt.EnableCaching
 
+	if err := validateProtonAuthMethod(opt.AuthMethod); err != nil {
+		return nil, err
+	}
+	opt.AuthMethod = normalizeProtonAuthMethod(opt.AuthMethod)
+
 	// let's see if we have the cached access credential
 	uid, accessToken, refreshToken, saltedKeyPass, hasUseReusableLoginCredentials := getConfigMap(m)
 	_saltedKeyPass = saltedKeyPass
@@ -507,8 +545,35 @@ func newProtonDrive(ctx context.Context, f *Fs, opt *Options, m configmap.Mapper
 		}
 	}
 
+	if opt.AuthMethod == authMethodWeb {
+		fs.Logf(f, "No working cached Proton Drive session found; starting browser login")
+		credential, err := protonDriveAuthViaWeb(ctx, f, config.AppVersion, config.UserAgent, config.Transport)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't authenticate with Proton browser login: %w", err)
+		}
+
+		config.UseReusableLogin = true
+		config.ReusableCredential.UID = credential.UID
+		config.ReusableCredential.AccessToken = credential.AccessToken
+		config.ReusableCredential.RefreshToken = credential.RefreshToken
+		config.ReusableCredential.SaltedKeyPass = credential.SaltedKeyPass
+
+		protonDrive, _, err := protonDriveAPI.NewProtonDrive(ctx, config, authHandler, deAuthHandler)
+		if err != nil {
+			clearConfigMap(m)
+			return nil, fmt.Errorf("couldn't initialize a new proton drive instance using browser login credentials: %w", err)
+		}
+
+		fs.Debugf(f, "Used Proton browser login to initialize the ProtonDrive API")
+		setConfigMap(m, credential.UID, credential.AccessToken, credential.RefreshToken, credential.SaltedKeyPass)
+		return protonDrive, nil
+	}
+
 	// if not, let's try to log the user in using username and password (and 2FA if required)
 	fs.Debugf(f, "Using username and password to log in")
+	if opt.Username == "" || opt.Password == "" {
+		return nil, errors.New("username and password are required when auth_method=password")
+	}
 	config.UseReusableLogin = false
 	config.FirstLoginCredential.Username = opt.Username
 	config.FirstLoginCredential.Password = opt.Password

--- a/backend/protondrive/protondrive_internal_test.go
+++ b/backend/protondrive/protondrive_internal_test.go
@@ -2,9 +2,17 @@ package protondrive
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/rclone/go-proton-api"
@@ -93,4 +101,186 @@ func TestShouldRetry(t *testing.T) {
 			assert.Equal(t, tc.wantRetry, gotRetry)
 		})
 	}
+}
+
+func TestValidateProtonAuthMethod(t *testing.T) {
+	assert.NoError(t, validateProtonAuthMethod(""))
+	assert.NoError(t, validateProtonAuthMethod(authMethodPassword))
+	assert.NoError(t, validateProtonAuthMethod(authMethodWeb))
+	assert.Error(t, validateProtonAuthMethod("invalid"))
+}
+
+func TestNormalizeProtonAuthMethod(t *testing.T) {
+	assert.Equal(t, authMethodPassword, normalizeProtonAuthMethod(""))
+	assert.Equal(t, authMethodPassword, normalizeProtonAuthMethod(authMethodPassword))
+	assert.Equal(t, authMethodWeb, normalizeProtonAuthMethod(authMethodWeb))
+}
+
+func TestProtonGenerateSignInURL(t *testing.T) {
+	key, signInURL, err := protonGenerateSignInURL("ABCD1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, key, 32)
+
+	parsed, err := url.Parse(signInURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "https", parsed.Scheme)
+	assert.Equal(t, "account.proton.me", parsed.Host)
+	assert.Equal(t, "/desktop/login", parsed.Path)
+	assert.Equal(t, "drive", parsed.Query().Get("app"))
+	assert.Equal(t, "3", parsed.Query().Get("pv"))
+
+	const payloadPrefix = "#payload="
+	if !strings.HasPrefix(parsed.Fragment, strings.TrimPrefix(payloadPrefix, "#")) {
+		t.Fatalf("missing payload fragment in sign-in URL: %q", signInURL)
+	}
+
+	payload, err := url.QueryUnescape(strings.TrimPrefix(parsed.RawFragment, "payload="))
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(payload, ":")
+	if len(parts) != 4 {
+		t.Fatalf("unexpected sign-in payload parts: %q", payload)
+	}
+	assert.Equal(t, "0", parts[0])
+	assert.Equal(t, "ABCD1234", parts[1])
+	assert.Equal(t, protonWebAuthClientID, parts[3])
+
+	decodedKey, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, key, decodedKey)
+}
+
+func TestProtonParseForkKeyPassword(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	payload := map[string]string{"keyPassword": "salted-key-pass"}
+
+	encryptedPayload := mustEncryptProtonForkPayload(t, key, []byte("123456789012"), payload)
+
+	got, err := protonParseForkKeyPassword(key, encryptedPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "salted-key-pass", got)
+}
+
+func TestProtonParseForkKeyPasswordErrors(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "not base64", payload: "not base64"},
+		{name: "too short", payload: base64.StdEncoding.EncodeToString([]byte("short"))},
+		{name: "missing keyPassword", payload: mustEncryptProtonForkPayload(t, key, []byte("123456789012"), map[string]string{"other": "value"})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := protonParseForkKeyPassword(key, tc.payload)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestNormalizeSaltedKeyPass(t *testing.T) {
+	base64Value := base64.StdEncoding.EncodeToString([]byte("already encoded"))
+
+	assert.Equal(t, base64Value, normalizeSaltedKeyPass(base64Value))
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("raw key password")), normalizeSaltedKeyPass("raw key password"))
+}
+
+func TestProtonSessionForkHTTPFlow(t *testing.T) {
+	const appVersion = "external-drive-rclone@1.75.0-dev"
+	const userAgent = "rclone-test"
+
+	requests := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, appVersion, r.Header.Get("x-pm-appversion"))
+		assert.Equal(t, userAgent, r.Header.Get("User-Agent"))
+
+		requests = append(requests, r.URL.EscapedPath())
+		switch r.URL.EscapedPath() {
+		case "/auth/v4/sessions/forks":
+			_, _ = w.Write([]byte(`{"Code":1000,"Selector":"selector/with/slash","UserCode":"USERCODE"}`))
+		case "/auth/v4/sessions/forks/selector%2Fwith%2Fslash":
+			_, _ = w.Write([]byte(`{"Code":1000,"Payload":"payload","UID":"uid","AccessToken":"access","RefreshToken":"refresh"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	withProtonDriveAPIBaseURL(t, server.URL)
+
+	initResponse, err := protonSessionForkInit(context.Background(), server.Client(), appVersion, userAgent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "selector/with/slash", initResponse.Selector)
+	assert.Equal(t, "USERCODE", initResponse.UserCode)
+
+	statusResponse, ready, err := protonSessionForkStatus(context.Background(), server.Client(), appVersion, userAgent, initResponse.Selector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, ready)
+	assert.Equal(t, "uid", statusResponse.UID)
+	assert.Equal(t, "access", statusResponse.AccessToken)
+	assert.Equal(t, "refresh", statusResponse.RefreshToken)
+	assert.Equal(t, []string{"/auth/v4/sessions/forks", "/auth/v4/sessions/forks/selector%2Fwith%2Fslash"}, requests)
+}
+
+func TestProtonSessionForkStatusNotReady(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"Code":2001,"Error":"not ready"}`, http.StatusUnprocessableEntity)
+	}))
+	defer server.Close()
+
+	withProtonDriveAPIBaseURL(t, server.URL)
+
+	response, ready, err := protonSessionForkStatus(context.Background(), server.Client(), "app-version", "user-agent", "selector")
+	assert.NoError(t, err)
+	assert.False(t, ready)
+	assert.Nil(t, response)
+}
+
+func withProtonDriveAPIBaseURL(t *testing.T, value string) {
+	t.Helper()
+
+	old := protonDriveAPIBaseURL
+	protonDriveAPIBaseURL = value
+	t.Cleanup(func() {
+		protonDriveAPIBaseURL = old
+	})
+}
+
+func mustEncryptProtonForkPayload(t *testing.T, key, nonce []byte, payload map[string]string) string {
+	t.Helper()
+
+	plaintext, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sealed := gcm.Seal(nil, nonce, plaintext, protonForkAAD)
+	ciphertext := sealed[:len(sealed)-gcm.Overhead()]
+	tag := sealed[len(sealed)-gcm.Overhead():]
+
+	blob := append(append([]byte{}, nonce...), ciphertext...)
+	blob = append(blob, tag...)
+	return base64.StdEncoding.EncodeToString(blob)
 }

--- a/backend/protondrive/protondrive_internal_test.go
+++ b/backend/protondrive/protondrive_internal_test.go
@@ -2,9 +2,17 @@ package protondrive
 
 import (
 	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/rclone/go-proton-api"
@@ -94,4 +102,186 @@ func TestShouldRetry(t *testing.T) {
 			assert.Equal(t, tc.wantRetry, gotRetry)
 		})
 	}
+}
+
+func TestValidateProtonAuthMethod(t *testing.T) {
+	assert.NoError(t, validateProtonAuthMethod(""))
+	assert.NoError(t, validateProtonAuthMethod(authMethodPassword))
+	assert.NoError(t, validateProtonAuthMethod(authMethodWeb))
+	assert.Error(t, validateProtonAuthMethod("invalid"))
+}
+
+func TestNormalizeProtonAuthMethod(t *testing.T) {
+	assert.Equal(t, authMethodPassword, normalizeProtonAuthMethod(""))
+	assert.Equal(t, authMethodPassword, normalizeProtonAuthMethod(authMethodPassword))
+	assert.Equal(t, authMethodWeb, normalizeProtonAuthMethod(authMethodWeb))
+}
+
+func TestProtonGenerateSignInURL(t *testing.T) {
+	key, signInURL, err := protonGenerateSignInURL("ABCD1234")
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Len(t, key, 32)
+
+	parsed, err := url.Parse(signInURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "https", parsed.Scheme)
+	assert.Equal(t, "account.proton.me", parsed.Host)
+	assert.Equal(t, "/desktop/login", parsed.Path)
+	assert.Equal(t, "drive", parsed.Query().Get("app"))
+	assert.Equal(t, "3", parsed.Query().Get("pv"))
+
+	const payloadPrefix = "#payload="
+	if !strings.HasPrefix(parsed.Fragment, strings.TrimPrefix(payloadPrefix, "#")) {
+		t.Fatalf("missing payload fragment in sign-in URL: %q", signInURL)
+	}
+
+	payload, err := url.QueryUnescape(strings.TrimPrefix(parsed.RawFragment, "payload="))
+	if err != nil {
+		t.Fatal(err)
+	}
+	parts := strings.Split(payload, ":")
+	if len(parts) != 4 {
+		t.Fatalf("unexpected sign-in payload parts: %q", payload)
+	}
+	assert.Equal(t, "0", parts[0])
+	assert.Equal(t, "ABCD1234", parts[1])
+	assert.Equal(t, protonWebAuthClientID, parts[3])
+
+	decodedKey, err := base64.StdEncoding.DecodeString(parts[2])
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, key, decodedKey)
+}
+
+func TestProtonParseForkKeyPassword(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+	payload := map[string]string{"keyPassword": "salted-key-pass"}
+
+	encryptedPayload := mustEncryptProtonForkPayload(t, key, []byte("123456789012"), payload)
+
+	got, err := protonParseForkKeyPassword(key, encryptedPayload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "salted-key-pass", got)
+}
+
+func TestProtonParseForkKeyPasswordErrors(t *testing.T) {
+	key := []byte("0123456789abcdef0123456789abcdef")
+
+	for _, tc := range []struct {
+		name    string
+		payload string
+	}{
+		{name: "not base64", payload: "not base64"},
+		{name: "too short", payload: base64.StdEncoding.EncodeToString([]byte("short"))},
+		{name: "missing keyPassword", payload: mustEncryptProtonForkPayload(t, key, []byte("123456789012"), map[string]string{"other": "value"})},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := protonParseForkKeyPassword(key, tc.payload)
+			assert.Error(t, err)
+		})
+	}
+}
+
+func TestNormalizeSaltedKeyPass(t *testing.T) {
+	base64Value := base64.StdEncoding.EncodeToString([]byte("already encoded"))
+
+	assert.Equal(t, base64Value, normalizeSaltedKeyPass(base64Value))
+	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("raw key password")), normalizeSaltedKeyPass("raw key password"))
+}
+
+func TestProtonSessionForkHTTPFlow(t *testing.T) {
+	const appVersion = "external-drive-rclone@1.75.0-dev"
+	const userAgent = "rclone-test"
+
+	requests := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, appVersion, r.Header.Get("x-pm-appversion"))
+		assert.Equal(t, userAgent, r.Header.Get("User-Agent"))
+
+		requests = append(requests, r.URL.EscapedPath())
+		switch r.URL.EscapedPath() {
+		case "/auth/v4/sessions/forks":
+			_, _ = w.Write([]byte(`{"Code":1000,"Selector":"selector/with/slash","UserCode":"USERCODE"}`))
+		case "/auth/v4/sessions/forks/selector%2Fwith%2Fslash":
+			_, _ = w.Write([]byte(`{"Code":1000,"Payload":"payload","UID":"uid","AccessToken":"access","RefreshToken":"refresh"}`))
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	withProtonDriveAPIBaseURL(t, server.URL)
+
+	initResponse, err := protonSessionForkInit(context.Background(), server.Client(), appVersion, userAgent)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.Equal(t, "selector/with/slash", initResponse.Selector)
+	assert.Equal(t, "USERCODE", initResponse.UserCode)
+
+	statusResponse, ready, err := protonSessionForkStatus(context.Background(), server.Client(), appVersion, userAgent, initResponse.Selector)
+	if err != nil {
+		t.Fatal(err)
+	}
+	assert.True(t, ready)
+	assert.Equal(t, "uid", statusResponse.UID)
+	assert.Equal(t, "access", statusResponse.AccessToken)
+	assert.Equal(t, "refresh", statusResponse.RefreshToken)
+	assert.Equal(t, []string{"/auth/v4/sessions/forks", "/auth/v4/sessions/forks/selector%2Fwith%2Fslash"}, requests)
+}
+
+func TestProtonSessionForkStatusNotReady(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, `{"Code":2001,"Error":"not ready"}`, http.StatusUnprocessableEntity)
+	}))
+	defer server.Close()
+
+	withProtonDriveAPIBaseURL(t, server.URL)
+
+	response, ready, err := protonSessionForkStatus(context.Background(), server.Client(), "app-version", "user-agent", "selector")
+	assert.NoError(t, err)
+	assert.False(t, ready)
+	assert.Nil(t, response)
+}
+
+func withProtonDriveAPIBaseURL(t *testing.T, value string) {
+	t.Helper()
+
+	old := protonDriveAPIBaseURL
+	protonDriveAPIBaseURL = value
+	t.Cleanup(func() {
+		protonDriveAPIBaseURL = old
+	})
+}
+
+func mustEncryptProtonForkPayload(t *testing.T, key, nonce []byte, payload map[string]string) string {
+	t.Helper()
+
+	plaintext, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sealed := gcm.Seal(nil, nonce, plaintext, protonForkAAD)
+	ciphertext := sealed[:len(sealed)-gcm.Overhead()]
+	tag := sealed[len(sealed)-gcm.Overhead():]
+
+	blob := append(append([]byte{}, nonce...), ciphertext...)
+	blob = append(blob, tag...)
+	return base64.StdEncoding.EncodeToString(blob)
 }

--- a/backend/protondrive/protondrive_internal_test.go
+++ b/backend/protondrive/protondrive_internal_test.go
@@ -189,11 +189,13 @@ func TestProtonParseForkKeyPasswordErrors(t *testing.T) {
 	}
 }
 
-func TestNormalizeSaltedKeyPass(t *testing.T) {
-	base64Value := base64.StdEncoding.EncodeToString([]byte("already encoded"))
-
-	assert.Equal(t, base64Value, normalizeSaltedKeyPass(base64Value))
-	assert.Equal(t, base64.StdEncoding.EncodeToString([]byte("raw key password")), normalizeSaltedKeyPass("raw key password"))
+func TestEncodeSaltedKeyPass(t *testing.T) {
+	for _, keyPassword := range []string{
+		"raw key password",
+		"YWxyZWFkeSBiYXNlNjQ=",
+	} {
+		assert.Equal(t, base64.StdEncoding.EncodeToString([]byte(keyPassword)), encodeSaltedKeyPass(keyPassword))
+	}
 }
 
 func TestProtonSessionForkHTTPFlow(t *testing.T) {

--- a/backend/protondrive/session_fork.go
+++ b/backend/protondrive/session_fork.go
@@ -1,0 +1,251 @@
+package protondrive
+
+import (
+	"bytes"
+	"context"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+)
+
+const (
+	protonWebAuthClientID     = "external-drive"
+	protonWebAuthPollInterval = 5 * time.Second
+	protonWebAuthInitialDelay = 5 * time.Second
+	protonWebAuthMaxPollTime  = 10 * time.Minute
+)
+
+var (
+	protonDriveAPIBaseURL = "https://drive-api.proton.me"
+	protonAccountURL      = "https://account.proton.me"
+	protonForkAAD         = []byte("fork")
+)
+
+type protonForkInitResponse struct {
+	Code     int    `json:"Code"`
+	Selector string `json:"Selector"`
+	UserCode string `json:"UserCode"`
+}
+
+type protonForkStatusResponse struct {
+	Code         int    `json:"Code"`
+	Payload      string `json:"Payload"`
+	UID          string `json:"UID"`
+	AccessToken  string `json:"AccessToken"`
+	RefreshToken string `json:"RefreshToken"`
+}
+
+type protonForkPayload struct {
+	KeyPassword string `json:"keyPassword"`
+}
+
+type protonWebCredential struct {
+	UID           string
+	AccessToken   string
+	RefreshToken  string
+	SaltedKeyPass string
+}
+
+func protonDriveAuthViaWeb(ctx context.Context, f *Fs, appVersion, userAgent string, transport http.RoundTripper) (*protonWebCredential, error) {
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   30 * time.Second,
+	}
+	if client.Transport == nil {
+		client.Transport = http.DefaultTransport
+	}
+
+	initResponse, err := protonSessionForkInit(ctx, client, appVersion, userAgent)
+	if err != nil {
+		return nil, err
+	}
+	if initResponse.Selector == "" || initResponse.UserCode == "" {
+		return nil, errors.New("proton session fork response did not include selector and user code")
+	}
+
+	encryptionKey, signInURL, err := protonGenerateSignInURL(initResponse.UserCode)
+	if err != nil {
+		return nil, err
+	}
+
+	fs.Logf(f, "Open this Proton login URL in your browser:")
+	fs.Logf(f, "%s", signInURL)
+
+	if err := sleepContext(ctx, protonWebAuthInitialDelay); err != nil {
+		return nil, err
+	}
+
+	deadline := time.Now().Add(protonWebAuthMaxPollTime)
+	for {
+		if time.Now().After(deadline) {
+			return nil, errors.New("proton browser authentication timed out")
+		}
+
+		statusResponse, ready, err := protonSessionForkStatus(ctx, client, appVersion, userAgent, initResponse.Selector)
+		if err != nil {
+			return nil, err
+		}
+		if !ready {
+			fs.Debugf(f, "Proton browser authentication is not ready yet")
+			if err := sleepContext(ctx, protonWebAuthPollInterval); err != nil {
+				return nil, err
+			}
+			continue
+		}
+
+		keyPassword, err := protonParseForkKeyPassword(encryptionKey, statusResponse.Payload)
+		if err != nil {
+			return nil, err
+		}
+		if statusResponse.UID == "" || statusResponse.AccessToken == "" || statusResponse.RefreshToken == "" {
+			return nil, errors.New("proton browser authentication response did not include complete session tokens")
+		}
+
+		return &protonWebCredential{
+			UID:           statusResponse.UID,
+			AccessToken:   statusResponse.AccessToken,
+			RefreshToken:  statusResponse.RefreshToken,
+			SaltedKeyPass: normalizeSaltedKeyPass(keyPassword),
+		}, nil
+	}
+}
+
+func protonSessionForkInit(ctx context.Context, client *http.Client, appVersion, userAgent string) (*protonForkInitResponse, error) {
+	var response protonForkInitResponse
+	if err := protonJSONRequest(ctx, client, http.MethodGet, protonDriveAPIBaseURL+"/auth/v4/sessions/forks", appVersion, userAgent, nil, &response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+func protonSessionForkStatus(ctx context.Context, client *http.Client, appVersion, userAgent, selector string) (*protonForkStatusResponse, bool, error) {
+	var response protonForkStatusResponse
+	statusCode, err := protonJSONRequestStatus(ctx, client, http.MethodGet, protonDriveAPIBaseURL+"/auth/v4/sessions/forks/"+url.PathEscape(selector), appVersion, userAgent, nil, &response)
+	if statusCode == http.StatusUnprocessableEntity {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	return &response, true, nil
+}
+
+func protonJSONRequest(ctx context.Context, client *http.Client, method, url, appVersion, userAgent string, body io.Reader, out any) error {
+	_, err := protonJSONRequestStatus(ctx, client, method, url, appVersion, userAgent, body, out)
+	return err
+}
+
+func protonJSONRequestStatus(ctx context.Context, client *http.Client, method, url, appVersion, userAgent string, body io.Reader, out any) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, method, url, body)
+	if err != nil {
+		return 0, err
+	}
+	req.Header.Set("x-pm-appversion", appVersion)
+	if userAgent != "" {
+		req.Header.Set("User-Agent", userAgent)
+	}
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer func() {
+		_ = res.Body.Close()
+	}()
+
+	responseBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return res.StatusCode, err
+	}
+	if res.StatusCode < 200 || res.StatusCode > 299 {
+		return res.StatusCode, fmt.Errorf("proton API request failed: %s: %s", res.Status, string(responseBody))
+	}
+	if out == nil {
+		return res.StatusCode, nil
+	}
+	if err := json.Unmarshal(responseBody, out); err != nil {
+		return res.StatusCode, err
+	}
+	return res.StatusCode, nil
+}
+
+func protonGenerateSignInURL(userCode string) ([]byte, string, error) {
+	encryptionKey := make([]byte, 32)
+	if _, err := rand.Read(encryptionKey); err != nil {
+		return nil, "", err
+	}
+
+	payload := fmt.Sprintf("0:%s:%s:%s", userCode, base64.StdEncoding.EncodeToString(encryptionKey), protonWebAuthClientID)
+	signInURL := protonAccountURL + "/desktop/login?app=drive&pv=3#payload=" + url.QueryEscape(payload)
+	return encryptionKey, signInURL, nil
+}
+
+func protonParseForkKeyPassword(encryptionKey []byte, encryptedPayload string) (string, error) {
+	payloadBlob, err := base64.StdEncoding.DecodeString(encryptedPayload)
+	if err != nil {
+		return "", err
+	}
+	if len(payloadBlob) < 12+16 {
+		return "", errors.New("invalid Proton fork payload length")
+	}
+
+	nonce := payloadBlob[:12]
+	tag := payloadBlob[len(payloadBlob)-16:]
+	ciphertext := payloadBlob[12 : len(payloadBlob)-16]
+
+	block, err := aes.NewCipher(encryptionKey)
+	if err != nil {
+		return "", err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return "", err
+	}
+
+	sealed := append(bytes.Clone(ciphertext), tag...)
+	plaintext, err := gcm.Open(nil, nonce, sealed, protonForkAAD)
+	if err != nil {
+		return "", err
+	}
+
+	var payload protonForkPayload
+	if err := json.Unmarshal(plaintext, &payload); err != nil {
+		return "", err
+	}
+	if payload.KeyPassword == "" {
+		return "", errors.New("proton fork payload did not include keyPassword")
+	}
+	return payload.KeyPassword, nil
+}
+
+func normalizeSaltedKeyPass(keyPassword string) string {
+	if _, err := base64.StdEncoding.DecodeString(keyPassword); err == nil {
+		return keyPassword
+	}
+	return base64.StdEncoding.EncodeToString([]byte(keyPassword))
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
+}

--- a/backend/protondrive/session_fork.go
+++ b/backend/protondrive/session_fork.go
@@ -115,7 +115,7 @@ func protonDriveAuthViaWeb(ctx context.Context, f *Fs, appVersion, userAgent str
 			UID:           statusResponse.UID,
 			AccessToken:   statusResponse.AccessToken,
 			RefreshToken:  statusResponse.RefreshToken,
-			SaltedKeyPass: normalizeSaltedKeyPass(keyPassword),
+			SaltedKeyPass: encodeSaltedKeyPass(keyPassword),
 		}, nil
 	}
 }
@@ -231,10 +231,9 @@ func protonParseForkKeyPassword(encryptionKey []byte, encryptedPayload string) (
 	return payload.KeyPassword, nil
 }
 
-func normalizeSaltedKeyPass(keyPassword string) string {
-	if _, err := base64.StdEncoding.DecodeString(keyPassword); err == nil {
-		return keyPassword
-	}
+// encodeSaltedKeyPass wraps the literal fork key password in the bridge's
+// base64 transport format for reusable credentials.
+func encodeSaltedKeyPass(keyPassword string) string {
 	return base64.StdEncoding.EncodeToString([]byte(keyPassword))
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to rclone! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

#### What is the purpose of this change?

Adds an optional browser login authentication flow for the Proton Drive backend.

The existing username/password authentication flow remains the default. When `auth_method = web` is configured and cached credentials are missing or invalid, rclone starts Proton's browser session-fork login flow, prints the Proton login URL, polls until the login completes, decrypts the returned fork payload, and stores the resulting reusable credentials in the existing cached credential fields.

Existing Proton Drive configs without `auth_method` continue to use the username/password flow.

This provides an alternative for users who hit Proton anti-bot/CAPTCHA failures during direct username/password API login.

Related issues:

- #9397
- #7967

Testing performed:

```sh
nix shell nixpkgs#go nixpkgs#gcc -c env RCLONE_CONFIG=/tmp/rclone-test-empty.conf go test ./backend/protondrive
```

Manual live validation with a Proton Drive remote:

- Browser login flow completed successfully.
- Cached credentials were reused successfully.
- `lsd` listed Proton Drive folders.
- CRUD smoke test passed: `mkdir`, `copyto`, `cat`, `deletefile`, `rmdir`.

Full `fstests` integration suite was not run.

#### Was the change discussed in an issue or in the forum before?

Related issues:

- #9397 reports Proton Drive direct auth failures with CAPTCHA / anti-bot `Code=9001`.
- #7967 is an earlier Proton Drive CAPTCHA failure report.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

