### PR TITLE
gui: launch the gui on exe double click

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -536,6 +536,7 @@ func AddBackendFlags() {
 func Main() {
 	setupRootCommand(Root)
 	AddBackendFlags()
+	os.Args = guiLauncherArgs(os.Args, launchedFromExplorer())
 	if err := Root.Execute(); err != nil {
 		if strings.HasPrefix(err.Error(), "unknown command") && selfupdateEnabled {
 			Root.PrintErrf("You could use '%s selfupdate' to get latest features.\n\n", Root.CommandPath())
@@ -543,4 +544,12 @@ func Main() {
 		fs.Logf(nil, "Fatal error: %v", err)
 		os.Exit(exitcode.UsageError)
 	}
+}
+
+// guiLauncherArgs starts the GUI for a zero-argument Windows Explorer launch.
+func guiLauncherArgs(args []string, fromExplorer bool) []string {
+	if fromExplorer && len(args) == 1 {
+		return append(args, "gui", "--no-console", "--windows-explorer-launcher")
+	}
+	return args
 }

--- a/cmd/gui/gui.go
+++ b/cmd/gui/gui.go
@@ -33,14 +33,17 @@ var distZip []byte
 var distTag string
 
 var (
-	guiAddr       []string
-	apiAddr       []string
-	user          string
-	pass          string
-	noAuth        bool
-	noOpenBrowser bool
-	enableMetrics bool
+	guiAddr                 []string
+	apiAddr                 []string
+	user                    string
+	pass                    string
+	noAuth                  bool
+	noOpenBrowser           bool
+	enableMetrics           bool
+	windowsExplorerLauncher bool
 )
+
+var openBrowser = open.Start
 
 func init() {
 	cmd.Root.AddCommand(commandDefinition)
@@ -52,6 +55,8 @@ func init() {
 	f.BoolVar(&noAuth, "no-auth", false, "Don't require auth for the RC API")
 	f.BoolVar(&noOpenBrowser, "no-open-browser", false, "Skip opening the browser automatically")
 	f.BoolVar(&enableMetrics, "enable-metrics", false, "Enable OpenMetrics/Prometheus compatible endpoint at /metrics")
+	f.BoolVar(&windowsExplorerLauncher, "windows-explorer-launcher", false, "")
+	_ = f.MarkHidden("windows-explorer-launcher")
 }
 
 var commandDefinition = &cobra.Command{
@@ -65,6 +70,9 @@ ports, generates login credentials automatically unless --no-auth
 is specified, and opens the browser already authenticated.
 
     rclone gui
+
+On Windows, double-clicking rclone.exe in Explorer starts the GUI in
+the background. Double-clicking it again reopens the running GUI.
 
 By default rclone gui serves the web GUI that was embedded into the
 rclone binary at build time from https://github.com/rclone/rclone-web/
@@ -100,8 +108,25 @@ For more help see [the GUI docs](/gui/).
 		"versionIntroduced": "v1.74",
 		"groups":            "RC",
 	},
-	RunE: func(command *cobra.Command, args []string) error {
+	RunE: func(command *cobra.Command, args []string) (runErr error) {
+		if windowsExplorerLauncher {
+			defer func() {
+				if runErr != nil {
+					showLauncherError(runErr)
+				}
+			}()
+		}
 		cmd.CheckArgs(0, 1, command, args)
+		launcher, alreadyRunning, err := newDesktopLauncher(windowsExplorerLauncher)
+		if err != nil {
+			return err
+		}
+		if launcher != nil {
+			defer launcher.Close()
+		}
+		if alreadyRunning {
+			return nil
+		}
 		ctx := context.Background()
 
 		// Resolve the GUI source (embedded, directory, or .zip)
@@ -165,7 +190,9 @@ For more help see [the GUI docs](/gui/).
 		if !opt.NoAuth {
 			if opt.Auth.BasicUser == "" {
 				opt.Auth.BasicUser = "gui"
-				fs.Infof(nil, "No username specified. Using default username: %s", opt.Auth.BasicUser)
+				if !windowsExplorerLauncher {
+					fs.Infof(nil, "No username specified. Using default username: %s", opt.Auth.BasicUser)
+				}
 			}
 			if opt.Auth.BasicPass == "" {
 				randomPass, err := random.Password(128)
@@ -173,7 +200,9 @@ For more help see [the GUI docs](/gui/).
 					return fmt.Errorf("failed to make password: %w", err)
 				}
 				opt.Auth.BasicPass = randomPass
-				fs.Infof(nil, "No password specified. Using random password: %s", randomPass)
+				if !windowsExplorerLauncher {
+					fs.Infof(nil, "No password specified. Using random password: %s", randomPass)
+				}
 			}
 		}
 
@@ -205,11 +234,23 @@ For more help see [the GUI docs](/gui/).
 		fs.Logf(nil, "Serving GUI %s on %s", guiSource, guiURL)
 
 		// Open browser
-		loginURL := buildLoginURL(guiURL, rcURL, opt.Auth.BasicUser, opt.Auth.BasicPass, opt.NoAuth)
+		loginURL := buildLoginURL(guiURL, rcURL, opt.Auth.BasicUser, opt.Auth.BasicPass, opt.NoAuth, windowsExplorerLauncher)
+		if launcher != nil {
+			launcher.publishURL(loginURL)
+		}
 
-		fs.Logf(nil, "GUI available at %s", loginURL)
+		if windowsExplorerLauncher {
+			fs.Logf(nil, "GUI opened in the default browser")
+		} else {
+			fs.Logf(nil, "GUI available at %s", loginURL)
+		}
 		if !noOpenBrowser {
-			if err := open.Start(loginURL); err != nil {
+			if err := openBrowser(loginURL); err != nil {
+				if windowsExplorerLauncher {
+					_ = rcServer.Shutdown()
+					_ = guiServer.Shutdown()
+					return fmt.Errorf("failed to open GUI in browser: %w", err)
+				}
 				fs.Errorf(nil, "failed to open GUI in browser: %v", err)
 			}
 		}
@@ -300,20 +341,22 @@ func guiHandler(srcFS iofs.FS) (http.Handler, error) {
 // guiBaseURL is the GUI server's URL. rcURL is the RC API server's URL.
 // When auth is enabled it appends url, user, and pass as query
 // parameters so the React app can discover the API endpoint and
-// log in automatically.
-func buildLoginURL(guiBaseURL, rcURL, user, pass string, noAuth bool) string {
+// log in automatically. Desktop launches also include their UI mode.
+func buildLoginURL(guiBaseURL, rcURL, user, pass string, noAuth, desktop bool) string {
 	u, err := url.Parse(guiBaseURL)
 	if err != nil {
 		return guiBaseURL
 	}
-	if noAuth {
-		return u.String()
-	}
-	u.Path = "/login"
 	q := u.Query()
-	q.Set("url", rcURL)
-	q.Set("user", user)
-	q.Set("pass", pass)
+	if !noAuth {
+		u.Path = "/login"
+		q.Set("url", rcURL)
+		q.Set("user", user)
+		q.Set("pass", pass)
+	}
+	if desktop {
+		q.Set("mode", "desktop")
+	}
 	u.RawQuery = q.Encode()
 	return u.String()
 }

--- a/cmd/gui/gui_test.go
+++ b/cmd/gui/gui_test.go
@@ -25,13 +25,14 @@ const (
 
 func TestBuildLoginURL(t *testing.T) {
 	tests := []struct {
-		name   string
-		guiURL string
-		rcURL  string
-		user   string
-		pass   string
-		noAuth bool
-		want   string
+		name    string
+		guiURL  string
+		rcURL   string
+		user    string
+		pass    string
+		noAuth  bool
+		desktop bool
+		want    string
 	}{
 		{
 			name:   "with credentials",
@@ -43,6 +44,15 @@ func TestBuildLoginURL(t *testing.T) {
 			want:   "http://localhost:5580/login?pass=secret&url=http%3A%2F%2Flocalhost%3A5572%2F&user=gui",
 		},
 		{
+			name:    "desktop with credentials",
+			guiURL:  "http://localhost:5580/",
+			rcURL:   "http://localhost:5572/",
+			user:    "gui",
+			pass:    "secret",
+			desktop: true,
+			want:    "http://localhost:5580/login?mode=desktop&pass=secret&url=http%3A%2F%2Flocalhost%3A5572%2F&user=gui",
+		},
+		{
 			name:   "no auth",
 			guiURL: "http://localhost:5580/",
 			rcURL:  "http://localhost:5572/",
@@ -50,6 +60,13 @@ func TestBuildLoginURL(t *testing.T) {
 			pass:   "",
 			noAuth: true,
 			want:   "http://localhost:5580/",
+		},
+		{
+			name:    "desktop without auth",
+			guiURL:  "http://localhost:5580/",
+			noAuth:  true,
+			desktop: true,
+			want:    "http://localhost:5580/?mode=desktop",
 		},
 		{
 			name:   "no auth ignores credentials",
@@ -63,7 +80,7 @@ func TestBuildLoginURL(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := buildLoginURL(tt.guiURL, tt.rcURL, tt.user, tt.pass, tt.noAuth)
+			got := buildLoginURL(tt.guiURL, tt.rcURL, tt.user, tt.pass, tt.noAuth, tt.desktop)
 			assert.Equal(t, tt.want, got)
 		})
 	}

--- a/cmd/gui/launcher_other.go
+++ b/cmd/gui/launcher_other.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package gui
+
+type desktopLauncher struct{}
+
+func newDesktopLauncher(bool) (*desktopLauncher, bool, error) {
+	return nil, false, nil
+}
+
+func (l *desktopLauncher) publishURL(string) {}
+
+func (l *desktopLauncher) Close() {}
+
+func showLauncherError(error) {}

--- a/cmd/gui/launcher_windows.go
+++ b/cmd/gui/launcher_windows.go
@@ -1,0 +1,213 @@
+//go:build windows
+
+package gui
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+	"unsafe"
+
+	"github.com/Microsoft/go-winio"
+	"github.com/rclone/rclone/lib/atexit"
+	"golang.org/x/sys/windows"
+)
+
+const desktopLauncherTimeout = 10 * time.Second
+
+type desktopLauncher struct {
+	mutex        windows.Handle
+	listener     net.Listener
+	done         chan struct{}
+	urlReady     chan struct{}
+	url          string
+	urlMu        sync.RWMutex
+	urlOnce      sync.Once
+	closeOnce    sync.Once
+	acceptWG     sync.WaitGroup
+	handlerWG    sync.WaitGroup
+	atexitHandle atexit.FnHandle
+}
+
+func newDesktopLauncher(enabled bool) (*desktopLauncher, bool, error) {
+	if !enabled {
+		return nil, false, nil
+	}
+	sid, sessionID, err := desktopLauncherIdentity()
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to identify Windows user session: %w", err)
+	}
+	return startDesktopLauncher(
+		fmt.Sprintf(`Local\rclone-gui-%s-%d`, sid, sessionID),
+		fmt.Sprintf(`\\.\pipe\rclone-gui-%s-%d`, sid, sessionID),
+		fmt.Sprintf("D:P(A;;GA;;;%s)", sid),
+	)
+}
+
+func desktopLauncherIdentity() (string, uint32, error) {
+	user, err := windows.GetCurrentProcessToken().GetTokenUser()
+	if err != nil {
+		return "", 0, err
+	}
+	var sessionID uint32
+	if err := windows.ProcessIdToSessionId(uint32(os.Getpid()), &sessionID); err != nil {
+		return "", 0, err
+	}
+	return user.User.Sid.String(), sessionID, nil
+}
+
+func startDesktopLauncher(mutexName, pipeName, securityDescriptor string) (*desktopLauncher, bool, error) {
+	name, err := windows.UTF16PtrFromString(mutexName)
+	if err != nil {
+		return nil, false, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), desktopLauncherTimeout)
+	defer cancel()
+	for {
+		mutex, mutexErr := windows.CreateMutex(nil, false, name)
+		if mutexErr == nil {
+			launcher, err := listenDesktopLauncher(mutex, pipeName, securityDescriptor)
+			return launcher, false, err
+		}
+		if !errors.Is(mutexErr, windows.ERROR_ALREADY_EXISTS) {
+			return nil, false, mutexErr
+		}
+		_ = windows.CloseHandle(mutex)
+		connected, err := requestDesktopOpen(ctx, pipeName)
+		if connected {
+			return nil, true, err
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, false, fmt.Errorf("timed out waiting for the running GUI: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+}
+
+func listenDesktopLauncher(mutex windows.Handle, pipeName, securityDescriptor string) (*desktopLauncher, error) {
+	listener, err := winio.ListenPipe(pipeName, &winio.PipeConfig{SecurityDescriptor: securityDescriptor})
+	if err != nil {
+		_ = windows.CloseHandle(mutex)
+		return nil, err
+	}
+	launcher := &desktopLauncher{
+		mutex:    mutex,
+		listener: listener,
+		done:     make(chan struct{}),
+		urlReady: make(chan struct{}),
+	}
+	launcher.atexitHandle = atexit.Register(launcher.Close)
+	launcher.acceptWG.Add(1)
+	go launcher.serve()
+	return launcher, nil
+}
+
+func requestDesktopOpen(ctx context.Context, pipeName string) (bool, error) {
+	conn, err := winio.DialPipeContext(ctx, pipeName)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = conn.Close() }()
+	if deadline, ok := ctx.Deadline(); ok {
+		_ = conn.SetDeadline(deadline)
+	}
+	if _, err := fmt.Fprintln(conn, "open"); err != nil {
+		return true, err
+	}
+	response, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil {
+		return true, err
+	}
+	response = strings.TrimSpace(response)
+	if response == "ok" {
+		return true, nil
+	}
+	if message, found := strings.CutPrefix(response, "error "); found {
+		return true, errors.New(message)
+	}
+	return true, fmt.Errorf("unexpected response from running GUI: %q", response)
+}
+
+func (l *desktopLauncher) serve() {
+	defer l.acceptWG.Done()
+	for {
+		conn, err := l.listener.Accept()
+		if err != nil {
+			select {
+			case <-l.done:
+				return
+			default:
+				return
+			}
+		}
+		l.handlerWG.Add(1)
+		go l.handle(conn)
+	}
+}
+
+func (l *desktopLauncher) handle(conn net.Conn) {
+	defer l.handlerWG.Done()
+	defer func() { _ = conn.Close() }()
+	_ = conn.SetDeadline(time.Now().Add(desktopLauncherTimeout))
+	command, err := bufio.NewReader(conn).ReadString('\n')
+	if err != nil || strings.TrimSpace(command) != "open" {
+		return
+	}
+	select {
+	case <-l.urlReady:
+	case <-l.done:
+		_, _ = fmt.Fprintln(conn, "error GUI is shutting down")
+		return
+	}
+	l.urlMu.RLock()
+	loginURL := l.url
+	l.urlMu.RUnlock()
+	if err := openBrowser(loginURL); err != nil {
+		message := strings.NewReplacer("\r", " ", "\n", " ").Replace(err.Error())
+		_, _ = fmt.Fprintln(conn, "error "+message)
+		return
+	}
+	_, _ = fmt.Fprintln(conn, "ok")
+}
+
+func (l *desktopLauncher) publishURL(loginURL string) {
+	l.urlMu.Lock()
+	l.url = loginURL
+	l.urlMu.Unlock()
+	l.urlOnce.Do(func() { close(l.urlReady) })
+}
+
+func (l *desktopLauncher) Close() {
+	l.closeOnce.Do(func() {
+		atexit.Unregister(l.atexitHandle)
+		close(l.done)
+		_ = l.listener.Close()
+		l.acceptWG.Wait()
+		l.handlerWG.Wait()
+		_ = windows.CloseHandle(l.mutex)
+	})
+}
+
+func showLauncherError(err error) {
+	text, textErr := windows.UTF16PtrFromString("Rclone could not start the GUI:\n\n" + err.Error())
+	title, titleErr := windows.UTF16PtrFromString("Rclone GUI")
+	if textErr != nil || titleErr != nil {
+		return
+	}
+	messageBox := windows.NewLazySystemDLL("user32.dll").NewProc("MessageBoxW")
+	_, _, _ = messageBox.Call(
+		0,
+		uintptr(unsafe.Pointer(text)),
+		uintptr(unsafe.Pointer(title)),
+		0x00000010,
+	)
+}

--- a/cmd/gui/launcher_windows_test.go
+++ b/cmd/gui/launcher_windows_test.go
@@ -1,0 +1,136 @@
+//go:build windows
+
+package gui
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func desktopLauncherTestNames(t *testing.T) (string, string) {
+	t.Helper()
+	id := fmt.Sprintf("%d-%d", os.Getpid(), time.Now().UnixNano())
+	return `Local\rclone-gui-test-` + id, `\\.\pipe\rclone-gui-test-` + id
+}
+
+func TestDesktopLauncherReopensRunningGUI(t *testing.T) {
+	mutexName, pipeName := desktopLauncherTestNames(t)
+	opened := make(chan string, 1)
+	oldOpenBrowser := openBrowser
+	openBrowser = func(loginURL string) error {
+		opened <- loginURL
+		return nil
+	}
+	t.Cleanup(func() { openBrowser = oldOpenBrowser })
+
+	first, alreadyRunning, err := startDesktopLauncher(mutexName, pipeName, "")
+	require.NoError(t, err)
+	require.False(t, alreadyRunning)
+	t.Cleanup(first.Close)
+	first.publishURL("http://localhost/login?token=secret")
+
+	second, alreadyRunning, err := startDesktopLauncher(mutexName, pipeName, "")
+	require.NoError(t, err)
+	assert.Nil(t, second)
+	assert.True(t, alreadyRunning)
+	assert.Equal(t, "http://localhost/login?token=secret", <-opened)
+}
+
+func TestDesktopLauncherWaitsForURL(t *testing.T) {
+	mutexName, pipeName := desktopLauncherTestNames(t)
+	opened := make(chan string, 1)
+	oldOpenBrowser := openBrowser
+	openBrowser = func(loginURL string) error {
+		opened <- loginURL
+		return nil
+	}
+	t.Cleanup(func() { openBrowser = oldOpenBrowser })
+
+	first, _, err := startDesktopLauncher(mutexName, pipeName, "")
+	require.NoError(t, err)
+	t.Cleanup(first.Close)
+	result := make(chan error, 1)
+	go func() {
+		_, _, err := startDesktopLauncher(mutexName, pipeName, "")
+		result <- err
+	}()
+	select {
+	case err := <-result:
+		t.Fatalf("second launch returned before the GUI URL was ready: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+	first.publishURL("http://localhost/ready")
+	require.NoError(t, <-result)
+	assert.Equal(t, "http://localhost/ready", <-opened)
+}
+
+func TestDesktopLauncherReportsBrowserFailure(t *testing.T) {
+	mutexName, pipeName := desktopLauncherTestNames(t)
+	oldOpenBrowser := openBrowser
+	openBrowser = func(string) error { return errors.New("browser unavailable") }
+	t.Cleanup(func() { openBrowser = oldOpenBrowser })
+
+	first, _, err := startDesktopLauncher(mutexName, pipeName, "")
+	require.NoError(t, err)
+	t.Cleanup(first.Close)
+	first.publishURL("http://localhost/login")
+
+	second, alreadyRunning, err := startDesktopLauncher(mutexName, pipeName, "")
+	assert.Nil(t, second)
+	assert.True(t, alreadyRunning)
+	assert.EqualError(t, err, "browser unavailable")
+}
+
+func TestDesktopLauncherReleasesOwnership(t *testing.T) {
+	mutexName, pipeName := desktopLauncherTestNames(t)
+	first, _, err := startDesktopLauncher(mutexName, pipeName, "")
+	require.NoError(t, err)
+	first.Close()
+	first.Close()
+
+	next, alreadyRunning, err := startDesktopLauncher(mutexName, pipeName, "")
+	require.NoError(t, err)
+	require.False(t, alreadyRunning)
+	require.NotNil(t, next)
+	next.Close()
+}
+
+func TestDesktopLauncherConcurrentAcquisition(t *testing.T) {
+	mutexName, pipeName := desktopLauncherTestNames(t)
+	oldOpenBrowser := openBrowser
+	openBrowser = func(string) error { return nil }
+	t.Cleanup(func() { openBrowser = oldOpenBrowser })
+
+	results := make(chan struct {
+		launcher       *desktopLauncher
+		alreadyRunning bool
+		err            error
+	}, 2)
+	for range 2 {
+		go func() {
+			launcher, alreadyRunning, err := startDesktopLauncher(mutexName, pipeName, "")
+			results <- struct {
+				launcher       *desktopLauncher
+				alreadyRunning bool
+				err            error
+			}{launcher, alreadyRunning, err}
+		}()
+	}
+	owner := <-results
+	require.NoError(t, owner.err)
+	require.NotNil(t, owner.launcher)
+	require.False(t, owner.alreadyRunning)
+	owner.launcher.publishURL("http://localhost/login")
+	t.Cleanup(owner.launcher.Close)
+
+	reopened := <-results
+	require.NoError(t, reopened.err)
+	assert.Nil(t, reopened.launcher)
+	assert.True(t, reopened.alreadyRunning)
+}

--- a/cmd/launcher_other.go
+++ b/cmd/launcher_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package cmd
+
+func launchedFromExplorer() bool {
+	return false
+}

--- a/cmd/launcher_windows.go
+++ b/cmd/launcher_windows.go
@@ -1,0 +1,45 @@
+//go:build windows
+
+package cmd
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func launchedFromExplorer() bool {
+	snapshot, err := windows.CreateToolhelp32Snapshot(windows.TH32CS_SNAPPROCESS, 0)
+	if err != nil {
+		return false
+	}
+	defer func() { _ = windows.CloseHandle(snapshot) }()
+
+	processNames := map[uint32]string{}
+	parentProcessIDs := map[uint32]uint32{}
+	entry := windows.ProcessEntry32{Size: uint32(unsafe.Sizeof(windows.ProcessEntry32{}))}
+	if err := windows.Process32First(snapshot, &entry); err != nil {
+		return false
+	}
+	for {
+		processNames[entry.ProcessID] = windows.UTF16ToString(entry.ExeFile[:])
+		parentProcessIDs[entry.ProcessID] = entry.ParentProcessID
+		err = windows.Process32Next(snapshot, &entry)
+		if errors.Is(err, windows.ERROR_NO_MORE_FILES) {
+			break
+		}
+		if err != nil {
+			return false
+		}
+	}
+
+	return hasExplorerParent(uint32(os.Getpid()), parentProcessIDs, processNames)
+}
+
+func hasExplorerParent(processID uint32, parentProcessIDs map[uint32]uint32, processNames map[uint32]string) bool {
+	parentProcessID := parentProcessIDs[processID]
+	return parentProcessID != 0 && strings.EqualFold(processNames[parentProcessID], "explorer.exe")
+}

--- a/cmd/launcher_windows_test.go
+++ b/cmd/launcher_windows_test.go
@@ -1,0 +1,16 @@
+//go:build windows
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHasExplorerParent(t *testing.T) {
+	parentProcessIDs := map[uint32]uint32{100: 50}
+	assert.True(t, hasExplorerParent(100, parentProcessIDs, map[uint32]string{50: "Explorer.EXE"}))
+	assert.False(t, hasExplorerParent(100, parentProcessIDs, map[uint32]string{50: "cmd.exe"}))
+	assert.False(t, hasExplorerParent(200, parentProcessIDs, map[uint32]string{50: "explorer.exe"}))
+}

--- a/docs/content/gui.md
+++ b/docs/content/gui.md
@@ -70,7 +70,8 @@ Get quick info about your active serve instances, and start new ones.
 ### Settings
 
 Edit your `rclone.conf` file directly, set logging flags, and
-performance parameters.
+performance parameters. A desktop-launched Windows GUI also provides an
+option to exit rclone.
 
 ## How it works
 
@@ -104,6 +105,22 @@ A few good measures:
 If you want to access it remotely but want to avoid running a proxy
 and exposing ports, you can use Cloudflare Tunnels or localhost.run or
 Tailscale (all free).
+
+## Windows desktop launcher
+
+The Windows download remains a portable ZIP with no installer. You can
+double-click the icon-bearing `rclone.exe` in Explorer, or create a
+Desktop or Start-menu shortcut to it, to open the GUI without keeping a
+console window open. A console window may appear briefly during startup.
+
+Only one desktop-launched GUI runs per Windows user session. Opening the
+executable or shortcut again reopens the authenticated GUI in your
+browser. Commands run from CMD or PowerShell are unchanged, and an
+explicit `rclone gui` command remains a normal terminal process.
+
+The desktop-launched GUI includes **Exit rclone** under **Settings**.
+After confirmation, it stops rclone along with any active transfers,
+mounts, and serves.
 
 ## Options
 

--- a/docs/content/install.md
+++ b/docs/content/install.md
@@ -178,8 +178,15 @@ links. If not sure, use the first link.
 Open this file in the Explorer and extract `rclone.exe`. Rclone is a
 portable executable so you can place it wherever is convenient.
 
-Open a CMD window (or powershell) and run the binary. Note that rclone
-does not launch a GUI by default, it runs in the CMD Window.
+Double-click `rclone.exe`, or a shortcut to it, to open the Web GUI in
+your browser. The executable and shortcuts to it use the rclone icon. A
+console window may appear briefly while the GUI starts. Double-clicking
+again reopens the existing GUI instead of starting another copy. Use
+**Settings > Exit rclone** in the GUI to stop the desktop process; active
+transfers, mounts, and serves will also stop.
+
+Running `rclone.exe` from CMD or PowerShell is unchanged and uses the
+command line normally.
 
 - Run `rclone.exe config` to setup. See [rclone config docs](/docs/) for more details.
 - Optionally configure [automatic execution](#autostart).

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/FilenCloudDienste/filen-sdk-go v0.0.39
 	github.com/Files-com/files-sdk-go/v3 v3.3.82
 	github.com/Max-Sum/base32768 v0.0.0-20230304063302-18e6ce5945fd
+	github.com/Microsoft/go-winio v0.6.2
 	github.com/a1ex3/zstd-seekable-format-go/pkg v0.10.0
 	github.com/a8m/tree v0.0.0-20240104212747-2c8764a5f17e
 	github.com/aalpar/deheap v1.1.2
@@ -277,7 +278,6 @@ require (
 
 require (
 	github.com/IBM/go-sdk-core/v5 v5.21.2
-	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/golang-jwt/jwt/v4 v4.5.2
 	github.com/pkg/xattr v0.4.12


### PR DESCRIPTION


#### What does this change do?

Implements a version of @ncw's idea to launch the GUI on windows.

The other, smaller, set of changes lives in the web repo. It concerns the detection of the desktop mode launch and adding an Exit button that quits the process.


#### Checklist

- [ ] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] This Pull Request is ready for review.
