### PR TITLE
zoho: fix large file overwrite creating a duplicate instead of replacing - fixes #9585

### DIFF
--- a/backend/zoho/zoho.go
+++ b/backend/zoho/zoho.go
@@ -1169,11 +1169,13 @@ func (f *Fs) uploadLargeFile(ctx context.Context, name string, parent string, si
 		ContentType:   "application/octet-stream",
 		Options:       options,
 		ExtraHeaders: map[string]string{
-			"x-filename":          url.QueryEscape(name),
-			"x-parent_id":         parent,
-			"override-name-exist": "true",
-			"upload-id":           uuid.New().String(),
-			"x-streammode":        "1",
+			"x-filename":  url.QueryEscape(name),
+			"x-parent_id": parent,
+			// Must carry the x- prefix; without it the stream endpoint ignores
+			// the flag and creates a duplicate instead of overwriting.
+			"x-override-name-exist": "true",
+			"upload-id":             uuid.New().String(),
+			"x-streammode":          "1",
 		},
 	}
 


### PR DESCRIPTION
#### What does this change do?

Overwriting a file of 10 MiB or larger on Zoho WorkDrive created a duplicate instead of
replacing it. `uploadLargeFile` (`POST /stream/upload`, used at/above `--zoho-upload-cutoff`,
default 10 MiB) sent the overwrite flag as the un-prefixed header `override-name-exist`, but the
stream endpoint expects the `x-`-prefixed `x-override-name-exist` - like its siblings
`x-filename`, `x-parent_id` and `x-streammode`. The un-prefixed header is ignored, so Zoho
auto-renamed the new upload to `<name> <DD-MM-YYYY HH:MM:SS:mmm>.<ext>` and left the original in
place. rclone still logged `Copied (replaced existing)` (it builds the returned object under the
requested name), so the divergence from the server was silent - a data-integrity bug. The small
`upload` path is unaffected: it passes `override-name-exist` as a query parameter, which that
endpoint accepts.

The fix renames the header key to `x-override-name-exist` so the overwrite is honoured and the
existing file is replaced in place. On the wire the overwrite request changes from
`Override-Name-Exist: true` to `X-Override-Name-Exist: true`. This has been present since
v1.69.0.

#### Linked issue

Fixes #9585

#### For new or changed backends

Backend: **zoho** (data-path change: large-file upload / overwrite).

`go run ./fstest/test_all -backends zoho` on this branch (2026-07-08), passing on the first try:

```
"go test -v -timeout 2h0m0s -remote TestZoho:" - Finished OK in 8m6.451902s (try 1/5)
PASS: All tests finished OK in 8m6.4980206s
ok  	github.com/rclone/rclone/backend/zoho	483.201s
```

That is 94 PASS / 31 SKIP / 0 FAIL for the backend/zoho package. `TestFsPutChunked` is one of
the skips (`*zoho.Fs does not implement SetUploadChunkSizer`), so `test_all` does not exercise
the >= 10 MiB upload path itself; the before/after below is the coverage for this fix. A
`TestZoho:` entry already exists on the integration server (`fstest/test_all/config.yaml`).

Live before/after on `TestZoho:` (EU) with an 11 MiB file (>= the 10 MiB large-file cutoff):
create, then overwrite. The overwrite changes the content **and** the size (`printf 'X' >>`),
because a same-size change is skipped by rclone's size+modtime check and never re-uploads:

```shell
head -c 11000000 /dev/urandom > big.bin
rclone copy big.bin TestZoho:rclone-largefile-overwrite/            # create
printf 'X' >> big.bin
rclone copy big.bin TestZoho:rclone-largefile-overwrite/ -v         # overwrite
rclone lsl TestZoho:rclone-largefile-overwrite/
```

**Before** (master `2d6d0da37`) - the overwrite creates a duplicate, original left stale:

```text
2026/07/08 17:52:51 INFO  : big.bin: Copied (replaced existing)
$ rclone lsl TestZoho:rclone-largefile-overwrite/
 11000001 2026-07-08 17:52:56.674000000 big 08-07-2026 17:52:54:744.bin
 11000000 2026-07-08 17:52:16.563000000 big.bin
```

**After** (this change) - the overwrite replaces in place, one file, correct content:

```text
2026/07/08 17:56:59 INFO  : big.bin: Copied (replaced existing)
$ rclone lsl TestZoho:rclone-largefile-overwrite/
 11000001 2026-07-08 17:57:04.789000000 big.bin
$ rclone check big.bin TestZoho:rclone-largefile-overwrite/ --download
NOTICE: zoho root 'rclone-largefile-overwrite': 0 differences found
NOTICE: zoho root 'rclone-largefile-overwrite': 1 matching files
```

No unit test is added: the change is a header-key rename, and the backend has no HTTP-mock
harness for the upload path, so it is covered by the live before/after above and the clean
`test_all` run rather than a unit test. Happy to add an `httptest`-based test asserting the
request header if you'd prefer one.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
