### PR TITLE
zoho: handle WorkDrive 429 rate limiting - honour Retry-After, per-remote tps limit, per-folder listing limiter

### DIFF
--- a/backend/zoho/folderlist_test.go
+++ b/backend/zoho/folderlist_test.go
@@ -1,0 +1,238 @@
+package zoho
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/stretchr/testify/assert"
+)
+
+// maxRolling returns the largest number of grants falling inside any
+// half-open (t-window, t] interval - the quantity Zoho's throttle caps.
+func maxRolling(grants []time.Time, window time.Duration) int {
+	mx := 0
+	for i := range grants {
+		c := 0
+		for j := 0; j <= i; j++ {
+			if grants[i].Sub(grants[j]) < window {
+				c++
+			}
+		}
+		mx = max(mx, c)
+	}
+	return mx
+}
+
+func TestFolderListLimiter(t *testing.T) {
+	// Isolate from the process-wide registry and restore it afterwards, so this
+	// test neither observes nor leaves shared state for integration runs in the
+	// same process.
+	saved := folderListLimiterRegistry
+	folderListLimiterRegistry = &folderListLimiters{limiters: make(map[string]*folderListLimiterEntry)}
+	defer func() { folderListLimiterRegistry = saved }()
+
+	window := time.Duration(defaultListFolderWindow)
+	newFs := func(region string) *Fs {
+		f := &Fs{}
+		f.opt.Region = region
+		f.opt.ListFolderWindow = defaultListFolderWindow
+		f.opt.ListFolderLimit = defaultListFolderLimit
+		f.opt.ListFolderBurst = defaultListFolderBurst
+		return f
+	}
+	f := newFs("eu")
+
+	// The defaults must satisfy the limiter's own precondition (burst is carved
+	// out of the limit, so it has to leave at least one paced token).
+	assert.Less(t, defaultListFolderBurst, defaultListFolderLimit, "default burst must be below default limit")
+
+	// Same region+folder shares one limiter; a different folder, or the same
+	// folder id in a different region, is keyed separately.
+	limA := f.folderListLimiter("A")
+	assert.Same(t, limA, f.folderListLimiter("A"), "same folder shares one limiter")
+	assert.NotSame(t, limA, f.folderListLimiter("B"), "different folder gets its own limiter")
+	assert.NotSame(t, limA, newFs("com").folderListLimiter("A"), "same folder id in another region is distinct")
+
+	// Idle eviction: an entry not listed within the window is dropped on the
+	// next sweep. Age folder A and the last sweep by hand (no sleeping), then a
+	// listing of a different folder triggers the sweep.
+	reg := folderListLimiterRegistry
+	keyA := f.opt.Region + "\x00" + "A"
+	reg.mu.Lock()
+	reg.limiters[keyA].lastListed = time.Now().Add(-2 * window)
+	reg.lastSweep = time.Now().Add(-2 * window)
+	reg.mu.Unlock()
+
+	f.folderListLimiter("C") // triggers the sweep
+
+	reg.mu.Lock()
+	_, aKept := reg.limiters[keyA]
+	_, cKept := reg.limiters[f.opt.Region+"\x00"+"C"]
+	reg.mu.Unlock()
+	assert.False(t, aKept, "stale folder A is evicted")
+	assert.True(t, cKept, "freshly listed folder C is kept")
+}
+
+// TestFolderWindowLimiterShape drives reserve with a synthetic clock and
+// checks the promised flow: a burst at the window start, the rest of the
+// budget paced across the window, and the burst RE-ARMING at the next window
+// boundary (delayed only by the sliding safety margin).
+func TestFolderWindowLimiterShape(t *testing.T) {
+	saved := folderListLimiterRegistry
+	folderListLimiterRegistry = &folderListLimiters{limiters: make(map[string]*folderListLimiterEntry)}
+	defer func() { folderListLimiterRegistry = saved }()
+
+	f := &Fs{}
+	f.opt.Region = "eu"
+	f.opt.ListFolderWindow = defaultListFolderWindow
+	f.opt.ListFolderLimit = defaultListFolderLimit
+	f.opt.ListFolderBurst = defaultListFolderBurst
+	lim := f.folderListLimiter("shape")
+
+	window := time.Duration(defaultListFolderWindow)
+	interval := window / time.Duration(defaultListFolderLimit-defaultListFolderBurst)
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	var grants []time.Time
+	reserve := func(now time.Time) time.Time {
+		g := lim.reserve(now)
+		grants = append(grants, g)
+		return g
+	}
+
+	// Window 1: the first burst grants pass immediately...
+	for i := 0; i < defaultListFolderBurst; i++ {
+		assert.Equal(t, base, reserve(base), "burst grant %d passes immediately", i+1)
+	}
+	// ...then the paced phase spends the rest of the budget one interval apart
+	// (greedy demand: the caller comes back as soon as the last grant is due).
+	g := base
+	for k := 1; k <= defaultListFolderLimit-defaultListFolderBurst; k++ {
+		g = reserve(g)
+		assert.Equal(t, base.Add(time.Duration(k)*interval), g, "paced grant %d", k)
+	}
+	assert.Less(t, g.Sub(base), window, "the whole budget fits inside the window")
+
+	// Budget exhausted: the next grant jumps to the window boundary, where the
+	// burst re-arms; the sliding safety log defers it by its margin so the
+	// oldest grant has left Zoho's window.
+	reburst := reserve(g)
+	assert.Equal(t, base.Add(window+folderListSafetyMargin), reburst, "re-burst at the next window boundary")
+	for i := 1; i < defaultListFolderBurst; i++ {
+		assert.Equal(t, reburst, reserve(reburst), "window 2 burst grant %d is immediate", i+1)
+	}
+	// And window 2's paced phase continues from there.
+	assert.Equal(t, reburst.Add(interval), reserve(reburst), "window 2 paced phase")
+
+	assert.LessOrEqual(t, maxRolling(grants, window), defaultListFolderLimit, "never more than limit grants in any rolling window")
+}
+
+// TestFolderWindowLimiterIdleResume checks the corner the sliding safety log
+// exists for: consuming a full budget, going idle into the middle of a later
+// window and resuming - the rolling cap must hold across the grid boundaries.
+func TestFolderWindowLimiterIdleResume(t *testing.T) {
+	saved := folderListLimiterRegistry
+	folderListLimiterRegistry = &folderListLimiters{limiters: make(map[string]*folderListLimiterEntry)}
+	defer func() { folderListLimiterRegistry = saved }()
+
+	f := &Fs{}
+	f.opt.Region = "eu"
+	f.opt.ListFolderWindow = defaultListFolderWindow
+	f.opt.ListFolderLimit = defaultListFolderLimit
+	f.opt.ListFolderBurst = defaultListFolderBurst
+	lim := f.folderListLimiter("resume")
+
+	window := time.Duration(defaultListFolderWindow)
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	var grants []time.Time
+	g := base
+	// Spend window 1's full budget greedily.
+	for i := 0; i < defaultListFolderLimit; i++ {
+		g = lim.reserve(g)
+		grants = append(grants, g)
+	}
+	// Resume mid-window-2 after an idle gap and hammer across the 2->3
+	// boundary: a fresh burst fires on resume and again at the boundary.
+	g = base.Add(window + window/2)
+	for i := 0; i < defaultListFolderLimit; i++ {
+		g = lim.reserve(g)
+		grants = append(grants, g)
+	}
+	assert.LessOrEqual(t, maxRolling(grants, window), defaultListFolderLimit, "rolling cap holds across idle resume and grid boundaries")
+}
+
+// TestFolderWindowLimiterClamps checks the burst/limit clamps behaviourally.
+func TestFolderWindowLimiterClamps(t *testing.T) {
+	saved := folderListLimiterRegistry
+	folderListLimiterRegistry = &folderListLimiters{limiters: make(map[string]*folderListLimiterEntry)}
+	defer func() { folderListLimiterRegistry = saved }()
+
+	window := time.Duration(defaultListFolderWindow)
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	newFs := func(limit, burst int) *Fs {
+		f := &Fs{}
+		f.opt.Region = "eu"
+		f.opt.ListFolderWindow = defaultListFolderWindow
+		f.opt.ListFolderLimit = limit
+		f.opt.ListFolderBurst = burst
+		return f
+	}
+
+	// burst 0 clamps to 1: pacing starts from the second listing.
+	lim := newFs(defaultListFolderLimit, 0).folderListLimiter("Z")
+	assert.Equal(t, base, lim.reserve(base))
+	assert.Equal(t, base.Add(window/time.Duration(defaultListFolderLimit-1)), lim.reserve(base), "second listing is paced")
+
+	// burst >= limit clamps to limit-1, leaving one paced token per window.
+	lim = newFs(5, 99).folderListLimiter("Y")
+	for i := 0; i < 4; i++ {
+		assert.Equal(t, base, lim.reserve(base), "clamped burst grant %d", i+1)
+	}
+	assert.Equal(t, base.Add(window), lim.reserve(base), "5th grant rolls into the next window")
+
+	// limit 1 keeps a single burst token: one listing per window (+margin once
+	// the safety log is full).
+	lim = newFs(1, 3).folderListLimiter("X")
+	assert.Equal(t, base, lim.reserve(base))
+	assert.Equal(t, base.Add(window+folderListSafetyMargin), lim.reserve(base), "limit 1 waits a whole window")
+}
+
+// TestFolderListLimiterConcurrent hammers the process-wide, mutex-guarded
+// registry and one shared limiter from many goroutines at once. Correctness is
+// proven by `go test -race`; the rolling-cap invariant is asserted after the
+// fact. reserve never sleeps, so this still runs in ~0s.
+func TestFolderListLimiterConcurrent(t *testing.T) {
+	saved := folderListLimiterRegistry
+	folderListLimiterRegistry = &folderListLimiters{limiters: make(map[string]*folderListLimiterEntry)}
+	defer func() { folderListLimiterRegistry = saved }()
+
+	f := &Fs{}
+	f.opt.Region = "eu"
+	f.opt.ListFolderWindow = fs.Duration(time.Hour) // large so nothing is evicted mid-test
+	f.opt.ListFolderLimit = 19
+	f.opt.ListFolderBurst = 6
+
+	const workers, folders = 64, 5
+	var wg sync.WaitGroup
+	for i := range workers {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			f.folderListLimiter(fmt.Sprintf("dir-%d", i%folders)).reserve(time.Now())
+		}(i)
+	}
+	wg.Wait()
+
+	// Exactly one shared limiter per distinct folder, whatever the interleaving.
+	assert.Len(t, folderListLimiterRegistry.limiters, folders)
+	// And each limiter granted every reservation without breaching its own cap:
+	// grants are capped at limit entries and non-decreasing.
+	for _, e := range folderListLimiterRegistry.limiters {
+		assert.LessOrEqual(t, len(e.limiter.grants), e.limiter.limit)
+		for i := 1; i < len(e.limiter.grants); i++ {
+			assert.False(t, e.limiter.grants[i].Before(e.limiter.grants[i-1]), "grants are non-decreasing")
+		}
+	}
+}

