### PR TITLE
vfs/vfscache: don't discard a clean cached file when the remote lookup is unconfirmed

### DIFF
--- a/vfs/vfscache/item.go
+++ b/vfs/vfscache/item.go
@@ -860,20 +860,38 @@ func (item *Item) reload(ctx context.Context) error {
 //
 // call with lock held
 func (item *Item) _checkObject(o fs.Object) error {
-	if o == nil {
-		if item.info.Fingerprint != "" {
-			// no remote object && local object
-			// remove local object unless dirty
+	if o == nil && item.info.Fingerprint != "" {
+		// A nil object here is ambiguous: the remote object may have been
+		// deleted, or the directory listing may have been successful but
+		// incomplete - an eventually consistent backend, a stale negative right
+		// after a remount, or a flaky proxy returning empty without an error - so
+		// that o == nil arrives here with no error to signal it. Removing a clean,
+		// fully cached file on an *unconfirmed* deletion discards data that is
+		// otherwise still readable, so re-confirm with the remote before acting on
+		// the nil, mirroring the re-confirm the download path already does.
+		var rerr error
+		o, rerr = item.c.fremote.NewObject(item.c.ctx, item.name)
+		switch {
+		case errors.Is(rerr, fs.ErrorObjectNotFound) || errors.Is(rerr, fs.ErrorIsDir):
+			// Remote confirms the object is gone - remove unless dirty.
 			if !item.info.Dirty {
 				item._remove("stale (remote deleted)")
 			} else {
 				fs.Debugf(item.name, "vfs cache: remote object has gone but local object modified - keeping it")
 			}
-			//} else {
-			// no remote object && no local object
-			// OK
+			o = nil
+		case rerr != nil:
+			// Could not confirm the object (transient error / unconfirmed listing)
+			// - keep the cached copy rather than discard data we cannot prove was
+			// deleted. Its fingerprint matched when it was written, so serving it
+			// is safe.
+			fs.Infof(item.name, "vfs cache: remote lookup unconfirmed (%v) - keeping cached copy", rerr)
+			o = nil
 		}
-	} else {
+		// rerr == nil: o now holds the real remote object; fall through to the
+		// fingerprint check below as if it had been passed in.
+	}
+	if o != nil {
 		remoteFingerprint := fs.Fingerprint(item.c.ctx, o, item.c.opt.FastFingerprint)
 		fs.Debugf(item.name, "vfs cache: checking remote fingerprint %q against cached fingerprint %q", remoteFingerprint, item.info.Fingerprint)
 		if item.info.Fingerprint != "" {

--- a/vfs/vfscache/item.go
+++ b/vfs/vfscache/item.go
@@ -891,20 +891,40 @@ func (item *Item) reload(ctx context.Context) error {
 //
 // call with lock held
 func (item *Item) _checkObject(o fs.Object) error {
-	if o == nil {
-		if item.info.Fingerprint != "" {
-			// no remote object && local object
-			// remove local object unless dirty
-			if !item.info.Dirty {
+	if o == nil && item.info.Fingerprint != "" {
+		if item.info.Dirty {
+			// a dirty item is kept whatever the remote says, so don't pay for a
+			// lookup whose answer cannot change the outcome
+			fs.Debugf(item.name, "vfs cache: remote object has gone but local object modified - keeping it")
+		} else {
+			// A nil object here is ambiguous: the remote object may have been
+			// deleted, or the directory listing may have been successful but
+			// incomplete - an eventually consistent backend, a stale negative right
+			// after a remount, or a flaky proxy returning empty without an error - so
+			// that o == nil arrives here with no error to signal it. Removing a clean,
+			// fully cached file on an *unconfirmed* deletion discards data that is
+			// otherwise still readable, so re-confirm with the remote before acting on
+			// the nil, mirroring the re-confirm the download path already does.
+			var rerr error
+			o, rerr = item.c.fremote.NewObject(item.c.ctx, item.name)
+			switch {
+			case errors.Is(rerr, fs.ErrorObjectNotFound) || errors.Is(rerr, fs.ErrorIsDir):
+				// remote confirms the object is gone
 				item._remove("stale (remote deleted)")
-			} else {
-				fs.Debugf(item.name, "vfs cache: remote object has gone but local object modified - keeping it")
+				o = nil
+			case rerr != nil:
+				// Could not confirm the object (transient error / unconfirmed
+				// listing) - keep the cached copy rather than discard data we cannot
+				// prove was deleted. Its fingerprint matched when it was written, so
+				// serving it is safe.
+				fs.Infof(item.name, "vfs cache: remote lookup unconfirmed (%v) - keeping cached copy", rerr)
+				o = nil
 			}
-			//} else {
-			// no remote object && no local object
-			// OK
+			// rerr == nil: o now holds the real remote object; fall through to the
+			// fingerprint check below as if it had been passed in.
 		}
-	} else {
+	}
+	if o != nil {
 		remoteFingerprint := fs.Fingerprint(item.c.ctx, o, item.c.opt.FastFingerprint)
 		fs.Debugf(item.name, "vfs cache: checking remote fingerprint %q against cached fingerprint %q", remoteFingerprint, item.info.Fingerprint)
 		if item.info.Fingerprint != "" {

--- a/vfs/vfscache/item_test.go
+++ b/vfs/vfscache/item_test.go
@@ -4,11 +4,13 @@ package vfscache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -698,4 +700,99 @@ func TestItemHandleCachingReset(t *testing.T) {
 	rr, _, err = item.Reset()
 	require.NoError(t, err)
 	assert.Equal(t, RemovedNotInUse, rr)
+}
+
+// errNewObjectFs wraps an fs.Fs and, once armed, makes NewObject return a fixed
+// error. Used to drive the unconfirmed-remote branch of _checkObject. The arm
+// flag is atomic so the cache's background goroutines (which may call through
+// fremote) don't race with the test arming it; the wrapper is installed at
+// construction so c.fremote is never reassigned.
+type errNewObjectFs struct {
+	fs.Fs
+	armed atomic.Bool
+	err   error
+}
+
+func (f *errNewObjectFs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
+	if f.armed.Load() {
+		return nil, f.err
+	}
+	return f.Fs.NewObject(ctx, remote)
+}
+
+// newErrFsItemTestCache builds a cache whose remote is wrapped so NewObject can
+// be made to return lookupErr on demand (after rfs.armed is set).
+func newErrFsItemTestCache(t *testing.T, lookupErr error) (r *fstest.Run, c *Cache, rfs *errNewObjectFs) {
+	opt := vfscommon.Opt
+	opt.CachePollInterval = 0
+	opt.WriteBack = 0
+	opt.HandleCaching = 0
+
+	r = fstest.NewRun(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	rfs = &errNewObjectFs{Fs: r.Fremote, err: lookupErr}
+	avInfos = nil
+	c, err := New(ctx, rfs, &opt, addVirtual)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		rfs.armed.Store(false)
+		require.NoError(t, c.CleanUp())
+		cancel()
+	})
+	return r, c, rfs
+}
+
+// populate writes a clean cached item from the real remote (Open(obj) uses the
+// passed object, so it does not route through the wrapper's NewObject).
+func populateCleanItem(t *testing.T, r *fstest.Run, c *Cache) (contents string, item *Item) {
+	contents, obj, item := newFile(t, r, c, "existing")
+	require.NoError(t, item.Open(obj))
+	buf := make([]byte, 10)
+	_, err := item.ReadAt(buf, 10)
+	require.NoError(t, err)
+	require.NoError(t, item.Close(nil))
+	return contents, item
+}
+
+// TestItemCheckObjectUnconfirmedKept: when the remote lookup fails with a
+// transient (non-NotFound) error, a clean cached file must be kept, not
+// discarded - the data is still readable and its fingerprint matched when
+// written.
+func TestItemCheckObjectUnconfirmedKept(t *testing.T) {
+	r, c, rfs := newErrFsItemTestCache(t, errors.New("connection refused"))
+	contents, item := populateCleanItem(t, r, c)
+
+	rfs.armed.Store(true) // NewObject now returns a transient error
+
+	require.NoError(t, item.Open(nil))
+	size, err := item.GetSize()
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(contents)), size) // kept, not truncated to 0
+
+	fi, err := os.Stat(item.c.toOSPath(item.name))
+	require.NoError(t, err)
+	assert.Greater(t, fi.Size(), int64(0)) // cache file kept
+
+	require.NoError(t, item.Close(nil))
+}
+
+// TestItemCheckObjectConfirmedDeleted: when the remote confirms the object is
+// gone (ErrorObjectNotFound), the clean cached file is still discarded -
+// deletion propagation is preserved.
+func TestItemCheckObjectConfirmedDeleted(t *testing.T) {
+	r, c, rfs := newErrFsItemTestCache(t, fs.ErrorObjectNotFound)
+	_, item := populateCleanItem(t, r, c)
+
+	rfs.armed.Store(true) // NewObject now returns ErrorObjectNotFound
+
+	require.NoError(t, item.Open(nil))
+	size, err := item.GetSize()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), size) // discarded
+
+	fi, err := os.Stat(item.c.toOSPath(item.name))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), fi.Size())
+
+	require.NoError(t, item.Close(nil))
 }

--- a/vfs/vfscache/item_test.go
+++ b/vfs/vfscache/item_test.go
@@ -4,11 +4,13 @@ package vfscache
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
 	"os"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -381,6 +383,39 @@ func TestItemReloadRemoteGone(t *testing.T) {
 	fi, err := os.Stat(item.c.toOSPath(item.name))
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), fi.Size())
+
+	require.NoError(t, item.Close(nil))
+}
+
+// TestItemCheckObjectReconfirmedFound: when the listing gave no object but the
+// re-confirming lookup finds it, the item is fingerprint-checked as if the
+// object had been passed in - it is kept and item.o / the downloaders are
+// populated from the looked-up object.
+func TestItemCheckObjectReconfirmedFound(t *testing.T) {
+	r, c, rfs := newErrFsItemTestCache(t, errors.New("not used"))
+	contents, item := populateCleanItem(t, r, c)
+
+	before := rfs.calls.Load()
+
+	require.NoError(t, item.Open(nil))
+
+	assert.Greater(t, rfs.calls.Load(), before) // the re-confirming lookup ran
+
+	item.mu.Lock()
+	o, dls := item.o, item.downloaders
+	item.mu.Unlock()
+	require.NotNil(t, o)
+	assert.Equal(t, item.name, o.Remote())
+	assert.NotNil(t, dls)
+
+	size, err := item.GetSize()
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(contents)), size)
+
+	buf := make([]byte, 10)
+	_, err = item.ReadAt(buf, 0)
+	require.NoError(t, err)
+	assert.Equal(t, contents[:10], string(buf))
 
 	require.NoError(t, item.Close(nil))
 }
@@ -822,4 +857,101 @@ func TestItemHandleCachingReopenDuringGraceClose(t *testing.T) {
 		item.graceTimer.Stop()
 	}
 	item.mu.Unlock()
+}
+
+// errNewObjectFs wraps an fs.Fs and, once armed, makes NewObject return a fixed
+// error. Used to drive the unconfirmed-remote branch of _checkObject. The arm
+// flag is atomic so the cache's background goroutines (which may call through
+// fremote) don't race with the test arming it; the wrapper is installed at
+// construction so c.fremote is never reassigned.
+type errNewObjectFs struct {
+	fs.Fs
+	armed atomic.Bool
+	calls atomic.Int32
+	err   error
+}
+
+func (f *errNewObjectFs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
+	f.calls.Add(1)
+	if f.armed.Load() {
+		return nil, f.err
+	}
+	return f.Fs.NewObject(ctx, remote)
+}
+
+// newErrFsItemTestCache builds a cache whose remote is wrapped so NewObject can
+// be made to return lookupErr on demand (after rfs.armed is set).
+func newErrFsItemTestCache(t *testing.T, lookupErr error) (r *fstest.Run, c *Cache, rfs *errNewObjectFs) {
+	opt := vfscommon.Opt
+	opt.CachePollInterval = 0
+	opt.WriteBack = 0
+	opt.HandleCaching = 0
+
+	r = fstest.NewRun(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	rfs = &errNewObjectFs{Fs: r.Fremote, err: lookupErr}
+	avInfos = nil
+	c, err := New(ctx, rfs, &opt, addVirtual)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		rfs.armed.Store(false)
+		require.NoError(t, c.CleanUp())
+		cancel()
+	})
+	return r, c, rfs
+}
+
+// populate writes a clean cached item from the real remote (Open(obj) uses the
+// passed object, so it does not route through the wrapper's NewObject).
+func populateCleanItem(t *testing.T, r *fstest.Run, c *Cache) (contents string, item *Item) {
+	contents, obj, item := newFile(t, r, c, "existing")
+	require.NoError(t, item.Open(obj))
+	buf := make([]byte, 10)
+	_, err := item.ReadAt(buf, 10)
+	require.NoError(t, err)
+	require.NoError(t, item.Close(nil))
+	return contents, item
+}
+
+// TestItemCheckObjectUnconfirmedKept: when the remote lookup fails with a
+// transient (non-NotFound) error, a clean cached file must be kept, not
+// discarded - the data is still readable and its fingerprint matched when
+// written.
+func TestItemCheckObjectUnconfirmedKept(t *testing.T) {
+	r, c, rfs := newErrFsItemTestCache(t, errors.New("connection refused"))
+	contents, item := populateCleanItem(t, r, c)
+
+	rfs.armed.Store(true) // NewObject now returns a transient error
+
+	require.NoError(t, item.Open(nil))
+	size, err := item.GetSize()
+	require.NoError(t, err)
+	assert.Equal(t, int64(len(contents)), size) // kept, not truncated to 0
+
+	fi, err := os.Stat(item.c.toOSPath(item.name))
+	require.NoError(t, err)
+	assert.Greater(t, fi.Size(), int64(0)) // cache file kept
+
+	require.NoError(t, item.Close(nil))
+}
+
+// TestItemCheckObjectConfirmedDeleted: when the remote confirms the object is
+// gone (ErrorObjectNotFound), the clean cached file is still discarded -
+// deletion propagation is preserved.
+func TestItemCheckObjectConfirmedDeleted(t *testing.T) {
+	r, c, rfs := newErrFsItemTestCache(t, fs.ErrorObjectNotFound)
+	_, item := populateCleanItem(t, r, c)
+
+	rfs.armed.Store(true) // NewObject now returns ErrorObjectNotFound
+
+	require.NoError(t, item.Open(nil))
+	size, err := item.GetSize()
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), size) // discarded
+
+	fi, err := os.Stat(item.c.toOSPath(item.name))
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), fi.Size())
+
+	require.NoError(t, item.Close(nil))
 }


