### PR TITLE
zoho: treat R008 unauthorized as directory not found

### DIFF
--- a/backend/zoho/throttle_test.go
+++ b/backend/zoho/throttle_test.go
@@ -2,6 +2,7 @@ package zoho
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sync"
 	"testing"
@@ -73,6 +74,16 @@ func TestShouldRetry(t *testing.T) {
 		assert.True(t, retry)
 	})
 
+	// A bare 401 R008 body means the folder was deleted (Zoho no longer accepts
+	// its id). It is unrecoverable, so it is NOT retried.
+	t.Run("401 R008 deleted folder is not retried", func(t *testing.T) {
+		f := newTestFs()
+		resp := &http.Response{StatusCode: 401}
+		err := errors.New(`HTTP error 401: {"errors":[{"id":"R008","title":"Unauthorized access"}]}`)
+		retry, _ := f.shouldRetry(ctx, resp, err)
+		assert.False(t, retry)
+	})
+
 	// A cancelled context is never retried.
 	t.Run("cancelled context aborts", func(t *testing.T) {
 		f := newTestFs()
@@ -81,6 +92,26 @@ func TestShouldRetry(t *testing.T) {
 		retry, _ := f.shouldRetry(cctx, nil, nil)
 		assert.False(t, retry)
 	})
+}
+
+// isMissingResourceErr must match only a genuine 401 R008 body, so an unrelated
+// error that merely mentions R008 (or an R008 body on some other status) is not
+// mistaken for a deleted resource.
+func TestIsMissingResourceErr(t *testing.T) {
+	r008 := errors.New(`HTTP error 401: {"errors":[{"id":"R008","title":"Unauthorized access"}]}`)
+
+	// A 401 R008 body is a missing resource.
+	assert.True(t, isMissingResourceErr(&http.Response{StatusCode: 401}, r008))
+
+	// An R008 body on a non-401 status is not (guards the ungated substring).
+	assert.False(t, isMissingResourceErr(&http.Response{StatusCode: 500}, r008))
+
+	// A 401 that is not R008 is not a missing resource.
+	assert.False(t, isMissingResourceErr(&http.Response{StatusCode: 401}, errors.New("HTTP error 401: expired_token")))
+
+	// No response or no error is not a missing resource.
+	assert.False(t, isMissingResourceErr(nil, r008))
+	assert.False(t, isMissingResourceErr(&http.Response{StatusCode: 401}, nil))
 }
 
 // TestThrottleEpisode covers the once-per-episode logging state machine that

--- a/backend/zoho/zoho.go
+++ b/backend/zoho/zoho.go
@@ -657,12 +657,20 @@ func (f *Fs) logThrottle(wait time.Duration, err error) {
 	}
 }
 
+// isMissingResourceErr reports whether resp/err is Zoho's 401 "R008 Unauthorized
+// access" - returned (not a 404) for a resource id (folder or file) that was
+// deleted or never existed. A freshly refreshed token still gets it, so it is a
+// missing resource, not a token problem.
+func isMissingResourceErr(resp *http.Response, err error) bool {
+	return resp != nil && resp.StatusCode == 401 && err != nil && strings.Contains(err.Error(), "R008")
+}
+
 // shouldRetry reports whether the given resp and err deserve to be retried.
 //
 // A 429 is honoured via the Retry-After header (falling back to 60s plus a
 // margin) and starts or continues a throttling episode; expired OAuth tokens
 // are retried, missing OAuth scopes abort, and standard HTTP retry conditions
-// are also handled.
+// are also handled. A missing folder (R008) is not retried.
 //
 // Returns whether to retry, and the err as a convenience.
 func (f *Fs) shouldRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
@@ -687,6 +695,11 @@ func (f *Fs) shouldRetry(ctx context.Context, resp *http.Response, err error) (b
 	if resp != nil && resp.StatusCode == 401 && len(resp.Header["Www-Authenticate"]) == 1 && strings.Contains(resp.Header["Www-Authenticate"][0], "expired_token") {
 		authRetry = true
 		fs.Debugf(nil, "Should retry: %v", err)
+	}
+
+	// A missing resource never reappears, and retrying escalates to a 429 F7008.
+	if isMissingResourceErr(resp, err) {
+		return false, err
 	}
 	if resp != nil && resp.StatusCode == 429 {
 		// Zoho's listing API is heavily rate limited and tells us how long to
@@ -766,6 +779,16 @@ func (f *Fs) readMetaDataForPath(ctx context.Context, path string) (info *api.It
 		return false
 	})
 	if err != nil {
+		if err == fs.ErrorDirNotFound {
+			// The cached parent directory id is stale: its folder was deleted, so
+			// listing it returned R008 (mapped to ErrorDirNotFound). Flush the stale
+			// entry so a later create re-resolves (and recreates) the parent, and
+			// report the object as not found - it cannot exist if its parent is gone.
+			parent := strings.TrimSuffix(path[:len(path)-len(leaf)], "/")
+			fs.Debugf(f, "readMetaDataForPath %q: parent %q stale (R008), flushing dircache", path, parent)
+			f.dirCache.FlushDir(parent)
+			return nil, fs.ErrorObjectNotFound
+		}
 		return nil, err
 	}
 	if !found {
@@ -994,7 +1017,13 @@ OUTER:
 			return f.shouldRetry(ctx, resp, err)
 		})
 		if err != nil {
-			return found, fmt.Errorf("couldn't list files: %w", err)
+			// Surface a missing folder as directory-not-found so dircache/the VFS
+			// treat it as gone instead of hard-failing on a stale id.
+			if isMissingResourceErr(resp, err) {
+				fs.Debugf(f, "listAll %q: R008 unauthorized - treating as directory not found", dirID)
+				return false, fs.ErrorDirNotFound
+			}
+			return false, fmt.Errorf("couldn't list files: %w", err)
 		}
 		if len(result.Items) == 0 {
 			break


### PR DESCRIPTION
#### What does this change do?

Zoho WorkDrive returns `401 "R008 Unauthorized access"` (not a 404) for a folder id that was
deleted or never existed. The `zoho` backend retried it (futile, and it escalates to a
`429 F7008` penalty) and then surfaced it as a hard `couldn't list files: ... R008` error
that callers did not recover from - so a stale cached directory id (inevitable in a
long-running mount, or across the shared-dircache vfs test suite) failed hard on zoho where
Google Drive self-heals.

This treats R008 as a missing directory:
- `shouldRetry` no longer retries a bare R008 401.
- `listAll` maps R008 to `fs.ErrorDirNotFound` (idiomatic - most backends return this).
- `readMetaDataForPath` flushes the stale parent from the dircache and returns
  `fs.ErrorObjectNotFound`, so a read gets not-found and a later `Put` re-resolves and
  recreates the parent.

#### Linked issue

Fixes #9578

#### For new or changed backends

Backend: **zoho** (data-path change: listing / directory resolution).

- `go run ./fstest/test_all -backends zoho`: **96 PASS / 31 SKIP / 0 FAIL** (~8m, try 1), zero F7008.
- R008 A/B on the vfs directory tests 
  - `go test ./vfs -remote TestZoho: -run 'TestDir|TestFileOpen'` :
    - on master **21 PASS / 5 FAIL / 1 SKIP** - the 5 failures all R008 hard-fails
  (TestDirFileOpen, TestDirMetadataExtension, TestFileOpenRead, TestFileOpenWrite,
  TestFileOpen);
    - with this change **26 PASS / 0 FAIL / 1 SKIP** (R008 still occurs but is
  now self-healed).
- The `TestZoho:` integration account already exists on the test server
  (`fstest/test_all/config.yaml`).

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
