### PR TITLE
lib/http: allow Prefer request header in CORS preflight

### DIFF
--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -189,7 +189,7 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
-				w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, TimeOut, Translate")
+				w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, Prefer, TimeOut, Translate")
 				w.Header().Add("Access-Control-Allow-Methods", "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK")
 				w.Header().Add("Access-Control-Max-Age", "86400")
 			}

--- a/lib/http/middleware_test.go
+++ b/lib/http/middleware_test.go
@@ -471,6 +471,13 @@ func TestMiddlewareCORS(t *testing.T) {
 				expectedOrigin = ss.http.AllowOrigin
 			}
 			require.Equal(t, expectedOrigin, resp.Header.Get("Access-Control-Allow-Origin"), "allow origin should match")
+
+			// Regression for #9614: the Prefer request header (used by the rc
+			// server for RFC 7240 respond-async) must be listed in
+			// Access-Control-Allow-Headers so browser preflight succeeds when
+			// the GUI issues async rc calls cross-origin.
+			allowHeaders := resp.Header.Get("Access-Control-Allow-Headers")
+			require.Contains(t, allowHeaders, "Prefer", "Access-Control-Allow-Headers should include Prefer")
 		})
 	}
 }


### PR DESCRIPTION
#### What does this change do?

Adds `Prefer` to `Access-Control-Allow-Headers` in the shared CORS middleware (`lib/http/middleware.go`).

The rc server already understands the `Prefer: respond-async` request header (RFC 7240) in `fs/rc/rcserver/rcserver.go` so callers can request an asynchronous job. The embedded web GUI relies on this for long-running operations such as `/sync/copy`. However, the CORS middleware did not advertise `Prefer` in the preflight response, so browsers rejected the cross-origin `OPTIONS` request with:

```
Request header field prefer is not allowed by Access-Control-Allow-Headers in preflight response.
```

The `POST /sync/copy` never reached rclone, and the GUI reported "Transfer failed: Failed to fetch". This matches the reproduction in the linked issue: browsing and mkdir work (no custom header), copy fails (uses `Prefer`).

Fix: add `Prefer` to the allow-list. This is header-list only, no behaviour change for requests that do not send `Prefer`.

A regression test in `lib/http/middleware_test.go` asserts that `Access-Control-Allow-Headers` contains `Prefer` for the CORS server cases. Verified failing on master and passing with the fix.

#### Linked issue

Fixes #9614

#### For new or changed backends

Not a backend change.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.

#### AI-assisted contribution disclosure

This change was written with the assistance of Claude. I reviewed the diff and the regression test, confirmed the test fails on master and passes with the fix, and I take responsibility for the code.
