### PR TITLE
filter: add --files-from-strict flag support

### DIFF
--- a/docs/content/filtering.md
+++ b/docs/content/filtering.md
@@ -273,7 +273,9 @@ Any path/file included at that stage is processed by the rclone
 command.
 
 `--files-from`, `--files-from-raw` and `--files-from0` flags
-over-ride and cannot be combined with other filter options.
+over-ride and cannot be combined with other filter options, with the
+exception of the flag `--files-from-strict`, which makes the operation
+fail if at least one of the files does not exist.
 
 To see the internal combined rule list, in regular expression form,
 for a command add the `--dump filters` flag. Running an rclone command
@@ -733,6 +735,11 @@ E.g. to copy files listed by `find`:
 ```console
 find /path -print0 | rclone copy --files-from0 - / remote:path
 ```
+
+### `--files-from-strict` - Require all listed files to exist
+
+This is an optional flag that can be combined with `--files-from`.
+This ensures that each supplied file exists in the source filesystem.
 
 ### `--ignore-case` - make searches case insensitive
 

--- a/fs/filter/filter.go
+++ b/fs/filter/filter.go
@@ -51,6 +51,11 @@ var OptionsInfo = fs.Options{{
 	Help:    "Read list of source-file names from file using NUL as separator (use - to read from stdin)",
 	Groups:  "Filter",
 }, {
+	Name:    "files_from_strict",
+	Default: false,
+	Help:    "Require all listed files to exist",
+	Groups:  "Filter",
+}, {
 	Name:    "min_age",
 	Default: fs.DurationOff,
 	Help:    "Only transfer files older than this in s or suffix ms|s|m|h|d|w|M|y",
@@ -145,19 +150,20 @@ var OptionsInfo = fs.Options{{
 
 // Options configures the filter
 type Options struct {
-	DeleteExcluded bool          `config:"delete_excluded"`
-	RulesOpt                     // embedded so we don't change the JSON API
-	ExcludeFile    []string      `config:"exclude_if_present"`
-	FilesFrom      []string      `config:"files_from"`
-	FilesFromRaw   []string      `config:"files_from_raw"`
-	FilesFrom0     []string      `config:"files_from0"`
-	MetaRules      RulesOpt      `config:"metadata"`
-	MinAge         fs.Duration   `config:"min_age"`
-	MaxAge         fs.Duration   `config:"max_age"`
-	MinSize        fs.SizeSuffix `config:"min_size"`
-	MaxSize        fs.SizeSuffix `config:"max_size"`
-	IgnoreCase     bool          `config:"ignore_case"`
-	HashFilter     string        `config:"hash_filter"`
+	DeleteExcluded  bool          `config:"delete_excluded"`
+	RulesOpt                      // embedded so we don't change the JSON API
+	ExcludeFile     []string      `config:"exclude_if_present"`
+	FilesFrom       []string      `config:"files_from"`
+	FilesFromRaw    []string      `config:"files_from_raw"`
+	FilesFrom0      []string      `config:"files_from0"`
+	FilesFromStrict bool          `config:"files_from_strict"`
+	MetaRules       RulesOpt      `config:"metadata"`
+	MinAge          fs.Duration   `config:"min_age"`
+	MaxAge          fs.Duration   `config:"max_age"`
+	MinSize         fs.SizeSuffix `config:"min_size"`
+	MaxSize         fs.SizeSuffix `config:"max_size"`
+	IgnoreCase      bool          `config:"ignore_case"`
+	HashFilter      string        `config:"hash_filter"`
 }
 
 func init() {
@@ -647,8 +653,11 @@ func (f *Filter) MakeListR(ctx context.Context, NewObject func(ctx context.Conte
 				var entries = make(fs.DirEntries, 1)
 				for remote := range remotes {
 					entries[0], err = NewObject(gCtx, remote)
-					if err == fs.ErrorObjectNotFound {
+					if !f.Opt.FilesFromStrict && err == fs.ErrorObjectNotFound {
 						// Skip files that are not found
+					} else if err == fs.ErrorObjectNotFound {
+						fs.Errorf(remote, "--files-from: %v", err)
+						return err
 					} else if err != nil {
 						// Count and log the error but carry on so that one
 						// unreadable file (e.g. permission denied) doesn't stop

--- a/fs/filter/filter.go
+++ b/fs/filter/filter.go
@@ -51,6 +51,11 @@ var OptionsInfo = fs.Options{{
 	Help:    "Read list of source-file names from file using NUL as separator (use - to read from stdin)",
 	Groups:  "Filter",
 }, {
+	Name:    "files_from_strict",
+	Default: false,
+	Help:    "Require all listed files to exist",
+	Groups:  "Filter",
+}, {
 	Name:    "min_age",
 	Default: fs.DurationOff,
 	Help:    "Only transfer files older than this in s or suffix ms|s|m|h|d|w|M|y",
@@ -145,19 +150,20 @@ var OptionsInfo = fs.Options{{
 
 // Options configures the filter
 type Options struct {
-	DeleteExcluded bool          `config:"delete_excluded"`
-	RulesOpt                     // embedded so we don't change the JSON API
-	ExcludeFile    []string      `config:"exclude_if_present"`
-	FilesFrom      []string      `config:"files_from"`
-	FilesFromRaw   []string      `config:"files_from_raw"`
-	FilesFrom0     []string      `config:"files_from0"`
-	MetaRules      RulesOpt      `config:"metadata"`
-	MinAge         fs.Duration   `config:"min_age"`
-	MaxAge         fs.Duration   `config:"max_age"`
-	MinSize        fs.SizeSuffix `config:"min_size"`
-	MaxSize        fs.SizeSuffix `config:"max_size"`
-	IgnoreCase     bool          `config:"ignore_case"`
-	HashFilter     string        `config:"hash_filter"`
+	DeleteExcluded  bool          `config:"delete_excluded"`
+	RulesOpt                      // embedded so we don't change the JSON API
+	ExcludeFile     []string      `config:"exclude_if_present"`
+	FilesFrom       []string      `config:"files_from"`
+	FilesFromRaw    []string      `config:"files_from_raw"`
+	FilesFrom0      []string      `config:"files_from0"`
+	FilesFromStrict bool          `config:"files_from_strict"`
+	MetaRules       RulesOpt      `config:"metadata"`
+	MinAge          fs.Duration   `config:"min_age"`
+	MaxAge          fs.Duration   `config:"max_age"`
+	MinSize         fs.SizeSuffix `config:"min_size"`
+	MaxSize         fs.SizeSuffix `config:"max_size"`
+	IgnoreCase      bool          `config:"ignore_case"`
+	HashFilter      string        `config:"hash_filter"`
 }
 
 func init() {
@@ -647,8 +653,11 @@ func (f *Filter) MakeListR(ctx context.Context, NewObject func(ctx context.Conte
 				var entries = make(fs.DirEntries, 1)
 				for remote := range remotes {
 					entries[0], err = NewObject(gCtx, remote)
-					if err == fs.ErrorObjectNotFound {
+					if !f.Opt.FilesFromStrict && err == fs.ErrorObjectNotFound {
 						// Skip files that are not found
+					} else if f.Opt.FilesFromStrict && err != nil {
+						fs.Errorf(remote, "--files-from: %v", err)
+						return err
 					} else if err != nil {
 						// Count and log the error but carry on so that one
 						// unreadable file (e.g. permission denied) doesn't stop

--- a/fs/filter/filter_test.go
+++ b/fs/filter/filter_test.go
@@ -460,6 +460,57 @@ func TestNewFilterMakeListR(t *testing.T) {
 	assert.Equal(t, want, listRObjects)
 }
 
+func TestFilesFromStrictFilterMakeListR(t *testing.T) {
+	f, err := NewFilter(nil)
+	f.Opt.FilesFromStrict = true
+	require.NoError(t, err)
+
+	// Add some files
+	for _, path := range []string{
+		"path/to/dir/file1.png",
+		"/path/to/dir/file2.png",
+		"/path/to/file3.png",
+		"/path/to/dir2/file4.png",
+		"notfound",
+	} {
+		err = f.AddFile(path)
+		require.NoError(t, err)
+	}
+
+	assert.Equal(t, 5, len(f.files))
+
+	// NewObject function for MakeListR
+	newObjects := FilesMap{}
+	var newObjectMu sync.Mutex
+	NewObject := func(ctx context.Context, remote string) (fs.Object, error) {
+		newObjectMu.Lock()
+		defer newObjectMu.Unlock()
+		if remote == "notfound" {
+			return nil, fs.ErrorObjectNotFound
+		}
+		newObjects[remote] = struct{}{}
+		return mockobject.New(remote), nil
+	}
+
+	// Callback for ListRFn
+	listRObjects := FilesMap{}
+	var callbackMu sync.Mutex
+	listRcallback := func(entries fs.DirEntries) error {
+		callbackMu.Lock()
+		defer callbackMu.Unlock()
+		for _, entry := range entries {
+			listRObjects[entry.Remote()] = struct{}{}
+		}
+		return nil
+	}
+
+	// Make the listR and call it
+	listR := f.MakeListR(context.Background(), NewObject)
+	err = listR(context.Background(), "", listRcallback)
+
+	require.Error(t, err, "expected: fs.ErrorObjectNotFound, got: %v", err)
+}
+
 func TestNewFilterMinSize(t *testing.T) {
 	f, err := NewFilter(nil)
 	require.NoError(t, err)

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -66,9 +66,9 @@ type Marcher interface {
 // Note: this will flag filter-aware backends on the source side
 func (m *March) init(ctx context.Context) {
 	ci := fs.GetConfig(ctx)
-	m.srcListDir = m.makeListDir(ctx, m.Fsrc, m.SrcIncludeAll, m.srcKey)
+	m.srcListDir = m.makeListDir(ctx, m.Fsrc, m.SrcIncludeAll, m.srcKey, true)
 	if !m.NoTraverse {
-		m.dstListDir = m.makeListDir(ctx, m.Fdst, m.DstIncludeAll, m.dstKey)
+		m.dstListDir = m.makeListDir(ctx, m.Fdst, m.DstIncludeAll, m.dstKey, false)
 	}
 	// Now create the matching transform
 	// ..normalise the UTF8 first
@@ -129,11 +129,12 @@ func (m *March) dstKey(entry fs.DirEntry) string {
 // ensure listings are cancelled when the march context is cancelled.
 //
 // Note: this will optionally flag filter-aware backends!
-func (m *March) makeListDir(ctx context.Context, f fs.Fs, includeAll bool, keyFn list.KeyFn) listDirFn {
+func (m *March) makeListDir(ctx context.Context, f fs.Fs, includeAll bool, keyFn list.KeyFn, isSource bool) listDirFn {
 	ci := fs.GetConfig(ctx)
 	fi := filter.GetConfig(ctx)
 	if !(ci.UseListR && f.Features().ListR != nil) && // !--fast-list active and
-		!(ci.NoTraverse && fi.HaveFilesFrom()) { // !(--files-from and --no-traverse)
+		!(ci.NoTraverse && fi.HaveFilesFrom()) && // !(--files-from and --no-traverse)
+		!(isSource && fi.Opt.FilesFromStrict && fi.HaveFilesFrom()) { // force the files-from listing path on the source so --files-from-strict can verify each entry
 		return func(ctx context.Context, dir string, callback fs.ListRCallback) (err error) {
 			dirCtx := filter.SetUseFilter(ctx, f.Features().FilterAware && !includeAll) // make filter-aware backends constrain List
 			return list.DirSortedFn(dirCtx, f, includeAll, dir, callback, keyFn)

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -66,9 +66,9 @@ type Marcher interface {
 // Note: this will flag filter-aware backends on the source side
 func (m *March) init(ctx context.Context) {
 	ci := fs.GetConfig(ctx)
-	m.srcListDir = m.makeListDir(ctx, m.Fsrc, m.SrcIncludeAll, m.srcKey)
+	m.srcListDir = m.makeListDir(ctx, m.Fsrc, m.SrcIncludeAll, m.srcKey, true)
 	if !m.NoTraverse {
-		m.dstListDir = m.makeListDir(ctx, m.Fdst, m.DstIncludeAll, m.dstKey)
+		m.dstListDir = m.makeListDir(ctx, m.Fdst, m.DstIncludeAll, m.dstKey, false)
 	}
 	// Now create the matching transform
 	// ..normalise the UTF8 first
@@ -129,11 +129,12 @@ func (m *March) dstKey(entry fs.DirEntry) string {
 // ensure listings are cancelled when the march context is cancelled.
 //
 // Note: this will optionally flag filter-aware backends!
-func (m *March) makeListDir(ctx context.Context, f fs.Fs, includeAll bool, keyFn list.KeyFn) listDirFn {
+func (m *March) makeListDir(ctx context.Context, f fs.Fs, includeAll bool, keyFn list.KeyFn, isSource bool) listDirFn {
 	ci := fs.GetConfig(ctx)
 	fi := filter.GetConfig(ctx)
 	if !(ci.UseListR && f.Features().ListR != nil) && // !--fast-list active and
-		!(ci.NoTraverse && fi.HaveFilesFrom()) { // !(--files-from and --no-traverse)
+		!(ci.NoTraverse && fi.HaveFilesFrom()) && // !(--files-from and --no-traverse)
+		!(isSource && fi.Opt.FilesFromStrict && fi.HaveFilesFrom()) {
 		return func(ctx context.Context, dir string, callback fs.ListRCallback) (err error) {
 			dirCtx := filter.SetUseFilter(ctx, f.Features().FilterAware && !includeAll) // make filter-aware backends constrain List
 			return list.DirSortedFn(dirCtx, f, includeAll, dir, callback, keyFn)

--- a/fs/walk/walk.go
+++ b/fs/walk/walk.go
@@ -582,7 +582,7 @@ func NewDirTree(ctx context.Context, f fs.Fs, path string, includeAll bool, maxL
 	ci := fs.GetConfig(ctx)
 	fi := filter.GetConfig(ctx)
 	// if --no-traverse and --files-from build DirTree just from files
-	if ci.NoTraverse && fi.HaveFilesFrom() {
+	if (ci.NoTraverse || fi.Opt.FilesFromStrict) && fi.HaveFilesFrom() {
 		return walkRDirTree(ctx, f, path, includeAll, maxLevel, fi.MakeListR(ctx, f.NewObject))
 	}
 	// if have ListR; and recursing; and not using --files-from; then build a DirTree with ListR


### PR DESCRIPTION
#### What does this change do?

adds --files-from-strict flag support to force an error on missing files from source

#### Linked issue

Fixes #7842

#### Checklist

- [X] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] This Pull Request is ready for review.
