### PR TITLE
mount: properly use the _filter and _config parameters when called from RC

### DIFF
--- a/backend/archive/archive.go
+++ b/backend/archive/archive.go
@@ -34,6 +34,7 @@ import (
 	"github.com/rclone/rclone/fs/cache"
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/configstruct"
+	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fs/fspath"
 	"github.com/rclone/rclone/fs/hash"
 )
@@ -94,6 +95,15 @@ type archive struct {
 	f        fs.Fs             // the archive Fs, may be nil
 }
 
+var getArchiveFilter = sync.OnceValues(func() (*filter.Filter, error) {
+	return filter.NewFilter(&filter.Options{
+		MinAge:  fs.DurationOff,
+		MaxAge:  fs.DurationOff,
+		MinSize: -1,
+		MaxSize: -1,
+	})
+})
+
 // If remote is an archive then return it otherwise return nil
 func findArchive(remote string) *archive {
 	// FIXME use something faster than linear search?
@@ -144,7 +154,11 @@ func (a *archive) init(ctx context.Context, f fs.Fs) (fs.Fs, error) {
 	if a.f != nil {
 		return a.f, nil
 	}
-	newFs, err := a.archiver.New(ctx, f, a.remote, a.prefix, a.root)
+	noFilter, err := getArchiveFilter()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create archive filter: %w", err)
+	}
+	newFs, err := a.archiver.New(filter.ReplaceConfig(ctx, noFilter), f, a.remote, a.prefix, a.root)
 	if err != nil && err != fs.ErrorIsFile {
 		return nil, fmt.Errorf("failed to create archive %q: %w", a.remote, err)
 	}

--- a/backend/archive/archive_internal_test.go
+++ b/backend/archive/archive_internal_test.go
@@ -3,6 +3,7 @@
 package archive
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"fmt"
@@ -180,6 +181,32 @@ func testArchive(t *testing.T, archiveName string, archiveFn func(t *testing.T, 
 	// Now check the level above
 	checkTree(ctx, "Root", t, ":archive:"+output, inputRoot, checkFiles)
 	// run(t, "cp", "-a", inputRoot, output, "/tmp/test-"+archiveName)
+}
+
+func TestArchiveFilterDoesNotHideContainer(t *testing.T) {
+	archivePath := filepath.Join(t.TempDir(), "test.zip")
+	archiveFile, err := os.Create(archivePath)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = archiveFile.Close()
+	})
+	zipWriter := zip.NewWriter(archiveFile)
+	entry, err := zipWriter.Create("included.txt")
+	require.NoError(t, err)
+	_, err = entry.Write([]byte("included"))
+	require.NoError(t, err)
+	require.NoError(t, zipWriter.Close())
+	require.NoError(t, archiveFile.Close())
+
+	ctx, fi := filter.AddConfig(context.Background())
+	require.NoError(t, fi.AddRule("+ *.txt"))
+	require.NoError(t, fi.AddRule("- *"))
+
+	archiveFs, err := cache.Get(ctx, ":archive:"+archivePath)
+	require.NoError(t, err)
+	obj, err := archiveFs.NewObject(ctx, "included.txt")
+	require.NoError(t, err)
+	assert.Equal(t, "included", fstests.ReadObject(ctx, t, obj, -1))
 }
 
 // Make sure we have the executable named

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -366,6 +366,10 @@ func NewMountCommand(commandName string, hidden bool, mount MountFn) *cobra.Comm
 
 // Mount the remote at mountpoint
 func (m *MountPoint) Mount() (mountDaemon *os.Process, err error) {
+	return m.mount(context.Background())
+}
+
+func (m *MountPoint) mount(ctx context.Context) (mountDaemon *os.Process, err error) {
 
 	// Ensure sensible defaults
 	m.SetVolumeName(m.MountOpt.VolumeName)
@@ -379,7 +383,7 @@ func (m *MountPoint) Mount() (mountDaemon *os.Process, err error) {
 		}
 	}
 
-	m.VFS = vfs.New(context.Background(), m.Fs, &m.VFSOpt)
+	m.VFS = vfs.New(ctx, m.Fs, &m.VFSOpt)
 
 	var actualMountpoint string
 	m.ErrChan, m.UnmountFn, actualMountpoint, err = m.MountFn(m.VFS, m.MountPoint, &m.MountOpt)

