### PR TITLE
docs/crypt: fix encrypted size example

### DIFF
--- a/docs/content/crypt.md
+++ b/docs/content/crypt.md
@@ -787,9 +787,9 @@ This uses a 32 byte (256 bit key) key derived from the user password.
 1 MiB (1048576 bytes) file will encrypt to
 
 - 32 bytes header
-- 16 chunks of 65568 bytes
+- 16 chunks of 65552 bytes
 
-1049120 bytes total (a 0.05% overhead). This is the overhead for big
+1048864 bytes total (a 0.03% overhead). This is the overhead for big
 files.
 
 ### Name encryption


### PR DESCRIPTION
#### What is the purpose of this change?

Fix the encrypted file size example in the crypt documentation.

A full encrypted data chunk is 64 KiB of file content plus a 16 byte authenticator, so each full chunk is 65552 bytes. For a 1 MiB file this gives 16 full chunks plus the 32 byte header, for a total of 1048864 bytes.

#### Was the change discussed in an issue or in the forum before?

Fixes #9202.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)

