### PR TITLE
serve/http: compare zip test output semantically

### DIFF
--- a/cmd/serve/http/http_test.go
+++ b/cmd/serve/http/http_test.go
@@ -1,6 +1,8 @@
 package http
 
 import (
+	"archive/zip"
+	"bytes"
 	"compress/gzip"
 	"context"
 	"flag"
@@ -24,6 +26,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type zipEntry struct {
+	IsDir    bool
+	Contents string
+}
 
 var (
 	updateGolden = flag.Bool("updategolden", false, "update golden files for regression test")
@@ -102,10 +109,37 @@ func checkGolden(t *testing.T, fileName string, got []byte) {
 	} else {
 		want, err := os.ReadFile(fileName)
 		require.NoError(t, err)
+		if strings.HasSuffix(fileName, ".zip") {
+			assert.Equal(t, readZip(t, want), readZip(t, got), fileName)
+			return
+		}
 		wants := strings.Split(string(want), "\n")
 		gots := strings.Split(string(got), "\n")
 		assert.Equal(t, wants, gots, fileName)
 	}
+}
+
+func readZip(t *testing.T, data []byte) map[string]zipEntry {
+	t.Helper()
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	require.NoError(t, err)
+
+	entries := make(map[string]zipEntry, len(zr.File))
+	for _, f := range zr.File {
+		entry := zipEntry{
+			IsDir: f.FileInfo().IsDir(),
+		}
+		if !entry.IsDir {
+			rc, err := f.Open()
+			require.NoError(t, err)
+			contents, err := io.ReadAll(rc)
+			require.NoError(t, err)
+			require.NoError(t, rc.Close())
+			entry.Contents = string(contents)
+		}
+		entries[f.Name] = entry
+	}
+	return entries
 }
 
 func testGET(t *testing.T, useProxy bool) {


### PR DESCRIPTION
#### What does this change do?

Go 1.27 changes compress/flate output, which also changes archive/zip byte output. The HTTP zip download tests currently compare raw zip bytes against golden files, so they fail even though the generated zip archives contain the expected files.

Compare zip entries and decompressed contents instead of the exact compressed byte stream.

#### Linked issue

Fixes #9612

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