--- a/cmd/mountlib/mount.go
+++ b/cmd/mountlib/mount.go
@@ -383,7 +383,10 @@ func (m *MountPoint) mount(ctx context.Context) (mountDaemon *os.Process, err er
 		}
 	}
 
-	m.VFS = vfs.New(ctx, m.Fs, &m.VFSOpt)
+	m.VFS, err = vfs.NewWithError(ctx, m.Fs, &m.VFSOpt)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create VFS: %w", err)
+	}
 
 	var actualMountpoint string
 	m.ErrChan, m.UnmountFn, actualMountpoint, err = m.MountFn(m.VFS, m.MountPoint, &m.MountOpt)

--- a/cmd/mountlib/rc.go
+++ b/cmd/mountlib/rc.go
@@ -135,7 +135,7 @@ func mountRc(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 	}
 
 	mnt := NewMountPoint(mountFn, mountPoint, fdst, &mountOpt, &vfsOpt)
-	_, err = mnt.Mount()
+	_, err = mnt.mount(ctx)
 	if err != nil {
 		fs.Logf(nil, "mount FAILED: %v", err)
 		return nil, err

--- a/cmd/mountlib/rc_test.go
+++ b/cmd/mountlib/rc_test.go
@@ -48,6 +48,9 @@ func TestRcMountContext(t *testing.T) {
 	localDir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(localDir, "included.txt"), []byte("included"), 0666))
 	require.NoError(t, os.WriteFile(filepath.Join(localDir, "excluded.txt"), []byte("excluded"), 0666))
+	hiddenDir := filepath.Join(localDir, "hidden")
+	require.NoError(t, os.Mkdir(hiddenDir, 0777))
+	require.NoError(t, os.WriteFile(filepath.Join(hiddenDir, ".hide"), nil, 0666))
 	mountPoint := t.TempDir()
 	in := rc.Params{
 		"fs":         localDir,
@@ -58,6 +61,7 @@ func TestRcMountContext(t *testing.T) {
 		},
 		"_filter": rc.Params{
 			"ExcludeRule": []string{"excluded.txt"},
+			"ExcludeFile": []string{".hide"},
 		},
 	}
 

--- a/cmd/mountlib/rc_test.go
+++ b/cmd/mountlib/rc_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sync"
 	"testing"
 	"time"
 
