### PR TITLE
gui: fix cross-origin API requests when bound to a wildcard address

### DIFF
--- a/cmd/gui/gui.go
+++ b/cmd/gui/gui.go
@@ -8,6 +8,7 @@ import (
 	_ "embed"
 	"fmt"
 	iofs "io/fs"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -143,9 +144,6 @@ For more help see [the GUI docs](/gui/).
 			opt.HTTP.ListenAddr = []string{"localhost:0"}
 		}
 
-		// CORS: allow the GUI origin to make cross-port API requests.
-		opt.HTTP.AllowOrigin = guiOrigin
-
 		// Forward metrics flag to the RC server.
 		if command.Flags().Changed("enable-metrics") {
 			opt.EnableMetrics = enableMetrics
@@ -175,6 +173,21 @@ For more help see [the GUI docs](/gui/).
 				opt.Auth.BasicPass = randomPass
 				fs.Infof(nil, "No password specified. Using random password: %s", randomPass)
 			}
+		}
+
+		// When the GUI is bound to a wildcard address the bound origin
+		// (e.g. http://[::]:5522) is never what a browser sends in its
+		// Origin header, and the GUI may be reached via any number of
+		// hosts (localhost, a LAN IP, a Docker host), so no single
+		// origin can match them all.
+		switch addr, _ := guiServer.Addr().(*net.TCPAddr); {
+		case addr == nil || !addr.IP.IsUnspecified():
+			opt.HTTP.AllowOrigin = guiOrigin
+		case !opt.NoAuth:
+			opt.HTTP.AllowOrigin = "*"
+		default:
+			opt.HTTP.AllowOrigin = guiOrigin
+			fs.Logf(nil, "GUI bound to a wildcard address with --no-auth: browsers can only use the API from %s. Enable auth or bind --addr to a specific host.", guiOrigin)
 		}
 
 		// Start the RC server (unchanged rcserver.Start)


### PR DESCRIPTION

#### What does this change do?

When bound to a wildcard address the allowed origin is set to "*" so the API works from whichever host reaches the GUI. 
This is only safe with auth enabled, so under --no-auth we keep the specific origin and log a warning that browsers can only use the API from that host.

#### Linked issue

Fixes https://github.com/rclone/rclone-web/issues/71

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] This Pull Request is ready for review.
