### PR TITLE
zoho: preserve root_folder_id on reconnect and allow setting it

### DIFF
--- a/backend/zoho/zoho.go
+++ b/backend/zoho/zoho.go
@@ -151,6 +151,20 @@ func init() {
 					}
 				}
 
+				// If a root_folder_id is already set (from config, or a previous
+				// setup) don't overwrite it on update/reconnect unless the user
+				// asks to, mirroring how the drive backend gates its team drive id.
+				if rootID, _ := m.Get(configRootID); rootID != "" {
+					return fs.ConfigConfirm("root_change", false, "config_change_root", fmt.Sprintf("Change current root folder id %q?\n", rootID))
+				}
+				return fs.ConfigGoto("select_edition")
+			case "root_change":
+				if config.Result == "false" {
+					// Keep the existing root_folder_id; the token has already been refreshed.
+					return nil, nil
+				}
+				return fs.ConfigGoto("select_edition")
+			case "select_edition":
 				_, apiSrv, err := getSrvs()
 				if err != nil {
 					return nil, err
@@ -252,6 +266,11 @@ browser.`,
 				Value: "com.au",
 				Help:  "Australia",
 			}},
+		}, {
+			Name:      "root_folder_id",
+			Help:      "ID of the root folder.\n\nLeave blank normally.\n\nFill in to make rclone use a non root folder as its starting point.",
+			Advanced:  true,
+			Sensitive: true,
 		}, {
 			Name:     "upload_cutoff",
 			Help:     "Cutoff for switching to large file upload api (>= 10 MiB).",

--- a/backend/zoho/zoho_internal_test.go
+++ b/backend/zoho/zoho_internal_test.go
@@ -1,0 +1,71 @@
+package zoho
+
+import (
+	"context"
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestConfigRootFolderID drives the interactive Config state machine directly
+// and checks that an existing root_folder_id is preserved on update/reconnect:
+// workspace selection only runs when the id is empty or the user opts in. The
+// seeded token is already the Zoho type and no region service is contacted, so
+// these cases make no network calls.
+func TestConfigRootFolderID(t *testing.T) {
+	regInfo := fs.MustFind("zoho")
+	const rootID = "abc123rootfolderid"
+	// Already the Zoho custom type, so the "type" state's token rewrite is a
+	// no-op and nothing is sent to the network.
+	const token = `{"access_token":"x","token_type":"Zoho-oauthtoken"}`
+
+	newMapper := func(withRoot bool) configmap.Simple {
+		m := configmap.Simple{"region": "eu", "token": token}
+		if withRoot {
+			m[configRootID] = rootID
+		}
+		return m
+	}
+
+	ctx := context.Background()
+
+	t.Run("SetRootAsksBeforeChanging", func(t *testing.T) {
+		m := newMapper(true)
+		out, err := regInfo.Config(ctx, "zoho", m, fs.ConfigIn{State: "type"})
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		assert.Equal(t, "root_change", out.State)
+		require.NotNil(t, out.Option)
+		got, _ := m.Get(configRootID)
+		assert.Equal(t, rootID, got, "id must not change before the user answers")
+	})
+
+	t.Run("EmptyRootGoesToEdition", func(t *testing.T) {
+		m := newMapper(false)
+		out, err := regInfo.Config(ctx, "zoho", m, fs.ConfigIn{State: "type"})
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		assert.Equal(t, "select_edition", out.State)
+		assert.Nil(t, out.Option, "goto, not a question")
+	})
+
+	t.Run("KeepRootOnNo", func(t *testing.T) {
+		m := newMapper(true)
+		out, err := regInfo.Config(ctx, "zoho", m, fs.ConfigIn{State: "root_change", Result: "false"})
+		require.NoError(t, err)
+		assert.Nil(t, out, "answering No ends config and keeps the id")
+		got, _ := m.Get(configRootID)
+		assert.Equal(t, rootID, got)
+	})
+
+	t.Run("ChangeRootOnYes", func(t *testing.T) {
+		m := newMapper(true)
+		out, err := regInfo.Config(ctx, "zoho", m, fs.ConfigIn{State: "root_change", Result: "true"})
+		require.NoError(t, err)
+		require.NotNil(t, out)
+		assert.Equal(t, "select_edition", out.State)
+	})
+}


### PR DESCRIPTION
#### What does this change do?

Makes the Zoho backend preserve an existing `root_folder_id` when re-running the config
system, and exposes `root_folder_id` as a settable advanced option, marked `Sensitive`
(like drive/box/onedrive) so `rclone config redacted` masks it.

Previously the `workspace_end` state unconditionally ran `m.Set("root_folder_id",
workspaceID)` with `fs.ConfigChoose` defaulting to the first workspace, so every
`config create`, `config update` and `config reconnect` silently repointed the remote to
the first workspace root. Because `config reconnect` is the documented fix for the
`401 INVALID_OAUTHSCOPE` download error, users following that advice had their remote
moved to a different (often shared) workspace with no warning.

The fix mirrors the drive backend's team-drive handling (#5454): when a `root_folder_id`
is already set, the config system asks "Change current root folder id …?" defaulting to No
and keeps it; workspace selection only runs when it is empty or the user opts in. The
token-type rewrite still runs on every reconnect, so the scope refresh is unaffected.

#### Linked issue

Fixes #9575

#### For new or changed backends

`go run ./fstest/test_all -backends zoho` on this branch (2026-07-16, commit `3bc8f7ad6`):

```
PASS: All tests finished OK in 8m8s (try 1/5)
107 PASS / 31 SKIP / 0 FAIL
```

This change is confined to the interactive Config state machine and the options list, so
test_all does not exercise it directly - it confirms there is no data-path regression. The
added `TestConfigRootFolderID` unit test drives the Config state machine directly (root
preserved on No, workspace selection on Yes / empty id) and runs as part of the suite. The
config flows were also validated live against a real Zoho WorkDrive account:

- no id -> selects a workspace as before
  `rclone config create <remote> zoho region=eu`
- id set -> "Change current root folder id?" -> No keeps it
  `rclone config create <remote> zoho region=eu root_folder_id=ID`
- re-runs the prompts; id preserved on No
  `rclone config update <remote>`
- same prompt after token refresh; Yes reaches workspace selection
  `rclone config reconnect <remote>`

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