@@ -15,10 +16,72 @@ import (
 	"github.com/rclone/rclone/cmd/mountlib"
 	"github.com/rclone/rclone/fs/config/configfile"
 	"github.com/rclone/rclone/fs/rc"
+	"github.com/rclone/rclone/fs/rc/jobs"
 	"github.com/rclone/rclone/fstest/testy"
+	"github.com/rclone/rclone/vfs"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestRcMountContext(t *testing.T) {
+	ctx := context.Background()
+	configfile.Install()
+	mount := rc.Calls.Get("mount/mount")
+	require.NotNil(t, mount)
+	unmount := rc.Calls.Get("mount/unmount")
+	require.NotNil(t, unmount)
+
+	var mountedVFS *vfs.VFS
+	mountlib.AddRc("test-mount-context", func(VFS *vfs.VFS, _ string, _ *mountlib.Options) (<-chan error, func() error, string, error) {
+		mountedVFS = VFS
+		errChan := make(chan error, 1)
+		var once sync.Once
+		return errChan, func() error {
+			once.Do(func() {
+				VFS.Shutdown()
+				errChan <- nil
+			})
+			return nil
+		}, "", nil
+	})
+
+	localDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "included.txt"), []byte("included"), 0666))
+	require.NoError(t, os.WriteFile(filepath.Join(localDir, "excluded.txt"), []byte("excluded"), 0666))
+	mountPoint := t.TempDir()
+	in := rc.Params{
+		"fs":         localDir,
+		"mountPoint": mountPoint,
+		"mountType":  "test-mount-context",
+		"_config": rc.Params{
+			"Links": true,
+		},
+		"_filter": rc.Params{
+			"ExcludeRule": []string{"excluded.txt"},
+		},
+	}
+
+	mounted := false
+	t.Cleanup(func() {
+		if mounted {
+			_, _ = unmount.Fn(ctx, rc.Params{"mountPoint": mountPoint})
+		}
+	})
+	_, _, err := jobs.NewJob(ctx, mount.Fn, in)
+	require.NoError(t, err)
+	mounted = true
+	require.NotNil(t, mountedVFS)
+	assert.True(t, mountedVFS.Opt.Links)
+
+	entries, err := mountedVFS.ReadDir("")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "included.txt", entries[0].Name())
+
+	_, err = unmount.Fn(ctx, rc.Params{"mountPoint": mountPoint})
+	require.NoError(t, err)
+	mounted = false
+}
 
 func TestRc(t *testing.T) {
 	// Disable tests under macOS and the CI since they are locking up

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -199,10 +199,28 @@ var (
 // New creates a new VFS and root directory.  If opt is nil, then
 // DefaultOpt will be used.
 //
+// If the disk cache is already in use by an incompatible VFS, New logs the
+// error and disables caching for the new VFS.
+//
 // The ctx passed in is not used for cancellation but is used to find
 // the config in the context (if any) and filter config in the context
 // (if any).
 func New(ctx context.Context, f fs.Fs, opt *vfscommon.Options) *VFS {
+	vfs, err := NewWithError(ctx, f, opt)
+	if err == nil {
+		return vfs
+	}
+	fs.Errorf(f, "%v - disabling VFS cache", err)
+	fallbackOpt := vfscommon.Opt
+	if opt != nil {
+		fallbackOpt = *opt
+	}
+	fallbackOpt.CacheMode = vfscommon.CacheModeOff
+	vfs, _ = NewWithError(ctx, f, &fallbackOpt)
+	return vfs
+}
+
+func NewWithError(ctx context.Context, f fs.Fs, opt *vfscommon.Options) (*VFS, error) {
 	fsDir := fs.NewDir("", time.Now())
 	// Strip the ctx of any cancellation but copy the config across
 	newCtx := context.Background()
@@ -238,7 +256,15 @@ func New(ctx context.Context, f fs.Fs, opt *vfscommon.Options) *VFS {
 			fs.Debugf(f, "Reusing VFS from active cache")
 			activeVFS.inUse.Add(1)
 			cancel()
-			return activeVFS
+			return activeVFS, nil
+		}
+	}
+	if vfs.Opt.CacheMode > vfscommon.CacheModeOff {
+		for _, activeVFS := range active[configName] {
+			if activeVFS.Opt.CacheMode > vfscommon.CacheModeOff {
+				cancel()
+				return nil, fmt.Errorf("VFS cache for %q is already in use by an incompatible VFS", configName)
+			}
 		}
 	}
 	// Put the VFS into the active cache
@@ -283,7 +309,7 @@ func New(ctx context.Context, f fs.Fs, opt *vfscommon.Options) *VFS {
 	// This can take some time so do it after the Pin
 	vfs.SetCacheMode(vfs.Opt.CacheMode)
 
-	return vfs
+	return vfs, nil
 }
 
 // refresh the directory cache for all directories

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -220,6 +220,8 @@ func New(ctx context.Context, f fs.Fs, opt *vfscommon.Options) *VFS {
 	return vfs
 }
 
+// NewWithError creates a new VFS and returns an error if an incompatible active
+// VFS is already using the same disk cache.
 func NewWithError(ctx context.Context, f fs.Fs, opt *vfscommon.Options) (*VFS, error) {
 	fsDir := fs.NewDir("", time.Now())
 	// Strip the ctx of any cancellation but copy the config across

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -226,12 +226,15 @@ func New(ctx context.Context, f fs.Fs, opt *vfscommon.Options) *VFS {
 	// Fill out anything else
 	vfs.Opt.Init(ctx)
 
-	// Find a VFS with the same name and options and return it if possible
+	// Find a VFS with the same name, options and context and return it if possible
 	activeMu.Lock()
 	defer activeMu.Unlock()
 	configName := fs.ConfigString(f)
 	for _, activeVFS := range active[configName] {
-		if vfs.Opt == activeVFS.Opt {
+		if vfs.Opt == activeVFS.Opt &&
+			fs.GetConfig(vfs.ctx) == fs.GetConfig(activeVFS.ctx) &&
+			filter.GetConfig(vfs.ctx) == filter.GetConfig(activeVFS.ctx) &&
+			fs.IsRCRequest(vfs.ctx) == fs.IsRCRequest(activeVFS.ctx) {
 			fs.Debugf(f, "Reusing VFS from active cache")
 			activeVFS.inUse.Add(1)
 			cancel()

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/filter"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/vfs/vfscommon"
 	"github.com/stretchr/testify/assert"
@@ -153,6 +154,29 @@ func TestVFSNew(t *testing.T) {
 	vfs2.Shutdown()
 
 	checkActiveCacheEntries(1)
+
+	ctx, config := fs.AddConfig(context.Background())
+	config.BufferSize += fs.Mebi
+	vfs2 = New(ctx, r.Fremote, nil)
+	assert.NotSame(t, vfs, vfs2)
+	checkActiveCacheEntries(2)
+	vfs2.Shutdown()
+
+	filterOpt := filter.Opt
+	filterOpt.ExcludeRule = []string{"excluded"}
+	filterConfig, err := filter.NewFilter(&filterOpt)
+	require.NoError(t, err)
+	ctx = filter.ReplaceConfig(context.Background(), filterConfig)
+	vfs2 = New(ctx, r.Fremote, nil)
+	assert.NotSame(t, vfs, vfs2)
+	checkActiveCacheEntries(2)
+	vfs2.Shutdown()
+
+	ctx = fs.WithRCRequest(context.Background())
+	vfs2 = New(ctx, r.Fremote, nil)
+	assert.NotSame(t, vfs, vfs2)
+	checkActiveCacheEntries(2)
+	vfs2.Shutdown()
 
 	cleanupVFS(t, vfs)
 

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -160,6 +160,9 @@ func TestVFSNew(t *testing.T) {
 	vfs2 = New(ctx, r.Fremote, nil)
 	assert.NotSame(t, vfs, vfs2)
 	checkActiveCacheEntries(2)
+	vfs3 := New(ctx, r.Fremote, nil)
+	assert.Same(t, vfs2, vfs3)
+	vfs3.Shutdown()
 	vfs2.Shutdown()
 
 	filterOpt := filter.Opt
@@ -170,17 +173,51 @@ func TestVFSNew(t *testing.T) {
 	vfs2 = New(ctx, r.Fremote, nil)
 	assert.NotSame(t, vfs, vfs2)
 	checkActiveCacheEntries(2)
+	vfs3 = New(ctx, r.Fremote, nil)
+	assert.Same(t, vfs2, vfs3)
+	vfs3.Shutdown()
 	vfs2.Shutdown()
 
 	ctx = fs.WithRCRequest(context.Background())
 	vfs2 = New(ctx, r.Fremote, nil)
 	assert.NotSame(t, vfs, vfs2)
 	checkActiveCacheEntries(2)
+	vfs3 = New(ctx, r.Fremote, nil)
+	assert.Same(t, vfs2, vfs3)
+	vfs3.Shutdown()
 	vfs2.Shutdown()
 
 	cleanupVFS(t, vfs)
 
 	checkActiveCacheEntries(0)
+}
+
+func TestVFSNewCacheConflict(t *testing.T) {
+	r := fstest.NewRun(t)
+	opt := vfscommon.Opt
+	opt.CacheMode = vfscommon.CacheModeMinimal
+
+	ctx, _ := fs.AddConfig(context.Background())
+	first, err := NewWithError(ctx, r.Fremote, &opt)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		cleanupVFS(t, first)
+	})
+
+	reused, err := NewWithError(ctx, r.Fremote, &opt)
+	require.NoError(t, err)
+	assert.Same(t, first, reused)
+	reused.Shutdown()
+
+	otherCtx, _ := fs.AddConfig(context.Background())
+	conflicting, err := NewWithError(otherCtx, r.Fremote, &opt)
+	require.Error(t, err)
+	assert.Nil(t, conflicting)
+
+	fallback := New(otherCtx, r.Fremote, &opt)
+	assert.NotSame(t, first, fallback)
+	assert.Equal(t, vfscommon.CacheModeOff, fallback.Opt.CacheMode)
+	fallback.Shutdown()
 }
 
 // TestVFSNewWithOpts sees if the New command works properly


### PR DESCRIPTION

#### What does this change do?

Both request-scoped `_filter` and `_config` are affected. `_config` already reaches `rc.GetFs`, but the context is discarded before VFS initialization and runtime use. Besides that, active VFS caching can reuse an instance created with a different request context.

I've implemented the smallest changeset needed for this.

This approach preserves the public API and avoids retaining the full request context for the mount’s lifetime. It also prevents active VFS instances from being reused across incompatible config or filter contexts, with cross-platform tests that exercise the real RC preprocessing path without requiring FUSE.

#### Linked issue

#8838 (partially, needs a separate test to fully verify `serve` behavior too. can be added to this PR if requested or I can open another one)

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and I can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
