### PR TITLE
operations: fix core/du test with missing cache dir

### DIFF
--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -650,13 +650,16 @@ func TestRcCommand(t *testing.T) {
 func TestRcDu(t *testing.T) {
 	ctx := context.Background()
 	_, call := rcNewRun(t, "core/du")
-	in := rc.Params{}
+	dir := t.TempDir()
+	in := rc.Params{"dir": dir}
 	out, err := call.Fn(ctx, in)
 	if err == diskusage.ErrUnsupported {
 		t.Skip(err)
 	}
-	assert.NotEqual(t, "", out["dir"])
-	info := out["info"].(diskusage.Info)
+	require.NoError(t, err)
+	assert.Equal(t, dir, out["dir"])
+	info, ok := out["info"].(diskusage.Info)
+	require.True(t, ok)
 	assert.True(t, info.Total != 0)
 	assert.True(t, info.Total > info.Free)
 	assert.True(t, info.Total > info.Available)


### PR DESCRIPTION
#### What does this change do?

Makes `TestRcDu` independent of the configured cache directory already existing.

The test now passes an existing temporary directory to `core/du`, checks the returned error before inspecting the result, and verifies the `info` value type before using it. This avoids a panic in clean or container environments where the default cache directory has not been created yet.

#### Linked issue

None. This is a trivial test-only fix.

#### Testing

- `go build`
- `go test ./fs/operations -run '^TestRcDu$' -count=1 -v`
- `go test ./fs/operations -count=1`
- `go test ./lib/diskusage -count=1`
- `make quicktest` was also exercised. `TestRcDu` passes; the full run cannot complete in this container because FUSE/NFS mounts are unavailable and the self-update test requests an unpublished beta artifact.

#### For new or changed backends

Not applicable.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the contribution guidelines.
- [x] I used an AI tool, have read and understood the AI-assisted contributions guidance, and have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] Documentation changes are not applicable to this test-only fix.
- [x] All commit messages are in house style.
- [x] Backend integration testing is not applicable.
- [x] This Pull Request is ready for review.
