### PR TITLE
docs: clarify --password-command quoting for a path with spaces

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -2444,9 +2444,9 @@ setting the config password for the first time.
 The argument to this should be a command with a space separated list
 of arguments. If one of the arguments has a space in then enclose it
 in `"`, if you want a literal `"` in an argument then enclose the
-argument in `"` and double the `"`. See [CSV encoding](https://godoc.org/encoding/csv)
-for more info. This includes the command itself: if the path to the
-executable contains a space, it must be quoted too.
+argument in `"` and double the `"`. This includes the command itself:
+if the path to the executable contains a space, it must be quoted too.
+See [CSV encoding](https://godoc.org/encoding/csv) for more info.
 
 Eg
 

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -2445,7 +2445,8 @@ The argument to this should be a command with a space separated list
 of arguments. If one of the arguments has a space in then enclose it
 in `"`, if you want a literal `"` in an argument then enclose the
 argument in `"` and double the `"`. See [CSV encoding](https://godoc.org/encoding/csv)
-for more info.
+for more info. This includes the command itself: if the path to the
+executable contains a space, it must be quoted too.
 
 Eg
 
@@ -2453,6 +2454,7 @@ Eg
 --password-command "echo hello"
 --password-command 'echo "hello with space"'
 --password-command 'echo "hello with ""quotes"" and space"'
+--password-command '"/path with a space/get-password.sh"'
 ```
 
 Note that when changing the configuration password the environment


### PR DESCRIPTION
#### What does this change do?

Clarifies that the `--password-command` CSV/space-quoting rules apply to the command (the executable) itself, not only to its arguments: if the path to the executable contains a space it must be quoted. Adds an example showing a quoted path.

In #9596 a `--password-command` pointing at a script whose path contained a space failed with `fork/exec /Users/.../Mobile: no such file or directory`. The value is a `SpaceSepList`, so it is CSV-split on the space before `exec.Command` runs it. The docs already describe the quoting, but every example only quotes an *argument* with a space, never the command path — so this case wasn't obvious.

#### Linked issue

#9596

#### For new or changed backends

n/a — documentation only.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
