### PR TITLE
fs/list: don't double the slash when dir already ends in one

### DIFF
--- a/fs/list/list.go
+++ b/fs/list/list.go
@@ -103,7 +103,11 @@ func filterDir(ctx context.Context, entries fs.DirEntries, includeAll bool, dir 
 	prefix := ""
 	if dir != "" {
 		prefix = dir
-		if !bucket.IsAllSlashes(dir) {
+		// Don't double the slash if dir already ends in one - this
+		// happens for a pseudo-directory created by an object key
+		// containing "//", and doubling it here makes every real
+		// child entry fail the HasPrefix check below (#9383).
+		if !bucket.IsAllSlashes(dir) && !strings.HasSuffix(dir, "/") {
 			prefix += "/"
 		}
 	}

--- a/fs/list/list_test.go
+++ b/fs/list/list_test.go
@@ -87,6 +87,19 @@ func TestFilterAndSortCheckDirRoot(t *testing.T) {
 	)
 }
 
+func TestFilterDirHandlesDirRemoteEndingInSlash(t *testing.T) {
+	// Regression test for #9383: when dir itself already ends in "/"
+	// (e.g. a pseudo-directory created by an object key containing "//"),
+	// filterDir must not double the slash when building its prefix --
+	// otherwise every real child entry is wrongly rejected as "too short".
+	da := mockdir.New("dir/sub")
+	oA := mockobject.Object("dir/file")
+	entries := fs.DirEntries{da, oA}
+	newEntries, err := filterDir(context.Background(), entries, true, "dir/", nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, fs.DirEntries{da, oA}, newEntries)
+}
+
 type unknownDirEntry string
 
 func (o unknownDirEntry) Fs() fs.Info                               { return fs.Unknown }


### PR DESCRIPTION
## Summary
Fixes #9383.

`rclone copy`/`sync` silently drops objects under a "directory" whose own name ends in `/` — which happens for any object key containing a double slash (e.g. `2026/1//1d8c54b6416447b99897ab846100f7f6` on S3/S3-compatible storage creates a pseudo-directory named `2026/1/`). Listing that pseudo-directory logs:

```
ERROR : 2026/1/: Entry doesn't belong in directory "2026/1/" (too short) - ignoring
ERROR : 2026/1/0284fd2c76f24e3a8c4508aa1f60f899: Entry doesn't belong in directory "2026/1/" (too short) - ignoring
```

and the transfer completes with exit code 0, silently missing those objects.

## Root cause
`filterDir` (`fs/list/list.go`) builds its match prefix like this:
```go
prefix := ""
if dir != "" {
    prefix = dir
    if !bucket.IsAllSlashes(dir) {
        prefix += "/"
    }
}
```
This unconditionally appends `/` whenever `dir` isn't *all* slashes — but doesn't check whether `dir` already *ends* in one. When `dir` is `"2026/1/"` (a real, non-degenerate directory name that happens to end in `/`), this produces `prefix = "2026/1//"`. Every real child entry — e.g. `"2026/1/0284fd2c..."` — fails the `strings.HasPrefix(remote, prefix)` check against the doubled prefix and gets logged as `"too short"` and dropped, even though it unambiguously belongs under `"2026/1/"`.

## Fix
Only append `/` to the prefix when `dir` doesn't already end with one:
```go
if !bucket.IsAllSlashes(dir) && !strings.HasSuffix(dir, "/") {
    prefix += "/"
}
```
`IsAllSlashes` is still checked separately since an all-slashes `dir` (e.g. `"/"`) is itself already a valid prefix as-is — this change doesn't alter that path.

## Test plan
- [x] Added `TestFilterDirHandlesDirRemoteEndingInSlash` in `fs/list/list_test.go`, using the same `mockdir`/`mockobject` fixtures as the existing tests in this file.
- [x] Verified the new test **fails** against the pre-fix code (reproduces the exact `(too short)` rejection from the issue) and **passes** with the fix, by temporarily reverting just the `list.go` condition and re-running.
- [x] `go build ./...` — clean, no breakage elsewhere in the module.
- [x] `go vet ./fs/list/...` — clean.
- [x] `go test ./fs/list/...` — all tests pass (full package, including `TestFilterAndSortCheckDir`/`CheckDirRoot` which already cover the *single*-slash double-slash-dir case and are unaffected).
