### PR TITLE
fs: fix negative offset when a suffix Range request exceeds object size

### DIFF
--- a/fs/open_options.go
+++ b/fs/open_options.go
@@ -126,6 +126,12 @@ func (o *RangeOption) Decode(size int64) (offset, limit int64) {
 	} else {
 		if o.End >= 0 {
 			offset = size - o.End
+			if offset < 0 {
+				// RFC 7233 section 2.1: if the suffix-length is
+				// larger than the representation, use the entire
+				// representation.
+				offset = 0
+			}
 		} else {
 			offset = 0
 		}
@@ -162,7 +168,14 @@ func FixRangeOption(options []OpenOption, size int64) {
 		case *RangeOption:
 			// If start is < 0 then fetch from the end
 			if x.Start < 0 {
-				x = &RangeOption{Start: size - x.End, End: -1}
+				start := size - x.End
+				if start < 0 {
+					// RFC 7233 section 2.1: if the suffix-length is
+					// larger than the representation, use the entire
+					// representation (#6310).
+					start = 0
+				}
+				x = &RangeOption{Start: start, End: -1}
 				options[i] = x
 			}
 			// If end is too big or undefined, fetch to the end

--- a/fs/open_options_test.go
+++ b/fs/open_options_test.go
@@ -53,6 +53,13 @@ func TestRangeOptionDecode(t *testing.T) {
 		{in: RangeOption{Start: 1, End: -1}, size: 100, wantOffset: 1, wantLimit: -1},
 		{in: RangeOption{Start: -1, End: 90}, size: 100, wantOffset: 10, wantLimit: -1},
 		{in: RangeOption{Start: -1, End: -1}, size: 100, wantOffset: 0, wantLimit: -1},
+		// Regression test for #6310: a suffix range whose length exceeds
+		// the size of the object must not produce a negative offset -
+		// RFC 7233 section 2.1 says the entire representation should be
+		// used instead. "bytes=-90407" against a 5 byte object panicked
+		// downstream with "slice bounds out of range [-90402:]".
+		{in: RangeOption{Start: -1, End: 90407}, size: 5, wantOffset: 0, wantLimit: -1},
+		{in: RangeOption{Start: -1, End: 5}, size: 5, wantOffset: 0, wantLimit: -1},
 	} {
 		gotOffset, gotLimit := test.in.Decode(test.size)
 		what := fmt.Sprintf("%+v size=%d", test.in, test.size)
@@ -224,6 +231,20 @@ func TestFixRangeOptions(t *testing.T) {
 			},
 			want: []OpenOption{
 				&RangeOption{Start: 10, End: 99},
+			},
+			size: 100,
+		},
+		{
+			// Regression test for #6310: a suffix range longer than the
+			// object must clamp to the start of the file (Start: 0),
+			// not produce a negative Start which would corrupt the
+			// Range header sent to the remote.
+			name: "Fetch the last N bytes where N is bigger than size",
+			in: []OpenOption{
+				&RangeOption{Start: -1, End: 90407},
+			},
+			want: []OpenOption{
+				&RangeOption{Start: 0, End: 99},
 			},
 			size: 100,
 		},

--- a/lib/http/serve/serve_test.go
+++ b/lib/http/serve/serve_test.go
@@ -70,6 +70,24 @@ func TestObjectRange(t *testing.T) {
 	assert.Equal(t, "345", string(body))
 }
 
+func TestObjectRangeSuffixLongerThanObject(t *testing.T) {
+	// Regression test for #6310: a suffix range request (e.g. "bytes=-90407")
+	// asking for more bytes than the object contains used to compute a
+	// negative offset and panic with "slice bounds out of range". Per
+	// RFC 7233 section 2.1, the entire object should be served instead.
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "http://example.com/aFile", nil)
+	r.Header.Add("Range", "bytes=-90407")
+	o := mockobject.New("aFile").WithContent([]byte("hello"), mockobject.SeekModeNone)
+	Object(w, r, o)
+	resp := w.Result()
+	assert.Equal(t, http.StatusPartialContent, resp.StatusCode)
+	assert.Equal(t, "5", resp.Header.Get("Content-Length"))
+	assert.Equal(t, "bytes 0-4/5", resp.Header.Get("Content-Range"))
+	body, _ := io.ReadAll(resp.Body)
+	assert.Equal(t, "hello", string(body))
+}
+
 func TestObjectBadRange(t *testing.T) {
 	w := httptest.NewRecorder()
 	r := httptest.NewRequest("GET", "http://example.com/aFile", nil)


### PR DESCRIPTION
Fixes #6310

## Bug

A fuzzer-found crash: requesting a suffix range longer than the object's size (e.g. `Range: bytes=-90407` against a 5 byte object) panics:

```
panic: runtime error: slice bounds out of range [-90402:]
```

`RangeOption.Decode` computes the offset for a suffix range as `size - End`. When the requested suffix length (`End`) is larger than `size`, this goes negative, and `lib/http/serve.Object` passes that straight through as a byte offset/limit, eventually hitting a negative slice bound downstream.

`FixRangeOption` (used by backends without native suffix-range support, e.g. OneDrive/Box) has the same root cause: it builds a `RangeOption{Start: size - End, ...}`, producing a negative `Start`. That doesn't panic, but `RangeOption.Header()` silently omits a negative `Start` from the rendered `Range:` header, so the backend ends up requesting the wrong byte range (a different suffix range) instead of the whole file.

## Fix

Per [RFC 7233 §2.1](https://www.rfc-editor.org/rfc/rfc7233#section-2.1):

> If the selected representation is shorter than the specified suffix-length, the entire representation is used.

Clamp the computed offset/start to `0` in both `RangeOption.Decode` and `FixRangeOption` instead of letting it go negative.

## Tests

- `fs/open_options_test.go`: added cases to `TestRangeOptionDecode` and `TestFixRangeOptions` covering a suffix range longer than the object size.
- `lib/http/serve/serve_test.go`: added `TestObjectRangeSuffixLongerThanObject`, an end-to-end reproduction of the original PoC from the issue (`Range: bytes=-90407` against a 5-byte `mockobject`), asserting the whole object is served with `200/206` instead of panicking.

## Verification

- `go build ./...` (full module) — clean.
- `go vet ./fs/... ./lib/http/serve/...` — clean.
- `go test ./fs/... ./lib/http/serve/...` — all pass.
- Confirmed both new test cases actually catch the regression: temporarily reverted each fix individually, re-ran the affected test, observed it fail with the exact negative offset from the issue (`-90402`) and a corrupted `Range` header (`Start: -90307`) respectively, then restored the fix and confirmed both pass again.