### PR TITLE
s3: add Zero Services (ZERO-Z3) provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ directories to and from different cloud storage providers.
 - WebDAV [:page_facing_up:](https://rclone.org/webdav/)
 - Yandex Disk [:page_facing_up:](https://rclone.org/yandex/)
 - Zadara Object Storage [:page_facing_up:](https://rclone.org/s3/#zadara)
+- Zero Services (ZERO-Z3) [:page_facing_up:](https://rclone.org/s3/#zero-z3)
 - Zoho WorkDrive [:page_facing_up:](https://rclone.org/zoho/)
 - Zata.ai [:page_facing_up:](https://rclone.org/s3/#Zata)
 - The local filesystem [:page_facing_up:](https://rclone.org/local/)

--- a/backend/s3/provider/ZeroServices.yaml
+++ b/backend/s3/provider/ZeroServices.yaml
@@ -1,0 +1,17 @@
+name: ZeroServices
+description: Zero Services GmbH (ZERO-Z3)
+region:
+  zero-fra1: Frankfurt 1
+  zero-fra2: Frankfurt 2
+  zero-eyl1: Eyl 1
+endpoint:
+  fra1.s3.zeroservices.eu: Frankfurt 1
+  fra.s3.zeroservices.eu: Frankfurt 2
+  eyl1.s3.zeroservices.eu: Eyl 1
+location_constraint: {}
+acl: {}
+bucket_acl: true
+quirks:
+  force_path_style: true
+  list_url_encode: false
+  use_already_exists: false

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -224,6 +224,7 @@ WebDAV or S3, that work out of the box.)
 {{< provider name="WebDAV" home="https://en.wikipedia.org/wiki/WebDAV" config="/webdav/" >}}
 {{< provider name="Yandex Disk" home="https://disk.yandex.com/" config="/yandex/" >}}
 {{< provider name="Zadara Object Storage" home="https://www.zadara.com" config="/s3/#zadara" >}}
+{{< provider name="Zero Services (ZERO-Z3)" home="https://lp.zeroservices.eu/zero-z3/" config="/s3/#zero-z3" >}}
 {{< provider name="Zoho WorkDrive" home="https://www.zoho.com/workdrive/" config="/zoho/" >}}
 {{< provider name="Zata" home="https://zata.ai/" config="/s3/#Zata" end="true" >}}
 {{< provider name="The local filesystem" home="/local/" config="/local/" end="true">}}

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -60,7 +60,8 @@ The S3 backend can be used with a number of different providers:
 {{< provider name="US3" home="https://www.ucloud.cn/site/product/ufile.html" config="/s3/#us3" >}}
 {{< provider name="Wasabi" home="https://wasabi.com/" config="/s3/#wasabi" >}}
 {{< provider name="Zadara Object Storage" home="https://www.zadara.com" config="/s3/#zadara" >}}
-{{< provider name="Zata" home="https://zata.ai/" config="/s3/#Zata" end="true" >}}
+{{< provider name="Zata" home="https://zata.ai/" config="/s3/#Zata" >}}
+{{< provider name="Zero Services (ZERO-Z3)" home="https://lp.zeroservices.eu/zero-z3/" config="/s3/#zero-z3" end="true" >}}
 {{< /provider_list >}}
 
 <!-- markdownlint-restore -->
@@ -10352,6 +10353,98 @@ access_key_id = xxx
 secret_access_key = xxx
 region = us-east-1
 endpoint = idr01.zata.ai
+```
+
+### Zero Services (ZERO-Z3) {#zero-z3}
+
+[Zero Services GmbH](https://lp.zeroservices.eu/zero-z3/) offers ZERO-Z3, S3-compatible
+object storage hosted in the EU on its own network (AS215197). It is built on
+Ceph RADOS Gateway.
+
+First run:
+
+```console
+rclone config
+```
+
+```text
+This will guide you through an interactive setup process:
+
+n) New remote
+n/s/q> n
+
+Enter name for new remote.
+name> zero-z3
+
+Option Storage.
+Type of storage to configure.
+Choose a number from below, or type in your own value.
+[snip]
+XX / Amazon S3 Compliant Storage Providers including AWS, ..., ZeroServices, ... and others
+   \ (s3)
+Storage> s3
+
+Option provider.
+Choose your S3 provider.
+[snip]
+XX / Zero Services GmbH (ZERO-Z3)
+   \ (ZeroServices)
+provider> ZeroServices
+
+Option env_auth.
+Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars).
+ 1 / Enter AWS credentials in the next step.
+   \ (false)
+ 2 / Get AWS credentials from the environment (env vars or IAM).
+   \ (true)
+env_auth> 1
+
+Option access_key_id.
+AWS Access Key ID.
+access_key_id> ACCESS_KEY
+
+Option secret_access_key.
+AWS Secret Access Key (password).
+secret_access_key> SECRET_KEY
+
+Option region.
+Region to connect to.
+ 1 / Frankfurt 1
+   \ (zero-fra1)
+ 2 / Frankfurt 2
+   \ (zero-fra2)
+ 3 / Eyl 1
+   \ (zero-eyl1)
+region> 2
+
+Option endpoint.
+Endpoint for ZERO-Z3.
+ 1 / Frankfurt 1
+   \ (fra1.s3.zeroservices.eu)
+ 2 / Frankfurt 2
+   \ (fra.s3.zeroservices.eu)
+ 3 / Eyl 1
+   \ (eyl1.s3.zeroservices.eu)
+endpoint> 2
+
+Option acl.
+Canned ACL used when creating buckets and storing or copying objects.
+[snip]
+acl> 1
+
+Edit advanced config?
+y/n> n
+
+Configuration complete.
+Options:
+- type: s3
+- provider: ZeroServices
+- access_key_id: ACCESS_KEY
+- secret_access_key: SECRET_KEY
+- region: zero-fra2
+- endpoint: fra.s3.zeroservices.eu
+Keep this "zero-z3" remote?
+y/e/d> y
 ```
 
 ## Memory usage {#memory}


### PR DESCRIPTION
#### What is the purpose of this change?

Adds Zero Services GmbH (ZERO-Z3) as a named S3 provider.

ZERO-Z3 is S3-compatible object storage hosted in the EU on Zero Services' own
network (AS215197), built on Ceph RADOS Gateway, with region-specific endpoints
(zero-fra1, zero-fra2, zero-eyl1). This follows the same approach as other
Ceph-based hosts already listed (e.g. Hetzner Object Storage): a provider YAML
reusing the Ceph quirk profile, plus documentation.

#### Was the change discussed in an issue or in the forum before?

No — self-contained new-provider addition, per `backend/s3/README.md`
("Adding a new s3 provider").

#### Changes

- `backend/s3/provider/ZeroServices.yaml` — new provider (region + endpoint
  examples; quirks: `force_path_style: true`, `list_url_encode: false`,
  `use_already_exists: false`).
- `docs/content/s3.md` — provider added to the list + a config transcript section.
- `README.md` and `docs/content/_index.md` — provider + link added.

#### Testing

Built rclone from this branch and ran the S3 integration suite against a live
ZERO-Z3 endpoint:

    go test ./backend/s3/ -v -remote ZeroServices:<bucket>/rclone-inttest

**198 subtests pass** — including multipart/chunked upload & copy, Put/Get/Copy/
Move, listings, hashes, metadata, and the Versions read/list/VersionAt tests.

One assertion could not complete in the test account: the `use_already_exists`
probe re-creates an already-existing bucket to inspect the returned error code,
but the account is at its bucket quota, so the endpoint returns `TooManyBuckets`
instead of `BucketAlreadyOwnedByYou`. `use_already_exists` is therefore left at
`false` (matching the Hetzner/Ceph precedent); it can be revisited on an account
with bucket-quota headroom. Object Lock is likewise reported as unsupported for
the same quota reason.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added documentation for the new provider.
- [x] I have run the S3 integration tests against a live ZERO-Z3 endpoint (198 subtests pass; see Testing).
- [x] The commit message follows rclone's guidelines.