--- a/backend/zoho/pacer_test.go
+++ b/backend/zoho/pacer_test.go
@@ -1,0 +1,15 @@
+package zoho
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTPSMinSleep(t *testing.T) {
+	// A transactions-per-second rate maps to 1s divided by that rate.
+	assert.Equal(t, time.Second, tpsMinSleep(1))
+	assert.Equal(t, 500*time.Millisecond, tpsMinSleep(2))
+	assert.Equal(t, time.Second/6, tpsMinSleep(6)) // the default of 6 tps
+}

--- a/backend/zoho/throttle_test.go
+++ b/backend/zoho/throttle_test.go
@@ -3,6 +3,7 @@ package zoho
 import (
 	"context"
 	"net/http"
+	"sync"
 	"testing"
 	"time"
 
@@ -11,10 +12,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// newTestFs returns a bare *Fs so the 429/retry logic in shouldRetry can be
-// exercised in isolation. No network or pacer is involved.
+// newTestFs returns a bare *Fs carrying just the throttle state shouldRetry
+// touches, armed exactly as NewFs arms it. No network or pacer is involved, so
+// the 429/retry logic can be exercised in isolation.
 func newTestFs() *Fs {
-	return &Fs{}
+	f := &Fs{throttle: &throttleState{}}
+	f.throttle.progress.Store(true)
+	return f
 }
 
 func TestShouldRetry(t *testing.T) {
@@ -77,4 +81,53 @@ func TestShouldRetry(t *testing.T) {
 		retry, _ := f.shouldRetry(cctx, nil, nil)
 		assert.False(t, retry)
 	})
+}
+
+// TestThrottleEpisode covers the once-per-episode logging state machine that
+// logThrottle/shouldRetry drive through throttleState, without sleeping: the
+// penalty window is moved by hand instead of waited out.
+func TestThrottleEpisode(t *testing.T) {
+	ctx := context.Background()
+	f := newTestFs() // progress armed: the first 429 would log at NOTICE
+	resp429 := &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": {"1"}}}
+	respOK := &http.Response{StatusCode: 200}
+
+	// The first 429 consumes the armed flag (logs once) and opens a penalty window.
+	_, _ = f.shouldRetry(ctx, resp429, assert.AnError)
+	assert.False(t, f.throttle.progress.Load(), "first 429 disarms progress")
+
+	// A success still inside the penalty window must not re-arm (would let a
+	// burst of in-flight successes start a fresh episode too early).
+	_, _ = f.shouldRetry(ctx, respOK, nil)
+	assert.False(t, f.throttle.progress.Load(), "success during penalty window does not re-arm")
+
+	// Once the penalty window has elapsed, a success re-arms for the next episode.
+	f.throttle.penaltyUntilNano.Store(time.Now().Add(-time.Second).UnixNano())
+	_, _ = f.shouldRetry(ctx, respOK, nil)
+	assert.True(t, f.throttle.progress.Load(), "success after penalty window re-arms")
+}
+
+// TestThrottleStateConcurrent drives the lock-free throttleState (shared across
+// the shallow Fs copy) from many goroutines. Like the registry test, `go test
+// -race` is the real assertion: it would flag any non-atomic access. The final
+// flag is interleaving-dependent, so it is deliberately not asserted.
+func TestThrottleStateConcurrent(t *testing.T) {
+	ctx := context.Background()
+	f := newTestFs()
+	resp429 := &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": {"1"}}}
+	respOK := &http.Response{StatusCode: 200}
+
+	var wg sync.WaitGroup
+	for i := range 64 {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			if i%2 == 0 {
+				_, _ = f.shouldRetry(ctx, resp429, assert.AnError)
+			} else {
+				_, _ = f.shouldRetry(ctx, respOK, nil)
+			}
+		}(i)
+	}
+	wg.Wait()
 }

