### PR TITLE
seafile: don't implement IDer as the id is a content hash not a unique ID

### DIFF
--- a/backend/seafile/object.go
+++ b/backend/seafile/object.go
@@ -12,7 +12,6 @@ import (
 // Object describes a seafile object (also commonly called a file)
 type Object struct {
 	fs            *Fs       // what this object is part of
-	id            string    // internal ID of object
 	remote        string    // The remote path (full path containing library name if target at root)
 	pathInLibrary string    // Path of the object without the library name
 	size          int64     // size of the object
@@ -107,7 +106,6 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		}
 		// Set the properties from the upload back to the object
 		o.size = uploaded.Size
-		o.id = uploaded.ID
 
 		return nil
 	}
@@ -117,11 +115,4 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 // Remove this object
 func (o *Object) Remove(ctx context.Context) error {
 	return o.fs.deleteFile(ctx, o.libraryID, o.pathInLibrary)
-}
-
-// ==================== Optional Interface fs.IDer ====================
-
-// ID returns the ID of the Object if known, or "" if not
-func (o *Object) ID() string {
-	return o.id
 }

--- a/backend/seafile/seafile.go
+++ b/backend/seafile/seafile.go
@@ -550,7 +550,6 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	o := &Object{
 		fs:            f,
 		libraryID:     libraryID,
-		id:            fileDetails.ID,
 		remote:        remote,
 		pathInLibrary: filePath,
 		modTime:       modTime,
@@ -1239,7 +1238,6 @@ func (f *Fs) buildDirEntries(parentPath, libraryID, parentPathInLibrary string, 
 		} else if entry.Type == api.FileTypeFile {
 			object := &Object{
 				fs:            f,
-				id:            entry.ID,
 				remote:        filePath,
 				pathInLibrary: filePathInLibrary,
 				size:          entry.Size,
@@ -1359,5 +1357,4 @@ var (
 	_ fs.UserInfoer   = &Fs{}
 	_ fs.Shutdowner   = &Fs{}
 	_ fs.Object       = &Object{}
-	_ fs.IDer         = &Object{}
 )


### PR DESCRIPTION
Seafile returns a content-addressed `id` (a git-like hash of the file contents) rather than a unique per-object identifier. Two different files with identical contents get the same `id`, even on different servers (see #8300 for API examples from the thread).

`operations.SameObject` assumes IDs uniquely identify an object, so syncing between Seafile remotes treated two distinct but identical-content files as the same object. The guard in `NeedTransfer`, `if Equal(ctx, src, dst) && !SameObject(src, dst)`, then evaluated to false for unchanged files (`Equal` true because sizes matched, `SameObject` true because ids matched), so rclone re-uploaded them on every sync.

Seafile has no modtime and no usable content hash, so dropping the `IDer` implementation makes `SameObject` fall back to path comparison and lets unchanged files be skipped — the backend-local version of what @nielash suggested in the thread ("better not to implement IDer for backends that don't truly have unique IDs"). Seafile is not `CaseInsensitive`, so this does not affect the NFC/NFD rename workaround that also relies on `SameObject`. Trade-off: `lsf --format i`/`lsjson` no longer report a (misleading, non-unique) file ID for Seafile. Directory `SetID` is left in place as directories do not pass through `SameObject`.

Validation: full `go build ./...` passes, `go vet` clean on the touched packages, seafile unit tests and `fs/operations` tests pass. I run a self-hosted Seafile server and will follow up with a live before/after sync log against it.

Fixes #8300