### PR TITLE
docs: clarify copyto command description

### DIFF
--- a/cmd/copyto/copyto.go
+++ b/cmd/copyto/copyto.go
@@ -29,8 +29,9 @@ var commandDefinition = &cobra.Command{
 	Long: `If source:path is a file or directory then it copies it to a file or
 directory named dest:path.
 
-This can be used to upload single files to other than their current
-name.  If the source is a directory then it acts exactly like the
+This can be used to copy a single file to a destination with a name
+different from its source - for example, uploading and renaming in one
+step. If the source is a directory then it acts exactly like the
 [copy](/commands/rclone_copy/) command.
 
 So


### PR DESCRIPTION
#### What does this change do?

Clarifies the `copyto` command description so it explicitly says the command can copy a single file to a destination with a different name.

#### Linked issue

Fixes #9527

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
