### PR TITLE
vfs/vfscache: fix silent data loss when a Windows cache rename hits an open handle

### DIFF
--- a/lib/file/file_other.go
+++ b/lib/file/file_other.go
@@ -18,3 +18,11 @@ var OpenFile = os.OpenFile
 func IsReserved(path string) error {
 	return nil
 }
+
+// Rename renames (moves) oldPath to newPath, replacing newPath if it exists.
+//
+// On non-Windows platforms this is os.Rename, which already replaces the
+// destination and works when other handles have the file open.
+func Rename(oldPath, newPath string) error {
+	return os.Rename(oldPath, newPath)
+}

--- a/lib/file/file_test.go
+++ b/lib/file/file_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path"
+	"path/filepath"
 	"runtime"
 	"testing"
 
@@ -167,4 +168,35 @@ func TestIsReserved(t *testing.T) {
 	// Name end with a space or a period
 	require.Error(t, IsReserved("test."))
 	require.Error(t, IsReserved("test "))
+}
+
+// Test Rename, including renaming over a destination that still has an open
+// handle - the case that plain os.Rename fails on Windows.
+func TestRename(t *testing.T) {
+	dir := t.TempDir()
+
+	src := filepath.Join(dir, "src")
+	dst := filepath.Join(dir, "dst")
+
+	// Rename when the destination does not exist
+	require.NoError(t, os.WriteFile(src, []byte("one"), 0666))
+	require.NoError(t, Rename(src, dst))
+	_, err := os.Stat(src)
+	assert.True(t, os.IsNotExist(err))
+	buf, err := os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "one", string(buf))
+
+	// Rename over an existing destination that still has an open handle
+	require.NoError(t, os.WriteFile(src, []byte("two"), 0666))
+	f, err := Open(dst) // keep dst open across the rename
+	require.NoError(t, err)
+	require.NoError(t, Rename(src, dst))
+	assert.NoError(t, f.Close())
+
+	_, err = os.Stat(src)
+	assert.True(t, os.IsNotExist(err))
+	buf, err = os.ReadFile(dst)
+	require.NoError(t, err)
+	assert.Equal(t, "two", string(buf))
 }

--- a/lib/file/file_windows.go
+++ b/lib/file/file_windows.go
@@ -8,6 +8,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // OpenFile is the generalized open call; most users will use Open or Create
@@ -97,6 +100,78 @@ func IsReserved(path string) error {
 	// (https://docs.microsoft.com/en-gb/windows/win32/fileio/naming-a-file)
 	if reserved, _ := regexp.MatchString(`^(?i:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\.|$)`, base); reserved {
 		return errors.New("base file name is reserved windows device name (CON, PRN, AUX, NUL, COM[1-9], LPT[1-9])")
+	}
+	return nil
+}
+
+// fileRenameInfo mirrors the Windows FILE_RENAME_INFO structure as used with
+// the FileRenameInfoEx information class. Its first field holds the rename
+// flags (a union with the BOOLEAN ReplaceIfExists used by the older
+// FileRenameInfo class).
+type fileRenameInfo struct {
+	Flags          uint32
+	RootDirectory  windows.Handle
+	FileNameLength uint32
+	FileName       [1]uint16
+}
+
+// Rename renames (moves) oldPath to newPath, replacing newPath if it exists.
+//
+// Unlike os.Rename, on Windows this uses POSIX rename semantics
+// (SetFileInformationByHandle with FileRenameInfoEx and
+// FILE_RENAME_POSIX_SEMANTICS) so the rename succeeds even when another handle
+// has the source or destination open, provided those handles were opened with
+// FILE_SHARE_DELETE (as OpenFile above does). This matches the behaviour of
+// os.Rename on Unix.
+//
+// If the POSIX rename is not supported (e.g. an older Windows release or a
+// non-NTFS filesystem) it falls back to os.Rename.
+func Rename(oldPath, newPath string) error {
+	linkErr := func(err error) error {
+		return &os.LinkError{Op: "rename", Old: oldPath, New: newPath, Err: err}
+	}
+
+	namep, err := windows.UTF16PtrFromString(UNCPath(oldPath))
+	if err != nil {
+		return linkErr(err)
+	}
+
+	// Open the source with DELETE access and full sharing so the rename can
+	// proceed even while other handles are open.
+	handle, err := windows.CreateFile(
+		namep,
+		windows.DELETE,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		nil,
+		windows.OPEN_EXISTING,
+		windows.FILE_FLAG_BACKUP_SEMANTICS,
+		0,
+	)
+	if err != nil {
+		return linkErr(err)
+	}
+
+	targetp, err := windows.UTF16FromString(UNCPath(newPath))
+	if err != nil {
+		_ = windows.CloseHandle(handle)
+		return linkErr(err)
+	}
+
+	// FileNameLength is in bytes and excludes the terminating NUL.
+	nameLen := (len(targetp) - 1) * 2
+	bufLen := int(unsafe.Offsetof(fileRenameInfo{}.FileName)) + nameLen
+	buf := make([]byte, bufLen)
+	info := (*fileRenameInfo)(unsafe.Pointer(&buf[0]))
+	info.Flags = windows.FILE_RENAME_REPLACE_IF_EXISTS | windows.FILE_RENAME_POSIX_SEMANTICS
+	info.FileNameLength = uint32(nameLen)
+	copy(unsafe.Slice(&info.FileName[0], len(targetp)-1), targetp[:len(targetp)-1])
+
+	err = windows.SetFileInformationByHandle(handle, windows.FileRenameInfoEx, &buf[0], uint32(bufLen))
+	_ = windows.CloseHandle(handle)
+	if err != nil {
+		// POSIX rename is unsupported here (pre Windows 10 1607 or a non-NTFS
+		// filesystem); fall back to a plain rename.
+		return os.Rename(oldPath, newPath)
 	}
 	return nil
 }

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -285,7 +285,8 @@ func (f *File) rename(ctx context.Context, destDir *Dir, newName string) error {
 		// Rename in the cache
 		if d.vfs.cache != nil && d.vfs.cache.Exists(oldPath) {
 			if err := d.vfs.cache.Rename(oldPath, newPath, newObject); err != nil {
-				fs.Infof(f.Path(), "File.Rename failed in Cache: %v", err)
+				fs.Errorf(f.Path(), "File.Rename failed in Cache: %v", err)
+				return err
 			}
 		}
 		// Update the node with the new details

--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -411,7 +411,7 @@ func rename(osOldPath, osNewPath string) error {
 			return nil
 		}
 	}
