### PR TITLE
Set the content type header by default for webdav

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -513,6 +513,8 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 	f.srv = rest.NewClient(client).SetRoot(u.String())
 
+	f.srv.SetHeader("Content-Type", `application/xml; charset="utf-8"`)
+
 	f.features = (&fs.Features{
 		CanHaveEmptyDirectories: true,
 	}).Fill(ctx, f)


### PR DESCRIPTION
<!--
Thank you for contributing to rclone!

Please discuss anything more than a trivial fix in an issue FIRST - see the
"Linked issue" section below. Then fill in the questions to help us review.
-->

#### What does this change do?

This sets the Content-Type header by default in the webdav backend. The spec seems to has it down as a `SHOULD` for implementations <!-- Describe the change here. -->

#### Linked issue

<!--
Put `Fixes #1234` here if this closes an issue, or `#1234` to link without closing.

IMPORTANT: Anything beyond a trivial fix (typo, doc tweak, small obvious bug fix)
should be discussed and agreed in an issue BEFORE you open a pull request.
Pull requests for larger changes that have not been discussed in an issue first
may be closed. This saves everyone's time if the change needs a different approach
or isn't a good fit.
-->

Fixes #

#### For new or changed backends

<!--
Backend pull requests are often sent without the integration tests having been run.
We cannot merge a backend change until it passes the integration tests.

To be merged, a backend change REQUIRES:
  1. A clean run of `go run ./fstest/test_all -backends <remote>` (summarise the
     result below or paste a screenshot of the test_all output in the web browser).
  2. A test account so the maintainers can run the integration tests daily against
     the backend on the integration test server.

If the tests aren't quite passing yet and you need help getting them
to pass, then submit the PR and we can help getting you over the line.

See https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#writing-a-new-backend
and https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests
-->

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