--- a/backend/zoho/throttle_test.go
+++ b/backend/zoho/throttle_test.go
@@ -1,0 +1,80 @@
+package zoho
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/lib/pacer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestFs returns a bare *Fs so the 429/retry logic in shouldRetry can be
+// exercised in isolation. No network or pacer is involved.
+func newTestFs() *Fs {
+	return &Fs{}
+}
+
+func TestShouldRetry(t *testing.T) {
+	ctx := context.Background()
+
+	// A 429 with a numeric Retry-After is honoured, plus retryAfterMargin.
+	t.Run("429 honours Retry-After", func(t *testing.T) {
+		f := newTestFs()
+		resp := &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": {"5"}}}
+		retry, err := f.shouldRetry(ctx, resp, assert.AnError)
+		assert.True(t, retry)
+		wait, ok := pacer.IsRetryAfter(err)
+		require.True(t, ok)
+		assert.Equal(t, 5*time.Second+retryAfterMargin, wait)
+	})
+
+	// A 429 without a Retry-After header falls back to 60s + margin.
+	t.Run("429 without Retry-After falls back to 60s", func(t *testing.T) {
+		f := newTestFs()
+		resp := &http.Response{StatusCode: 429, Header: http.Header{}}
+		retry, err := f.shouldRetry(ctx, resp, assert.AnError)
+		assert.True(t, retry)
+		wait, ok := pacer.IsRetryAfter(err)
+		require.True(t, ok)
+		assert.Equal(t, 60*time.Second+retryAfterMargin, wait)
+	})
+
+	// An unparseable Retry-After is ignored in favour of the 60s fallback.
+	t.Run("429 with unparseable Retry-After falls back", func(t *testing.T) {
+		f := newTestFs()
+		resp := &http.Response{StatusCode: 429, Header: http.Header{"Retry-After": {"soon"}}}
+		retry, err := f.shouldRetry(ctx, resp, assert.AnError)
+		assert.True(t, retry)
+		wait, ok := pacer.IsRetryAfter(err)
+		require.True(t, ok)
+		assert.Equal(t, 60*time.Second+retryAfterMargin, wait)
+	})
+
+	// A missing OAuth scope is fatal and must not be retried.
+	t.Run("401 missing scope aborts", func(t *testing.T) {
+		f := newTestFs()
+		resp := &http.Response{StatusCode: 401, Status: "401 INVALID_OAUTHSCOPE"}
+		retry, _ := f.shouldRetry(ctx, resp, assert.AnError)
+		assert.False(t, retry)
+	})
+
+	// An expired OAuth token is retried so the token can refresh.
+	t.Run("401 expired token retries", func(t *testing.T) {
+		f := newTestFs()
+		resp := &http.Response{StatusCode: 401, Header: http.Header{"Www-Authenticate": {`Bearer error="expired_token"`}}}
+		retry, _ := f.shouldRetry(ctx, resp, assert.AnError)
+		assert.True(t, retry)
+	})
+
+	// A cancelled context is never retried.
+	t.Run("cancelled context aborts", func(t *testing.T) {
+		f := newTestFs()
+		cctx, cancel := context.WithCancel(ctx)
+		cancel()
+		retry, _ := f.shouldRetry(cctx, nil, nil)
+		assert.False(t, retry)
+	})
+}

--- a/backend/zoho/zoho.go
+++ b/backend/zoho/zoho.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -291,6 +292,17 @@ type Fs struct {
 	uploadsrv   *rest.Client       // the connection to the upload server
 	dirCache    *dircache.DirCache // Map of directory path to directory id
 	pacer       *fs.Pacer          // pacer for API calls
+	throttle    *throttleState     // once-per-episode 429 logging state (shared across Fs copies)
+}
+
+// throttleState tracks 429 throttling for once-per-episode logging (see
+// logThrottle). It sits behind a pointer so the "assume it is a file" shallow
+// copy of Fs shares one state; both fields are atomic, so it is lock-free. An
+// "episode" is a run of 429s with no recovery (a success after the penalty
+// window clears) between them.
+type throttleState struct {
+	penaltyUntilNano atomic.Int64 // unix-nanos the current 429 penalty should clear
+	progress         atomic.Bool  // a call succeeded after the last penalty window
 }
 
 // Object describes a Zoho WorkDrive object
@@ -421,16 +433,40 @@ var retryErrorCodes = []int{
 	509, // Bandwidth Limit Exceeded
 }
 
