### PR TITLE
internxt: persist rotated token returned by the user info call

### DIFF
--- a/backend/internxt/auth.go
+++ b/backend/internxt/auth.go
@@ -28,6 +28,7 @@ type userInfo struct {
 	Bucket       string
 	BridgeUser   string
 	UserID       string
+	NewToken     string
 }
 
 type userInfoConfig struct {
@@ -61,6 +62,7 @@ func getUserInfo(ctx context.Context, cfg *userInfoConfig) (*userInfo, error) {
 		Bucket:       resp.User.Bucket,
 		BridgeUser:   resp.User.BridgeUser,
 		UserID:       resp.User.UserID,
+		NewToken:     resp.NewToken,
 	}
 
 	fs.Debugf(nil, "User info: rootFolderId=%s, bucket=%s",

--- a/backend/internxt/internxt.go
+++ b/backend/internxt/internxt.go
@@ -367,6 +367,25 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	f.bridgeUser = userInfo.BridgeUser
 	f.userID = userInfo.UserID
 
+	// The refresh endpoint rotates the token on every successful call.
+	// Persist the rotated token so routine use keeps the stored token
+	// current; otherwise it keeps its original expiry and accounts that
+	// cannot re-login non-interactively (2FA) eventually strand.
+	if userInfo.NewToken != "" {
+		if rotated, rotErr := jwtToOAuth2Token(userInfo.NewToken); rotErr != nil {
+			fs.Debugf(f, "Not adopting rotated token from user info: %v", rotErr)
+		} else {
+			// Use the rotated token for this session even if saving it
+			// fails; persistence is best-effort.
+			f.cfg.Token = userInfo.NewToken
+			if putErr := oauthutil.PutToken(name, m, rotated, false); putErr != nil {
+				fs.Debugf(f, "Failed to save rotated token from user info: %v", putErr)
+			} else {
+				fs.Debugf(f, "Persisted rotated token from user info, expiry: %v", rotated.Expiry)
+			}
+		}
+	}
+
 	f.features = (&fs.Features{
 		CanHaveEmptyDirectories: true,
 	}).Fill(ctx, f)


### PR DESCRIPTION
#### What does this change do?

Internxt's refresh endpoint returns a rotated token with a fresh expiry on every successful call. `getUserInfo` (called from `NewFs`) received that token and discarded it, so routine use never extended the stored token's life. Once the stored token aged out, accounts with 2FA enabled could not recover non-interactively (see #9583) and required a manual `rclone config reconnect`; for unattended use (mounts, scheduled syncs) that is a hard stop.

This change carries `resp.NewToken` out of `getUserInfo` and persists it in `NewFs` via the same `jwtToOAuth2Token` + `oauthutil.PutToken` path that `refreshJWTToken` already uses, keeping `f.cfg.Token` in sync (the same pattern as `refreshOrReLogin`).

**Behavior change to review consciously:** every successful `NewFs` on an internxt remote now saves the rotated token to the config (`PutToken` writes only-if-changed, and the token changes on each call). This moves a config write from the rare refresh path to the common path. If you would rather gate this behind an opt-in option, I am happy to rework it.

Design note: `getUserInfo` deliberately has a narrow signature with no access to `(name, m)`, so persistence happens at its only call site (`NewFs`) rather than widening the helper's API.

Test evidence (live account, 2FA enabled):

- Stock v1.74.3: a successful `rclone lsd` left the stored token's decoded `iat` unchanged (rotated server-side, discarded client-side).
- With this patch: one `rclone lsd` moved the stored token's decoded `iat` from `14:15:06Z` to `17:13:41Z` (the exact run time), `exp` moved forward accordingly, and the debug log shows `Persisted rotated token from user info, expiry: ...`.
- A concurrently running external token refresher coexisted cleanly, as expected from `TokenSource.reReadToken` picking up concurrent updates.

Verified with `gofmt`, `go vet`, and a full build.

#### Linked issue

Fixes #9584 (companion issue: #9583)

#### For new or changed backends

Not a new backend; a 17-line fix to the existing internxt backend's token handling. Verified against a live account as described above. Can run the internxt integration subset if required.
