### PR TITLE
config: fix config_template_file and config_template being ignored via config/create - fixes #9572

### DIFF
--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -565,6 +565,7 @@ func updateRemote(ctx context.Context, name string, keyValues rc.Params, opt Upd
 	}
 
 	choices := configmap.Simple{}
+	ephemeral := configmap.Simple{}
 	m := fs.ConfigMap(ri.Prefix, ri.Options, name, nil)
 
 	// Set the config
@@ -588,7 +589,13 @@ func updateRemote(ctx context.Context, name string, keyValues rc.Params, opt Upd
 		choices.Set(k, vStr)
 		if !strings.HasPrefix(k, fs.ConfigKeyEphemeralPrefix) {
 			m.Set(k, vStr)
+		} else {
+			ephemeral.Set(k, vStr)
 		}
+	}
+	// Add a getter to make sure ephemeral config is still visible
+	if len(ephemeral) > 0 {
+		m.AddGetter(ephemeral, configmap.PriorityNormal)
 	}
 	if opt.Edit {
 		choices[fs.ConfigEdit] = "true"

--- a/fs/config/config_test.go
+++ b/fs/config/config_test.go
@@ -3,11 +3,16 @@
 package config_test
 
 import (
+	"context"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/config/configfile"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fs/rc"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -28,4 +33,39 @@ func TestConfigLoad(t *testing.T) {
 	keys := config.Data().GetKeyList("nounc")
 	expect = []string{"type", "nounc"}
 	assert.Equal(t, expect, keys)
+}
+
+// TestCreateRemoteEphemeralConfigKeysReachBackend checks that config_* parameters
+// (#9572) are readable by the backend via the mapper but not saved to the config file.
+func TestCreateRemoteEphemeralConfigKeysReachBackend(t *testing.T) {
+	defer testConfigFile(t, simpleOptions, "ephemeral.conf")()
+	ctx := context.Background()
+
+	var seenTemplateFile, seenTemplate string
+	backendName := "config_template_test_remote"
+	if regInfo, _ := fs.Find(backendName); regInfo == nil {
+		fs.Register(&fs.RegInfo{
+			Name: backendName,
+			Config: func(_ context.Context, _ string, m configmap.Mapper, _ fs.ConfigIn) (*fs.ConfigOut, error) {
+				seenTemplateFile, _ = m.Get("config_template_file")
+				seenTemplate, _ = m.Get("config_template")
+				return nil, nil
+			},
+		})
+	}
+
+	_, err := config.CreateRemote(ctx, "eph", backendName, rc.Params{
+		"config_template_file": "/path/to/template.html",
+		"config_template":      "<html>ok</html>",
+	}, config.UpdateRemoteOpt{NonInteractive: true})
+	require.NoError(t, err)
+
+	// The backend must be able to read the ephemeral config_* parameters
+	// through the mapper (before the fix these came back empty).
+	assert.Equal(t, "/path/to/template.html", seenTemplateFile)
+	assert.Equal(t, "<html>ok</html>", seenTemplate)
+
+	// ...but they must not be persisted to the config file.
+	assert.Equal(t, "", config.GetValue("eph", "config_template_file"))
+	assert.Equal(t, "", config.GetValue("eph", "config_template"))
 }


### PR DESCRIPTION
#### What does this change do?

When creating or updating a remote through the rc api (`config/create`, `config/update`), parameters whose name starts with the ephemeral prefix `config_` (for example `config_template_file` and `config_template`, used to customise the OAuth success page) were silently ignored, and the default `DefaultAuthResponseTemplate` was always rendered.

`updateRemote` sets each supplied parameter into the config mapper `m`, but skips the `config_` prefixed keys so they are never written to the config file. That guard is correct in itself, because the mapper's setter writes to the config file and these values are meant to be ephemeral. The problem is that backends read these values back from the mapper (`oauthutil` reads `config_template_file` and `config_template` via `m.Get`), so dropping them entirely meant they could never reach the backend.

This change collects the ephemeral parameters into a separate map and adds it to the mapper as a getter overlay at `PriorityNormal` after the loop. The values are now readable through `m.Get` without being written to the config file. This is the same approach `rclone authorize` already uses to expose a template supplied on the command line (`m.AddGetter` of an overlay that is never wired to the config-file setter).

I added a regression test (`fs/config/rc_config_template_test.go`) that registers a backend whose `Config` state reads `config_template_file` / `config_template` from the mapper, creates a remote with those parameters, and asserts they are visible to the backend but not persisted to the config file. It fails before this change (the backend reads empty strings) and passes after it. Verified locally: `go test ./fs/config/...` and `go test ./lib/oauthutil/...` pass, `go vet` and `gofmt` are clean.

The diagnosis and the fix approach come from the issue thread: thanks to @Hakanbaban53 for the report and root-cause trace, and to @maximilize for confirming it and outlining the getter-overlay fix. They are credited as co-authors on the commit.

#### Linked issue

Fixes #9572

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] This Pull Request is ready for review.
