### PR TITLE
fs/operations: correct DeleteFile --backup-dir documentation

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -546,7 +546,11 @@ func SuffixName(ctx context.Context, remote string) string {
 // and accumulating stats and errors.
 //
 // If backupDir is set then it moves the file to there instead of
-// deleting
+// deleting.
+//
+// Use BackupDir to find backupDir from --backup-dir. That lookup is
+// relatively expensive, so when deleting many files do it once outside
+// the loop rather than calling it for every object.
 func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs) (err error) {
 	tr := accounting.Stats(ctx).NewCheckingTransfer(dst, "deleting")
 	defer func() {
@@ -579,8 +583,8 @@ func DeleteFileWithBackupDir(ctx context.Context, dst fs.Object, backupDir fs.Fs
 
 // DeleteFile deletes a single file respecting --dry-run and accumulating stats and errors.
 //
-// If useBackupDir is set and --backup-dir is in effect then it moves
-// the file to there instead of deleting
+// DeleteFile does not honour --backup-dir: it always deletes. Call
+// DeleteFileWithBackupDir instead if --backup-dir support is required.
 func DeleteFile(ctx context.Context, dst fs.Object) (err error) {
 	return DeleteFileWithBackupDir(ctx, dst, nil)
 }


### PR DESCRIPTION
### What

Fixes the misleading doc comment on `operations.DeleteFile`, as discussed in #7566.

`DeleteFile` always calls `DeleteFileWithBackupDir(ctx, dst, nil)`, so `backupDir` is always nil and `--backup-dir` is never honoured. The old comment said it would move the file into the backup dir when `--backup-dir` was in effect, which does not match what the code does. The comment also referred to a `useBackupDir` argument that the function does not take.

This updates the comment to state that `DeleteFile` always deletes, and that callers should use `DeleteFileWithBackupDir` when they need `--backup-dir` support.

I also added a note on `DeleteFileWithBackupDir` that the `backupDir` value comes from `BackupDir`, which is relatively expensive, so it should be looked up once outside any delete loop rather than per object. This follows the suggestion in the issue.

### Call site audit

The issue also asked to audit the existing `operations.DeleteFile` callers to see whether any of them should be honouring `--backup-dir`. I went through them:

- `fs/sync/sync.go`: the bulk deletions already go through `DeleteFilesWithBackupDir(..., s.backupDir)` (the `markDeletes`/`deleteFiles` paths), so they do honour `--backup-dir`. The two remaining `DeleteFile` calls remove the source object after a successful move, where backing up the source would not make sense, so leaving them as plain deletes looks intentional.
- `cmd/deletefile`, `cmd/ncdu`, `fs/operations/dedupe.go`, `fs/operations/rc.go`: these are explicit delete actions where `--backup-dir` is not part of the documented behaviour today.

So I have not changed any call site behaviour in this PR, only the documentation. If you would like any of those call sites to start honouring `--backup-dir`, I am happy to do that as a follow up so the behaviour change can be reviewed on its own.

### Testing

`go build`, `go vet`, and `gofmt -l` are clean, and `go test ./fs/operations/ -run TestDelete` passes. The change is comment only.