### PR TITLE
fs: fix --no-check-dest with --backup-dir or --suffix losing old file versions

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -2306,6 +2306,7 @@ This means that:
 - files are always transferred
 - this can cause duplicates on remotes which allow it (e.g. Google Drive)
 - `--retries 1` is recommended otherwise you'll transfer everything again on a retry
+- it can't be used with `sync`, `--immutable`, `--backup-dir` or `--suffix`
 
 This flag is useful to minimise the transactions if you know that none
 of the files are on the destination.

--- a/fs/operations/copy_test.go
+++ b/fs/operations/copy_test.go
@@ -189,6 +189,33 @@ func TestCopyFileBackupDir(t *testing.T) {
 	r.CheckRemoteItems(t, file1old, file1)
 }
 
+// Test --no-check-dest is rejected with --backup-dir and with --suffix
+func TestCopyFileNoCheckDestBackupDir(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	r := fstest.NewRun(t)
+
+	ci.NoCheckDest = true
+	ci.BackupDir = r.FremoteName + "/backup"
+
+	file1 := r.WriteFile("dst/file1", "file1 contents", t1)
+	r.CheckLocalItems(t, file1)
+
+	file1old := r.WriteObject(ctx, "dst/file1", "file1 contents old", t1)
+	r.CheckRemoteItems(t, file1old)
+
+	err := operations.CopyFile(ctx, r.Fremote, r.Flocal, file1.Path, file1.Path)
+	require.EqualError(t, err, "can't use --no-check-dest with --backup-dir")
+	r.CheckRemoteItems(t, file1old)
+
+	ci.BackupDir = ""
+	ci.Suffix = ".bak"
+
+	err = operations.CopyFile(ctx, r.Fremote, r.Flocal, file1.Path, file1.Path)
+	require.EqualError(t, err, "can't use --no-check-dest with --suffix")
+	r.CheckRemoteItems(t, file1old)
+}
+
 // Test with CompareDest set
 func TestCopyFileCompareDest(t *testing.T) {
 	ctx := context.Background()

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -2018,6 +2018,16 @@ func MoveCaseInsensitive(ctx context.Context, fdst fs.Fs, fsrc fs.Fs, dstFileNam
 // moveOrCopyFile moves or copies a single file possibly to a new name
 func moveOrCopyFile(ctx context.Context, fdst fs.Fs, fsrc fs.Fs, dstFileName string, srcFileName string, cp bool, allowOverlap bool) (err error) {
 	ci := fs.GetConfig(ctx)
+	if ci.NoCheckDest {
+		// Backing up the destination file needs the destination
+		// object, which --no-check-dest never fetches
+		if ci.BackupDir != "" {
+			return errors.New("can't use --no-check-dest with --backup-dir")
+		}
+		if ci.Suffix != "" {
+			return errors.New("can't use --no-check-dest with --suffix")
+		}
+	}
 	logger, usingLogger := GetLogger(ctx)
 	dstFilePath := path.Join(fdst.Root(), dstFileName)
 	srcFilePath := path.Join(fsrc.Root(), srcFileName)

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -233,8 +233,13 @@ func newSyncCopyMove(ctx context.Context, fdst, fsrc fs.Fs, deleteMode fs.Delete
 		if ci.Immutable {
 			return nil, errors.New("can't use --no-check-dest with --immutable")
 		}
-		if s.backupDir != nil {
+		// s.backupDir isn't set until later in the constructor, so
+		// check the config
+		if ci.BackupDir != "" {
 			return nil, errors.New("can't use --no-check-dest with --backup-dir")
+		}
+		if ci.Suffix != "" {
+			return nil, errors.New("can't use --no-check-dest with --suffix")
 		}
 	}
 	if s.trackRenames {

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -245,6 +245,54 @@ func TestCopyNoTraverseDeadlock(t *testing.T) {
 	r.CheckRemoteItems(t, items...)
 }
 
+// Test --no-check-dest with --backup-dir is rejected, as --no-check-dest
+// never reads the destination so no backup can be made
+func TestCopyNoCheckDestBackupDir(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	r := fstest.NewRun(t)
+
+	ci.NoCheckDest = true
+	ci.BackupDir = r.FremoteName + "/backup"
+
+	file1 := r.WriteFile("existing", "potatoes", t1)
+	r.CheckLocalItems(t, file1)
+	file2 := r.WriteObject(ctx, "dst/existing", "potato", t2)
+	r.CheckRemoteItems(t, file2)
+
+	fdst, err := fs.NewFs(ctx, r.FremoteName+"/dst")
+	require.NoError(t, err)
+
+	err = CopyDir(ctx, fdst, r.Flocal, false)
+	require.EqualError(t, err, "can't use --no-check-dest with --backup-dir")
+
+	// Check the destination file was not overwritten
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
+}
+
+// Test --no-check-dest with --suffix is rejected - see above
+func TestCopyNoCheckDestSuffix(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	r := fstest.NewRun(t)
+
+	ci.NoCheckDest = true
+	ci.Suffix = ".bak"
+
+	file1 := r.WriteFile("existing", "potatoes", t1)
+	r.CheckLocalItems(t, file1)
+	file2 := r.WriteObject(ctx, "existing", "potato", t2)
+	r.CheckRemoteItems(t, file2)
+
+	err := CopyDir(ctx, r.Fremote, r.Flocal, false)
+	require.EqualError(t, err, "can't use --no-check-dest with --suffix")
+
+	// Check the destination file was not overwritten
+	r.CheckLocalItems(t, file1)
+	r.CheckRemoteItems(t, file2)
+}
+
 // Now with --check-first
 func TestCopyCheckFirst(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
#### What is the problem being solved?

Since `--no-check-dest` was added in 207474ab (v1.50) it has intended to reject `--backup-dir`:

```go
if s.backupDir != nil {
    return nil, errors.New("can't use --no-check-dest with --backup-dir")
}
```

but `s.backupDir` is only set further down the constructor, so the check has never fired. The combination runs without complaint — and because `--no-check-dest` never reads the destination, `MoveBackupDir` (which needs the destination object) can never run: existing destination files are overwritten in place and nothing reaches the backup dir (or gets the `--suffix` rename). The old versions the user asked to keep are silently lost. Proven on master: `rclone copy /src remote:dst --no-check-dest --backup-dir remote:bak` overwrites `dst/existing` and leaves the backup dir empty, with no error.

#### What is the fix

Check `ci.BackupDir`/`ci.Suffix` directly, so the intended error fires like the neighbouring `--immutable` check. `--suffix` alone is rejected too since it enables the same backup machinery. The single-file path (`copyto`/`moveto`), which had no check at all, gets the same guard.

#### Testing

New tests fail before the fix (combination silently succeeds, destination overwritten, backup dir never created) and pass after. Full `fs/sync` and `fs/operations` suites pass locally; gofmt/go vet clean.

#### Checklist

I found this while reading the sync code, not from an issue report. This fix was written with AI assistance (Claude); I have reviewed and tested every line.
