### PR TITLE
internxt: surface re-login error when re-auth fails in NewFs

### DIFF
--- a/backend/internxt/internxt.go
+++ b/backend/internxt/internxt.go
@@ -343,7 +343,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 			fs.Debugf(f, "getUserInfo returned 401, attempting re-auth")
 			authErr := f.refreshOrReLogin(ctx)
 			if authErr != nil {
-				return nil, fmt.Errorf("failed to fetch user info (re-auth failed): %w", err)
+				return nil, fmt.Errorf("failed to fetch user info (re-auth failed: %w): %w", authErr, err)
 			}
 			userInfo, err = getUserInfo(ctx, &userInfoConfig{Token: f.cfg.Token})
 			if err == nil {


### PR DESCRIPTION
#### What does this change do?

When an Internxt remote's stored JWT has expired and the `refreshOrReLogin` recovery in `NewFs` also fails, the returned error wrapped the original 401 and discarded `authErr`, hiding the actionable reason. The prominent case is an account with 2FA enabled, where the hidden text is literally the remedy: `account requires 2FA - please run: rclone config reconnect remote:`.

This change wraps both errors so the user sees why re-auth failed:

```go
return nil, fmt.Errorf("failed to fetch user info (re-auth failed: %w): %w", authErr, err)
```

Notes for reviewers:

- Both errors stay in the unwrap tree. `lib/errors.Walk` handles the `Unwrap() []error` case, so `fserrors` retry classification still sees the original HTTP error. Happy to switch to `errors.Join(err, authErr)` if you prefer that form.
- Verified with `gofmt`, `go vet`, and a full build. The failure path itself only triggers with an expired token on a 2FA-enabled account, which I could not reproduce on demand without letting a live remote die, so the behavior claim is source-verified rather than exercised end to end.
- The same swallow pattern exists in the runtime 401 path (`shouldRetry` -> `reAuthorize` logs `authErr` at DEBUG only). Left out of scope to keep this a one-line fix; happy to address it in a follow-up if wanted.

#### Linked issue

Fixes #9583 (companion issue: #9584)

#### For new or changed backends

Not a new backend; one-line error-message fix to the existing internxt backend. No integration-test-visible behavior change (error text on a failure path only). Can run the internxt integration subset if required.