-	if err = os.Rename(osOldPath, osNewPath); err != nil {
+	if err = file.Rename(osOldPath, osNewPath); err != nil {
 		return fmt.Errorf("failed to rename in cache: %s to %s: %w", osOldPath, osNewPath, err)
 	}
 	return nil


### PR DESCRIPTION
Two commits fixing silent data loss on Windows mounts when a VFS cache rename races an open handle (e.g. an in-flight `--vfs-write-back` upload).

### The bug

On Windows `os.Rename` fails with `Access is denied` when another handle holds the destination open. In the VFS cache this happens when a cache file is renamed while its write-back upload is still in flight. `File.Rename` logged the failure at Info level and then returned success, so the FUSE layer saw `errc=0` while the cache file kept the old name and the just-written bytes were dropped, representing a silent data loss.

It reproduces with any app that does the download-then-rename-temp→target pattern; an editor's atomic save (write `foo.tmp`, rename over `foo`) is exactly this. Observed with Claude Code's `Edit`/`Write` over an rclone SFTP mount: the tool reports success, the file silently reverts, and the next read may throw `EIO`. This is the scenario in the long-standing #4293.

### The fix (two commits)

1. **`vfs: return error when the VFS cache rename fails`** — stop swallowing the cache-rename error in `File.Rename`; propagate it so the failure is visible instead of silently discarding data.
2. **`lib/file: add Rename using Windows POSIX semantics …`** — new `file.Rename`: on Windows it renames via `SetFileInformationByHandle` + `FileRenameInfoEx` with `FILE_RENAME_POSIX_SEMANTICS | FILE_RENAME_REPLACE_IF_EXISTS`, which can replace a file that has open handles (opened with `FILE_SHARE_DELETE`, as `file.OpenFile` already does), matching `os.Rename` on Unix. Falls back to `os.Rename` if the POSIX call is unsupported (pre-Windows-10-1607 or non-NTFS). Non-Windows platforms are unchanged (`Rename = os.Rename`). `vfs/vfscache` uses it for the cache rename.

### Testing

- New `TestRename` in `lib/file` covers renaming over a destination that still has an open handle.
- `go test ./lib/file/... ./vfs/vfscache/... ./vfs/...` pass; `gofmt` / `go vet` clean.
- Validated end-to-end on Windows 11 + WinFsp over the SFTP backend with `--vfs-cache-mode writes --vfs-write-back 30s`: rapid temp-file-then-rename saves all persisted with no `File.Rename failed in Cache` errors, whereas the stock binary silently reverted them.

### Known limitation

POSIX rename still cannot replace a target held open by a third party *without* `FILE_SHARE_DELETE` (e.g. some antivirus scanning the cache file). That case now surfaces as an error rather than silent data loss, thanks to commit 1.

Approach suggested by @ncw on the forum (make the error visible, then fix via `lib/file`).

Refs #4293
