### PR TITLE
vfs/vfstest: add Mknod test exercising all three mount backends

### DIFF
--- a/vfs/vfstest/fs.go
+++ b/vfs/vfstest/fs.go
@@ -107,6 +107,7 @@ func RunTests(t *testing.T, useVFS bool, minimumRequiredCacheMode vfscommon.Cach
 			t.Run("TestWriteFileDup", TestWriteFileDup)
 			t.Run("TestWriteFileAppend", TestWriteFileAppend)
 			t.Run("TestSymlinks", TestSymlinks)
+			t.Run("TestMknod", TestMknod)
 		})
 		fs.Logf(nil, "Finished test run with %s (ok=%v)", what, ok)
 		run.Finalise()

--- a/vfs/vfstest/mknod_other.go
+++ b/vfs/vfstest/mknod_other.go
@@ -1,0 +1,13 @@
+//go:build !linux && !darwin && !freebsd && !openbsd
+
+package vfstest
+
+import (
+	"runtime"
+	"testing"
+)
+
+// TestMknod is not supported on this platform.
+func TestMknod(t *testing.T) {
+	t.Skip("not supported on " + runtime.GOOS)
+}

--- a/vfs/vfstest/mknod_unix.go
+++ b/vfs/vfstest/mknod_unix.go
@@ -1,0 +1,42 @@
+//go:build linux || darwin || freebsd || openbsd
+
+package vfstest
+
+import (
+	"os"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// TestMknod checks that Mknod creates a regular file through the mount.
+//
+// The VFS only supports regular files (S_IFREG) - this is the path the
+// kernel NFS server drives when a client creates a file over an exported
+// mount (device nodes are rejected). All three mount backends (mount,
+// mount2, cmount) implement Mknod, so this runs against each via RunTests.
+func TestMknod(t *testing.T) {
+	run.skipIfVFS(t) // Mknod is a mount syscall; no Mknod on the direct-VFS pass
+	run.skipIfNoFUSE(t)
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping test on OSX") // macFUSE Mknod support is unreliable
+	}
+
+	const name = "testmknod"
+	path := run.path(name)
+
+	// S_IFREG => regular file; dev 0 since it is not a device node.
+	err := unix.Mknod(path, unix.S_IFREG|0640, 0)
+	require.NoError(t, err)
+
+	fi, err := os.Stat(path)
+	require.NoError(t, err)
+	assert.Truef(t, fi.Mode().IsRegular(), "expected a regular file, got mode %v", fi.Mode())
+	assert.Equal(t, int64(0), fi.Size())
+
+	run.waitForWriters()
+	run.rm(t, name)
+}


### PR DESCRIPTION
As suggested by @ncw in #9548 — now that `Mknod` is implemented by all three mount backends (mount, mount2, cmount), this adds a shared `vfstest` for it.

`TestMknod` creates a regular file (`S_IFREG`) through the mounted path and asserts it reads back as a 0-byte regular file — the path the kernel NFS server drives when a client creates a file over an exported mount. It runs against each backend via `RunTests`, and skips on the direct-VFS pass, on macOS (macFUSE `Mknod` is unreliable), and on non-unix platforms.

Verified locally against the `mount2` backend across all VFS cache modes.
