### PR TITLE
accounting: fix goroutine leak in NewStatsGroup for zero-transfer rc jobs

### DIFF
--- a/fs/accounting/stats_groups.go
+++ b/fs/accounting/stats_groups.go
@@ -301,9 +301,16 @@ func GlobalStats() *StatsInfo {
 }
 
 // NewStatsGroup creates new stats under named group.
+//
+// The averageLoop is intentionally NOT started here: it is started on
+// demand by NewTransfer / NewTransferRemoteSize when real transfer
+// activity begins and stopped by DoneTransferring when the last
+// transfer completes. Starting it eagerly leaked one goroutine per
+// group that never performed a transfer (issue #9567) - e.g. rcd
+// daemons driven by frequent rc sync/move calls where each call gets
+// a fresh job/N group and the source is often empty.
 func NewStatsGroup(ctx context.Context, group string) *StatsInfo {
 	stats := NewStats(ctx)
-	stats.startAverageLoop()
 	stats.group = group
 	groups.set(ctx, group, stats)
 	return stats

--- a/fs/accounting/stats_groups_test.go
+++ b/fs/accounting/stats_groups_test.go
@@ -271,3 +271,42 @@ func percentDiff(start, end uint64) uint64 {
 	}
 	return (diff * 100) / start
 }
+
+// Regression for #9567: NewStatsGroup used to start the averageLoop
+// goroutine unconditionally at group creation. When an rcd daemon was
+// driven by many rc sync/move calls that transferred zero files, each
+// call created a fresh job/N group whose averageLoop was started but
+// never stopped (nothing ever went transferring->empty), leaking one
+// goroutine per call. The loop must only start on demand from
+// NewTransfer / NewTransferRemoteSize, and it must still stop when the
+// last transfer completes.
+func TestNewStatsGroupDoesNotStartAverageLoop(t *testing.T) {
+	ctx := context.Background()
+	defer func() {
+		groups = newStatsGroups()
+	}()
+
+	stats := NewStatsGroup(ctx, "test-group-9567")
+
+	stats.mu.RLock()
+	started := stats.average.started
+	stats.mu.RUnlock()
+	assert.False(t, started,
+		"NewStatsGroup must not start averageLoop for a zero-transfer group (issue #9567)")
+
+	// The loop must still start on demand when a real transfer is added,
+	// and stop cleanly once the last transfer completes.
+	tr := stats.NewTransferRemoteSize("regression-9567", 0, nil, nil)
+	stats.mu.RLock()
+	startedAfterTransfer := stats.average.started
+	stats.mu.RUnlock()
+	assert.True(t, startedAfterTransfer,
+		"averageLoop should start on demand when a transfer is added")
+
+	tr.Done(ctx, nil)
+	stats.mu.RLock()
+	startedAfterDone := stats.average.started
+	stats.mu.RUnlock()
+	assert.False(t, startedAfterDone,
+		"averageLoop should stop when the last transfer is done")
+}


### PR DESCRIPTION
#### What does this change do?

Stops `NewStatsGroup` from starting the `averageLoop` goroutine at group creation, closing the goroutine leak reported in #9567.

An rcd daemon driven by frequent short-lived `rc sync/move` calls (no `_group`) creates a fresh `job/N` stats group per call. Each group used to spawn its `averageLoop` immediately, but the loop is only stopped from `DoneTransferring` when the transferring/checking maps drain from non-empty back to empty. For a job that transferred zero files, that state transition never fires, so the goroutine (and the `StatsInfo` it retains) leaks. The reporter observed ~61k goroutines and ~640 MB RSS after ~7 days of a per-minute timer over 6 mappings, i.e. one goroutine per rc call.

This is the same class of leak fixed for `NewStats` in #8571 and is fixed the same way: don't auto-start the loop. `NewTransfer` / `NewTransferRemoteSize` already start it on demand when real transfer work begins, and `DoneTransferring` already stops it when the last transfer completes, so behaviour is unchanged for groups that actually transfer bytes. Groups that never transfer anything now cost zero goroutines.

The bundled regression test (`TestNewStatsGroupDoesNotStartAverageLoop`) asserts all three legs:

1. `NewStatsGroup` alone does not start the loop.
2. Adding a transfer via `NewTransferRemoteSize` still starts it.
3. `tr.Done` still stops it once the last transfer finishes.

I verified the test fails on `master` (assertion `average.started == false` after `NewStatsGroup`) and passes with this patch. `go test ./fs/accounting/` is green and `golangci-lint run ./fs/accounting/...` reports 0 issues.

#### Linked issue

Fixes #9567

#### For new or changed backends

Not a backend change.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.

#### AI disclosure

This patch was written with the assistance of Claude. I have reviewed the diff and the test and take responsibility for the code.
