### PR TITLE
serve smb: add SMB 2/3 server to serve any remote over SMB

### DIFF
--- a/cmd/all/all.go
+++ b/cmd/all/all.go
@@ -66,6 +66,7 @@ import (
 	_ "github.com/rclone/rclone/cmd/serve/restic"
 	_ "github.com/rclone/rclone/cmd/serve/s3"
 	_ "github.com/rclone/rclone/cmd/serve/sftp"
+	_ "github.com/rclone/rclone/cmd/serve/smb"
 	_ "github.com/rclone/rclone/cmd/serve/webdav"
 	_ "github.com/rclone/rclone/cmd/settier"
 	_ "github.com/rclone/rclone/cmd/sha1sum"

--- a/cmd/serve/servetest/servetest.go
+++ b/cmd/serve/servetest/servetest.go
@@ -36,7 +36,7 @@ type StartFn func(f fs.Fs) (configmap.Simple, func())
 // If backingRemote is non-empty (e.g. "TestS3Minio:") it is used as the
 // backing Fs that the server wraps, instead of a fresh local directory.
 // The matching fstest/testserver/init.d script is started automatically.
-func run(t *testing.T, name string, start StartFn, useProxy bool, backingRemote string) {
+func run(t *testing.T, name string, start StartFn, useProxy bool, backingRemote, root string) {
 	fremote, clean, err := makeBackingFs(backingRemote)
 	require.NoError(t, err)
 	defer clean()
@@ -81,7 +81,10 @@ func run(t *testing.T, name string, start StartFn, useProxy bool, backingRemote 
 	if *fstest.Verbose {
 		args = append(args, "-verbose")
 	}
-	remoteName := "serve" + name + "test:"
+	// root lets a server that exports a named prefix (e.g. an smb share) run the
+	// backend tests under that prefix rather than at the connection root.
+	configName := "serve" + name + "test"
+	remoteName := configName + ":" + root
 	if *subRun != "" {
 		args = append(args, "-run", *subRun)
 	}
@@ -91,7 +94,7 @@ func run(t *testing.T, name string, start StartFn, useProxy bool, backingRemote 
 
 	// Configure the backend with environment variables
 	cmd.Env = os.Environ()
-	prefix := "RCLONE_CONFIG_" + strings.ToUpper(remoteName[:len(remoteName)-1]) + "_"
+	prefix := "RCLONE_CONFIG_" + strings.ToUpper(configName) + "_"
 	for k, v := range config {
 		cmd.Env = append(cmd.Env, prefix+strings.ToUpper(k)+"="+v)
 	}
@@ -121,13 +124,24 @@ func Run(t *testing.T, name string, start StartFn) {
 func RunWithBackend(t *testing.T, name string, start StartFn, backingRemote string) {
 	fstest.Initialise()
 	t.Run("Normal", func(t *testing.T) {
-		run(t, name, start, false, backingRemote)
+		run(t, name, start, false, backingRemote, "")
 	})
 	if backingRemote == "" {
 		t.Run("AuthProxy", func(t *testing.T) {
-			run(t, name, start, true, backingRemote)
+			run(t, name, start, true, backingRemote, "")
 		})
 	}
+}
+
+// RunNoAuthProxy runs the server then the backend integration tests against it,
+// but without the auth-proxy sub-test. Use it for a server that does not (yet)
+// implement the auth proxy. root is the remote prefix the tests run under (e.g.
+// an smb share name), or "" for the connection root.
+func RunNoAuthProxy(t *testing.T, name, root string, start StartFn) {
+	fstest.Initialise()
+	t.Run("Normal", func(t *testing.T) {
+		run(t, name, start, false, "", root)
+	})
 }
 
 // makeBackingFs returns the Fs that the server should wrap, plus a

--- a/cmd/serve/smb/create.go
+++ b/cmd/serve/smb/create.go
@@ -1,0 +1,325 @@
+package smb
+
+import (
+	"errors"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/vfs"
+)
+
+// CreateDisposition values ([MS-SMB2] 2.2.13).
+const (
+	dispSupersede   uint32 = 0
+	dispOpen        uint32 = 1
+	dispCreate      uint32 = 2
+	dispOpenIf      uint32 = 3
+	dispOverwrite   uint32 = 4
+	dispOverwriteIf uint32 = 5
+)
+
+// CreateOptions bit flags ([MS-SMB2] 2.2.13).
+const (
+	optDirectoryFile    uint32 = 0x00000001
+	optNonDirectoryFile uint32 = 0x00000040
+	optDeleteOnClose    uint32 = 0x00001000
+)
+
+// CreateAction values ([MS-SMB2] 2.2.14).
+const (
+	actionOpened      uint32 = 1
+	actionCreated     uint32 = 2
+	actionOverwritten uint32 = 3
+)
+
+// File attribute flags ([MS-FSCC] 2.6).
+const (
+	fileAttrDirectory uint32 = 0x00000010
+	fileAttrNormal    uint32 = 0x00000080
+)
+
+// DesiredAccess bits we test for write intent ([MS-SMB2] 2.2.13.1).
+const (
+	accFileWriteData  uint32 = 0x00000002
+	accFileAppendData uint32 = 0x00000004
+	accGenericAll     uint32 = 0x10000000
+	accGenericWrite   uint32 = 0x40000000
+)
+
+// openFile is a server-side open: an entry in a connection's handle table
+// keyed by the 16-byte SMB2 FileId.
+type openFile struct {
+	fileID        [16]byte
+	path          string     // VFS path (forward-slash, no leading slash)
+	node          vfs.Node   // the file or directory node
+	handle        vfs.Handle // open IO handle for files (nil for directories)
+	isDir         bool
+	deleteOnClose bool
+
+	// directory enumeration state for QUERY_DIRECTORY
+	dirEntries []vfs.Node
+	dirPos     int
+	dirLoaded  bool
+}
+
+// maxOpenFiles caps the number of open handles per connection so a client that
+// never sends CLOSE can't exhaust the process's file descriptors.
+const maxOpenFiles = 16384
+
+// handleCreate handles an SMB2 CREATE request: it opens or creates a file or
+// directory and adds it to the connection's handle table.
+func (c *conn) handleCreate(h header, body []byte) (uint32, []byte) {
+	if len(body) < 56 {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	if len(c.handles) >= maxOpenFiles {
+		return statusInsufficientResources, errorResponseBody()
+	}
+	desiredAccess := le.Uint32(body[24:28])
+	createDisposition := le.Uint32(body[36:40])
+	createOptions := le.Uint32(body[40:44])
+	name := ""
+	if buf := bufferAt(body, le.Uint16(body[44:46]), le.Uint16(body[46:48])); buf != nil {
+		name = utf16leToString(buf)
+	}
+	path := nameToPath(name)
+
+	node, statErr := c.statPath(path)
+	exists := statErr == nil
+
+	// Disposition preconditions.
+	switch createDisposition {
+	case dispOpen, dispOverwrite:
+		if !exists {
+			return mapVFSError(statErr), errorResponseBody()
+		}
+	case dispCreate:
+		if exists {
+			return statusObjectNameCollision, errorResponseBody()
+		}
+	}
+
+	var of *openFile
+	var action uint32
+
+	switch {
+	case exists && node.IsDir():
+		if createOptions&optNonDirectoryFile != 0 {
+			return statusFileIsADirectory, errorResponseBody()
+		}
+		of = &openFile{path: path, node: node, isDir: true}
+		action = actionOpened
+	case !exists && createOptions&optDirectoryFile != 0:
+		if err := c.server.vfs.Mkdir(path, 0777); err != nil {
+			return mapVFSError(err), errorResponseBody()
+		}
+		newNode, err := c.statPath(path)
+		if err != nil {
+			return mapVFSError(err), errorResponseBody()
+		}
+		of = &openFile{path: path, node: newNode, isDir: true}
+		action = actionCreated
+	case exists && !node.IsDir() && createOptions&optDirectoryFile != 0:
+		// The client asked to open a directory (FILE_DIRECTORY_FILE) but the name
+		// is a regular file.
+		return statusNotADirectory, errorResponseBody()
+	default:
+		flags := accessToFlags(desiredAccess, createDisposition)
+		handle, err := c.server.vfs.OpenFile(path, flags, 0666)
+		if err != nil {
+			return mapVFSError(err), errorResponseBody()
+		}
+		of = &openFile{path: path, node: handle.Node(), handle: handle}
+		switch {
+		case !exists:
+			action = actionCreated
+		case flags&os.O_TRUNC != 0:
+			action = actionOverwritten
+		default:
+			action = actionOpened
+		}
+	}
+
+	if createOptions&optDeleteOnClose != 0 {
+		of.deleteOnClose = true
+	}
+	of.fileID = c.newFileID()
+	c.addHandle(of)
+	return statusSuccess, c.buildCreateResp(action, of)
+}
+
+// buildCreateResp builds the CREATE response body ([MS-SMB2] 2.2.14).
+func (c *conn) buildCreateResp(action uint32, of *openFile) []byte {
+	attrs, size, mtime := nodeAttrs(of.node)
+	ft := timeToFiletime(mtime)
+	body := make([]byte, 89)
+	le.PutUint16(body[0:2], 89) // StructureSize (fixed magic value)
+	le.PutUint32(body[4:8], action)
+	le.PutUint64(body[8:16], ft)  // CreationTime
+	le.PutUint64(body[16:24], ft) // LastAccessTime
+	le.PutUint64(body[24:32], ft) // LastWriteTime
+	le.PutUint64(body[32:40], ft) // ChangeTime
+	le.PutUint64(body[40:48], uint64(size))
+	le.PutUint64(body[48:56], uint64(size))
+	le.PutUint32(body[56:60], attrs)
+	copy(body[64:80], of.fileID[:])
+	return body
+}
+
+// nodeAttrs returns the SMB file attributes, size and modification time of a
+// VFS node.
+func nodeAttrs(node vfs.Node) (attrs uint32, size int64, mtime time.Time) {
+	if node.IsDir() {
+		attrs = fileAttrDirectory
+	} else {
+		attrs = fileAttrNormal
+	}
+	return attrs, node.Size(), node.ModTime()
+}
+
+// accessToFlags converts an SMB DesiredAccess and CreateDisposition into the
+// os.OpenFile flags used by the VFS.
+func accessToFlags(access, disposition uint32) int {
+	write := access&(accGenericWrite|accGenericAll|accFileWriteData|accFileAppendData) != 0
+	flags := os.O_RDONLY
+	if write {
+		flags = os.O_RDWR
+	}
+	if access&accFileAppendData != 0 && access&accFileWriteData == 0 {
+		flags |= os.O_APPEND
+	}
+	switch disposition {
+	case dispCreate:
+		flags |= os.O_CREATE | os.O_EXCL
+	case dispOpenIf:
+		flags |= os.O_CREATE
+	case dispOverwrite:
+		flags |= os.O_TRUNC
+	case dispOverwriteIf, dispSupersede:
+		flags |= os.O_CREATE | os.O_TRUNC
+	}
+	return flags
+}
+
+// nameToPath converts an SMB share-relative name (backslash separated, UTF-16
+// decoded) into a VFS path (forward-slash, no leading or trailing slash). It
+// cleans "." and ".." components and anchors the result at the share root so a
+// client cannot escape the share with "..".
+func nameToPath(name string) string {
+	p := strings.ReplaceAll(name, `\`, `/`)
+	p = path.Clean("/" + p)
+	return strings.Trim(p, "/")
+}
+
+// statPath looks up a VFS node by path, treating the empty path as the root.
+func (c *conn) statPath(path string) (vfs.Node, error) {
+	if path == "" {
+		root, err := c.server.vfs.Root()
+		return root, err
+	}
+	return c.server.vfs.Stat(path)
+}
+
+// listDir returns the directory entries at the given VFS path.
+func (c *conn) listDir(path string) ([]vfs.Node, error) {
+	node, err := c.statPath(path)
+	if err != nil {
+		return nil, err
+	}
+	dir, ok := node.(*vfs.Dir)
+	if !ok {
+		return nil, vfs.ENOSYS
+	}
+	nodes, err := dir.ReadDirAll()
+	if err != nil {
+		return nil, err
+	}
+	return nodes, nil
+}
+
+// mapVFSError maps a VFS/os error to the closest NTSTATUS code.
+func mapVFSError(err error) uint32 {
+	switch {
+	case err == nil:
+		return statusSuccess
+	case errors.Is(err, os.ErrNotExist):
+		return statusObjectNameNotFound
+	case errors.Is(err, os.ErrExist):
+		return statusObjectNameCollision
+	case errors.Is(err, os.ErrPermission):
+		return statusAccessDenied
+	case errors.Is(err, vfs.EROFS):
+		return statusMediaWriteProtected
+	case errors.Is(err, vfs.ENOTEMPTY):
+		return statusDirectoryNotEmpty
+	case errors.Is(err, vfs.ENOSYS):
+		return statusNotSupported
+	case errors.Is(err, os.ErrInvalid):
+		return statusInvalidParameter
+	default:
+		// OS-specific errors that the portable os sentinels don't catch (e.g. a
+		// Windows sharing violation on a file another process holds open). Mapping
+		// these to a precise status rather than the STATUS_UNSUCCESSFUL catch-all
+		// lets SMB clients skip the item instead of aborting the operation.
+		if s, ok := osErrorStatus(err); ok {
+			return s
+		}
+		return statusUnsuccessful
+	}
+}
+
+// --- handle table (per connection) ---
+
+func (c *conn) newFileID() [16]byte {
+	c.mu.Lock()
+	c.handleCtr++
+	id := c.handleCtr
+	c.mu.Unlock()
+	var fid [16]byte
+	le.PutUint64(fid[0:8], id)  // Persistent
+	le.PutUint64(fid[8:16], id) // Volatile
+	return fid
+}
+
+func (c *conn) addHandle(of *openFile) {
+	c.mu.Lock()
+	c.handles[of.fileID] = of
+	c.mu.Unlock()
+}
+
+func (c *conn) getHandle(fileID []byte) *openFile {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.handles[fileIDKey(fileID)]
+}
+
+func (c *conn) removeHandle(fileID []byte) *openFile {
+	k := fileIDKey(fileID)
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	of := c.handles[k]
+	delete(c.handles, k)
+	return of
+}
+
+func (c *conn) closeAllHandles() {
+	c.mu.Lock()
+	handles := c.handles
+	c.handles = map[[16]byte]*openFile{}
+	c.mu.Unlock()
+	for _, of := range handles {
+		if of.handle != nil {
+			if err := of.handle.Close(); err != nil {
+				fs.Errorf(c.server.vfs.Fs(), "SMB: error closing handle on teardown: %v", err)
+			}
+		}
+	}
+}
+
+func fileIDKey(b []byte) (k [16]byte) {
+	copy(k[:], b)
+	return k
+}

--- a/cmd/serve/smb/crypto.go
+++ b/cmd/serve/smb/crypto.go
@@ -1,0 +1,231 @@
+package smb
+
+import (
+	"crypto/aes"
+	"crypto/hmac"
+	"crypto/md5"
+	"crypto/rc4"
+	"crypto/sha256"
+	"strings"
+
+	"golang.org/x/crypto/md4" //nolint:staticcheck // MD4 is required by the NTLM protocol
+)
+
+// NTLMSSP negotiate flag for session key exchange.
+const ntlmNegotiateKeyExch uint32 = 0x40000000
+
+// NTLMSSP negotiate flag indicating the message carries an 8-byte OS Version
+// field after the negotiate flags. Windows clients set this; we read the major
+// version to spot a Windows client (which can't use guest) and warn.
+const ntlmNegotiateVersion uint32 = 0x02000000
+
+// ntHash returns the NTLM hash of a password: MD4(UTF-16LE(password)).
+func ntHash(password string) []byte {
+	h := md4.New()
+	_, _ = h.Write(stringToUTF16le(password))
+	return h.Sum(nil)
+}
+
+// ntowfv2 computes the NTLMv2 one-way function:
+// HMAC-MD5(NTHash, UPPERCASE(user) + domain).
+func ntowfv2(user, password, domain string) []byte {
+	mac := hmac.New(md5.New, ntHash(password))
+	_, _ = mac.Write(stringToUTF16le(strings.ToUpper(user) + domain))
+	return mac.Sum(nil)
+}
+
+// validateNTLMv2 checks an NTLMv2 NtChallengeResponse (NTProofStr followed by
+// the client blob) against the proof computed from responseKeyNT (the NTOWFv2)
+// and the server challenge.
+func validateNTLMv2(responseKeyNT []byte, serverChallenge [8]byte, ntResponse []byte) bool {
+	if len(ntResponse) < 16 {
+		return false
+	}
+	proof := ntResponse[:16]
+	blob := ntResponse[16:]
+	mac := hmac.New(md5.New, responseKeyNT)
+	_, _ = mac.Write(serverChallenge[:])
+	_, _ = mac.Write(blob)
+	return hmac.Equal(proof, mac.Sum(nil))
+}
+
+// exportedSessionKey recovers the NTLMv2 session key the client derived, used
+// as the basis for SMB signing keys. ntProofStr is the first 16 bytes of the
+// NtChallengeResponse.
+func exportedSessionKey(responseKeyNT, ntProofStr []byte, flags uint32, encRandomSessionKey []byte) []byte {
+	mac := hmac.New(md5.New, responseKeyNT)
+	_, _ = mac.Write(ntProofStr)
+	keyExchangeKey := mac.Sum(nil) // SessionBaseKey == KeyExchangeKey for NTLMv2
+	if flags&ntlmNegotiateKeyExch != 0 && len(encRandomSessionKey) == 16 {
+		cipher, err := rc4.NewCipher(keyExchangeKey)
+		if err == nil {
+			out := make([]byte, 16)
+			cipher.XORKeyStream(out, encRandomSessionKey)
+			return out
+		}
+	}
+	return keyExchangeKey
+}
+
+// kdf is the SP 800-108 counter-mode KDF used by SMB 3.x key derivation
+// (h=256, r=32, L=128).
+func kdf(ki, label, context []byte) []byte {
+	h := hmac.New(sha256.New, ki)
+	_, _ = h.Write([]byte{0x00, 0x00, 0x00, 0x01})
+	_, _ = h.Write(label)
+	_, _ = h.Write([]byte{0x00})
+	_, _ = h.Write(context)
+	_, _ = h.Write([]byte{0x00, 0x00, 0x00, 0x80})
+	return h.Sum(nil)[:16]
+}
+
+// ntlmAuthenticate holds the fields we need from an NTLMSSP AUTHENTICATE
+// (Type 3) message.
+type ntlmAuthenticate struct {
+	user          string
+	domain        string
+	ntResponse    []byte
+	flags         uint32
+	encSessionKey []byte
+	osMajor       byte // NTLMSSP Version ProductMajorVersion (0 if no Version field)
+}
+
+// parseNTLMAuthenticate parses an NTLMSSP AUTHENTICATE (Type 3) message
+// ([MS-NLMP] 2.2.1.3). It assumes Unicode (UTF-16LE) names, which our CHALLENGE
+// negotiates.
+func parseNTLMAuthenticate(msg []byte) (ntlmAuthenticate, bool) {
+	if len(msg) < 64 || string(msg[0:8]) != string(ntlmSignature) || le.Uint32(msg[8:12]) != ntlmTypeAuthenticate {
+		return ntlmAuthenticate{}, false
+	}
+	field := func(off int) []byte {
+		length := int(le.Uint16(msg[off : off+2]))
+		start := int(le.Uint32(msg[off+4 : off+8]))
+		if length == 0 || start < 0 || start+length > len(msg) {
+			return nil
+		}
+		return msg[start : start+length]
+	}
+	flags := le.Uint32(msg[60:64]) // NegotiateFlags
+	var osMajor byte
+	// The 8-byte Version field follows the negotiate flags when NEGOTIATE_VERSION
+	// is set; its first byte is ProductMajorVersion.
+	if flags&ntlmNegotiateVersion != 0 && len(msg) >= 65 {
+		osMajor = msg[64]
+	}
+	return ntlmAuthenticate{
+		domain:        utf16leToString(field(28)), // DomainNameFields
+		user:          utf16leToString(field(36)), // UserNameFields
+		ntResponse:    field(20),                  // NtChallengeResponseFields
+		encSessionKey: field(52),                  // EncryptedRandomSessionKeyFields
+		flags:         flags,
+		osMajor:       osMajor,
+	}, true
+}
+
+// signMessage signs an SMB2 message in place using the given signing key and
+// the algorithm for the negotiated dialect (HMAC-SHA256 for 2.x, AES-CMAC for
+// 3.x). The signature covers the whole message with the signature field zeroed
+// and the SMB2_FLAGS_SIGNED flag set.
+func signMessage(signKey []byte, dialect uint16, msg []byte) {
+	for i := 48; i < 64; i++ {
+		msg[i] = 0
+	}
+	le.PutUint32(msg[16:20], le.Uint32(msg[16:20])|flagsSigned)
+	var sig []byte
+	switch dialect {
+	case dialect300, dialect302:
+		sig = aesCMAC(signKey, msg)
+	default:
+		mac := hmac.New(sha256.New, signKey)
+		_, _ = mac.Write(msg)
+		sig = mac.Sum(nil)
+	}
+	copy(msg[48:64], sig[:16])
+}
+
+// verifyMessage reports whether a signed inbound SMB2 message carries a valid
+// signature for the given key and dialect. It recomputes the signature over the
+// message with the signature field zeroed (as the sender did) and compares it in
+// constant time, restoring the field before returning.
+func verifyMessage(signKey []byte, dialect uint16, msg []byte) bool {
+	if len(msg) < 64 {
+		return false
+	}
+	var received [16]byte
+	copy(received[:], msg[48:64])
+	for i := 48; i < 64; i++ {
+		msg[i] = 0
+	}
+	var sig []byte
+	switch dialect {
+	case dialect300, dialect302:
+		sig = aesCMAC(signKey, msg)
+	default:
+		mac := hmac.New(sha256.New, signKey)
+		_, _ = mac.Write(msg)
+		sig = mac.Sum(nil)
+	}
+	copy(msg[48:64], received[:])
+	return hmac.Equal(received[:], sig[:16])
+}
+
+// aesCMAC computes the AES-CMAC of msg (RFC 4493 / NIST SP 800-38B).
+func aesCMAC(key, msg []byte) []byte {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return make([]byte, 16)
+	}
+	const bs = 16
+	subkey := make([]byte, bs)
+	block.Encrypt(subkey, subkey) // L = AES(K, 0)
+	k1 := gfMulX(subkey)
+	k2 := gfMulX(k1)
+
+	full := len(msg) / bs
+	rem := len(msg) % bs
+	if rem == 0 && full > 0 {
+		full--
+		rem = bs
+	}
+
+	x := make([]byte, bs)
+	tmp := make([]byte, bs)
+	for i := 0; i < full; i++ {
+		xorBytes(tmp, x, msg[i*bs:i*bs+bs])
+		block.Encrypt(x, tmp)
+	}
+
+	last := make([]byte, bs)
+	if rem == bs {
+		copy(last, msg[full*bs:full*bs+bs])
+		xorBytes(last, last, k1)
+	} else {
+		copy(last, msg[full*bs:])
+		last[rem] = 0x80
+		xorBytes(last, last, k2)
+	}
+	xorBytes(tmp, x, last)
+	block.Encrypt(x, tmp)
+	return x
+}
+
+// gfMulX multiplies a 128-bit big-endian value by x in GF(2^128) (a left shift
+// with conditional reduction by the CMAC polynomial 0x87).
+func gfMulX(in []byte) []byte {
+	out := make([]byte, len(in))
+	var carry byte
+	for i := len(in) - 1; i >= 0; i-- {
+		out[i] = (in[i] << 1) | carry
+		carry = in[i] >> 7
+	}
+	if carry != 0 {
+		out[len(out)-1] ^= 0x87
+	}
+	return out
+}
+
+func xorBytes(dst, a, b []byte) {
+	for i := range dst {
+		dst[i] = a[i] ^ b[i]
+	}
+}

--- a/cmd/serve/smb/info.go
+++ b/cmd/serve/smb/info.go
@@ -1,0 +1,550 @@
+package smb
+
+import (
+	"crypto/md5"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/vfs"
+)
+
+// QUERY_INFO / SET_INFO InfoType values ([MS-SMB2] 2.2.37).
+const (
+	infoTypeFile       byte = 0x01
+	infoTypeFilesystem byte = 0x02
+)
+
+// File information classes ([MS-FSCC] 2.4).
+const (
+	classFileBasic        byte = 0x04
+	classFileStandard     byte = 0x05
+	classFileInternal     byte = 0x06
+	classFileEa           byte = 0x07
+	classFileRename       byte = 0x0A
+	classFileDisposition  byte = 0x0D
+	classFileAll          byte = 0x12
+	classFileEndOfFile    byte = 0x14
+	classFileNetworkOpen  byte = 0x22
+	classFileAttributeTag byte = 0x23
+)
+
+// File system information classes ([MS-FSCC] 2.5).
+const (
+	classFsVolume    byte = 0x01
+	classFsSize      byte = 0x03
+	classFsDevice    byte = 0x04
+	classFsAttribute byte = 0x05
+	classFsFullSize  byte = 0x07
+)
+
+// handleQueryInfo handles an SMB2 QUERY_INFO request ([MS-SMB2] 2.2.37).
+func (c *conn) handleQueryInfo(h header, body []byte) (uint32, []byte) {
+	if len(body) < 40 {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	infoType := body[2]
+	infoClass := body[3]
+	of := c.getHandle(body[24:40])
+	if of == nil {
+		return statusInvalidParameter, errorResponseBody()
+	}
+
+	var info []byte
+	switch infoType {
+	case infoTypeFile:
+		attrs, size, mtime := nodeAttrs(of.node)
+		switch infoClass {
+		case classFileAll:
+			info = fileAllInfo(attrs, size, mtime, of.node)
+		case classFileStandard:
+			info = fileStandardInfo(size, of.node.IsDir())
+		case classFileBasic:
+			info = fileBasicInfo(attrs, mtime)
+		case classFileInternal:
+			info = fileInternalInfo(pathFileID(of.path))
+		case classFileEa:
+			info = make([]byte, 4) // FileEaInformation: EaSize = 0
+		case classFileNetworkOpen:
+			info = fileNetworkOpenInfo(attrs, size, mtime)
+		case classFileAttributeTag:
+			info = fileAttributeTagInfo(attrs)
+		default:
+			return statusNotSupported, errorResponseBody()
+		}
+	case infoTypeFilesystem:
+		switch infoClass {
+		case classFsFullSize:
+			info = fsFullSizeInfo(c.server.vfs)
+		case classFsSize:
+			info = fsSizeInfo(c.server.vfs)
+		case classFsAttribute:
+			info = fsAttributeInfo()
+		case classFsVolume:
+			info = fsVolumeInfo(c.server.serverGUID)
+		case classFsDevice:
+			info = fsDeviceInfo()
+		default:
+			return statusNotSupported, errorResponseBody()
+		}
+	default:
+		return statusNotSupported, errorResponseBody()
+	}
+	return statusSuccess, infoResponseBody(info)
+}
+
+// handleQueryDirectory handles an SMB2 QUERY_DIRECTORY request ([MS-SMB2]
+// 2.2.33). We return all entries in the first response and STATUS_NO_MORE_FILES
+// thereafter.
+func (c *conn) handleQueryDirectory(h header, body []byte) (uint32, []byte) {
+	if len(body) < 32 {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	infoClass := body[2]
+	flags := body[3]
+	outputBufferLength := int(le.Uint32(body[28:32]))
+	if outputBufferLength > 1<<20 {
+		outputBufferLength = 1 << 20
+	}
+	of := c.getHandle(body[8:24])
+	if of == nil || !of.isDir {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	// Search pattern ([MS-SMB2] 2.2.33 FileName): a client looks up a child by
+	// name with a single-entry pattern query, so it must be honoured -- ignoring
+	// it makes Windows path resolution follow the wrong entry (the first one).
+	pattern := ""
+	if l := le.Uint16(body[26:28]); l > 0 {
+		if b := bufferAt(body, le.Uint16(body[24:26]), l); b != nil {
+			pattern = utf16leToString(b)
+		}
+	}
+	const (
+		flagRestartScans      = 0x01
+		flagReturnSingleEntry = 0x02
+	)
+	if flags&flagRestartScans != 0 {
+		of.dirLoaded = false
+		of.dirEntries = nil
+		of.dirPos = 0
+	}
+	if !of.dirLoaded {
+		entries, err := c.listDir(of.path)
+		if err != nil {
+			// A directory we can't enumerate (locked by another process, denied)
+			// must not fail the request with a generic error: the Windows shell
+			// copy engine aborts a whole recursive copy when its scan hits
+			// STATUS_UNSUCCESSFUL. Surface it as empty so the client skips it and
+			// keeps going -- the same way rclone's ReadDirAll already reports most
+			// unreadable directories.
+			fs.Infof(c.server.vfs.Fs(), "SMB: cannot list %q, reporting it empty: %v", of.path, err)
+			entries = nil
+		}
+		of.dirEntries = filterByPattern(entries, pattern, c.server.vfs.Opt.CaseInsensitive)
+		of.dirPos = 0
+		of.dirLoaded = true
+	}
+	if of.dirPos >= len(of.dirEntries) {
+		return statusNoMoreFiles, errorResponseBody()
+	}
+	// Return as many entries as fit in the client's output buffer; the rest
+	// come on subsequent calls until we report STATUS_NO_MORE_FILES.
+	// A client may set SMB2_RETURN_SINGLE_ENTRY (e.g. Windows FindFirstFile) to
+	// request exactly one entry. We must honour it: if we pack more, the client
+	// keeps only the first and resumes after it, while our position advances past
+	// all we sent, silently dropping the entries in between from the listing.
+	entries := of.dirEntries[of.dirPos:]
+	if flags&flagReturnSingleEntry != 0 && len(entries) > 1 {
+		entries = entries[:1]
+	}
+	buf, n := buildDirInfoBuffer(entries, outputBufferLength, infoClass)
+	if n == 0 {
+		return statusNoMoreFiles, errorResponseBody()
+	}
+	of.dirPos += n
+	return statusSuccess, infoResponseBody(buf)
+}
+
+// filterByPattern returns the directory entries whose name matches an SMB2
+// search pattern. An empty pattern or "*" matches everything. caseInsensitive
+// follows the VFS setting (Opt.CaseInsensitive) so matching is consistent with
+// how the backend resolves names -- case-sensitive on Linux, insensitive on
+// Windows/macOS by default.
+func filterByPattern(entries []vfs.Node, pattern string, caseInsensitive bool) []vfs.Node {
+	if pattern == "" || pattern == "*" {
+		return entries
+	}
+	out := make([]vfs.Node, 0, len(entries))
+	for _, n := range entries {
+		if matchPattern(pattern, n.Name(), caseInsensitive) {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// matchPattern reports whether name matches an SMB2 search pattern. It supports
+// the '*' and '?' wildcards (mapping the legacy DOS wildcards '<' and '>' onto
+// them); a pattern with no wildcard is matched for equality. Case is folded only
+// when caseInsensitive is set.
+func matchPattern(pattern, name string, caseInsensitive bool) bool {
+	pattern = strings.NewReplacer("<", "*", ">", "?").Replace(pattern)
+	if !strings.ContainsAny(pattern, "*?") {
+		if caseInsensitive {
+			return strings.EqualFold(pattern, name)
+		}
+		return pattern == name
+	}
+	if caseInsensitive {
+		pattern, name = strings.ToLower(pattern), strings.ToLower(name)
+	}
+	return wildcardMatch([]rune(pattern), []rune(name))
+}
+
+// wildcardMatch matches name against a lower-cased pattern of '*' (any run) and
+// '?' (any single rune) using the standard linear backtracking algorithm.
+func wildcardMatch(pattern, name []rune) bool {
+	p, n, star, mark := 0, 0, -1, 0
+	for n < len(name) {
+		switch {
+		case p < len(pattern) && (pattern[p] == '?' || pattern[p] == name[n]):
+			p++
+			n++
+		case p < len(pattern) && pattern[p] == '*':
+			star, mark = p, n
+			p++
+		case star >= 0:
+			p = star + 1
+			mark++
+			n = mark
+		default:
+			return false
+		}
+	}
+	for p < len(pattern) && pattern[p] == '*' {
+		p++
+	}
+	return p == len(pattern)
+}
+
+// handleSetInfo handles an SMB2 SET_INFO request ([MS-SMB2] 2.2.39).
+func (c *conn) handleSetInfo(h header, body []byte) (uint32, []byte) {
+	if len(body) < 32 {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	infoType := body[2]
+	infoClass := body[3]
+	bufLen := le.Uint32(body[4:8])
+	bufOff := int(le.Uint16(body[8:10])) - smb2HeaderSize
+	of := c.getHandle(body[16:32])
+	if of == nil {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	// int64 arithmetic so a >2 GiB bufLen can't wrap negative on 32-bit builds.
+	if bufOff < 0 || int64(bufOff)+int64(bufLen) > int64(len(body)) {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	buf := body[bufOff : bufOff+int(bufLen)]
+	if infoType != infoTypeFile {
+		return statusNotSupported, errorResponseBody()
+	}
+
+	switch infoClass {
+	case classFileDisposition:
+		if len(buf) >= 1 {
+			of.deleteOnClose = buf[0] != 0
+		}
+	case classFileEndOfFile:
+		if len(buf) >= 8 {
+			if err := c.truncate(of, int64(le.Uint64(buf[0:8]))); err != nil {
+				return mapVFSError(err), errorResponseBody()
+			}
+		}
+	case classFileRename:
+		if len(buf) >= 20 {
+			replaceIfExists := buf[0] != 0
+			nameLen := le.Uint32(buf[16:20])
+			if 20+int64(nameLen) <= int64(len(buf)) {
+				newPath := nameToPath(utf16leToString(buf[20 : 20+int(nameLen)]))
+				// Honour ReplaceIfExists: without it, refuse to clobber an existing
+				// target (Windows relies on this to prompt "replace or skip").
+				if !replaceIfExists {
+					if _, err := c.statPath(newPath); err == nil {
+						return statusObjectNameCollision, errorResponseBody()
+					}
+				}
+				if err := c.server.vfs.Rename(of.path, newPath); err != nil {
+					return mapVFSError(err), errorResponseBody()
+				}
+				of.path = newPath
+			}
+		}
+	case classFileBasic:
+		if len(buf) >= 32 && of.node != nil {
+			if lastWrite := le.Uint64(buf[16:24]); lastWrite != 0 {
+				_ = of.node.SetModTime(filetimeToTime(lastWrite))
+			}
+		}
+	default:
+		// Unhandled info classes (e.g. FileLink, FileAllocation) must not report
+		// success having done nothing.
+		return statusInvalidInfoClass, errorResponseBody()
+	}
+	return statusSuccess, setInfoResponseBody()
+}
+
+// truncate sets the size of an open file.
+func (c *conn) truncate(of *openFile, size int64) error {
+	if of.handle != nil {
+		return of.handle.Truncate(size)
+	}
+	if of.node != nil {
+		return of.node.Truncate(size)
+	}
+	return nil
+}
+
+// --- response wrappers ---
+
+// infoResponseBody wraps an info buffer in a QUERY_INFO / QUERY_DIRECTORY
+// response body ([MS-SMB2] 2.2.34 / 2.2.38), which share a layout.
+func infoResponseBody(info []byte) []byte {
+	body := make([]byte, 8+len(info))
+	le.PutUint16(body[0:2], 9)                // StructureSize (fixed magic value)
+	le.PutUint16(body[2:4], smb2HeaderSize+8) // OutputBufferOffset = 72
+	le.PutUint32(body[4:8], uint32(len(info)))
+	copy(body[8:], info)
+	return body
+}
+
+// setInfoResponseBody builds the SET_INFO response ([MS-SMB2] 2.2.40).
+func setInfoResponseBody() []byte {
+	b := make([]byte, 2)
+	le.PutUint16(b[0:2], 2)
+	return b
+}
+
+// --- information class encoders ([MS-FSCC]) ---
+
+func fileBasicInfo(attrs uint32, t time.Time) []byte {
+	b := make([]byte, 40)
+	ft := timeToFiletime(t)
+	le.PutUint64(b[0:8], ft)
+	le.PutUint64(b[8:16], ft)
+	le.PutUint64(b[16:24], ft)
+	le.PutUint64(b[24:32], ft)
+	le.PutUint32(b[32:36], attrs)
+	return b
+}
+
+// pathFileID returns a stable, unique 64-bit FileId for a VFS path. The VFS
+// inode (Node.Inode()) is a per-process counter that resets on restart and
+// changes when a node is re-cached, so Windows clients -- which cache FileIds
+// and treat them as stable identifiers -- mis-navigate after a restart.
+// Deriving the FileId from the path keeps it constant across restarts and cache
+// evictions, mirroring how "serve nfs" hashes the path for its on-disk handle
+// cache (cmd/serve/nfs/cache.go).
+func pathFileID(path string) uint64 {
+	sum := md5.Sum([]byte(path))
+	return le.Uint64(sum[:8])
+}
+
+func fileInternalInfo(inode uint64) []byte {
+	b := make([]byte, 8)
+	le.PutUint64(b[0:8], inode) // IndexNumber
+	return b
+}
+
+func fileNetworkOpenInfo(attrs uint32, size int64, t time.Time) []byte {
+	b := make([]byte, 56)
+	ft := timeToFiletime(t)
+	le.PutUint64(b[0:8], ft)
+	le.PutUint64(b[8:16], ft)
+	le.PutUint64(b[16:24], ft)
+	le.PutUint64(b[24:32], ft)
+	le.PutUint64(b[32:40], uint64(size)) // AllocationSize
+	le.PutUint64(b[40:48], uint64(size)) // EndOfFile
+	le.PutUint32(b[48:52], attrs)
+	return b
+}
+
+func fileAttributeTagInfo(attrs uint32) []byte {
+	b := make([]byte, 8)
+	le.PutUint32(b[0:4], attrs) // FileAttributes; ReparseTag (4:8) = 0
+	return b
+}
+
+func fileStandardInfo(size int64, isDir bool) []byte {
+	b := make([]byte, 24)
+	le.PutUint64(b[0:8], uint64(size))  // AllocationSize
+	le.PutUint64(b[8:16], uint64(size)) // EndOfFile
+	le.PutUint32(b[16:20], 1)           // NumberOfLinks
+	if isDir {
+		b[21] = 1 // Directory
+	}
+	return b
+}
+
+func fileAllInfo(attrs uint32, size int64, t time.Time, node vfs.Node) []byte {
+	// The name keeps the buffer at or above the 101-byte minimum that clients
+	// (cifs) require for FileAllInformation.
+	name := stringToUTF16le(node.Name())
+	if len(name) == 0 {
+		name = []byte{0x00, 0x00}
+	}
+	b := make([]byte, 96+4+len(name))
+	copy(b[0:40], fileBasicInfo(attrs, t))
+	copy(b[40:64], fileStandardInfo(size, node.IsDir()))
+	le.PutUint64(b[64:72], pathFileID(node.Path())) // InternalInformation.IndexNumber
+	// EaInformation, AccessInformation, PositionInformation, ModeInformation and
+	// AlignmentInformation (offsets 72-96) are left zero.
+	le.PutUint32(b[96:100], uint32(len(name))) // NameInformation.FileNameLength
+	copy(b[100:], name)
+	return b
+}
+
+func fsFullSizeInfo(v *vfs.VFS) []byte {
+	total, _, free := v.Statfs()
+	const bytesPerSector = 512
+	const sectorsPerUnit = 8
+	unit := int64(bytesPerSector * sectorsPerUnit)
+	b := make([]byte, 32)
+	le.PutUint64(b[0:8], allocUnits(total, unit))  // TotalAllocationUnits
+	le.PutUint64(b[8:16], allocUnits(free, unit))  // CallerAvailableAllocationUnits
+	le.PutUint64(b[16:24], allocUnits(free, unit)) // ActualAvailableAllocationUnits
+	le.PutUint32(b[24:28], sectorsPerUnit)
+	le.PutUint32(b[28:32], bytesPerSector)
+	return b
+}
+
+func fsSizeInfo(v *vfs.VFS) []byte {
+	total, _, free := v.Statfs()
+	const bytesPerSector = 512
+	const sectorsPerUnit = 8
+	unit := int64(bytesPerSector * sectorsPerUnit)
+	b := make([]byte, 24)
+	le.PutUint64(b[0:8], allocUnits(total, unit))
+	le.PutUint64(b[8:16], allocUnits(free, unit))
+	le.PutUint32(b[16:20], sectorsPerUnit)
+	le.PutUint32(b[20:24], bytesPerSector)
+	return b
+}
+
+func fsAttributeInfo() []byte {
+	name := stringToUTF16le("rclone")
+	b := make([]byte, 12+len(name))
+	le.PutUint32(b[0:4], 0x00000002) // FILE_CASE_PRESERVED_NAMES
+	le.PutUint32(b[4:8], 255)        // MaximumComponentNameLength
+	le.PutUint32(b[8:12], uint32(len(name)))
+	copy(b[12:], name)
+	return b
+}
+
+func fsVolumeInfo(guid [16]byte) []byte {
+	label := stringToUTF16le("rclone")
+	b := make([]byte, 18+len(label))
+	le.PutUint32(b[8:12], le.Uint32(guid[0:4])) // VolumeSerialNumber
+	le.PutUint32(b[12:16], uint32(len(label)))
+	copy(b[18:], label)
+	return b
+}
+
+func fsDeviceInfo() []byte {
+	b := make([]byte, 8)
+	le.PutUint32(b[0:4], 0x00000007) // FILE_DEVICE_DISK
+	return b
+}
+
+// allocUnits returns n/unit clamped to be non-negative.
+func allocUnits(n, unit int64) uint64 {
+	if n <= 0 {
+		return 0
+	}
+	return uint64(n / unit)
+}
+
+// dirInfoLayout returns the fixed-part size and the file-name offset for a
+// directory-enumeration FileInformationClass ([MS-FSCC] 2.4), and whether the
+// class is supported.
+func dirInfoLayout(class byte) (fixed, nameOff int, ok bool) {
+	switch class {
+	case 0x01: // FileDirectoryInformation
+		return 64, 64, true
+	case 0x02: // FileFullDirectoryInformation
+		return 68, 68, true
+	case 0x03: // FileBothDirectoryInformation
+		return 94, 94, true
+	case 0x0C: // FileNamesInformation
+		return 12, 12, true
+	case 0x25: // FileIdBothDirectoryInformation
+		return 104, 104, true
+	case 0x26: // FileIdFullDirectoryInformation
+		return 80, 80, true
+	}
+	return 0, 0, false
+}
+
+// buildDirInfoBuffer encodes directory entries as a chain of directory
+// information structures of the requested class, packing as many as fit within
+// maxLen bytes. It returns the buffer and the number of entries encoded (always
+// at least one, to guarantee progress).
+func buildDirInfoBuffer(entries []vfs.Node, maxLen int, class byte) ([]byte, int) {
+	fixed, nameOff, ok := dirInfoLayout(class)
+	if !ok {
+		fixed, nameOff = 64, 64 // default to FileDirectoryInformation
+	}
+	var buf []byte
+	count := 0
+	lastStart := 0
+	for _, node := range entries {
+		nameBytes := stringToUTF16le(node.Name())
+		padded := roundUp(fixed+len(nameBytes), 8)
+		if count > 0 && len(buf)+padded > maxLen {
+			break
+		}
+		start := len(buf)
+		e := make([]byte, padded)
+		le.PutUint32(e[0:4], uint32(padded)) // NextEntryOffset (cleared on the last entry below)
+		if class == 0x0C {
+			// FileNamesInformation: only the name.
+			le.PutUint32(e[8:12], uint32(len(nameBytes)))
+		} else {
+			ft := timeToFiletime(node.ModTime())
+			le.PutUint64(e[8:16], ft)
+			le.PutUint64(e[16:24], ft)
+			le.PutUint64(e[24:32], ft)
+			le.PutUint64(e[32:40], ft)
+			le.PutUint64(e[40:48], uint64(node.Size())) // EndOfFile
+			le.PutUint64(e[48:56], uint64(node.Size())) // AllocationSize
+			le.PutUint32(e[56:60], fileInfoAttrs(node))
+			le.PutUint32(e[60:64], uint32(len(nameBytes)))
+			switch class {
+			case 0x26: // FileId at offset 72
+				le.PutUint64(e[72:80], pathFileID(node.Path()))
+			case 0x25: // FileId at offset 96
+				le.PutUint64(e[96:104], pathFileID(node.Path()))
+			}
+		}
+		copy(e[nameOff:], nameBytes)
+		buf = append(buf, e...)
+		lastStart = start
+		count++
+	}
+	if count > 0 {
+		le.PutUint32(buf[lastStart:lastStart+4], 0) // last entry terminates the chain
+	}
+	return buf, count
+}
+
+func fileInfoAttrs(fi os.FileInfo) uint32 {
+	if fi.IsDir() {
+		return fileAttrDirectory
+	}
+	return fileAttrNormal
+}
+
+// roundUp rounds n up to the next multiple of align (a power of two).
+func roundUp(n, align int) int {
+	return (n + align - 1) &^ (align - 1)
+}

--- a/cmd/serve/smb/io.go
+++ b/cmd/serve/smb/io.go
@@ -1,0 +1,134 @@
+package smb
+
+import (
+	"errors"
+	"io"
+)
+
+// maxIOSize is the largest single READ/WRITE payload we accept. It matches the
+// MaxReadSize/MaxWriteSize advertised in NEGOTIATE, so a client can't drive an
+// arbitrarily large allocation off a wire-supplied length.
+const maxIOSize = 0x00100000 // 1 MiB
+
+// handleRead handles an SMB2 READ request ([MS-SMB2] 2.2.19).
+func (c *conn) handleRead(h header, body []byte) (uint32, []byte) {
+	if len(body) < 48 {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	length := le.Uint32(body[4:8])
+	offset := le.Uint64(body[8:16])
+	of := c.getHandle(body[16:32])
+	if of == nil || of.handle == nil {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	// Reject reads larger than the advertised MaxReadSize rather than allocating
+	// an attacker-chosen buffer (a 4 GiB Length would otherwise OOM/panic here).
+	if length > maxIOSize {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	if length == 0 {
+		return statusSuccess, readResponseBody(nil)
+	}
+
+	buf := make([]byte, length)
+	n, err := of.handle.ReadAt(buf, int64(offset))
+	if n <= 0 {
+		// A read entirely at or after EOF must be answered with
+		// STATUS_END_OF_FILE, which the client turns into io.EOF.
+		if err == nil || errors.Is(err, io.EOF) {
+			return statusEndOfFile, errorResponseBody()
+		}
+		return mapVFSError(err), errorResponseBody()
+	}
+	return statusSuccess, readResponseBody(buf[:n])
+}
+
+// handleWrite handles an SMB2 WRITE request ([MS-SMB2] 2.2.21).
+func (c *conn) handleWrite(h header, body []byte) (uint32, []byte) {
+	if len(body) < 48 {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	dataOffset := int(le.Uint16(body[2:4])) - smb2HeaderSize
+	length := le.Uint32(body[4:8])
+	offset := le.Uint64(body[8:16])
+	of := c.getHandle(body[16:32])
+	if of == nil || of.handle == nil {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	// length stays uint32 and is bounded before any int conversion so it cannot
+	// wrap negative and defeat the bounds check on 32-bit builds.
+	if length > maxIOSize || dataOffset < 0 || dataOffset+int(length) > len(body) {
+		return statusInvalidParameter, errorResponseBody()
+	}
+
+	n, err := of.handle.WriteAt(body[dataOffset:dataOffset+int(length)], int64(offset))
+	if err != nil {
+		return mapVFSError(err), errorResponseBody()
+	}
+	return statusSuccess, writeResponseBody(uint32(n))
+}
+
+// handleFlush handles an SMB2 FLUSH request ([MS-SMB2] 2.2.17).
+func (c *conn) handleFlush(h header, body []byte) (uint32, []byte) {
+	if len(body) < 24 {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	if of := c.getHandle(body[8:24]); of != nil && of.handle != nil {
+		if err := of.handle.Flush(); err != nil {
+			return mapVFSError(err), errorResponseBody()
+		}
+	}
+	return statusSuccess, flushResponseBody()
+}
+
+// handleClose handles an SMB2 CLOSE request ([MS-SMB2] 2.2.15). If the open was
+// marked delete-on-close, the node is removed.
+func (c *conn) handleClose(h header, body []byte) (uint32, []byte) {
+	if len(body) < 24 {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	of := c.removeHandle(body[8:24])
+	if of != nil {
+		if of.handle != nil {
+			// Close finalises a streaming upload (cache-mode off/writes); a failure
+			// here means the write did not land, so report it instead of SUCCESS.
+			if err := of.handle.Close(); err != nil {
+				return mapVFSError(err), errorResponseBody()
+			}
+		}
+		if of.deleteOnClose && of.node != nil {
+			if err := of.node.Remove(); err != nil {
+				return mapVFSError(err), errorResponseBody()
+			}
+		}
+	}
+	return statusSuccess, closeResponseBody()
+}
+
+// readResponseBody builds the READ response ([MS-SMB2] 2.2.20) carrying data.
+func readResponseBody(data []byte) []byte {
+	body := make([]byte, 16+len(data))
+	le.PutUint16(body[0:2], 17) // StructureSize (fixed magic value)
+	// DataOffset is measured from the start of the SMB2 header. The data sits
+	// at body offset 16, i.e. wire offset 64+16 = 80. The client validates
+	// DataOffset >= 80 and then subtracts 64 to locate the data in the body.
+	body[2] = smb2HeaderSize + 16
+	le.PutUint32(body[4:8], uint32(len(data)))
+	copy(body[16:], data)
+	return body
+}
+
+// writeResponseBody builds the WRITE response ([MS-SMB2] 2.2.22).
+func writeResponseBody(count uint32) []byte {
+	body := make([]byte, 17)
+	le.PutUint16(body[0:2], 17)
+	le.PutUint32(body[4:8], count)
+	return body
+}
+
+// flushResponseBody builds the FLUSH response ([MS-SMB2] 2.2.18).
+func flushResponseBody() []byte {
+	b := make([]byte, 4)
+	le.PutUint16(b[0:2], 4)
+	return b
+}

--- a/cmd/serve/smb/ioctl.go
+++ b/cmd/serve/smb/ioctl.go
@@ -1,0 +1,46 @@
+package smb
+
+// IOCTL control codes ([MS-FSCC] 2.3).
+const (
+	// fsctlValidateNegotiateInfo is sent by Windows clients after connecting
+	// over SMB 3.x with signing, to detect a tampered NEGOTIATE ([MS-SMB2]
+	// 2.2.31.4). If we do not answer it correctly the client disconnects.
+	fsctlValidateNegotiateInfo uint32 = 0x00140204
+	// fsctlDfsGetReferrals is sent (by cifs) to resolve DFS paths. We are not a
+	// DFS server, so we report no referral.
+	fsctlDfsGetReferrals uint32 = 0x00060194
+)
+
+// handleIoctl handles an SMB2 IOCTL request ([MS-SMB2] 2.2.31). We implement
+// FSCTL_VALIDATE_NEGOTIATE_INFO and report "not a DFS path" for DFS referrals;
+// all other control codes are unsupported.
+func (c *conn) handleIoctl(h header, body []byte) (uint32, []byte) {
+	if len(body) < 56 {
+		return statusInvalidParameter, errorResponseBody()
+	}
+	ctlCode := le.Uint32(body[4:8])
+	if ctlCode == fsctlDfsGetReferrals {
+		return statusNotFound, errorResponseBody()
+	}
+	if ctlCode != fsctlValidateNegotiateInfo {
+		return statusNotSupported, errorResponseBody()
+	}
+	fileID := body[8:24]
+
+	// VALIDATE_NEGOTIATE_INFO response ([MS-SMB2] 2.2.32.1): the values must
+	// match what we sent in the NEGOTIATE response.
+	out := make([]byte, 24)
+	le.PutUint32(out[0:4], 0)                         // Capabilities
+	copy(out[4:20], c.server.serverGUID[:])           // ServerGuid
+	le.PutUint16(out[20:22], negotiateSigningEnabled) // SecurityMode
+	le.PutUint16(out[22:24], c.dialect)               // Dialect
+
+	resp := make([]byte, 48+len(out))
+	le.PutUint16(resp[0:2], 49)                  // StructureSize (fixed magic value)
+	le.PutUint32(resp[4:8], ctlCode)             // CtlCode
+	copy(resp[8:24], fileID)                     // FileId (echoed)
+	le.PutUint32(resp[32:36], smb2HeaderSize+48) // OutputOffset (=112)
+	le.PutUint32(resp[36:40], uint32(len(out)))  // OutputCount
+	copy(resp[48:], out)
+	return statusSuccess, resp
+}

--- a/cmd/serve/smb/misc.go
+++ b/cmd/serve/smb/misc.go
@@ -1,0 +1,42 @@
+package smb
+
+// Small fixed-size response bodies for the simple commands.
+
+// echoResponseBody is the SMB2 ECHO response ([MS-SMB2] 2.2.29): StructureSize 4.
+func echoResponseBody() []byte {
+	b := make([]byte, 4)
+	le.PutUint16(b[0:2], 4)
+	return b
+}
+
+// treeDisconnectResponseBody is the SMB2 TREE_DISCONNECT response: StructureSize 4.
+func treeDisconnectResponseBody() []byte {
+	b := make([]byte, 4)
+	le.PutUint16(b[0:2], 4)
+	return b
+}
+
+// logoffResponseBody is the SMB2 LOGOFF response: StructureSize 4.
+func logoffResponseBody() []byte {
+	b := make([]byte, 4)
+	le.PutUint16(b[0:2], 4)
+	return b
+}
+
+// closeResponseBody is the SMB2 CLOSE response ([MS-SMB2] 2.2.16):
+// StructureSize 60, with all attribute fields zeroed (we never request
+// post-query attributes).
+func closeResponseBody() []byte {
+	b := make([]byte, 60)
+	le.PutUint16(b[0:2], 60)
+	return b
+}
+
+// lockResponseBody is the SMB2 LOCK response ([MS-SMB2] 2.2.27): StructureSize
+// 4. We do not enforce byte-range locks but grant every request so clients
+// (notably Windows) that rely on advisory locking can proceed.
+func lockResponseBody() []byte {
+	b := make([]byte, 4)
+	le.PutUint16(b[0:2], 4)
+	return b
+}

--- a/cmd/serve/smb/negotiate.go
+++ b/cmd/serve/smb/negotiate.go
@@ -1,0 +1,81 @@
+package smb
+
+import "time"
+
+// supportedDialects lists the SMB dialects we implement, highest preference
+// first. We negotiate up to SMB 3.0.2; 3.1.1 (which adds negotiate contexts and
+// pre-auth integrity) is not offered.
+var supportedDialects = []uint16{dialect302, dialect300, dialect210, dialect202}
+
+// handleNegotiate handles an SMB2 NEGOTIATE request. It selects the highest
+// dialect that both the client and we support. SMB 3.x guest sessions are
+// unsigned and unencrypted, like 2.x.
+func (c *conn) handleNegotiate(h header, body []byte) (uint32, []byte) {
+	dialect, ok := chooseDialect(body)
+	if !ok {
+		// No dialect we implement was offered; fail cleanly rather than forcing
+		// 2.0.2 on a client that never offered it (e.g. a 3.1.1-only client).
+		return statusNotSupported, errorResponseBody()
+	}
+	c.dialect = dialect
+	return statusSuccess, negotiateRespBody(c.dialect, c.server.serverGUID)
+}
+
+// negotiateRespBody builds the NEGOTIATE response body for the given dialect.
+func negotiateRespBody(dialect uint16, guid [16]byte) []byte {
+	resp := make([]byte, 64)                              // fixed portion; no security buffer payload
+	le.PutUint16(resp[0:2], 65)                           // StructureSize (fixed magic value)
+	le.PutUint16(resp[2:4], negotiateSigningEnabled)      // SecurityMode (enabled, not required)
+	le.PutUint16(resp[4:6], dialect)                      // DialectRevision
+	le.PutUint16(resp[6:8], 0)                            // NegotiateContextCount
+	copy(resp[8:24], guid[:])                             // ServerGuid
+	le.PutUint32(resp[24:28], 0)                          // Capabilities
+	le.PutUint32(resp[28:32], maxIOSize)                  // MaxTransactSize
+	le.PutUint32(resp[32:36], maxIOSize)                  // MaxReadSize
+	le.PutUint32(resp[36:40], maxIOSize)                  // MaxWriteSize
+	le.PutUint64(resp[40:48], timeToFiletime(time.Now())) // SystemTime
+	le.PutUint64(resp[48:56], 0)                          // ServerStartTime
+	le.PutUint16(resp[56:58], smb2HeaderSize+64)          // SecurityBufferOffset (=128)
+	le.PutUint16(resp[58:60], 0)                          // SecurityBufferLength
+	le.PutUint32(resp[60:64], 0)                          // NegotiateContextOffset
+	return resp
+}
+
+// smb1NegotiateResponse builds an SMB2 NEGOTIATE response to a legacy SMB1
+// multi-protocol negotiate request. It advertises the SMB2 wildcard dialect
+// (0x02FF) so the client re-negotiates using SMB2.
+func (c *conn) smb1NegotiateResponse() []byte {
+	body := negotiateRespBody(dialectWildcard, c.server.serverGUID)
+	out := make([]byte, smb2HeaderSize+len(body))
+	copy(out[0:4], smb2Magic)
+	le.PutUint16(out[4:6], smb2HeaderSize)       // StructureSize
+	le.PutUint16(out[12:14], cmdNegotiate)       // Command
+	le.PutUint16(out[14:16], 1)                  // CreditResponse
+	le.PutUint32(out[16:20], flagsServerToRedir) // Flags
+	copy(out[smb2HeaderSize:], body)
+	return out
+}
+
+// chooseDialect parses the dialects offered in a NEGOTIATE request body and
+// returns the highest one we support. ok is false when the body is malformed or
+// offers no dialect we implement.
+func chooseDialect(body []byte) (dialect uint16, ok bool) {
+	if len(body) < 36 {
+		return 0, false
+	}
+	count := int(le.Uint16(body[2:4]))
+	offered := make(map[uint16]bool, count)
+	for i := 0; i < count; i++ {
+		off := 36 + i*2
+		if off+2 > len(body) {
+			break
+		}
+		offered[le.Uint16(body[off:off+2])] = true
+	}
+	for _, d := range supportedDialects {
+		if offered[d] {
+			return d, true
+		}
+	}
+	return 0, false
+}

--- a/cmd/serve/smb/oserror_other.go
+++ b/cmd/serve/smb/oserror_other.go
@@ -1,0 +1,6 @@
+//go:build !windows
+
+package smb
+
+// osErrorStatus has no extra OS-specific mappings on non-Windows platforms.
+func osErrorStatus(err error) (uint32, bool) { return 0, false }

--- a/cmd/serve/smb/oserror_windows.go
+++ b/cmd/serve/smb/oserror_windows.go
@@ -1,0 +1,26 @@
+package smb
+
+import (
+	"errors"
+	"syscall"
+)
+
+// Windows error codes that are not surfaced through the portable os sentinels.
+const (
+	errnoSharingViolation syscall.Errno = 32 // ERROR_SHARING_VIOLATION
+	errnoLockViolation    syscall.Errno = 33 // ERROR_LOCK_VIOLATION
+)
+
+// osErrorStatus maps OS-specific errors (that errors.Is against the portable os
+// sentinels misses) to an NTSTATUS. A file another process holds open is the
+// common one when serving a live Windows volume.
+func osErrorStatus(err error) (uint32, bool) {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		switch errno {
+		case errnoSharingViolation, errnoLockViolation:
+			return statusSharingViolation, true
+		}
+	}
+	return 0, false
+}

--- a/cmd/serve/smb/packet.go
+++ b/cmd/serve/smb/packet.go
@@ -1,0 +1,203 @@
+package smb
+
+import (
+	"time"
+	"unicode/utf16"
+)
+
+// SMB2 protocol constants. See [MS-SMB2] for the authoritative reference.
+const (
+	smb2HeaderSize = 64
+	smb2Magic      = "\xfeSMB"
+)
+
+// SMB2 command codes ([MS-SMB2] 2.2.1).
+const (
+	cmdNegotiate      uint16 = 0x0000
+	cmdSessionSetup   uint16 = 0x0001
+	cmdLogoff         uint16 = 0x0002
+	cmdTreeConnect    uint16 = 0x0003
+	cmdTreeDisconnect uint16 = 0x0004
+	cmdCreate         uint16 = 0x0005
+	cmdClose          uint16 = 0x0006
+	cmdFlush          uint16 = 0x0007
+	cmdRead           uint16 = 0x0008
+	cmdWrite          uint16 = 0x0009
+	cmdLock           uint16 = 0x000A
+	cmdIoctl          uint16 = 0x000B
+	cmdCancel         uint16 = 0x000C
+	cmdEcho           uint16 = 0x000D
+	cmdQueryDirectory uint16 = 0x000E
+	cmdChangeNotify   uint16 = 0x000F
+	cmdQueryInfo      uint16 = 0x0010
+	cmdSetInfo        uint16 = 0x0011
+	cmdOplockBreak    uint16 = 0x0012
+)
+
+// SMB2 header flags ([MS-SMB2] 2.2.1.2).
+const (
+	flagsServerToRedir uint32 = 0x00000001
+	flagsAsyncCommand  uint32 = 0x00000002
+	flagsRelatedOps    uint32 = 0x00000004
+	flagsSigned        uint32 = 0x00000008
+)
+
+// SMB2 dialect revisions ([MS-SMB2] 2.2.3).
+const (
+	dialect202      uint16 = 0x0202
+	dialect210      uint16 = 0x0210
+	dialect300      uint16 = 0x0300
+	dialect302      uint16 = 0x0302
+	dialect311      uint16 = 0x0311
+	dialectWildcard uint16 = 0x02FF // SMB2 wildcard, used to upgrade from an SMB1 negotiate
+)
+
+// Negotiate SecurityMode flags.
+const (
+	negotiateSigningEnabled  uint16 = 0x0001
+	negotiateSigningRequired uint16 = 0x0002
+)
+
+// SESSION_SETUP response SessionFlags.
+const (
+	sessionFlagIsGuest     uint16 = 0x0001
+	sessionFlagIsNull      uint16 = 0x0002
+	sessionFlagEncryptData uint16 = 0x0004
+)
+
+// TREE_CONNECT response ShareType.
+const (
+	shareTypeDisk byte = 0x01
+	shareTypePipe byte = 0x02
+)
+
+// NTSTATUS codes ([MS-ERREF] 2.3.1) that we use.
+const (
+	statusSuccess                uint32 = 0x00000000
+	statusPending                uint32 = 0x00000103
+	statusNoMoreFiles            uint32 = 0x80000006
+	statusMoreProcessingRequired uint32 = 0xC0000016
+	statusNoSuchFile             uint32 = 0xC000000F
+	statusObjectNameNotFound     uint32 = 0xC0000034
+	statusObjectNameCollision    uint32 = 0xC0000035
+	statusObjectPathNotFound     uint32 = 0xC000003A
+	statusAccessDenied           uint32 = 0xC0000022
+	statusBadNetworkName         uint32 = 0xC00000CC
+	statusLogonFailure           uint32 = 0xC000006D
+	statusUserSessionDeleted     uint32 = 0xC0000203
+	statusInsufficientResources  uint32 = 0xC000009A
+	statusNotSupported           uint32 = 0xC00000BB
+	statusNotFound               uint32 = 0xC0000225
+	statusNotImplemented         uint32 = 0xC0000002
+	statusInvalidParameter       uint32 = 0xC000000D
+	statusEndOfFile              uint32 = 0xC0000011
+	statusFileIsADirectory       uint32 = 0xC00000BA
+	statusNotADirectory          uint32 = 0xC0000103
+	statusInvalidInfoClass       uint32 = 0xC0000003
+	statusSharingViolation       uint32 = 0xC0000043
+	statusDirectoryNotEmpty      uint32 = 0xC0000101
+	statusMediaWriteProtected    uint32 = 0xC00000A2
+	statusUnsuccessful           uint32 = 0xC0000001
+)
+
+// header holds the fields of an SMB2 message header that we need.
+type header struct {
+	creditCharge  uint16
+	command       uint16
+	creditReqResp uint16
+	flags         uint32
+	nextCommand   uint32
+	messageID     uint64
+	treeID        uint32
+	sessionID     uint64
+}
+
+// parseHeader parses the 64-byte SMB2 header at the start of b.
+func parseHeader(b []byte) (h header, ok bool) {
+	if len(b) < smb2HeaderSize || string(b[0:4]) != smb2Magic {
+		return header{}, false
+	}
+	h = header{
+		creditCharge:  le.Uint16(b[6:8]),
+		command:       le.Uint16(b[12:14]),
+		creditReqResp: le.Uint16(b[14:16]),
+		flags:         le.Uint32(b[16:20]),
+		nextCommand:   le.Uint32(b[20:24]),
+		messageID:     le.Uint64(b[24:32]),
+		treeID:        le.Uint32(b[36:40]),
+		sessionID:     le.Uint64(b[40:48]),
+	}
+	return h, true
+}
+
+// buildResponse assembles a full SMB2 response message (a 64-byte header
+// followed by body). The reply echoes the request's MessageId and carries the
+// supplied status, session and tree ids and granted credits.
+func buildResponse(reqH header, command uint16, status uint32, sessionID uint64, treeID uint32, credits uint16, body []byte) []byte {
+	out := make([]byte, smb2HeaderSize+len(body))
+	copy(out[0:4], smb2Magic)
+	le.PutUint16(out[4:6], smb2HeaderSize)    // StructureSize (always 64)
+	le.PutUint16(out[6:8], reqH.creditCharge) // echo the request's CreditCharge (2.1+)
+	le.PutUint32(out[8:12], status)
+	le.PutUint16(out[12:14], command)
+	le.PutUint16(out[14:16], credits) // CreditResponse
+	le.PutUint32(out[16:20], flagsServerToRedir)
+	// NextCommand [20:24] = 0 (we do not compound responses)
+	le.PutUint64(out[24:32], reqH.messageID)
+	// Reserved [32:36] = 0
+	le.PutUint32(out[36:40], treeID)
+	le.PutUint64(out[40:48], sessionID)
+	// Signature [48:64] = 0 (we do not sign guest sessions)
+	copy(out[smb2HeaderSize:], body)
+	return out
+}
+
+// errorResponseBody returns the minimal SMB2 ERROR Response body
+// ([MS-SMB2] 2.2.2): StructureSize 9, no error context data.
+func errorResponseBody() []byte {
+	b := make([]byte, 9)
+	le.PutUint16(b[0:2], 9)
+	return b
+}
+
+// filetimeEpochDelta is the number of 100-nanosecond intervals between the
+// FILETIME epoch (1601-01-01) and the Unix epoch (1970-01-01).
+const filetimeEpochDelta = 116444736000000000
+
+// timeToFiletime converts a time.Time to a Windows FILETIME.
+func timeToFiletime(t time.Time) uint64 {
+	if t.IsZero() {
+		return 0
+	}
+	return uint64(t.UnixNano()/100 + filetimeEpochDelta)
+}
+
+// filetimeToTime converts a Windows FILETIME to a time.Time.
+func filetimeToTime(ft uint64) time.Time {
+	if ft == 0 {
+		return time.Time{}
+	}
+	return time.Unix(0, (int64(ft)-filetimeEpochDelta)*100)
+}
+
+// utf16leToString decodes a little-endian UTF-16 byte slice to a string.
+func utf16leToString(b []byte) string {
+	if len(b)%2 != 0 {
+		b = b[:len(b)-1]
+	}
+	u := make([]uint16, len(b)/2)
+	for i := range u {
+		u[i] = le.Uint16(b[2*i:])
+	}
+	return string(utf16.Decode(u))
+}
+
+// stringToUTF16le encodes a string as a little-endian UTF-16 byte slice.
+func stringToUTF16le(s string) []byte {
+	u := utf16.Encode([]rune(s))
+	b := make([]byte, 2*len(u))
+	for i, v := range u {
+		le.PutUint16(b[2*i:], v)
+	}
+	return b
+}

--- a/cmd/serve/smb/server.go
+++ b/cmd/serve/smb/server.go
@@ -1,0 +1,438 @@
+package smb
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"net"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config"
+	"github.com/rclone/rclone/vfs"
+	"github.com/rclone/rclone/vfs/vfscommon"
+)
+
+// Server is an SMB server exposing a single share backed by a VFS.
+type Server struct {
+	opt        Options
+	vfs        *vfs.VFS
+	ctx        context.Context    // server-scoped; cancelled on Shutdown to unblock in-flight VFS ops
+	cancel     context.CancelFunc // cancels ctx
+	shareName  string
+	serverGUID [16]byte
+	listener   net.Listener
+	sessionCtr atomic.Uint64
+	treeCtr    atomic.Uint32
+
+	mu      sync.Mutex
+	conns   map[*conn]struct{}
+	closing chan struct{}
+	wg      sync.WaitGroup
+}
+
+// newServer creates a new SMB server listening on opt.ListenAddr and serving f
+// through a VFS. The listener is opened immediately so that Addr reports the
+// bound address (which matters when binding to port 0).
+func newServer(ctx context.Context, f fs.Fs, opt *Options, vfsOpt *vfscommon.Options) (*Server, error) {
+	if opt.User != "" && opt.Pass == "" {
+		return nil, errors.New("smb: a password (--pass) is required when --user is set")
+	}
+	ctx, cancel := context.WithCancel(ctx)
+	s := &Server{
+		opt:       *opt,
+		vfs:       vfs.New(ctx, f, vfsOpt),
+		ctx:       ctx,
+		cancel:    cancel,
+		shareName: opt.ShareName,
+		conns:     map[*conn]struct{}{},
+		closing:   make(chan struct{}),
+	}
+	if s.shareName == "" {
+		s.shareName = "rclone"
+	}
+	if _, err := rand.Read(s.serverGUID[:]); err != nil {
+		cancel()
+		s.vfs.Shutdown()
+		return nil, err
+	}
+	l, err := net.Listen("tcp", opt.ListenAddr)
+	if err != nil {
+		cancel()
+		s.vfs.Shutdown()
+		return nil, fmt.Errorf("smb: failed to listen on %q: %w", opt.ListenAddr, err)
+	}
+	s.listener = l
+	return s, nil
+}
+
+// Addr returns the network address the server is listening on.
+func (s *Server) Addr() net.Addr {
+	return s.listener.Addr()
+}
+
+// Serve accepts and serves connections until Shutdown is called.
+func (s *Server) Serve() error {
+	fs.Logf(s.vfs.Fs(), "SMB server started on %s, share \\\\%s\\%s", s.listener.Addr(), hostOf(s.listener.Addr()), s.shareName)
+	if s.opt.User == "" {
+		fs.Logf(s.vfs.Fs(), "SMB: running with no authentication (guest access). Windows SMB clients "+
+			"will reject guest sessions (a guest session is unsigned and Windows requires signing); "+
+			"use --user and --pass for Windows clients. Linux and macOS clients can use guest.")
+	}
+	if s.vfs.Fs().Features().IsLocal && s.vfs.Opt.CacheMode != vfscommon.CacheModeOff {
+		fs.Logf(s.vfs.Fs(), "SMB: serving a local backend with --vfs-cache-mode %v caches files in the "+
+			"VFS cache (%s), needlessly duplicating local data; with the cache size unlimited by default a "+
+			"very large file can fill that disk. Use --vfs-cache-mode off for a local drive.",
+			s.vfs.Opt.CacheMode, config.GetCacheDir())
+	}
+	var acceptDelay time.Duration
+	for {
+		nc, err := s.listener.Accept()
+		if err != nil {
+			select {
+			case <-s.closing:
+				return nil
+			default:
+			}
+			// A transient accept error (e.g. fd exhaustion) must not kill the whole
+			// server; back off and retry instead of returning.
+			if acceptDelay == 0 {
+				acceptDelay = 5 * time.Millisecond
+			} else {
+				acceptDelay *= 2
+			}
+			if acceptDelay > time.Second {
+				acceptDelay = time.Second
+			}
+			fs.Errorf(s.vfs.Fs(), "SMB: accept error, retrying in %v: %v", acceptDelay, err)
+			time.Sleep(acceptDelay)
+			continue
+		}
+		acceptDelay = 0
+		fs.Debugf(s.vfs.Fs(), "SMB: accepted connection from %s", nc.RemoteAddr())
+		c := newConn(s, nc)
+		s.mu.Lock()
+		select {
+		case <-s.closing:
+			// Shutdown already ran and snapshotted s.conns; registering now would
+			// leak this connection past that snapshot and hang wg.Wait on it.
+			s.mu.Unlock()
+			_ = nc.Close()
+			return nil
+		default:
+		}
+		s.conns[c] = struct{}{}
+		s.wg.Add(1)
+		s.mu.Unlock()
+		go func() {
+			defer s.wg.Done()
+			c.serve()
+			s.mu.Lock()
+			delete(s.conns, c)
+			s.mu.Unlock()
+		}()
+	}
+}
+
+// Shutdown stops the server and closes all active connections.
+func (s *Server) Shutdown() error {
+	s.mu.Lock()
+	select {
+	case <-s.closing:
+		s.mu.Unlock()
+		return nil // already shut down
+	default:
+		close(s.closing)
+	}
+	conns := make([]*conn, 0, len(s.conns))
+	for c := range s.conns {
+		conns = append(conns, c)
+	}
+	s.mu.Unlock()
+
+	err := s.listener.Close()
+	for _, c := range conns {
+		_ = c.nc.Close()
+	}
+	s.cancel() // interrupt any in-flight VFS operation so wg.Wait can't hang on a wedged backend
+	s.wg.Wait()
+	s.vfs.Shutdown()
+	return err
+}
+
+func (s *Server) nextSessionID() uint64 { return s.sessionCtr.Add(1) }
+func (s *Server) nextTreeID() uint32    { return s.treeCtr.Add(1) }
+
+// hostOf returns the host portion of a network address for display.
+func hostOf(addr net.Addr) string {
+	if host, _, err := net.SplitHostPort(addr.String()); err == nil {
+		return host
+	}
+	return addr.String()
+}
+
+// conn is a single client TCP connection. SMB2 messages on a connection are
+// processed one at a time by serve, so the handle table is only accessed from
+// that goroutine (the mutex guards against the Shutdown path).
+type conn struct {
+	server *Server
+	nc     net.Conn
+
+	dialect            uint16              // negotiated SMB dialect
+	authChallenge      [8]byte             // NTLM server challenge for the in-progress session setup
+	signKey            []byte              // message signing key (nil for guest/unsigned sessions)
+	warnedWindowsGuest bool                // a Windows-client-as-guest warning was already logged
+	authedSessions     map[uint64]struct{} // SessionIds that completed authentication (only enforced when opt.User != "")
+	pipeTrees          map[uint32]struct{} // TreeIds of IPC$ (named-pipe) shares; file opens on them are rejected
+
+	mu        sync.Mutex
+	handles   map[[16]byte]*openFile
+	handleCtr uint64
+}
+
+func newConn(s *Server, nc net.Conn) *conn {
+	return &conn{
+		server:         s,
+		nc:             nc,
+		handles:        map[[16]byte]*openFile{},
+		authedSessions: map[uint64]struct{}{},
+		pipeTrees:      map[uint32]struct{}{},
+	}
+}
+
+// serve reads and dispatches SMB2 messages until the connection closes.
+func (c *conn) serve() {
+	defer func() {
+		// A panic in one request handler must not take down the whole rclone
+		// process; log it and drop just this connection.
+		if r := recover(); r != nil {
+			fs.Errorf(c.server.vfs.Fs(), "SMB: recovered from panic serving %s: %v", c.nc.RemoteAddr(), r)
+		}
+		c.closeAllHandles()
+		_ = c.nc.Close()
+	}()
+	for {
+		msg, err := readMessage(c.nc)
+		if err != nil {
+			fs.Debugf(c.server.vfs.Fs(), "SMB: connection from %s closed: %v", c.nc.RemoteAddr(), err)
+			return
+		}
+		if len(msg) < smb2HeaderSize {
+			continue
+		}
+		out, err := c.dispatch(msg)
+		if err != nil {
+			fs.Debugf(c.server.vfs.Fs(), "SMB: dispatch error: %v", err)
+			return
+		}
+		if out != nil {
+			if err := writeMessage(c.nc, out); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// chainCtx carries state shared between the commands of a compound request: the
+// FileId established by a CREATE (used by later "related" commands) and the
+// session and tree ids to report.
+type chainCtx struct {
+	fileID    []byte
+	sessionID uint64
+	treeID    uint32
+}
+
+// dispatch handles an incoming SMB2 message, which may be a single command or a
+// compound chain of commands ([MS-SMB2] 3.3.5.2.7), and returns the response
+// message, or nil if no response should be sent.
+func (c *conn) dispatch(msg []byte) ([]byte, error) {
+	// The Windows redirector opens with a legacy SMB1 multi-protocol negotiate
+	// (0xFF 'SMB', command 0x72 = NEGOTIATE) advertising SMB2 dialects. Reply
+	// with an SMB2 negotiate so it switches to SMB2.
+	if len(msg) >= 5 && msg[0] == 0xFF && string(msg[1:4]) == "SMB" && msg[4] == 0x72 {
+		return c.smb1NegotiateResponse(), nil
+	}
+	if _, ok := parseHeader(msg); !ok {
+		n := len(msg)
+		if n > 16 {
+			n = 16
+		}
+		fs.Debugf(c.server.vfs.Fs(), "SMB: unparseable message len=%d first bytes: % x", len(msg), msg[:n])
+		return nil, errors.New("invalid SMB2 header")
+	}
+	var pdus [][]byte
+	var ctx chainCtx
+	offset := 0
+	for offset+smb2HeaderSize <= len(msg) {
+		h, ok := parseHeader(msg[offset:])
+		if !ok {
+			break
+		}
+		next := int(h.nextCommand)
+		var seg []byte
+		if next >= smb2HeaderSize && offset+next <= len(msg) {
+			seg = msg[offset : offset+next]
+		} else {
+			seg = msg[offset:]
+		}
+		if pdu := c.handleCommand(h, seg, &ctx); pdu != nil {
+			pdus = append(pdus, pdu)
+		}
+		if next < smb2HeaderSize {
+			break
+		}
+		offset += next
+	}
+	return c.assembleResponse(pdus), nil
+}
+
+// handleCommand processes one SMB2 command (one element of a possibly compound
+// request) and returns its full response PDU (header + body), or nil if no
+// response is required.
+func (c *conn) handleCommand(h header, seg []byte, ctx *chainCtx) []byte {
+	body := seg[smb2HeaderSize:]
+	fs.Debugf(c.server.vfs.Fs(), "SMB >> cmd=%d msgid=%d flags=0x%x len=%d", h.command, h.messageID, h.flags, len(seg))
+
+	credits := h.creditReqResp
+	if credits < 1 {
+		credits = 1
+	}
+
+	sessionID := h.sessionID
+	treeID := h.treeID
+	// Related compound commands inherit the session, tree and file handle of the
+	// preceding command rather than carrying their own.
+	if h.flags&flagsRelatedOps != 0 {
+		sessionID = ctx.sessionID
+		treeID = ctx.treeID
+		if ctx.fileID != nil {
+			substituteFileID(h.command, body, ctx.fileID)
+		}
+	} else {
+		ctx.sessionID = sessionID
+		ctx.treeID = treeID
+	}
+
+	// Enforce authentication: with a user configured, every command other than
+	// the pre-auth handshake (NEGOTIATE/SESSION_SETUP) requires a SessionId that
+	// finished authenticating. Without this a client could skip SESSION_SETUP and
+	// still TREE_CONNECT and open files.
+	if c.server.opt.User != "" && h.command != cmdNegotiate && h.command != cmdSessionSetup {
+		if _, ok := c.authedSessions[sessionID]; !ok {
+			fs.Debugf(c.server.vfs.Fs(), "SMB: rejected cmd=%d on unauthenticated session %d", h.command, sessionID)
+			return buildResponse(h, h.command, statusUserSessionDeleted, sessionID, treeID, credits, errorResponseBody())
+		}
+	}
+
+	// Verify the signature of a signed request from an authenticated session so a
+	// man-in-the-middle can't tamper with it (we already sign our responses).
+	if c.signKey != nil && h.flags&flagsSigned != 0 && !verifyMessage(c.signKey, c.dialect, seg) {
+		fs.Debugf(c.server.vfs.Fs(), "SMB: rejected cmd=%d with a bad signature on session %d", h.command, sessionID)
+		return buildResponse(h, h.command, statusAccessDenied, sessionID, treeID, credits, errorResponseBody())
+	}
+
+	status := statusSuccess
+	var respBody []byte
+
+	switch h.command {
+	case cmdNegotiate:
+		status, respBody = c.handleNegotiate(h, body)
+	case cmdSessionSetup:
+		status, sessionID, respBody = c.handleSessionSetup(h, body)
+		ctx.sessionID = sessionID
+	case cmdTreeConnect:
+		status, treeID, respBody = c.handleTreeConnect(h, body)
+		ctx.treeID = treeID
+	case cmdTreeDisconnect:
+		respBody = treeDisconnectResponseBody()
+	case cmdLogoff:
+		respBody = logoffResponseBody()
+	case cmdEcho:
+		respBody = echoResponseBody()
+	case cmdCreate:
+		if _, isPipe := c.pipeTrees[treeID]; isPipe {
+			// We don't serve named pipes; opening one must fail rather than hit the VFS.
+			status, respBody = statusObjectNameNotFound, errorResponseBody()
+		} else {
+			status, respBody = c.handleCreate(h, body)
+			if status == statusSuccess && len(respBody) >= 80 {
+				ctx.fileID = append([]byte(nil), respBody[64:80]...)
+			}
+		}
+	case cmdClose:
+		status, respBody = c.handleClose(h, body)
+	case cmdRead:
+		status, respBody = c.handleRead(h, body)
+	case cmdWrite:
+		status, respBody = c.handleWrite(h, body)
+	case cmdFlush:
+		status, respBody = c.handleFlush(h, body)
+	case cmdQueryDirectory:
+		status, respBody = c.handleQueryDirectory(h, body)
+	case cmdQueryInfo:
+		status, respBody = c.handleQueryInfo(h, body)
+	case cmdSetInfo:
+		status, respBody = c.handleSetInfo(h, body)
+	case cmdIoctl:
+		status, respBody = c.handleIoctl(h, body)
+	case cmdLock:
+		respBody = lockResponseBody()
+	case cmdCancel:
+		return nil // CANCEL has no response
+	default:
+		status = statusNotSupported
+		respBody = errorResponseBody()
+	}
+
+	fs.Debugf(c.server.vfs.Fs(), "SMB << cmd=%d status=0x%08x bodylen=%d", h.command, status, len(respBody))
+	return buildResponse(h, h.command, status, sessionID, treeID, credits, respBody)
+}
+
+// assembleResponse concatenates response PDUs into a single (possibly compound)
+// message, setting each NextCommand offset and signing each PDU.
+func (c *conn) assembleResponse(pdus [][]byte) []byte {
+	if len(pdus) == 0 {
+		return nil
+	}
+	type span struct{ start, end int }
+	var out []byte
+	var spans []span
+	for i, pdu := range pdus {
+		start := len(out)
+		out = append(out, pdu...)
+		if i < len(pdus)-1 {
+			for len(out)%8 != 0 {
+				out = append(out, 0)
+			}
+			le.PutUint32(out[start+20:start+24], uint32(len(out)-start)) // NextCommand
+		}
+		spans = append(spans, span{start, len(out)})
+	}
+	// Sign each PDU once a signing key is established (authenticated sessions).
+	if c.signKey != nil {
+		for _, s := range spans {
+			signMessage(c.signKey, c.dialect, out[s.start:s.end])
+		}
+	}
+	return out
+}
+
+// substituteFileID overwrites the FileId field of a related compound command's
+// body with the handle from the preceding CREATE ([MS-SMB2] 3.3.5.2.7.2).
+func substituteFileID(command uint16, body, fileID []byte) {
+	off := -1
+	switch command {
+	case cmdClose, cmdFlush, cmdIoctl, cmdQueryDirectory:
+		off = 8
+	case cmdRead, cmdWrite, cmdSetInfo:
+		off = 16
+	case cmdQueryInfo:
+		off = 24
+	}
+	if off >= 0 && off+16 <= len(body) {
+		copy(body[off:off+16], fileID)
+	}
+}

--- a/cmd/serve/smb/session.go
+++ b/cmd/serve/smb/session.go
@@ -1,0 +1,145 @@
+package smb
+
+import (
+	"crypto/rand"
+	"strings"
+
+	"github.com/rclone/rclone/fs"
+)
+
+// handleSessionSetup handles an SMB2 SESSION_SETUP request. NTLM authentication
+// is a two round-trip handshake wrapped in SPNEGO:
+//
+//  1. client sends NTLMSSP NEGOTIATE (Type 1); we reply STATUS_MORE_PROCESSING_
+//     REQUIRED with an NTLMSSP CHALLENGE (Type 2) carrying a server challenge,
+//     and
+//  2. client sends NTLMSSP AUTHENTICATE (Type 3); we validate it and reply
+//     STATUS_SUCCESS (or STATUS_LOGON_FAILURE).
+//
+// When no --user is configured the server accepts any client as a guest, which
+// tells the client not to sign its requests.
+func (c *conn) handleSessionSetup(h header, body []byte) (status uint32, sessionID uint64, respBody []byte) {
+	if len(body) < 24 {
+		return statusInvalidParameter, h.sessionID, errorResponseBody()
+	}
+	secBuf := bufferAt(body, le.Uint16(body[12:14]), le.Uint16(body[14:16]))
+
+	// The NTLMSSP token is delivered either wrapped in SPNEGO/GSS (Windows and
+	// go-smb2) or as a bare NTLMSSP message (Linux cifs over SMB2/3). Detect
+	// which form was used so we can reply in kind.
+	rawNTLM := len(secBuf) >= 8 && string(secBuf[:8]) == string(ntlmSignature)
+	var token []byte
+	if rawNTLM {
+		token = secBuf
+	} else {
+		token, _ = spnegoExtractNTLM(secBuf)
+	}
+
+	sessionID = h.sessionID
+	if sessionID == 0 {
+		sessionID = c.server.nextSessionID()
+	}
+
+	if ntlmMessageType(token) == ntlmTypeAuthenticate {
+		sessionFlags, ok := c.authenticate(token)
+		if !ok {
+			return statusLogonFailure, sessionID, errorResponseBody()
+		}
+		if c.server.opt.User != "" {
+			// Record the session as authenticated so later commands pass the auth
+			// gate in handleCommand.
+			c.authedSessions[sessionID] = struct{}{}
+		}
+		c.maybeWarnWindowsGuest(token)
+		// Final reply: empty for raw NTLMSSP, an "accept completed" SPNEGO
+		// token otherwise.
+		var reply []byte
+		if !rawNTLM {
+			reply = buildNegTokenResp(negStateAcceptCompleted, false, nil)
+		}
+		return statusSuccess, sessionID, sessionSetupRespBody(sessionFlags, reply)
+	}
+
+	// First round trip: generate and remember a challenge, then send it back in
+	// the same wrapping the client used.
+	_, _ = rand.Read(c.authChallenge[:])
+	challenge := buildNTLMChallenge(c.authChallenge)
+	reply := challenge
+	if !rawNTLM {
+		reply = buildNegTokenResp(negStateAcceptIncomplete, true, challenge)
+	}
+	return statusMoreProcessingRequired, sessionID, sessionSetupRespBody(0, reply)
+}
+
+// authenticate validates an NTLMSSP AUTHENTICATE token. It returns the session
+// flags to report and whether authentication succeeded. With no --user
+// configured every client is accepted as a guest. On a successful
+// authenticated logon it derives the message signing key for the session.
+func (c *conn) authenticate(token []byte) (sessionFlags uint16, ok bool) {
+	if c.server.opt.User == "" {
+		return sessionFlagIsGuest, true
+	}
+	auth, ok := parseNTLMAuthenticate(token)
+	if !ok {
+		return 0, false
+	}
+	if !strings.EqualFold(auth.user, c.server.opt.User) {
+		return 0, false
+	}
+	responseKeyNT := ntowfv2(c.server.opt.User, c.server.opt.Pass, auth.domain)
+	if !validateNTLMv2(responseKeyNT, c.authChallenge, auth.ntResponse) {
+		return 0, false
+	}
+	// Derive the SMB signing key for this session so responses can be signed.
+	sessionKey := exportedSessionKey(responseKeyNT, auth.ntResponse[:16], auth.flags, auth.encSessionKey)
+	switch c.dialect {
+	case dialect300, dialect302:
+		c.signKey = kdf(sessionKey, []byte("SMB2AESCMAC\x00"), []byte("SmbSign\x00"))
+	default:
+		c.signKey = sessionKey
+	}
+	return 0, true
+}
+
+// maybeWarnWindowsGuest logs a one-time hint when a Windows client connects in
+// guest mode. Windows rejects guest sessions (they are unsigned and Windows
+// requires SMB signing), so this points the user at --user/--pass. The client
+// is recognised as Windows from the NTLMSSP OS Version major; raw-NTLM clients
+// (e.g. Linux cifs) are never Windows and are skipped.
+func (c *conn) maybeWarnWindowsGuest(token []byte) {
+	if c.server.opt.User != "" || c.warnedWindowsGuest {
+		return
+	}
+	// Windows 10/11 (NTLMSSP OS major version 10) are the clients that block guest;
+	// Linux cifs reports major 6, so this avoids warning about clients that work.
+	auth, ok := parseNTLMAuthenticate(token)
+	if !ok || auth.osMajor < 10 {
+		return
+	}
+	c.warnedWindowsGuest = true
+	fs.Logf(c.server.vfs.Fs(), "SMB: a Windows client connected as guest and will likely reject the "+
+		"session -- Windows requires SMB signing, which a guest session cannot provide. Use --user "+
+		"and --pass for Windows clients.")
+}
+
+// sessionSetupRespBody builds the SESSION_SETUP response body ([MS-SMB2]
+// 2.2.6) carrying the supplied session flags and SPNEGO security buffer.
+func sessionSetupRespBody(sessionFlags uint16, secBuf []byte) []byte {
+	body := make([]byte, 8+len(secBuf))
+	le.PutUint16(body[0:2], 9) // StructureSize (fixed magic value)
+	le.PutUint16(body[2:4], sessionFlags)
+	le.PutUint16(body[4:6], smb2HeaderSize+8) // SecurityBufferOffset (=72)
+	le.PutUint16(body[6:8], uint16(len(secBuf)))
+	copy(body[8:], secBuf)
+	return body
+}
+
+// bufferAt returns the slice of a request body referenced by an offset (from
+// the start of the SMB2 header) and length, or nil if out of range.
+func bufferAt(body []byte, fileOffset, length uint16) []byte {
+	start := int(fileOffset) - smb2HeaderSize
+	if start < 0 || length == 0 || start+int(length) > len(body) {
+		return nil
+	}
+	return body[start : start+int(length)]
+}

--- a/cmd/serve/smb/smb.go
+++ b/cmd/serve/smb/smb.go
@@ -1,0 +1,189 @@
+// Package smb implements an SMB server to serve a VFS remote over the network.
+package smb
+
+import (
+	"context"
+	"strings"
+
+	"github.com/rclone/rclone/cmd"
+	"github.com/rclone/rclone/cmd/serve"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configstruct"
+	"github.com/rclone/rclone/fs/config/flags"
+	"github.com/rclone/rclone/fs/rc"
+	"github.com/rclone/rclone/vfs"
+	"github.com/rclone/rclone/vfs/vfscommon"
+	"github.com/rclone/rclone/vfs/vfsflags"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// OptionsInfo describes the Options in use
+var OptionsInfo = fs.Options{{
+	Name:    "addr",
+	Default: "127.0.0.1:1445",
+	Help:    "IPaddress:Port or :Port to bind server to",
+}, {
+	Name:    "name",
+	Default: "rclone",
+	Help:    "Name of the SMB share to expose",
+}, {
+	Name:    "user",
+	Default: "",
+	Help:    "User name for authentication (empty means allow guest/no authentication)",
+}, {
+	Name:    "pass",
+	Default: "",
+	Help:    "Password for authentication",
+}}
+
+func init() {
+	fs.RegisterGlobalOptions(fs.OptionsInfo{Name: "smb", Opt: &Opt, Options: OptionsInfo})
+}
+
+// Options contains options for the SMB Server
+type Options struct {
+	ListenAddr string `config:"addr"` // Address to listen on
+	ShareName  string `config:"name"` // Name of the share to expose
+	User       string `config:"user"` // User name for authentication
+	Pass       string `config:"pass"` // Password for authentication
+}
+
+// Opt is the default set of serve smb options
+var Opt Options
+
+// AddFlags adds flags for serve smb
+func AddFlags(flagSet *pflag.FlagSet) {
+	flags.AddFlagsFromOptions(flagSet, "", OptionsInfo)
+}
+
+func init() {
+	vfsflags.AddFlags(Command.Flags())
+	AddFlags(Command.Flags())
+	serve.Command.AddCommand(Command)
+	serve.AddRc("smb", func(ctx context.Context, f fs.Fs, in rc.Params) (serve.Handle, error) {
+		// Read VFS opts
+		var vfsOpt = vfscommon.Opt
+		if err := configstruct.SetAny(in, &vfsOpt); err != nil {
+			return nil, err
+		}
+		// Read opts
+		var opt = Opt
+		if err := configstruct.SetAny(in, &opt); err != nil {
+			return nil, err
+		}
+		s, err := newServer(ctx, f, &opt, &vfsOpt)
+		if err != nil {
+			return nil, err
+		}
+		return s, nil
+	})
+}
+
+// Run the command
+func Run(command *cobra.Command, args []string) {
+	cmd.CheckArgs(1, 1, command, args)
+	f := cmd.NewFsSrc(args)
+	cmd.Run(false, true, command, func() error {
+		s, err := newServer(context.Background(), f, &Opt, &vfscommon.Opt)
+		if err != nil {
+			return err
+		}
+		return s.Serve()
+	})
+}
+
+// Command is the definition of the command
+var Command = &cobra.Command{
+	Use:   "smb remote:path",
+	Short: `Serve the remote over SMB.`,
+	Long: strings.ReplaceAll(`Run an SMB server to serve a remote over the SMB protocol.
+
+This implements an SMB/CIFS server to serve any rclone remote over the
+network. The share can be browsed and (with VFS caching) written by SMB
+clients on Linux, macOS and Windows.
+
+SMB dialects 2.0.2 through 3.0.2 are negotiated. Connections may be made
+as a guest (no authentication) or with NTLM username/password
+authentication, and authenticated sessions support SMB message signing.
+
+### Server address and port
+
+Use the |--addr| flag to set the IP address and port to listen on, e.g.
+|--addr 0.0.0.0:1445| to listen on all interfaces. By default the server
+listens on |127.0.0.1:1445|, the loopback interface only, so it is
+reachable only from the local machine.
+
+The default port is 1445 rather than the standard SMB port 445 so that
+the server can run without administrator/root privileges and without
+clashing with a system SMB service. Use |--addr <address>:445| for the
+standard port.
+
+### Authentication
+
+By default the server runs with no authentication and grants guest
+access to any client that can reach it. For this reason the default
+listening address is the loopback interface. To safely expose the server
+to other machines, set a username and password with |--user| and
+|--pass|, or restrict access with a firewall or tunnel.
+
+Windows SMB clients reject guest (unauthenticated) access on recent
+builds: Windows requires SMB signing and guest sessions cannot be signed,
+so the client refuses the guest session even with insecure guest logons
+enabled. Use |--user| and |--pass| for Windows clients; Linux and macOS
+clients can use guest.
+
+If you do need guest access from a Windows client, run these as an
+administrator and reboot (this lowers the client below its default
+security, so prefer |--user|/|--pass|):
+
+    Set-SmbClientConfiguration -EnableInsecureGuestLogons $true
+    Set-SmbClientConfiguration -RequireSecuritySignature $false
+
+### Caching
+
+The |--vfs-cache-mode| flag controls how files are cached. For a cloud
+remote, |--vfs-cache-mode full| improves random access and retries by
+copying each accessed file into the cache directory. When the backend is a
+**local** directory this only duplicates data, and because the cache size is
+unlimited by default, accessing a very large file copies the whole thing
+into the cache and can fill that disk, making the server unresponsive.
+
+For serving a local drive, use |--vfs-cache-mode off| (or |minimal|). If you
+do use a cache, bound it with |--vfs-cache-max-size| and
+|--vfs-cache-min-free-space| (both off by default) -- note these drive a
+background cleaner that evicts idle files, not a check that refuses a file
+too big to fit.
+
+### Connecting
+
+The share is exposed with the name set by |--name| (default |rclone|),
+so it is reachable as |\\HOST\rclone|.
+
+Linux:
+
+    smbclient //127.0.0.1/rclone -p 1445 -N
+    sudo mount -t cifs //127.0.0.1/rclone /mnt -o port=1445,guest
+
+macOS, in Finder use Go > Connect to Server:
+
+    smb://127.0.0.1:1445/rclone
+
+Windows 11 can connect to the non-standard port with:
+
+    net use X: \\127.0.0.1\rclone /TCPPORT:1445
+
+### VFS
+
+Modifying files through the server requires VFS caching. Use the
+|--vfs-cache-mode| flag to enable it (|--vfs-cache-mode full| is
+recommended). Without a VFS cache the share is effectively read-only.
+
+`, "|", "`") + strings.TrimSpace(vfs.Help()),
+	Annotations: map[string]string{
+		"versionIntroduced": "v1.75",
+		"groups":            "Filter",
+		"status":            "Experimental",
+	},
+	Run: Run,
+}

--- a/cmd/serve/smb/smb_backend_test.go
+++ b/cmd/serve/smb/smb_backend_test.go
@@ -1,0 +1,71 @@
+// Serve smb tests set up a server and run the integration tests for the
+// smb backend against it.
+//
+// We skip tests on platforms with troublesome character mappings.
+
+//go:build !windows && !darwin
+
+package smb
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	_ "github.com/rclone/rclone/backend/local"
+	"github.com/rclone/rclone/cmd/serve/servetest"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fs/config/obscure"
+	"github.com/rclone/rclone/vfs/vfscommon"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSMB runs the smb server then runs the integration tests for the smb
+// backend against it over loopback.
+func TestSMB(t *testing.T) {
+	const (
+		user = "rclone"
+		pass = "password"
+	)
+	const share = "rclone"
+	start := func(f fs.Fs) (configmap.Simple, func()) {
+		opt := Opt
+		opt.ListenAddr = "localhost:0"
+		opt.ShareName = share
+		opt.User = user
+		opt.Pass = pass
+
+		// The integration tests write, which needs a VFS cache.
+		vfsOpt := vfscommon.Opt
+		vfsOpt.CacheMode = vfscommon.CacheModeFull
+		// SMB shares are conventionally case-insensitive (the smb backend
+		// defaults to case_insensitive=true), so serve the VFS that way too —
+		// otherwise name lookups that vary case fail against a case-sensitive
+		// backing store like Linux local.
+		vfsOpt.CaseInsensitive = true
+
+		s, err := newServer(context.Background(), f, &opt, &vfsOpt)
+		require.NoError(t, err)
+		go func() { _ = s.Serve() }()
+
+		host, port, err := net.SplitHostPort(s.Addr().String())
+		require.NoError(t, err)
+
+		// Config for the smb backend we'll use to connect to the server
+		config := configmap.Simple{
+			"type": "smb",
+			"host": host,
+			"port": port,
+			"user": user,
+			"pass": obscure.MustObscure(pass),
+		}
+
+		return config, func() {
+			require.NoError(t, s.Shutdown())
+		}
+	}
+
+	// Run the backend tests under our single share.
+	servetest.RunNoAuthProxy(t, "smb", share, start)
+}

--- a/cmd/serve/smb/smb_test.go
+++ b/cmd/serve/smb/smb_test.go
@@ -1,0 +1,912 @@
+package smb
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	smb2 "github.com/cloudsoda/go-smb2"
+	_ "github.com/rclone/rclone/backend/local"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/vfs"
+	"github.com/rclone/rclone/vfs/vfscommon"
+	"github.com/stretchr/testify/require"
+)
+
+// newTestServer starts an SMB server backed by a local fs at dir, listening on
+// a random loopback port. cacheFull enables the VFS write cache.
+func newTestServer(t *testing.T, dir string, cacheFull bool) string {
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	if cacheFull {
+		vfsOpt.CacheMode = vfscommon.CacheModeFull
+	}
+
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	go func() { _ = s.Serve() }()
+	t.Cleanup(func() { _ = s.Shutdown() })
+	return s.Addr().String()
+}
+
+// dialShare connects to the server as a guest and mounts the share.
+func dialShare(t *testing.T, addr string) (*smb2.Session, *smb2.Share) {
+	nc, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+
+	d := &smb2.Dialer{Initiator: &smb2.NTLMInitiator{User: "guest"}}
+	session, err := d.DialConn(context.Background(), nc, addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Logoff() })
+
+	share, err := session.Mount("rclone")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = share.Umount() })
+	return session, share
+}
+
+// TestServeGuestConnect checks negotiate, guest authentication, ECHO and tree
+// connect (milestone M1).
+func TestServeGuestConnect(t *testing.T) {
+	addr := newTestServer(t, t.TempDir(), false)
+	session, share := dialShare(t, addr)
+	require.NoError(t, session.Echo())
+	require.NotNil(t, share)
+}
+
+// TestServeRead checks stat, directory listing and reading (milestone M2).
+func TestServeRead(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "hello.txt"), []byte("hello world"), 0644))
+	require.NoError(t, os.Mkdir(filepath.Join(dir, "sub"), 0755))
+
+	addr := newTestServer(t, dir, false)
+	_, share := dialShare(t, addr)
+
+	// Stat a file.
+	fi, err := share.Stat("hello.txt")
+	require.NoError(t, err)
+	require.Equal(t, int64(11), fi.Size())
+	require.False(t, fi.IsDir())
+
+	// Read a file.
+	data, err := share.ReadFile("hello.txt")
+	require.NoError(t, err)
+	require.Equal(t, "hello world", string(data))
+
+	// List the root directory.
+	entries, err := share.ReadDir(".")
+	require.NoError(t, err)
+	names := dirNames(entries)
+	require.Contains(t, names, "hello.txt")
+	require.Contains(t, names, "sub")
+
+	// Stat a directory.
+	di, err := share.Stat("sub")
+	require.NoError(t, err)
+	require.True(t, di.IsDir())
+}
+
+// TestServeWrite checks writing, mkdir, rename and delete (milestone M3).
+func TestServeWrite(t *testing.T) {
+	addr := newTestServer(t, t.TempDir(), true)
+	_, share := dialShare(t, addr)
+
+	// Write a file and read it back.
+	require.NoError(t, share.WriteFile("new.txt", []byte("written data"), 0644))
+	data, err := share.ReadFile("new.txt")
+	require.NoError(t, err)
+	require.Equal(t, "written data", string(data))
+
+	// Make a directory.
+	require.NoError(t, share.Mkdir("newdir", 0755))
+	di, err := share.Stat("newdir")
+	require.NoError(t, err)
+	require.True(t, di.IsDir())
+
+	// Write into the subdirectory.
+	require.NoError(t, share.WriteFile("newdir/inner.txt", []byte("inner"), 0644))
+	data, err = share.ReadFile("newdir/inner.txt")
+	require.NoError(t, err)
+	require.Equal(t, "inner", string(data))
+
+	// Rename.
+	require.NoError(t, share.Rename("new.txt", "renamed.txt"))
+	_, err = share.Stat("new.txt")
+	require.Error(t, err)
+	renamed, err := share.ReadFile("renamed.txt")
+	require.NoError(t, err)
+	require.Equal(t, "written data", string(renamed))
+
+	// Delete.
+	require.NoError(t, share.Remove("renamed.txt"))
+	_, err = share.Stat("renamed.txt")
+	require.Error(t, err)
+}
+
+// TestServeAuth checks NTLM username/password authentication (milestone M4).
+func TestServeAuth(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "secret.txt"), []byte("top secret"), 0644))
+
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	opt.User = "alice"
+	opt.Pass = "s3cret"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	go func() { _ = s.Serve() }()
+	t.Cleanup(func() { _ = s.Shutdown() })
+	addr := s.Addr().String()
+
+	// Correct credentials succeed and can read.
+	nc, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	d := &smb2.Dialer{Initiator: &smb2.NTLMInitiator{User: "alice", Password: "s3cret"}}
+	session, err := d.DialConn(ctx, nc, addr)
+	require.NoError(t, err)
+	share, err := session.Mount("rclone")
+	require.NoError(t, err)
+	data, err := share.ReadFile("secret.txt")
+	require.NoError(t, err)
+	require.Equal(t, "top secret", string(data))
+	require.NoError(t, share.Umount())
+	require.NoError(t, session.Logoff())
+
+	// Wrong password fails the session setup.
+	nc2, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	d2 := &smb2.Dialer{Initiator: &smb2.NTLMInitiator{User: "alice", Password: "wrong"}}
+	_, err = d2.DialConn(ctx, nc2, addr)
+	require.Error(t, err)
+}
+
+// startAuthServer starts a server that requires user alice/s3cret.
+func startAuthServer(t *testing.T, dir string) string {
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	opt.User = "alice"
+	opt.Pass = "s3cret"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	go func() { _ = s.Serve() }()
+	t.Cleanup(func() { _ = s.Shutdown() })
+	return s.Addr().String()
+}
+
+// readAuthShare connects requiring signing, optionally pinning a dialect, and
+// returns the bytes of f.txt — exercising server message signing (milestone M4).
+func readAuthShare(t *testing.T, addr string, dialect uint16) string {
+	nc, err := net.Dial("tcp", addr)
+	require.NoError(t, err)
+	d := &smb2.Dialer{
+		Negotiator: smb2.Negotiator{RequireMessageSigning: true, SpecifiedDialect: dialect},
+		Initiator:  &smb2.NTLMInitiator{User: "alice", Password: "s3cret"},
+	}
+	session, err := d.DialConn(context.Background(), nc, addr)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = session.Logoff() })
+	share, err := session.Mount("rclone")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = share.Umount() })
+	data, err := share.ReadFile("f.txt")
+	require.NoError(t, err)
+	return string(data)
+}
+
+// TestServeSignedSMB3 checks AES-CMAC signing over SMB 3.0.2 (milestone M4).
+func TestServeSignedSMB3(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("signed3"), 0644))
+	addr := startAuthServer(t, dir)
+	require.Equal(t, "signed3", readAuthShare(t, addr, 0x0302))
+}
+
+// TestServeSignedSMB2 checks HMAC-SHA256 signing over SMB 2.0.2 (milestone M4).
+func TestServeSignedSMB2(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("signed2"), 0644))
+	addr := startAuthServer(t, dir)
+	require.Equal(t, "signed2", readAuthShare(t, addr, 0x0202))
+}
+
+// TestServeQueryDirSingleEntry checks that QUERY_DIRECTORY honours
+// SMB2_RETURN_SINGLE_ENTRY (set by Windows' FindFirstFile): it must return
+// exactly one entry. If it returns more, the client keeps only the first and
+// resumes past the rest, silently dropping entries from the listing.
+func TestServeQueryDirSingleEntry(t *testing.T) {
+	dir := t.TempDir()
+	const n = 5
+	for i := 0; i < n; i++ {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, fmt.Sprintf("f%d.txt", i)), nil, 0644))
+	}
+
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+
+	// Register a directory handle for the share root ("").
+	c := newConn(s, nil)
+	of := &openFile{isDir: true}
+	of.fileID[0] = 1
+	c.handles[of.fileID] = of
+
+	// QUERY_DIRECTORY body: InfoClass[2], Flags[3], FileId[8:24], OutputBufferLength[28:32].
+	body := make([]byte, 32)
+	body[2] = 0x01 // FileDirectoryInformation
+	copy(body[8:24], of.fileID[:])
+	le.PutUint32(body[28:32], 1<<16)
+
+	// With SMB2_RETURN_SINGLE_ENTRY the server must return exactly one entry.
+	body[3] = 0x02
+	status, _ := c.handleQueryDirectory(header{}, body)
+	require.Equal(t, statusSuccess, status)
+	require.Equal(t, 1, of.dirPos, "RETURN_SINGLE_ENTRY must yield exactly one entry")
+
+	// The remaining entries come on subsequent calls; none are skipped.
+	body[3] = 0x00
+	status, _ = c.handleQueryDirectory(header{}, body)
+	require.Equal(t, statusSuccess, status)
+	require.Equal(t, n, of.dirPos, "all entries must be enumerated, none skipped")
+
+	// Then STATUS_NO_MORE_FILES.
+	status, _ = c.handleQueryDirectory(header{}, body)
+	require.Equal(t, statusNoMoreFiles, status)
+}
+
+// TestServeQueryDirFileID checks that the FileId reported for a directory entry
+// is derived from the path (pathFileID), not the ephemeral VFS inode, so it is
+// stable across server restarts and cache evictions as Windows clients require.
+func TestServeQueryDirFileID(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.tmp"), nil, 0644))
+
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+
+	c := newConn(s, nil)
+	of := &openFile{isDir: true}
+	of.fileID[0] = 1
+	c.handles[of.fileID] = of
+
+	// FileIdBothDirectoryInformation (0x25): FileId is at offset 96 in each entry.
+	body := make([]byte, 32)
+	body[2] = 0x25
+	copy(body[8:24], of.fileID[:])
+	le.PutUint32(body[28:32], 1<<16)
+	status, resp := c.handleQueryDirectory(header{}, body)
+	require.Equal(t, statusSuccess, status)
+
+	info := resp[8:] // QUERY_DIRECTORY response: 8-byte header, then the info buffer
+	require.GreaterOrEqual(t, len(info), 104)
+	require.Equal(t, pathFileID("file.tmp"), le.Uint64(info[96:104]),
+		"dir-entry FileId must be the stable path-derived id, not the VFS inode")
+
+	// pathFileID is a pure function of the path: stable and path-unique.
+	require.Equal(t, pathFileID("a/b"), pathFileID("a/b"))
+	require.NotEqual(t, pathFileID("a/b"), pathFileID("a/c"))
+}
+
+// TestServeQueryDirPattern checks that QUERY_DIRECTORY honours the search
+// pattern: a client resolves a child by name with a single-entry pattern query,
+// so ignoring it made Windows path resolution follow the wrong entry.
+func TestServeQueryDirPattern(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"alpha", "bravo", "charlie"} {
+		require.NoError(t, os.Mkdir(filepath.Join(dir, name), 0755))
+	}
+
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+
+	c := newConn(s, nil)
+	of := &openFile{isDir: true}
+	of.fileID[0] = 1
+	c.handles[of.fileID] = of
+
+	// QUERY_DIRECTORY with RESTART_SCANS|RETURN_SINGLE_ENTRY and pattern "bravo".
+	pat := stringToUTF16le("bravo")
+	body := make([]byte, 32+len(pat))
+	body[2] = 0x25 // FileIdBothDirectoryInformation
+	body[3] = 0x03 // RESTART_SCANS | RETURN_SINGLE_ENTRY
+	copy(body[8:24], of.fileID[:])
+	le.PutUint16(body[24:26], uint16(smb2HeaderSize+32)) // FileNameOffset
+	le.PutUint16(body[26:28], uint16(len(pat)))          // FileNameLength
+	le.PutUint32(body[28:32], 1<<16)                     // OutputBufferLength
+	copy(body[32:], pat)
+
+	status, resp := c.handleQueryDirectory(header{}, body)
+	require.Equal(t, statusSuccess, status)
+	info := resp[8:]
+	nameLen := int(le.Uint32(info[60:64]))
+	require.Equal(t, "bravo", utf16leToString(info[104:104+nameLen]),
+		"a pattern query must return the matching entry, not the first one")
+
+	require.True(t, matchPattern("Users", "users", true))   // case-insensitive
+	require.False(t, matchPattern("Users", "users", false)) // case-sensitive: distinct
+	require.True(t, matchPattern("Users", "Users", false))  // exact
+	require.True(t, matchPattern("*.txt", "a.TXT", true))   // wildcard, folded
+	require.False(t, matchPattern("*.txt", "a.TXT", false)) // wildcard, case-sensitive
+	require.False(t, matchPattern("Users", "Default", true))
+}
+
+// treeConnectSeg builds a TREE_CONNECT request PDU (64-byte header + body) for
+// \\host\<share>, for driving handleCommand directly.
+func treeConnectSeg(share string) []byte {
+	path := stringToUTF16le(`\\host\` + share)
+	body := make([]byte, 8+len(path))
+	le.PutUint16(body[0:2], 9)                 // StructureSize
+	le.PutUint16(body[4:6], smb2HeaderSize+8)  // PathOffset (from header)
+	le.PutUint16(body[6:8], uint16(len(path))) // PathLength
+	copy(body[8:], path)
+	seg := make([]byte, smb2HeaderSize+len(body))
+	copy(seg[smb2HeaderSize:], body)
+	return seg
+}
+
+// TestServeRequireAuth checks that with --user set, a command on a session that
+// never authenticated is rejected (the auth-bypass fix), while an authenticated
+// session is allowed and a guest server (no --user) is not gated.
+func TestServeRequireAuth(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	seg := treeConnectSeg("rclone")
+	vfsOpt := vfscommon.Opt
+
+	// Server that requires authentication.
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	opt.User = "alice"
+	opt.Pass = "s3cret"
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+	c := newConn(s, nil)
+	status := func(sessionID uint64) uint32 {
+		resp := c.handleCommand(header{command: cmdTreeConnect, sessionID: sessionID}, seg, &chainCtx{})
+		return le.Uint32(resp[8:12])
+	}
+
+	require.Equal(t, statusUserSessionDeleted, status(999),
+		"TREE_CONNECT on an unauthenticated session must be rejected when --user is set")
+	c.authedSessions[999] = struct{}{}
+	require.Equal(t, statusSuccess, status(999),
+		"TREE_CONNECT on an authenticated session must succeed")
+
+	// Guest server (no --user): the auth gate is not applied.
+	optG := Opt
+	optG.ListenAddr = "127.0.0.1:0"
+	optG.ShareName = "rclone"
+	sg, err := newServer(ctx, f, &optG, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = sg.Shutdown() })
+	cg := newConn(sg, nil)
+	resp := cg.handleCommand(header{command: cmdTreeConnect, sessionID: 42}, seg, &chainCtx{})
+	require.Equal(t, statusSuccess, le.Uint32(resp[8:12]), "guest server must not gate commands")
+}
+
+// panicOnReadConn is a net.Conn whose Read panics, used to check serve() recovers.
+type panicOnReadConn struct{}
+
+func (panicOnReadConn) Read([]byte) (int, error)         { panic("simulated panic while processing a message") }
+func (panicOnReadConn) Write(b []byte) (int, error)      { return len(b), nil }
+func (panicOnReadConn) Close() error                     { return nil }
+func (panicOnReadConn) LocalAddr() net.Addr              { return &net.TCPAddr{} }
+func (panicOnReadConn) RemoteAddr() net.Addr             { return &net.TCPAddr{} }
+func (panicOnReadConn) SetDeadline(time.Time) error      { return nil }
+func (panicOnReadConn) SetReadDeadline(time.Time) error  { return nil }
+func (panicOnReadConn) SetWriteDeadline(time.Time) error { return nil }
+
+// TestServeRecover checks that a panic while serving a connection is recovered
+// (the connection is dropped) rather than crashing the whole rclone process.
+func TestServeRecover(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+
+	c := newConn(s, panicOnReadConn{})
+	require.NotPanics(t, func() { c.serve() }, "a panic while serving must be recovered, not propagated")
+}
+
+// TestServeReadLengthClamp checks that a READ whose Length exceeds MaxReadSize
+// is rejected rather than allocating an attacker-chosen buffer.
+func TestServeReadLengthClamp(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("hello"), 0644))
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+
+	handle, err := s.vfs.OpenFile("f.txt", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+	c := newConn(s, nil)
+	of := &openFile{handle: handle, node: handle.Node()}
+	of.fileID[0] = 1
+	c.handles[of.fileID] = of
+
+	readBody := func(length uint32) []byte {
+		body := make([]byte, 48)
+		le.PutUint32(body[4:8], length) // Length
+		copy(body[16:32], of.fileID[:]) // FileId
+		return body
+	}
+
+	// Over the limit (the 4 GiB DoS lives on this same path) -> rejected.
+	status, _ := c.handleRead(header{}, readBody(maxIOSize+1))
+	require.Equal(t, statusInvalidParameter, status, "oversized READ must be rejected, not allocated")
+	// Within the limit -> still works.
+	status, resp := c.handleRead(header{}, readBody(5))
+	require.Equal(t, statusSuccess, status)
+	require.Equal(t, "hello", string(resp[16:21]))
+}
+
+// closeErrHandle wraps a real VFS handle but fails on Close, to check that
+// CLOSE surfaces the error instead of reporting success.
+type closeErrHandle struct{ vfs.Handle }
+
+func (closeErrHandle) Close() error { return errors.New("simulated upload failure") }
+
+// TestServeCloseError checks that a failed handle Close is reported to the
+// client, not swallowed (which would be silent data loss).
+func TestServeCloseError(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0644))
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+
+	real, err := s.vfs.OpenFile("f.txt", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = real.Close() })
+	c := newConn(s, nil)
+	of := &openFile{handle: closeErrHandle{real}, node: real.Node()}
+	of.fileID[0] = 1
+	c.handles[of.fileID] = of
+
+	body := make([]byte, 24)
+	copy(body[8:24], of.fileID[:]) // FileId
+	status, _ := c.handleClose(header{}, body)
+	require.NotEqual(t, statusSuccess, status, "CLOSE must surface a handle Close() error, not report success")
+}
+
+// TestServeShutdown checks that Shutdown returns promptly (does not hang on
+// wg.Wait) while a connection is live.
+func TestServeShutdown(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	go func() { _ = s.Serve() }()
+
+	nc, err := net.Dial("tcp", s.Addr().String())
+	require.NoError(t, err)
+	defer func() { _ = nc.Close() }()
+	time.Sleep(100 * time.Millisecond) // let the connection register
+
+	done := make(chan struct{})
+	go func() { _ = s.Shutdown(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Shutdown hung with a live connection")
+	}
+}
+
+// TestServeVerifySignature checks that a signed request from an authenticated
+// session is accepted only if its signature is valid.
+func TestServeVerifySignature(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+
+	c := newConn(s, nil)
+	c.signKey = make([]byte, 16) // a session signing key
+	c.dialect = dialect202       // HMAC-SHA256 signing path
+
+	// A correctly signed ECHO request.
+	seg := make([]byte, smb2HeaderSize+4)
+	copy(seg[0:4], smb2Magic)
+	le.PutUint16(seg[4:6], smb2HeaderSize) // header StructureSize
+	le.PutUint16(seg[12:14], cmdEcho)      // Command
+	le.PutUint32(seg[16:20], flagsSigned)  // Flags: SIGNED
+	le.PutUint16(seg[smb2HeaderSize:], 4)  // ECHO StructureSize
+	signMessage(c.signKey, c.dialect, seg)
+	h, ok := parseHeader(seg)
+	require.True(t, ok)
+
+	resp := c.handleCommand(h, seg, &chainCtx{})
+	require.Equal(t, statusSuccess, le.Uint32(resp[8:12]), "a correctly signed request must be accepted")
+
+	seg[48] ^= 0xFF // tamper the signature
+	resp = c.handleCommand(h, seg, &chainCtx{})
+	require.Equal(t, statusAccessDenied, le.Uint32(resp[8:12]), "a bad signature must be rejected")
+}
+
+// setInfoRenameBody builds a SET_INFO FileRenameInformation request body.
+func setInfoRenameBody(fileID [16]byte, target string, replace bool) []byte {
+	name := stringToUTF16le(target)
+	info := make([]byte, 20+len(name))
+	if replace {
+		info[0] = 1 // ReplaceIfExists
+	}
+	le.PutUint32(info[16:20], uint32(len(name))) // FileNameLength
+	copy(info[20:], name)
+
+	body := make([]byte, 32+len(info))
+	body[2] = infoTypeFile                      // InfoType
+	body[3] = classFileRename                   // FileInfoClass
+	le.PutUint32(body[4:8], uint32(len(info)))  // BufferLength
+	le.PutUint16(body[8:10], smb2HeaderSize+32) // BufferOffset (from header)
+	copy(body[16:32], fileID[:])                // FileId
+	copy(body[32:], info)
+	return body
+}
+
+// TestServeRenameReplaceIfExists checks that a rename onto an existing target
+// fails with a collision unless ReplaceIfExists is set.
+func TestServeRenameReplaceIfExists(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "src.txt"), []byte("s"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "dst.txt"), []byte("d"), 0644))
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+
+	node, err := s.vfs.Stat("src.txt")
+	require.NoError(t, err)
+	c := newConn(s, nil)
+	of := &openFile{path: "src.txt", node: node}
+	of.fileID[0] = 1
+	c.handles[of.fileID] = of
+
+	// Onto an existing target with ReplaceIfExists=0 -> collision.
+	status, _ := c.handleSetInfo(header{}, setInfoRenameBody(of.fileID, "dst.txt", false))
+	require.Equal(t, statusObjectNameCollision, status, "rename onto an existing target must collide")
+
+	// Onto a free name -> success.
+	status, _ = c.handleSetInfo(header{}, setInfoRenameBody(of.fileID, "moved.txt", false))
+	require.Equal(t, statusSuccess, status)
+}
+
+// createSeg builds a CREATE request PDU that opens the named file.
+func createSeg(name string) []byte {
+	n := stringToUTF16le(name)
+	body := make([]byte, 56+len(n))
+	le.PutUint16(body[0:2], 57)                  // StructureSize
+	le.PutUint32(body[36:40], dispOpen)          // CreateDisposition = OPEN
+	le.PutUint16(body[44:46], smb2HeaderSize+56) // NameOffset (from header)
+	le.PutUint16(body[46:48], uint16(len(n)))    // NameLength
+	copy(body[56:], n)
+	seg := make([]byte, smb2HeaderSize+len(body))
+	copy(seg[smb2HeaderSize:], body)
+	return seg
+}
+
+// TestServeIPCTreeRejectsCreate checks that opening a name on the IPC$ tree is
+// rejected instead of being resolved as a VFS path (which could open a real
+// file that happens to share a pipe's name, e.g. srvsvc).
+func TestServeIPCTreeRejectsCreate(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "srvsvc"), []byte("data"), 0644))
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+	c := newConn(s, nil)
+
+	// On the disk share, opening the real file works.
+	respD := c.handleCommand(header{command: cmdTreeConnect}, treeConnectSeg("rclone"), &chainCtx{})
+	diskTree := le.Uint32(respD[36:40])
+	respC := c.handleCommand(header{command: cmdCreate, treeID: diskTree}, createSeg("srvsvc"), &chainCtx{})
+	require.Equal(t, statusSuccess, le.Uint32(respC[8:12]), "opening a real file on the disk share must work")
+
+	// On the IPC$ tree, the same open must be rejected.
+	respI := c.handleCommand(header{command: cmdTreeConnect}, treeConnectSeg("IPC$"), &chainCtx{})
+	pipeTree := le.Uint32(respI[36:40])
+	respP := c.handleCommand(header{command: cmdCreate, treeID: pipeTree}, createSeg("srvsvc"), &chainCtx{})
+	require.Equal(t, statusObjectNameNotFound, le.Uint32(respP[8:12]), "CREATE on the IPC$ tree must be rejected")
+}
+
+// negotiateBody builds a NEGOTIATE request body offering the given dialects.
+func negotiateBody(dialects ...uint16) []byte {
+	body := make([]byte, 36+len(dialects)*2)
+	le.PutUint16(body[0:2], 36)                    // StructureSize
+	le.PutUint16(body[2:4], uint16(len(dialects))) // DialectCount
+	for i, d := range dialects {
+		le.PutUint16(body[36+i*2:], d)
+	}
+	return body
+}
+
+// TestServeNegotiateNoOverlap checks that NEGOTIATE fails when the client offers
+// no dialect we support, rather than forcing an unrequested 2.0.2.
+func TestServeNegotiateNoOverlap(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+	c := newConn(s, nil)
+
+	status, _ := c.handleNegotiate(header{}, negotiateBody(dialect311)) // 3.1.1 only (unsupported)
+	require.Equal(t, statusNotSupported, status, "no supported dialect must fail NEGOTIATE")
+
+	status, _ = c.handleNegotiate(header{}, negotiateBody(dialect202))
+	require.Equal(t, statusSuccess, status)
+}
+
+// TestServeHandleCap checks that a connection can't open more than maxOpenFiles
+// handles (a leaky client would otherwise exhaust file descriptors).
+func TestServeHandleCap(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("x"), 0644))
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+	c := newConn(s, nil)
+
+	for i := 0; i < maxOpenFiles; i++ {
+		var id [16]byte
+		le.PutUint64(id[:8], uint64(i)+1)
+		c.handles[id] = &openFile{}
+	}
+	resp := c.handleCommand(header{command: cmdCreate}, createSeg("f.txt"), &chainCtx{})
+	require.Equal(t, statusInsufficientResources, le.Uint32(resp[8:12]),
+		"a CREATE past the per-connection handle cap must be refused")
+}
+
+// TestServeShutdownCancelsContext checks that Shutdown cancels the server
+// context so in-flight VFS operations on a wedged backend are interrupted.
+func TestServeShutdownCancelsContext(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	require.NoError(t, s.ctx.Err(), "server context must be live before Shutdown")
+	require.NoError(t, s.Shutdown())
+	require.Error(t, s.ctx.Err(), "Shutdown must cancel the server context")
+}
+
+// TestServeRequirePass checks that --user without --pass is rejected.
+func TestServeRequirePass(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	vfsOpt := vfscommon.Opt
+	mk := func(user, pass string) error {
+		opt := Opt
+		opt.ListenAddr = "127.0.0.1:0"
+		opt.ShareName = "rclone"
+		opt.User = user
+		opt.Pass = pass
+		s, err := newServer(ctx, f, &opt, &vfsOpt)
+		if s != nil {
+			t.Cleanup(func() { _ = s.Shutdown() })
+		}
+		return err
+	}
+	require.Error(t, mk("alice", ""), "--user without --pass must be rejected")
+	require.NoError(t, mk("alice", "s3cret"))
+	require.NoError(t, mk("", "")) // guest is fine
+}
+
+// TestServeProtocolNits covers a few edge-case status codes.
+func TestServeProtocolNits(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "f.txt"), []byte("hello"), 0644))
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+	c := newConn(s, nil)
+
+	// Opening a regular file with FILE_DIRECTORY_FILE -> NOT_A_DIRECTORY.
+	seg := createSeg("f.txt")
+	le.PutUint32(seg[smb2HeaderSize+40:], optDirectoryFile) // CreateOptions
+	resp := c.handleCommand(header{command: cmdCreate}, seg, &chainCtx{})
+	require.Equal(t, statusNotADirectory, le.Uint32(resp[8:12]), "FILE_DIRECTORY_FILE on a file must fail")
+
+	handle, err := s.vfs.OpenFile("f.txt", os.O_RDONLY, 0)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = handle.Close() })
+	of := &openFile{path: "f.txt", handle: handle, node: handle.Node()}
+	of.fileID[0] = 1
+	c.handles[of.fileID] = of
+
+	// Zero-length READ -> SUCCESS.
+	rbody := make([]byte, 48)
+	copy(rbody[16:32], of.fileID[:]) // Length stays 0
+	status, _ := c.handleRead(header{}, rbody)
+	require.Equal(t, statusSuccess, status, "zero-length READ must succeed")
+
+	// SET_INFO with an unknown info class -> INVALID_INFO_CLASS.
+	sbody := make([]byte, 32)
+	sbody[2] = infoTypeFile
+	sbody[3] = 0xEE // unknown FileInfoClass
+	le.PutUint16(sbody[8:10], smb2HeaderSize+32)
+	copy(sbody[16:32], of.fileID[:])
+	status, _ = c.handleSetInfo(header{}, sbody)
+	require.Equal(t, statusInvalidInfoClass, status, "unknown SET_INFO class must be rejected")
+}
+
+// TestServeDoubleShutdown checks that a second Shutdown is a no-op, not an error.
+func TestServeDoubleShutdown(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	require.NoError(t, s.Shutdown())
+	require.NoError(t, s.Shutdown(), "a second Shutdown must be a no-op, not an error")
+}
+
+// TestServeQueryDirUnreadable checks that a directory whose contents can't be
+// listed (locked/denied) reports as empty (STATUS_NO_MORE_FILES) rather than
+// failing the request -- a generic failure makes the Windows shell copy engine
+// abort a whole recursive copy.
+func TestServeQueryDirUnreadable(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, dir)
+	require.NoError(t, err)
+	opt := Opt
+	opt.ListenAddr = "127.0.0.1:0"
+	opt.ShareName = "rclone"
+	vfsOpt := vfscommon.Opt
+	s, err := newServer(ctx, f, &opt, &vfsOpt)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = s.Shutdown() })
+	c := newConn(s, nil)
+
+	// A directory handle whose path can't be listed (here it doesn't exist, which
+	// makes listDir error the same way a locked/denied directory does).
+	of := &openFile{path: "nope-does-not-exist", isDir: true}
+	of.fileID[0] = 1
+	c.handles[of.fileID] = of
+
+	body := make([]byte, 32)
+	body[2] = 0x25 // FileIdBothDirectoryInformation
+	copy(body[8:24], of.fileID[:])
+	le.PutUint32(body[28:32], 65536) // OutputBufferLength
+	status, _ := c.handleQueryDirectory(header{}, body)
+	require.Equal(t, statusNoMoreFiles, status,
+		"an unreadable directory must report empty, not fail the request")
+}
+
+func dirNames(entries []os.FileInfo) []string {
+	names := make([]string, len(entries))
+	for i, e := range entries {
+		names[i] = e.Name()
+	}
+	sort.Strings(names)
+	return names
+}

--- a/cmd/serve/smb/smb_test.go
+++ b/cmd/serve/smb/smb_test.go
@@ -13,7 +13,9 @@ import (
 
 	smb2 "github.com/cloudsoda/go-smb2"
 	_ "github.com/rclone/rclone/backend/local"
+	"github.com/rclone/rclone/cmd/serve/servetest"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/rc"
 	"github.com/rclone/rclone/vfs"
 	"github.com/rclone/rclone/vfs/vfscommon"
 	"github.com/stretchr/testify/require"
@@ -900,6 +902,15 @@ func TestServeQueryDirUnreadable(t *testing.T) {
 	status, _ := c.handleQueryDirectory(header{}, body)
 	require.Equal(t, statusNoMoreFiles, status,
 		"an unreadable directory must report empty, not fail the request")
+}
+
+// TestRc checks that serve smb can be started and stopped via the rc
+// serve/start and serve/stop calls.
+func TestRc(t *testing.T) {
+	servetest.TestRc(t, rc.Params{
+		"type":           "smb",
+		"vfs_cache_mode": "off",
+	})
 }
 
 func dirNames(entries []os.FileInfo) []string {

--- a/cmd/serve/smb/spnego.go
+++ b/cmd/serve/smb/spnego.go
@@ -1,0 +1,217 @@
+package smb
+
+import "time"
+
+// This file implements just enough SPNEGO/GSS-API and NTLMSSP to complete an
+// SMB2 SESSION_SETUP. The security buffer in SESSION_SETUP is a SPNEGO token
+// (DER encoded). We need to:
+//
+//   - extract the inner NTLMSSP message from the client's tokens, and
+//   - build our own SPNEGO negTokenResp wrapping an NTLMSSP CHALLENGE.
+//
+// For guest (no auth) we do not validate the NTLMSSP messages; we only use the
+// NTLMSSP MessageType to tell the two SESSION_SETUP round trips apart.
+
+// oidNLMP is the full DER TLV (tag 0x06) for the NTLMSSP mechanism OID
+// 1.3.6.1.4.1.311.2.2.10.
+var oidNLMP = []byte{0x06, 0x0A, 0x2b, 0x06, 0x01, 0x04, 0x01, 0x82, 0x37, 0x02, 0x02, 0x0A}
+
+// SPNEGO negotiation states.
+const (
+	negStateAcceptCompleted  byte = 0
+	negStateAcceptIncomplete byte = 1
+)
+
+// NTLMSSP message signature and the message types we care about.
+var ntlmSignature = []byte("NTLMSSP\x00")
+
+const (
+	ntlmTypeNegotiate    uint32 = 1
+	ntlmTypeChallenge    uint32 = 2
+	ntlmTypeAuthenticate uint32 = 3
+)
+
+// ntlmDefaultFlags are the NTLMSSP negotiate flags we advertise in the
+// CHALLENGE message (matches the common reference set used by SMB clients).
+const ntlmDefaultFlags uint32 = 0xE2898215
+
+// ntlmNegotiateTargetTypeServer marks the CHALLENGE target name as a server name.
+const ntlmNegotiateTargetTypeServer uint32 = 0x00020000
+
+// derLen encodes a DER length.
+func derLen(n int) []byte {
+	switch {
+	case n < 0x80:
+		return []byte{byte(n)}
+	case n < 0x100:
+		return []byte{0x81, byte(n)}
+	default:
+		return []byte{0x82, byte(n >> 8), byte(n)}
+	}
+}
+
+// derTLV encodes a DER tag-length-value.
+func derTLV(tag byte, content []byte) []byte {
+	out := make([]byte, 0, 1+len(content)+3)
+	out = append(out, tag)
+	out = append(out, derLen(len(content))...)
+	out = append(out, content...)
+	return out
+}
+
+// derReadTLV reads a single DER tag-length-value from the front of b. It
+// returns the tag, the contents, and the bytes following the element.
+func derReadTLV(b []byte) (tag byte, content, rest []byte, ok bool) {
+	if len(b) < 2 {
+		return 0, nil, nil, false
+	}
+	tag = b[0]
+	n := int(b[1])
+	i := 2
+	if n&0x80 != 0 {
+		nbytes := n & 0x7f
+		if nbytes == 0 || nbytes > 4 || len(b) < 2+nbytes {
+			return 0, nil, nil, false
+		}
+		n = 0
+		for j := 0; j < nbytes; j++ {
+			n = n<<8 | int(b[2+j])
+		}
+		i = 2 + nbytes
+	}
+	if n < 0 || len(b) < i+n {
+		return 0, nil, nil, false
+	}
+	return tag, b[i : i+n], b[i+n:], true
+}
+
+// spnegoExtractNTLM extracts the inner NTLMSSP token from a SPNEGO security
+// buffer. It handles both negTokenInit (GSS-API APPLICATION tag 0x60, used in
+// the first SESSION_SETUP request) and negTokenResp (tag 0xA1, used in
+// subsequent requests).
+func spnegoExtractNTLM(buf []byte) ([]byte, bool) {
+	tag, content, _, ok := derReadTLV(buf)
+	if !ok {
+		return nil, false
+	}
+	var seq []byte
+	switch tag {
+	case 0x60: // GSS-API negTokenInit: OID + [0] NegTokenInit
+		_, _, afterOID, ok := derReadTLV(content) // skip SPNEGO OID
+		if !ok {
+			return nil, false
+		}
+		t, c, _, ok := derReadTLV(afterOID) // [0]
+		if !ok || t != 0xA0 {
+			return nil, false
+		}
+		t, c, _, ok = derReadTLV(c) // SEQUENCE
+		if !ok || t != 0x30 {
+			return nil, false
+		}
+		seq = c
+	case 0xA1: // negTokenResp: [1] NegTokenResp -> SEQUENCE
+		t, c, _, ok := derReadTLV(content)
+		if !ok || t != 0x30 {
+			return nil, false
+		}
+		seq = c
+	default:
+		return nil, false
+	}
+	// Walk the SEQUENCE looking for [2] (mechToken / responseToken).
+	for len(seq) > 0 {
+		t, c, next, ok := derReadTLV(seq)
+		if !ok {
+			return nil, false
+		}
+		if t == 0xA2 {
+			t2, c2, _, ok := derReadTLV(c) // OCTET STRING
+			if !ok || t2 != 0x04 {
+				return nil, false
+			}
+			return c2, true
+		}
+		seq = next
+	}
+	return nil, false
+}
+
+// ntlmMessageType returns the NTLMSSP MessageType of token, or 0 if token is
+// not a valid NTLMSSP message.
+func ntlmMessageType(token []byte) uint32 {
+	if len(token) < 12 || string(token[0:8]) != string(ntlmSignature) {
+		return 0
+	}
+	return le.Uint32(token[8:12])
+}
+
+// buildNegTokenResp builds a SPNEGO negTokenResp. supportedMech adds the
+// NTLMSSP mechanism OID (required in the server's first reply); token, when
+// non-nil, is wrapped as the responseToken.
+func buildNegTokenResp(state byte, supportedMech bool, token []byte) []byte {
+	var seq []byte
+	seq = append(seq, derTLV(0xA0, derTLV(0x0A, []byte{state}))...) // [0] negState
+	if supportedMech {
+		seq = append(seq, derTLV(0xA1, oidNLMP)...) // [1] supportedMech
+	}
+	if token != nil {
+		seq = append(seq, derTLV(0xA2, derTLV(0x04, token))...) // [2] responseToken
+	}
+	return derTLV(0xA1, derTLV(0x30, seq))
+}
+
+// avPair encodes an NTLMSSP AV_PAIR ([MS-NLMP] 2.2.2.1).
+func avPair(id uint16, value []byte) []byte {
+	b := make([]byte, 4+len(value))
+	le.PutUint16(b[0:2], id)
+	le.PutUint16(b[2:4], uint16(len(value)))
+	copy(b[4:], value)
+	return b
+}
+
+// buildNTLMChallenge builds an NTLMSSP CHALLENGE (Type 2) message ([MS-NLMP]
+// 2.2.1.2) carrying the given 8-byte server challenge plus a target name and a
+// full target-info block (computer/domain names and a timestamp). Windows
+// requires these AV pairs to compute its NTLMv2 response.
+func buildNTLMChallenge(serverChallenge [8]byte) []byte {
+	const computer = "RCLONE"
+	const domain = "WORKGROUP"
+	nbComputer := stringToUTF16le(computer)
+	nbDomain := stringToUTF16le(domain)
+	targetName := nbDomain
+
+	timestamp := make([]byte, 8)
+	le.PutUint64(timestamp, timeToFiletime(time.Now()))
+
+	var targetInfo []byte
+	targetInfo = append(targetInfo, avPair(2, nbDomain)...)   // MsvAvNbDomainName
+	targetInfo = append(targetInfo, avPair(1, nbComputer)...) // MsvAvNbComputerName
+	targetInfo = append(targetInfo, avPair(4, nbDomain)...)   // MsvAvDnsDomainName
+	targetInfo = append(targetInfo, avPair(3, nbComputer)...) // MsvAvDnsComputerName
+	targetInfo = append(targetInfo, avPair(7, timestamp)...)  // MsvAvTimestamp
+	targetInfo = append(targetInfo, avPair(0, nil)...)        // MsvAvEOL
+
+	const fixedLen = 56 // includes the 8-byte Version field
+	targetNameOff := fixedLen
+	targetInfoOff := targetNameOff + len(targetName)
+
+	b := make([]byte, fixedLen+len(targetName)+len(targetInfo))
+	copy(b[0:8], ntlmSignature)
+	le.PutUint32(b[8:12], ntlmTypeChallenge)
+	le.PutUint16(b[12:14], uint16(len(targetName)))
+	le.PutUint16(b[14:16], uint16(len(targetName)))
+	le.PutUint32(b[16:20], uint32(targetNameOff))
+	le.PutUint32(b[20:24], ntlmDefaultFlags|ntlmNegotiateTargetTypeServer)
+	copy(b[24:32], serverChallenge[:])
+	// Reserved [32:40] = 0
+	le.PutUint16(b[40:42], uint16(len(targetInfo)))
+	le.PutUint16(b[42:44], uint16(len(targetInfo)))
+	le.PutUint32(b[44:48], uint32(targetInfoOff))
+	// Version [48:56]: Windows-style {major 10, minor 0, build 0, NTLM rev 15}
+	b[48] = 10
+	b[55] = 0x0f
+	copy(b[targetNameOff:], targetName)
+	copy(b[targetInfoOff:], targetInfo)
+	return b
+}

--- a/cmd/serve/smb/transport.go
+++ b/cmd/serve/smb/transport.go
@@ -1,0 +1,59 @@
+package smb
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+)
+
+// maxMessageSize is the largest SMB2 message we will accept over the Direct
+// TCP transport. SMB2 messages are negotiated to be much smaller than this,
+// so it only acts as a sanity limit to protect against malicious clients.
+const maxMessageSize = 16 * 1024 * 1024
+
+// readMessage reads a single SMB2 message framed using the Direct TCP
+// transport (MS-SMB2 §2.1, RFC 1002 style framing): a 4-byte header where the
+// first byte is zero and the next three bytes are the big-endian length of the
+// message that follows.
+func readMessage(r io.Reader) ([]byte, error) {
+	var hdr [4]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	// The high byte must be zero; the length is a 24-bit big-endian value.
+	n := uint32(hdr[1])<<16 | uint32(hdr[2])<<8 | uint32(hdr[3])
+	if n == 0 {
+		return []byte{}, nil
+	}
+	if n > maxMessageSize {
+		return nil, fmt.Errorf("smb: incoming message too large: %d bytes", n)
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// writeMessage writes a single SMB2 message using the Direct TCP transport
+// framing described above.
+func writeMessage(w io.Writer, msg []byte) error {
+	n := len(msg)
+	if n > maxMessageSize {
+		return fmt.Errorf("smb: outgoing message too large: %d bytes", n)
+	}
+	var hdr [4]byte
+	// hdr[0] stays zero; the length is a 24-bit big-endian value.
+	hdr[1] = byte(n >> 16)
+	hdr[2] = byte(n >> 8)
+	hdr[3] = byte(n)
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(msg)
+	return err
+}
+
+// le is a convenience alias for the little-endian byte order used throughout
+// the SMB2 wire format.
+var le = binary.LittleEndian

--- a/cmd/serve/smb/tree.go
+++ b/cmd/serve/smb/tree.go
@@ -1,0 +1,54 @@
+package smb
+
+import "strings"
+
+// handleTreeConnect handles an SMB2 TREE_CONNECT request. We expose a single
+// share (named by --name), so we accept a connection to that share and reject
+// everything else with STATUS_BAD_NETWORK_NAME.
+func (c *conn) handleTreeConnect(h header, body []byte) (status uint32, treeID uint32, respBody []byte) {
+	if len(body) < 8 {
+		return statusInvalidParameter, 0, errorResponseBody()
+	}
+	path := ""
+	if buf := bufferAt(body, le.Uint16(body[4:6]), le.Uint16(body[6:8])); buf != nil {
+		path = utf16leToString(buf)
+	}
+	share := shareFromPath(path)
+
+	// Accept our disk share and the special IPC$ share. cifs (Linux) connects
+	// to IPC$ for DFS referral resolution and refuses to mount without it.
+	var shareType byte
+	switch {
+	case strings.EqualFold(share, c.server.shareName):
+		shareType = shareTypeDisk
+	case strings.EqualFold(share, "IPC$"):
+		shareType = shareTypePipe
+	default:
+		return statusBadNetworkName, 0, errorResponseBody()
+	}
+
+	treeID = c.server.nextTreeID()
+	if shareType == shareTypePipe {
+		// IPC$: remember the tree so file opens on it are rejected rather than
+		// resolved as VFS paths (a real file named e.g. srvsvc must not be opened).
+		c.pipeTrees[treeID] = struct{}{}
+	}
+	rb := make([]byte, 16)
+	le.PutUint16(rb[0:2], 16)           // StructureSize
+	rb[2] = shareType                   // ShareType
+	rb[3] = 0                           // Reserved
+	le.PutUint32(rb[4:8], 0)            // ShareFlags
+	le.PutUint32(rb[8:12], 0)           // Capabilities
+	le.PutUint32(rb[12:16], 0x001F01FF) // MaximalAccess (full)
+	return statusSuccess, treeID, rb
+}
+
+// shareFromPath extracts the share name from a UNC path like
+// `\\host\share` (the final path component).
+func shareFromPath(p string) string {
+	p = strings.TrimPrefix(p, `\\`)
+	if i := strings.LastIndex(p, `\`); i >= 0 {
+		return p[i+1:]
+	}
+	return p
+}


### PR DESCRIPTION
#### What does this change do?

Adds `rclone serve smb`, a from-scratch SMB2/SMB3 server, so any rclone remote can be served over the SMB protocol and used by the native clients on Windows (Explorer / `net use`), macOS (Finder) and Linux (`smbclient` / `mount -t cifs`).

  - SMB dialects 2.0.2, 2.1, 3.0 and 3.0.2, chosen by negotiation
  - Guest access (default) or NTLMv2 `--user`/`--pass` authentication
  - SMB2 (HMAC-SHA256) and SMB3 (AES-128-CMAC) message signing, with verification of signed inbound requests and `FSCTL_VALIDATE_NEGOTIATE_INFO` for signed Windows 3.x clients
  - Single share (named by `--name`) backed by the rclone VFS, so all the `--vfs-*` flags apply; writing requires a VFS cache mode
  - Binds `127.0.0.1:1445` by default (port 1445 needs no elevated privileges; loopback because guest is the default). Windows rejects unsigned guest sessions, so guest is documented as Linux/macOS-only and the server warns when run without auth.

#### Linked issue

Fixes #7596

#### For new or changed backends

  `serve smb` is a command (`cmd/serve/smb`), not a backend, so it is covered by
  its own unit + in-process integration tests rather than `test_all`:

  - `go test ./cmd/serve/smb/...` — **24 tests pass**. These drive a real SMB client (`github.com/cloudsoda/go-smb2`) against the server in-process:
    negotiate, guest + NTLM auth, signed SMB2 and SMB3 reads, directory listing/patterns, write/rename/delete, plus regression tests for auth enforcement, signature verification and the edge cases fixed during review.
  - Verified against real native clients across a client × server × auth matrix (Linux `cifs` and Windows redirector, guest + NTLM): RoundTrip, EmptyFile, LargeFile (64 MB), EditAppendDelete, SpecialFilenames, DirectoryTree, ManySmallFiles (200), ClientEnumeration and ConcurrentWrites — **38/38 applicable combinations pass**. The 2 skips are Windows-client + Guest, which Windows itself refuses (unsigned guest sessions), as documented.
  - Builds and `go vet` clean for both `windows` and `linux`; `golangci-lint` clean on the package.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