+// logThrottle logs the first 429 in a throttling episode at NOTICE level.
+//
+// The err value contains the server response body. Further 429s are not logged
+// until shouldRetry observes a real recovery, which prevents sustained
+// throttling from flooding the log. The pacer still logs every retry at DEBUG.
+// Using recovery instead of a fixed time window works with both Zoho penalty
+// regimes.
+func (f *Fs) logThrottle(wait time.Duration, err error) {
+	newBurst := f.throttle.progress.Swap(false)
+	f.throttle.penaltyUntilNano.Store(time.Now().Add(wait).UnixNano())
+	secs := int(wait / time.Second)
+	if newBurst {
+		fs.Logf(f, "Too many requests: Trying again in %d seconds. %v", secs, err)
+	}
+}
+
 // shouldRetry reports whether the given resp and err deserve to be retried.
 //
 // A 429 is honoured via the Retry-After header (falling back to 60s plus a
-// margin); expired OAuth tokens are retried, missing OAuth scopes abort, and
-// standard HTTP retry conditions are also handled.
+// margin) and starts or continues a throttling episode; expired OAuth tokens
+// are retried, missing OAuth scopes abort, and standard HTTP retry conditions
+// are also handled.
 //
 // Returns whether to retry, and the err as a convenience.
 func (f *Fs) shouldRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
 	if fserrors.ContextError(ctx, &err) {
 		return false, err
+	}
+	if err == nil && resp != nil && resp.StatusCode < 400 {
+		// Treat as recovered only after the latest 429 wait ends, so in-flight
+		// successes don't start a new throttling episode too early.
+		if time.Now().UnixNano() > f.throttle.penaltyUntilNano.Load() {
+			f.throttle.progress.Store(true)
+		}
 	}
 	authRetry := false
 
@@ -454,10 +490,12 @@ func (f *Fs) shouldRetry(ctx context.Context, resp *http.Response, err error) (b
 				fs.Logf(f, "Failed to parse Retry-After: %q: %v", values[0], parseErr)
 			} else {
 				wait := time.Duration(retryAfter)*time.Second + retryAfterMargin
+				f.logThrottle(wait, err)
 				return true, pacer.RetryAfterError(err, wait)
 			}
 		}
 		wait := 60*time.Second + retryAfterMargin
+		f.logThrottle(wait, err)
 		return true, pacer.RetryAfterError(err, wait)
 	}
 	return authRetry || fserrors.ShouldRetry(err) || fserrors.ShouldRetryHTTP(resp, retryErrorCodes), err
@@ -595,7 +633,10 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		downloadsrv: rest.NewClient(oAuthClient).SetRoot(downloadURL),
 		uploadsrv:   rest.NewClient(oAuthClient).SetRoot(uploadURL),
 		pacer:       fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(pacerMinSleep), pacer.Burst(pacerBurst))),
+		throttle:    &throttleState{},
 	}
+	// Arm progress so the very first 429 is logged at NOTICE.
+	f.throttle.progress.Store(true)
 	f.features = (&fs.Features{
 		CanHaveEmptyDirectories: true,
 	}).Fill(ctx, f)