### PR DESCRIPTION
In `_checkObject`, a `nil` remote object was treated as a confirmed deletion and the clean cached file was removed (`stale (remote deleted)`), so the next read returned 0 bytes. But `o` is also `nil` when the **directory listing was successful but incomplete** — an eventually-consistent backend, a stale negative right after a remount, or a proxy returning empty-without-error — so `o == nil` arrives with no error to signal it. (A genuine connection failure already surfaces as an I/O error via `list.DirSorted`, so that case isn't affected.)

This re-confirms with `NewObject` before acting on the `nil`, the same pattern the download path already uses (#6190/#6235):

- `ErrorObjectNotFound` / `ErrorIsDir` → remove as before (deletion propagation preserved)
- other (transient) error → keep the cached file; its fingerprint matched when written, so serving it is safe (logged at INFO — happy to return the error instead if you'd prefer)
- success → fingerprint-check it like the normal path

It does **not** cure eventual consistency: if both the listing *and* the `NewObject` HEAD return a stale negative in the same window, the item is still discarded. It fixes the transient-error and "list stale but HEAD authoritative" cases.

Adds two tests (transient → kept, `ErrorObjectNotFound` → removed) and `TestItemReloadRemoteGone` still passes as the deletion-propagation regression guard.

Fixes #9530
