### PR TITLE
s3: correct documented copy_cutoff minimum to 1 byte

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -286,7 +286,7 @@ large file of a known size to stay below this number of chunks limit.
 Any files larger than this that need to be server-side copied will be
 copied in chunks of this size.
 
-The minimum is 0 and the maximum is 5 GiB.`,
+The minimum is 1 byte and the maximum is 5 GiB.`,
 			Default:  fs.SizeSuffix(maxSizeForCopy),
 			Advanced: true,
 		}, {


### PR DESCRIPTION
#### What does this change do?

Corrects the `copy_cutoff` option help: the documented minimum was `0`, but since #7400 `checkCopyCutoff` rejects any value below `fs.SizeSuffixBase` (1 byte), so `--s3-copy-cutoff=0` now fails at startup. This updates the help text to say the minimum is 1 byte.

Doc-only, as requested in the issue — no regenerated docs and no backend behaviour change.

#### Linked issue

Fixes #7391

#### For new or changed backends

N/A — documentation-only change, no backend behaviour is altered.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