--- a/backend/zoho/zoho.go
+++ b/backend/zoho/zoho.go
@@ -12,6 +12,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -53,6 +54,28 @@ const (
 	// defaultTPSLimitBurst is the token-bucket capacity; keep at 1 as burst > 1
 	// caused synchronized 429 clusters.
 	defaultTPSLimitBurst = 1
+
+	// defaultListFolderWindow / defaultListFolderLimit / defaultListFolderBurst
+	// configure the per-folder listing limiter; folderListLimiter documents the
+	// measured throttle model. Zoho allows ~19 listings of one folder in any
+	// rolling ~60s window and the 20th returns F7008 (measured live 2026-07-05:
+	// every trip landed exactly on the 20th listing inside 60s, every clean run
+	// stayed at <=19 - including a deliberate over-limit probe tripping at #20).
+	// The limiter guarantees at most limit listings per window: each window
+	// starts with burst listings passing immediately (the burst RE-ARMS at every
+	// window boundary) and the remaining limit-burst are paced window/(limit-burst)
+	// apart, while a sliding log of the last limit grants enforces the cap across
+	// window boundaries and idle resumes. burst never raises the per-window total -
+	// it only sets how many listings may go back-to-back. Bursts of 4, 5 and 6
+	// under this cap all ran clean live; 6 is the largest validated, hence the
+	// default. Only repeated same-folder listings are paced; set limit to 0 to
+	// disable entirely.
+	defaultListFolderWindow = fs.Duration(60 * time.Second)
+	defaultListFolderLimit  = 19 // 0 = disabled
+	defaultListFolderBurst  = 6
+	// folderListLimitersMaxEntries caps the per-folder limiter map against unbounded
+	// growth on very long-lived processes.
+	folderListLimitersMaxEntries = 100000
 
 	// retryAfterMargin adds a small extra delay after Zoho's Retry-After value.
 	// This gives rate-limit tokens time to refill and helps avoid another 429.
@@ -260,6 +283,63 @@ synchronized clusters of 429 errors.`,
 			Default:  defaultTPSLimitBurst,
 			Advanced: true,
 		}, {
+			Name: "list_folder_limit",
+			Help: `Max listings of the SAME folder allowed per --zoho-list-folder-window.
+
+Zoho WorkDrive rate limits its listing API (GET files/{id}/files) PER
+folder, independently of --zoho-tpslimit: listing one folder too often in a
+short time returns HTTP 429 (error F7008) with a multi-minute Retry-After
+penalty, which a tight polling loop can hit even at a low overall rate.
+Measured live, Zoho allows ~19 listings of one folder in any rolling ~60s
+window and the 20th fails, which the defaults (19 per 60s) model exactly.
+
+This is a true per-window cap for any traffic pattern: each window starts
+with --zoho-list-folder-burst listings passing back-to-back (the burst
+re-arms at every window boundary) and the rest are spaced
+--zoho-list-folder-window/(limit - burst) apart (the defaults give ~4.6s),
+while a sliding log of recent listings enforces the cap across window
+boundaries. 0 disables the limiter. Only REPEATED listings of one folder are
+delayed; different folders, or a folder listed fewer than
+--zoho-list-folder-burst times, never are.
+
+A HIGHER value means MORE listings per window, not more safety: raising it
+above 19 trips F7008. Lower it for a wider margin at the cost of listing
+responsiveness.`,
+			Default:  defaultListFolderLimit,
+			Advanced: true,
+		}, {
+			Name: "list_folder_window",
+			Help: `The window for --zoho-list-folder-limit.
+
+The default of 60s (shown as 1m0s) matches Zoho's real sliding window: at
+most --zoho-list-folder-limit listings of one folder are allowed in any
+window of this length. A bare number is parsed as seconds ("60" = "60s").
+
+Widen it (or lower the limit) for a bigger safety margin; the sustained
+spacing between same-folder listings is window/(limit - burst).`,
+			Default:  defaultListFolderWindow,
+			Advanced: true,
+		}, {
+			Name: "list_folder_burst",
+			Help: `Same-folder listings allowed back-to-back before --zoho-list-folder-limit paces them.
+
+The burst is carved out of --zoho-list-folder-limit, so raising it never
+raises the per-window total: this many listings may fire immediately and the
+remaining limit - burst are spaced window/(limit - burst) apart. The burst
+RE-ARMS at every window boundary, so sustained re-listing gets a fresh burst
+each window while a sliding log of recent listings still enforces the
+per-window cap. A folder listed only a handful of times (the common case - a
+sync re-listing one directory a few times then moving on) never waits.
+
+The default 6 is the largest burst validated live under the default 19-per-60s
+cap (bursts of 4, 5 and 6 all ran clean; an over-cap probe tripped F7008
+exactly at the 20th listing in a window). Keep it well below ~15 - Zoho also
+has an instantaneous back-to-back cap around 15-16 regardless of the window.
+Set to 1 to pace from the second listing. Values >= the limit are clamped to
+limit - 1.`,
+			Default:  defaultListFolderBurst,
+			Advanced: true,
+		}, {
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,
 			Advanced: true,
@@ -273,12 +353,15 @@ synchronized clusters of 429 errors.`,
 
 // Options defines the configuration for this backend
 type Options struct {
-	UploadCutoff  fs.SizeSuffix        `config:"upload_cutoff"`
-	RootFolderID  string               `config:"root_folder_id"`
-	Region        string               `config:"region"`
-	TPSLimit      float64              `config:"tpslimit"`
-	TPSLimitBurst int                  `config:"tpslimit_burst"`
-	Enc           encoder.MultiEncoder `config:"encoding"`
+	UploadCutoff     fs.SizeSuffix        `config:"upload_cutoff"`
+	RootFolderID     string               `config:"root_folder_id"`
+	Region           string               `config:"region"`
+	TPSLimit         float64              `config:"tpslimit"`
+	TPSLimitBurst    int                  `config:"tpslimit_burst"`
+	ListFolderLimit  int                  `config:"list_folder_limit"`
+	ListFolderWindow fs.Duration          `config:"list_folder_window"`
+	ListFolderBurst  int                  `config:"list_folder_burst"`
+	Enc              encoder.MultiEncoder `config:"encoding"`
 }
 
 // Fs represents a remote workdrive
@@ -303,6 +386,131 @@ type Fs struct {
 type throttleState struct {
 	penaltyUntilNano atomic.Int64 // unix-nanos the current 429 penalty should clear
 	progress         atomic.Bool  // a call succeeded after the last penalty window
+}
+
+// folderListLimiters holds the per-folder-id listing rate limiters and the time
+// each folder was last listed. One instance is shared process-wide (folderListLimiterRegistry)
+// rather than per-*Fs because Zoho keys its listing throttle to the folder id:
+// a per-Fs limiter would let each new Fs re-list a shared ancestor with a fresh,
+// full-burst limiter, draining the bucket -> F7008.
+type folderListLimiters struct {
+	mu        sync.Mutex
+	limiters  map[string]*folderListLimiterEntry
+	lastSweep time.Time
+}
+
+// folderListLimiterRegistry is the process-wide registry of per-folder listing
+// limiters, shared by every *Fs and keyed by region+folder-id so entries never
+// collide across accounts or regions.
+var folderListLimiterRegistry = &folderListLimiters{limiters: make(map[string]*folderListLimiterEntry)}
+
+// folderListLimiterEntry is a per-folder listing rate limiter plus the time the folder
+// was last listed, used for idle eviction.
+type folderListLimiterEntry struct {
+	limiter    *folderWindowLimiter
+	lastListed time.Time
+}
+
+// folderWindowLimiter shapes same-folder listings to at most limit per window
+// with a burst re-armed at each window boundary. Two layers:
+//
+// Shape (fixed window): a grid anchored at the first request advances in whole
+// windows; each window's first burst grants pass immediately and the remaining
+// limit-burst are spaced interval = window/(limit-burst) apart, so under
+// continuous demand every window starts with a fast burst - the flow the
+// options promise.
+//
+// Safety (sliding log): grants keeps the last limit grant times; a new grant
+// is also forced to be >= grants[len-limit] + window + margin, so no rolling
+// window ever sees more than limit grants even across grid boundaries or on
+// resume-after-idle, where the fixed-window shape alone could cluster a
+// boundary burst too close to earlier grants.
+type folderWindowLimiter struct {
+	mu          sync.Mutex
+	window      time.Duration // Zoho's per-folder window (--zoho-list-folder-window)
+	limit       int           // window budget AND sliding cap (--zoho-list-folder-limit)
+	burst       int           // grants passed immediately at each window start
+	interval    time.Duration // spacing of the paced phase: window/(limit-burst)
+	windowStart time.Time     // fixed grid anchor; zero until the first grant
+	used        int           // grants handed out in the current window
+	lastGrant   time.Time     // time of the most recent grant
+	grants      []time.Time   // last <=limit grant times (sliding safety log)
+}
+
+// folderListSafetyMargin is added on top of the sliding-log wait so a grant
+// lands strictly after the matching old grant has left Zoho's window.
+const folderListSafetyMargin = 500 * time.Millisecond
+
+// reserve commits the next grant at or after now and returns its time.
+// It converges in at most a few passes: rolling the grid forward resets the
+// window budget, and the sliding log can push the candidate at most once more.
+func (l *folderWindowLimiter) reserve(now time.Time) time.Time {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	if l.windowStart.IsZero() {
+		l.windowStart = now
+	}
+	cand := now
+	for range 4 {
+		// Roll the fixed grid forward so cand lies in the current window,
+		// re-arming the burst for the new window.
+		if d := cand.Sub(l.windowStart); d >= l.window {
+			l.windowStart = l.windowStart.Add(l.window * (d / l.window))
+			l.used = 0
+		}
+		next := cand
+		switch {
+		case l.used < l.burst:
+			// window-start burst passes immediately
+		case l.used < l.limit:
+			if t := l.lastGrant.Add(l.interval); t.After(next) {
+				next = t
+			}
+		default:
+			// window budget exhausted - wait for the next window's burst
+			next = l.windowStart.Add(l.window)
+		}
+		// Sliding safety: never more than limit grants in any rolling window.
+		if len(l.grants) >= l.limit {
+			if t := l.grants[len(l.grants)-l.limit].Add(l.window + folderListSafetyMargin); t.After(next) {
+				next = t
+			}
+		}
+		if next.Equal(cand) {
+			break
+		}
+		cand = next
+	}
+	l.used++
+	l.lastGrant = cand
+	if len(l.grants) < l.limit {
+		l.grants = append(l.grants, cand)
+	} else {
+		copy(l.grants, l.grants[1:])
+		l.grants[len(l.grants)-1] = cand
+	}
+	return cand
+}
+
+// Wait blocks until the limiter grants a listing or ctx is cancelled. A grant
+// reserved by a cancelled Wait is not returned - erring on the safe side, it
+// just leaves a little of the window budget unused.
+func (l *folderWindowLimiter) Wait(ctx context.Context) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	d := time.Until(l.reserve(time.Now()))
+	if d <= 0 {
+		return nil
+	}
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 // Object describes a Zoho WorkDrive object
@@ -684,10 +892,89 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 // Should return true to finish processing
 type listAllFn func(*api.Item) bool
 
+// folderListLimiter provides the shared per-folder listing rate limiter for dirID.
+//
+// Zoho WorkDrive throttles its listing API (GET files/{id}/files) PER folder,
+// independently of --zoho-tpslimit. Measured live (2026-07-05), that per-folder
+// throttle is a sliding window: ~19 listings of one folder within any rolling
+// ~60s are allowed and the 20th returns F7008 with a ~300s Retry-After. Every
+// observed trip landed exactly on the 20th listing inside 60s and every clean
+// run stayed at <=19, including a deliberate over-limit probe (window total 22)
+// tripping at #20; an earlier token-bucket refill model fitted the same data
+// inconsistently. There is also a much smaller instantaneous cap (~15-16
+// back-to-back listings trip on their own), so burst must stay well below that.
+//
+// The limiter (folderWindowLimiter) guarantees at most limit listings per
+// window for any traffic pattern: each window starts with burst listings
+// passing back-to-back - the burst RE-ARMS at every window boundary - and the
+// remaining limit-burst are paced window/(limit-burst) apart, while the
+// sliding log of the last limit grants enforces the cap across window
+// boundaries and idle resumes. Raising burst therefore never raises the
+// per-window total - it only front-loads it, widening the sustained spacing
+// to compensate. Different folders, or a folder listed fewer than burst
+// times, are never delayed - only tps applies unless the SAME folder is
+// re-listed enough to drain the burst.
+//
+// It paces repeated listings of the same folder; without it, listing one folder
+// too often trips Zoho's per-folder throttle and returns HTTP 429. The limiter is
+// created on demand in folderListLimiterRegistry, and limiters idle longer than
+// the window are evicted (at most once per window): after a full window idle
+// Zoho's sliding window is empty and the limiter is fully refilled, so dropping
+// it is lossless. Only called when --zoho-list-folder-limit > 0, so limit is
+// never zero.
+//
+// Returns the folder's *folderWindowLimiter, ready to Wait on before listing.
+func (f *Fs) folderListLimiter(dirID string) *folderWindowLimiter {
+	flReg := folderListLimiterRegistry
+	window := time.Duration(f.opt.ListFolderWindow)
+	// Key by region+folder-id so one limiter is shared per physical folder
+	// across every *Fs without colliding across accounts or regions.
+	key := f.opt.Region + "\x00" + dirID
+	flReg.mu.Lock()
+	defer flReg.mu.Unlock()
+	now := time.Now()
+	if now.Sub(flReg.lastSweep) > window || len(flReg.limiters) > folderListLimitersMaxEntries {
+		before := len(flReg.limiters)
+		for id, e := range flReg.limiters {
+			if now.Sub(e.lastListed) > window {
+				delete(flReg.limiters, id)
+			}
+		}
+		flReg.lastSweep = now
+		fs.Debugf(f, "folder listing limiter sweep: evicted %d of %d idle limiters", before-len(flReg.limiters), before)
+	}
+	e := flReg.limiters[key]
+	if e == nil {
+		// The first Fs to list this folder fixes the shape; in the normal case
+		// every Fs for the same account shares the same limit/window/burst.
+		// limit > 0 is guaranteed by the caller; clamp burst into [1, limit-1]
+		// (at limit 1 the burst token itself is the whole window's budget).
+		burst := min(max(f.opt.ListFolderBurst, 1), max(f.opt.ListFolderLimit-1, 1))
+		intervalTokens := max(f.opt.ListFolderLimit-burst, 1)
+		e = &folderListLimiterEntry{limiter: &folderWindowLimiter{
+			window:   window,
+			limit:    f.opt.ListFolderLimit,
+			burst:    burst,
+			interval: window / time.Duration(intervalTokens),
+		}}
+		flReg.limiters[key] = e
+	}
+	e.lastListed = now
+	return e.limiter
+}
+
 // Lists the directory required calling the user function on each item found
 //
 // If the user fn ever returns true then it early exits with found = true
 func (f *Fs) listAll(ctx context.Context, dirID string, directoriesOnly bool, filesOnly bool, fn listAllFn) (found bool, err error) {
+	// Pace repeated listings of the SAME folder under Zoho's per-folder throttle
+	// (see --zoho-list-folder-limit). One token per listAll call, not per page,
+	// so multi-page listings of a single folder are not penalised.
+	if f.opt.ListFolderLimit > 0 {
+		if err = f.folderListLimiter(dirID).Wait(ctx); err != nil {
+			return false, err
+		}
+	}
 	const listItemsLimit = 1000
 	opts := rest.Opts{
 		Method:       "GET",

--- a/backend/zoho/zoho.go
+++ b/backend/zoho/zoho.go
@@ -42,6 +42,10 @@ const (
 	configRootID                = "root_folder_id"
 
 	defaultUploadCutoff = 10 * 1024 * 1024 // 10 MiB
+
+	// retryAfterMargin adds a small extra delay after Zoho's Retry-After value.
+	// This gives rate-limit tokens time to refill and helps avoid another 429.
+	retryAfterMargin = 1 * time.Second
 )
 
 // Globals
@@ -380,9 +384,14 @@ var retryErrorCodes = []int{
 	509, // Bandwidth Limit Exceeded
 }
 
-// shouldRetry returns a boolean as to whether this resp and err
-// deserve to be retried.  It returns the err as a convenience
-func shouldRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
+// shouldRetry reports whether the given resp and err deserve to be retried.
+//
+// A 429 is honoured via the Retry-After header (falling back to 60s plus a
+// margin); expired OAuth tokens are retried, missing OAuth scopes abort, and
+// standard HTTP retry conditions are also handled.
+//
+// Returns whether to retry, and the err as a convenience.
+func (f *Fs) shouldRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
 	if fserrors.ContextError(ctx, &err) {
 		return false, err
 	}
@@ -399,9 +408,20 @@ func shouldRetry(ctx context.Context, resp *http.Response, err error) (bool, err
 		fs.Debugf(nil, "Should retry: %v", err)
 	}
 	if resp != nil && resp.StatusCode == 429 {
-		err = pacer.RetryAfterError(err, 60*time.Second)
-		fs.Debugf(nil, "Too many requests. Trying again in %d seconds.", 60)
-		return true, err
+		// Zoho's listing API is heavily rate limited and tells us how long to
+		// wait in the Retry-After header. Honour it so we don't retry too early
+		// (which makes Zoho escalate the penalty), falling back to 60s.
+		if values := resp.Header["Retry-After"]; len(values) == 1 && values[0] != "" {
+			retryAfter, parseErr := strconv.Atoi(values[0])
+			if parseErr != nil {
+				fs.Logf(f, "Failed to parse Retry-After: %q: %v", values[0], parseErr)
+			} else {
+				wait := time.Duration(retryAfter)*time.Second + retryAfterMargin
+				return true, pacer.RetryAfterError(err, wait)
+			}
+		}
+		wait := 60*time.Second + retryAfterMargin
+		return true, pacer.RetryAfterError(err, wait)
 	}
 	return authRetry || fserrors.ShouldRetry(err) || fserrors.ShouldRetryHTTP(resp, retryErrorCodes), err
 }
@@ -484,7 +504,7 @@ func (f *Fs) readMetaDataForID(ctx context.Context, id string) (*api.Item, error
 	var err error
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.CallJSON(ctx, &opts, nil, &result)
-		return shouldRetry(ctx, resp, err)
+		return f.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
 		return nil, err
@@ -591,7 +611,7 @@ OUTER:
 		var resp *http.Response
 		err = f.pacer.Call(func() (bool, error) {
 			resp, err = f.srv.CallJSON(ctx, &opts, nil, &result)
-			return shouldRetry(ctx, resp, err)
+			return f.shouldRetry(ctx, resp, err)
 		})
 		if err != nil {
 			return found, fmt.Errorf("couldn't list files: %w", err)
@@ -704,7 +724,7 @@ func (f *Fs) CreateDir(ctx context.Context, pathID, leaf string) (newID string, 
 	}
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.CallJSON(ctx, &opts, &mkdir, &info)
-		return shouldRetry(ctx, resp, err)
+		return f.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
 		//fmt.Printf("...Error %v\n", err)
@@ -782,7 +802,7 @@ func (f *Fs) uploadLargeFile(ctx context.Context, name string, parent string, si
 	var uploadResponse *api.LargeUploadResponse
 	err = f.pacer.CallNoRetry(func() (bool, error) {
 		resp, err = f.uploadsrv.CallJSON(ctx, &opts, nil, &uploadResponse)
-		return shouldRetry(ctx, resp, err)
+		return f.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("upload large error: %v", err)
@@ -838,7 +858,7 @@ func (f *Fs) upload(ctx context.Context, name string, parent string, size int64,
 	var uploadResponse *api.UploadResponse
 	err = f.pacer.CallNoRetry(func() (bool, error) {
 		resp, err = f.srv.CallJSON(ctx, &opts, nil, &uploadResponse)
-		return shouldRetry(ctx, resp, err)
+		return f.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("upload error: %w", err)
@@ -937,7 +957,7 @@ func (f *Fs) deleteObject(ctx context.Context, id string) (err error) {
 	}
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.CallJSON(ctx, &opts, &delete, nil)
-		return shouldRetry(ctx, resp, err)
+		return f.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
 		return fmt.Errorf("delete object failed: %w", err)
@@ -1007,7 +1027,7 @@ func (f *Fs) rename(ctx context.Context, id, name string) (item *api.Item, err e
 	var result *api.ItemInfo
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.CallJSON(ctx, &opts, &rename, &result)
-		return shouldRetry(ctx, resp, err)
+		return f.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("rename failed: %w", err)
@@ -1060,7 +1080,7 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 	var result *api.ItemList
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.CallJSON(ctx, &opts, &copyFile, &result)
-		return shouldRetry(ctx, resp, err)
+		return f.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("couldn't copy file: %w", err)
@@ -1105,7 +1125,7 @@ func (f *Fs) move(ctx context.Context, srcID, parentID string) (item *api.Item, 
 	var result *api.ItemList
 	err = f.pacer.Call(func() (bool, error) {
 		resp, err = f.srv.CallJSON(ctx, &opts, &moveFile, &result)
-		return shouldRetry(ctx, resp, err)
+		return f.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("move failed: %w", err)
@@ -1348,7 +1368,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	}
 	err = o.fs.pacer.Call(func() (bool, error) {
 		resp, err = o.fs.downloadsrv.Call(ctx, &opts)
-		return shouldRetry(ctx, resp, err)
+		return o.fs.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {
 		return nil, err

--- a/backend/zoho/zoho.go
+++ b/backend/zoho/zoho.go
@@ -36,12 +36,22 @@ import (
 const (
 	rcloneClientID              = "1000.46MXF275FM2XV7QCHX5A7K3LGME66B"
 	rcloneEncryptedClientSecret = "U-2gxclZQBcOG9NPhjiXAhj-f0uQ137D0zar8YyNHXHkQZlTeSpIOQfmCb4oSpvosJp_SJLXmLLeUA"
-	minSleep                    = 10 * time.Millisecond
-	maxSleep                    = 60 * time.Second
-	decayConstant               = 2 // bigger for slower decay, exponential
 	configRootID                = "root_folder_id"
+	// minSleep is the pacer's minimum delay between calls when --zoho-tpslimit
+	// is 0 (cap disabled); a small floor always remains because backoff and
+	// Retry-After still apply.
+	minSleep = 10 * time.Millisecond
 
 	defaultUploadCutoff = 10 * 1024 * 1024 // 10 MiB
+
+	// defaultTPSLimit is the sustainable refill rate (API calls/second) of
+	// Zoho WorkDrive's throttle, measured live. Going faster drains the token
+	// bucket and then triggers long (~119s) 429 Retry-After stalls (see
+	// --zoho-tpslimit).
+	defaultTPSLimit = 6.0
+	// defaultTPSLimitBurst is the token-bucket capacity; keep at 1 as burst > 1
+	// caused synchronized 429 clusters.
+	defaultTPSLimitBurst = 1
 
 	// retryAfterMargin adds a small extra delay after Zoho's Retry-After value.
 	// This gives rate-limit tokens time to refill and helps avoid another 429.
@@ -224,6 +234,31 @@ browser.`,
 			Default:  fs.SizeSuffix(defaultUploadCutoff),
 			Advanced: true,
 		}, {
+			Name: "tpslimit",
+			Help: `Max number of API transactions per second.
+
+Zoho WorkDrive rate limits its API and returns HTTP 429 (error F7008,
+"Request rate limit exceeded") when called too quickly, so the data API
+calls (list, upload, download, copy, move, delete) are paced to this rate.
+
+Set to 0 to disable the cap, matching the global --tpslimit; pacing still
+can't be turned off entirely because backoff and Retry-After always apply.
+
+The default of 6 is a safe sustainable rate. Higher values can trigger long
+429 Retry-After stalls that make throughput WORSE, so raise it only if your
+account tolerates more.`,
+			Default:  defaultTPSLimit,
+			Advanced: true,
+		}, {
+			Name: "tpslimit_burst",
+			Help: `Number of API calls to allow back-to-back without sleeping, for --zoho-tpslimit.
+
+This is the token-bucket capacity. Keep at 1 for Zoho: a burst > 1
+lets several calls fire at once after an idle gap, which can trigger
+synchronized clusters of 429 errors.`,
+			Default:  defaultTPSLimitBurst,
+			Advanced: true,
+		}, {
 			Name:     config.ConfigEncoding,
 			Help:     config.ConfigEncodingHelp,
 			Advanced: true,
@@ -237,10 +272,12 @@ browser.`,
 
 // Options defines the configuration for this backend
 type Options struct {
-	UploadCutoff fs.SizeSuffix        `config:"upload_cutoff"`
-	RootFolderID string               `config:"root_folder_id"`
-	Region       string               `config:"region"`
-	Enc          encoder.MultiEncoder `config:"encoding"`
+	UploadCutoff  fs.SizeSuffix        `config:"upload_cutoff"`
+	RootFolderID  string               `config:"root_folder_id"`
+	Region        string               `config:"region"`
+	TPSLimit      float64              `config:"tpslimit"`
+	TPSLimitBurst int                  `config:"tpslimit_burst"`
+	Enc           encoder.MultiEncoder `config:"encoding"`
 }
 
 // Fs represents a remote workdrive
@@ -512,6 +549,12 @@ func (f *Fs) readMetaDataForID(ctx context.Context, id string) (*api.Item, error
 	return &result.Item, nil
 }
 
+// tpsMinSleep converts a transactions-per-second rate into the pacer's minimum
+// sleep between calls.
+func tpsMinSleep(tps float64) time.Duration {
+	return time.Duration(float64(time.Second) / tps)
+}
+
 // NewFs constructs an Fs from the path, container:path
 func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, error) {
 	// Parse config into Options struct
@@ -535,6 +578,15 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		return nil, err
 	}
 
+	// Add a delay between API calls to respect Zoho's per-second request limit.
+	// The wait time is calculated from the configured TPS value and retried on errors.
+	pacerMinSleep := minSleep
+	pacerBurst := 1
+	if opt.TPSLimit > 0 {
+		pacerMinSleep = tpsMinSleep(opt.TPSLimit)
+		pacerBurst = max(opt.TPSLimitBurst, 1)
+	}
+
 	f := &Fs{
 		name:        name,
 		root:        root,
@@ -542,7 +594,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		srv:         rest.NewClient(oAuthClient).SetRoot(rootURL),
 		downloadsrv: rest.NewClient(oAuthClient).SetRoot(downloadURL),
 		uploadsrv:   rest.NewClient(oAuthClient).SetRoot(uploadURL),
-		pacer:       fs.NewPacer(ctx, pacer.NewDefault(pacer.MinSleep(minSleep), pacer.MaxSleep(maxSleep), pacer.DecayConstant(decayConstant))),
+		pacer:       fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(pacerMinSleep), pacer.Burst(pacerBurst))),
 	}
 	f.features = (&fs.Features{
 		CanHaveEmptyDirectories: true,


### PR DESCRIPTION
#### What does this change do?

Makes the zoho backend respect Zoho WorkDrive's rate limits, in four self-contained commits (one per concern, each compiling and passing tests on its own):

1. **zoho: honour Retry-After header on 429** - WorkDrive now sends `Retry-After`; the hard-coded 60s wait retried too early and escalated the penalty (observed 84s -> 239s). The header is honoured plus a 1s margin (retrying at exactly Retry-After finds an empty token bucket and burns ~16 immediate 429s), with 60s kept as the fallback. `shouldRetry` becomes a method on `*Fs`.
2. **zoho: add --zoho-tpslimit and --zoho-tpslimit-burst** - per-remote pacer options (default 6/1, measured sustainable rate) using the same token-bucket pacer as the Google Drive backend. `--zoho-tpslimit 0` disables the cap.
3. **zoho: log throttling once per episode at NOTICE** - a 429 stall was only visible at DEBUG, so rclone appeared to hang for minutes; now the first 429 of each episode logs at NOTICE with the wait time. State is two atomics, safe under concurrent checkers.
4. **zoho: rate limit repeated listings of the same folder** - WorkDrive throttles listings PER folder (~20 back-to-back per ~300s, refilling ~1/3.3s, measured); this is what made the integration suite fail. A process-wide limiter keyed by region+folder id spaces repeated same-folder listings evenly (`--zoho-list-folder-limit` 95 per `--zoho-list-folder-window` 5m ~= 3.16s). Different folders, or a folder listed once, are never delayed.

The measurements and throttle model behind the defaults are written up in #9570. All defaults are proposals derived from those measurements - happy to adjust.

New unit tests (`throttle_test.go`, `pacer_test.go`, `folderlist_test.go`) are plain `package zoho` tests: they run in quicktest with no remote configured and pass with `-race`. Option docs live in the `Help:` fields; the autogenerated section of `docs/content/zoho.md` is intentionally untouched.

#### Linked issue

Fixes #9570

#### For new or changed backends

`go run ./fstest/test_all -backends zoho` on this branch (2026-07-04):

```
PASS: All tests finished OK in 8m3.8s (try 1/5)
91 PASS / 31 SKIP / 0 FAIL - zero 429/F7008/Retry-After events in the log
```

Before this change the suite could not complete on this account (429 at the ~20th re-listing of the working directory - details in #9570). A `TestZoho:` entry already exists on the integration server (`fstest/test_all/config.yaml`); note the current nightly zoho failures are partly an unrelated stale-token `INVALID_OAUTHSCOPE` on that server, also flagged in #9570.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
