### PR TITLE
mount2: allow the mount to be exported by the kernel NFS server

### DIFF
--- a/cmd/mount2/fs.go
+++ b/cmd/mount2/fs.go
@@ -75,6 +75,7 @@ func setAttr(node vfs.Node, attr *fuse.Attr) {
 	vfs := node.VFS()
 	attr.Owner.Gid = vfs.Opt.GID
 	attr.Owner.Uid = vfs.Opt.UID
+	attr.Ino = node.Inode()
 	attr.Mode = getMode(node)
 	attr.Size = Size
 	attr.Nlink = 1

--- a/cmd/mount2/node.go
+++ b/cmd/mount2/node.go
@@ -201,7 +201,7 @@ func (n *Node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (ino
 	// out.SetAttrTimeout(dt time.Duration)
 	n.fsys.setEntryOut(vfsNode, out)
 
-	return n.NewInode(ctx, newNode, fusefs.StableAttr{Mode: out.Attr.Mode}), 0
+	return n.NewInode(ctx, newNode, fusefs.StableAttr{Mode: out.Attr.Mode, Ino: newNode.node.Inode()}), 0
 }
 
 var _ = (fusefs.NodeLookuper)((*Node)(nil))
@@ -337,7 +337,7 @@ func (n *Node) Mkdir(ctx context.Context, name string, mode uint32, out *fuse.En
 	}
 	newNode := newNode(n.fsys, newDir)
 	n.fsys.setEntryOut(newNode.node, out)
-	newInode := n.NewInode(ctx, newNode, fusefs.StableAttr{Mode: out.Attr.Mode})
+	newInode := n.NewInode(ctx, newNode, fusefs.StableAttr{Mode: out.Attr.Mode, Ino: newNode.node.Inode()})
 	return newInode, 0
 }
 
@@ -379,7 +379,7 @@ func (n *Node) Create(ctx context.Context, name string, flags uint32, mode uint3
 	n.fsys.setEntryOut(vfsNode, out)
 	newNode := newNode(n.fsys, vfsNode)
 	fs.Debugf(nil, "attr=%#v", out.Attr)
-	newInode := n.NewInode(ctx, newNode, fusefs.StableAttr{Mode: out.Attr.Mode})
+	newInode := n.NewInode(ctx, newNode, fusefs.StableAttr{Mode: out.Attr.Mode, Ino: newNode.node.Inode()})
 	return newInode, fh, 0, 0
 }
 
@@ -528,7 +528,7 @@ func (n *Node) Symlink(ctx context.Context, target, name string, out *fuse.Entry
 
 	n.fsys.setEntryOut(vfsNode, out)
 	newNode := newNode(n.fsys, vfsNode)
-	newInode := n.NewInode(ctx, newNode, fusefs.StableAttr{Mode: out.Attr.Mode})
+	newInode := n.NewInode(ctx, newNode, fusefs.StableAttr{Mode: out.Attr.Mode, Ino: newNode.node.Inode()})
 
 	return newInode, 0
 }

--- a/cmd/mount2/node.go
+++ b/cmd/mount2/node.go
@@ -271,16 +271,22 @@ func (ds *dirStream) Next() (de fuse.DirEntry, errno syscall.Errno) {
 func (ds *dirStream) Close() {
 }
 
-// Seekdir implements fusefs.FileSeekdirer so go-fuse can rewind the directory
-// stream when the kernel calls lseek(fd, 0, SEEK_SET) before a second getdents.
-// Without this, go-fuse returns ENOTSUP and ls returns empty on every call after
-// the first. See: https://github.com/hanwen/go-fuse/issues/549
+// Seekdir implements fusefs.FileSeekdirer so go-fuse can reposition the
+// directory stream. The kernel calls this both to rewind (lseek(fd, 0,
+// SEEK_SET) before a second getdents) and, for a kernel-NFS-exported mount,
+// to resume from a previously returned directory cookie: nfsd is stateless,
+// so it opens a fresh handle and seeks to the last offset on every readdir
+// continuation. Handling only offset 0 made go-fuse return ENOTSUP for those
+// resumes, so any listing spanning more than one readdir batch failed over NFS.
+//
+// dirStream is a snapshot taken at Readdir time and go-fuse assigns each entry
+// a sequential offset in Next() order (the entry yielded at index i carries
+// offset i+1), so repositioning to off means the next entry is the one at
+// index off. Values past the end clamp to EOF via HasNext.
+// See: https://github.com/hanwen/go-fuse/issues/549
 func (ds *dirStream) Seekdir(_ context.Context, off uint64) syscall.Errno {
-	if off == 0 {
-		ds.i = 0
-		return 0
-	}
-	return syscall.ENOTSUP
+	ds.i = int(off)
+	return 0
 }
 
 var _ fusefs.DirStream = (*dirStream)(nil)

--- a/cmd/mount2/node.go
+++ b/cmd/mount2/node.go
@@ -385,6 +385,39 @@ func (n *Node) Create(ctx context.Context, name string, flags uint32, mode uint3
 
 var _ = (fusefs.NodeCreater)((*Node)(nil))
 
+// Mknod creates a regular file. The kernel NFS server creates regular files
+// with MKNOD (it creates-then-opens, so vfs_create routes through fuse_create
+// which sends FUSE_MKNOD when there is no open intent), so without this an
+// NFS-exported mount fails every file creation with ENOTSUPP. Local and SMB
+// clients create via Create (FUSE_CREATE) and are unaffected. This mirrors the
+// cmd/mount (bazil) backend, which implements mknod for the same reason
+// (see #2115).
+//
+// Device/special files are not supported by the VFS, so a non-zero rdev is
+// rejected. Mknod returns no open handle (unlike Create), so the handle Create
+// opens is flushed (to instantiate the file and surface any I/O error) and
+// released before returning.
+func (n *Node) Mknod(ctx context.Context, name string, mode uint32, rdev uint32, out *fuse.EntryOut) (node *fusefs.Inode, errno syscall.Errno) {
+	defer log.Trace(n, "name=%q, mode=%#o, rdev=%d", name, mode, rdev)("node=%v, errno=%v", &node, &errno)
+	if rdev != 0 {
+		fs.Errorf(n, "Can't create device node %q", name)
+		return nil, syscall.EIO
+	}
+	node, fh, _, errno := n.Create(ctx, name, uint32(os.O_CREATE|os.O_WRONLY), mode, out)
+	if errno != 0 {
+		return nil, errno
+	}
+	if fh != nil {
+		if errno := fh.(fusefs.FileFlusher).Flush(ctx); errno != 0 {
+			return nil, errno
+		}
+		_ = fh.(fusefs.FileReleaser).Release(ctx)
+	}
+	return node, 0
+}
+
+var _ = (fusefs.NodeMknoder)((*Node)(nil))
+
 // Unlink should remove a child from this directory.  If the
 // return status is OK, the Inode is removed as child in the
 // FS tree automatically. Default is to return EROFS.

--- a/cmd/mount2/node_test.go
+++ b/cmd/mount2/node_test.go
@@ -1,0 +1,45 @@
+//go:build linux || (darwin && amd64)
+
+package mount2
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// TestDirStreamSeekdir checks that Seekdir repositions the snapshot directory
+// stream to an arbitrary offset. A kernel-NFS-exported mount needs this for
+// readdir continuation: the stateless server opens a fresh handle and seeks to
+// the last returned cookie on every batch. Offset 0 must still reset to the
+// start (the rewind / re-read case) and offsets at or past the end must clamp
+// to EOF.
+func TestDirStreamSeekdir(t *testing.T) {
+	ctx := context.Background()
+	// 3 real entries plus the synthesized "." and ".." => 5 entries total,
+	// occupying internal indices 0..4 (go-fuse offsets 1..5). HasNext is true
+	// while i < len(nodes)+2, i.e. i < 5.
+	ds := &dirStream{nodes: make([]os.FileInfo, 3)}
+
+	for _, tc := range []struct {
+		off      uint64
+		wantI    int
+		wantNext bool
+	}{
+		{0, 0, true},    // rewind to start (the re-read case)
+		{2, 2, true},    // resume at the first real entry
+		{4, 4, true},    // last entry
+		{5, 5, false},   // exactly at end => EOF
+		{99, 99, false}, // past end => clamped to EOF via HasNext
+	} {
+		if errno := ds.Seekdir(ctx, tc.off); errno != 0 {
+			t.Fatalf("Seekdir(%d) returned errno %v, want 0", tc.off, errno)
+		}
+		if ds.i != tc.wantI {
+			t.Errorf("Seekdir(%d): i = %d, want %d", tc.off, ds.i, tc.wantI)
+		}
+		if got := ds.HasNext(); got != tc.wantNext {
+			t.Errorf("Seekdir(%d): HasNext() = %v, want %v", tc.off, got, tc.wantNext)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #9547.

Makes a `mount2` (go-fuse) mount work when re-exported by the Linux kernel NFS server, bringing it to parity with `cmd/mount` (fixed for the same use case in #2115). Three `cmd/mount2`-only gaps, all fixed here in `cmd/mount2/` (no go.mod / go-fuse change):

1. **`Mknod`** — nfsd creates regular files via `FUSE_MKNOD`; mount2 only had `Create`. Rejects device nodes (`rdev != 0` → `EIO`), delegates to `Create`, then flushes + releases the handle (Mknod returns none). Mirrors the `cmd/mount` handler from #2115. Fixes `ENOTSUPP` on create.
2. **Stable inodes** — set `attr.Ino` in `setAttr` and `StableAttr.Ino` at the four `NewInode` sites. Fixes `ESTALE` on `chmod`/`chown`/`truncate` right after a write (inode 0 broke NFS file-handle validation).
3. **`Seekdir` for arbitrary offsets** — 00bd00d intentionally limited `Seekdir` to offset 0. `dirStream` is a snapshot with sequential offsets, so `ds.i = int(off)` resumes correctly at any readdir cookie; off==0 still resets (preserving the re-read fix), past-end clamps to EOF. Fixes `Unknown error 524` on large listings.

### Tests
- `TestDirStreamSeekdir` — rewind to 0, mid-stream resume, and EOF clamp at/past the end.
- The existing `TestMount` (`vfstest`) still covers the local mount path — regression guard for the Create/inode/readdir changes.
- The NFS-export paths need a kernel NFS server (not in CI), so they were validated against a real Linux `nfs-kernel-server` export (`fsid=`) over **NFSv3, v4.0, v4.2**: create/read/write, post-write `chmod`/`chown`/`truncate`, large directory listings, and a stale handle correctly returning `ESTALE` (not aliasing) after a server restart.

### Note / question
Gap 3 overrides the deliberate offset-0-only choice from 00bd00d. I believe arbitrary offsets are safe because `dirStream.nodes` is a fixed snapshot taken at `Readdir`, so an in-range seek is well-defined and a stale NFS cookie at worst lands on a valid index or clamps to EOF — but happy to gate it differently if you'd prefer.

### Limitations
Writing through the export needs `--vfs-cache-mode writes` (or higher), same as `cmd/mount`. Tested with the Linux kernel NFS server only.
