### PR TITLE
sftp: allow silencing no hostkey validation warning

### DIFF
--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -120,7 +120,7 @@ Set this if you have a signed certificate you want to use for authentication.` +
 			Name: "known_hosts_file",
 			Help: `Optional path to known_hosts file.
 
-Set this value to enable server host key validation.` + env.ShellExpandHelp,
+Set this value to enable server host key validation. Set to ` + "`none`" + ` to silence the "No host key validation" notice.` + env.ShellExpandHelp,
 			Advanced: true,
 			Examples: []fs.OptionExample{{
 				Value: "~/.ssh/known_hosts",
@@ -1312,6 +1312,9 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	switch {
+	case opt.KnownHostsFile == "none":
+		// Silence Host key validation warning if explicitly disabled
+		sshConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
 	case opt.KnownHostsFile != "":
 		hostcallback, err := knownhosts.New(env.ShellExpand(opt.KnownHostsFile))
 		if err != nil {
@@ -1336,7 +1339,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		}
 	default:
 		sshConfig.HostKeyCallback = ssh.InsecureIgnoreHostKey()
-		fs.Logf(name, "No host key validation is being performed. Set known_hosts_file or use --sftp-pin-host-key to enable it. See: https://rclone.org/sftp/#host-key-validation")
+		fs.Logf(name, "No host key validation is being performed. Set known_hosts_file (to \"none\" to silence this notice) or use --sftp-pin-host-key to enable it. See: https://rclone.org/sftp/#host-key-validation")
 	}
 
 	if opt.UseInsecureCipher && (opt.Ciphers != nil || opt.KeyExchange != nil) {

--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -216,7 +216,9 @@ is being performed` each time the backend is started in this mode.
 
 Host key matching, using standard ssh `known_hosts` files can be
 turned on by enabling the `known_hosts_file` option. This can point to
-the file maintained by `OpenSSH` or can point to a unique file.
+the file maintained by `OpenSSH` or can point to a unique file. To
+explicitly disable host key checking and silence the warning, the
+`known_hosts_file` option can be set to `none`.
 
 Alternatively rclone can maintain server host keys in a `host_keys`
 setting in the config file. This can be updated automatically with


### PR DESCRIPTION
#### What does this change do?

This change allows the SFTP `known_hosts_file` option to be set to `none` to disable the new "No host key validation is being performed." warning.

All major SFTP software that I know of allows explicitly disabling host key checks, and will not nag you when doing so. Although it's understood that it is not generally desirable, it is left up to the user. I understand rclone has these checks disabled by default and wants to make users aware of that.

However, after an update, I have found that one of my processes, which invokes rclone very frequently, has been producing hundreds of thousands of lines of the following notice in my logs:

```
NOTICE: mesh: No host key validation is being performed. Set known_hosts_file to enable it. 
See: https://rclone.org/sftp/#host-key-validation
```
Unfortunately, for this process it is not practical to use host key verification, and I do not want to enable it. I think it is undesirable to be swamped in noise as a result.

I think it is a reasonable and practical compromise: while the notice is useful for users who may not understand that host key verification is disabled by default, allowing one to signal that it is disabled by desire, the notice is no longer necessary.



#### For new or changed backends

Test output is about 900 lines, but it passes.
```
PASS
ok  	github.com/rclone/rclone/backend/sftp	36.932s
```

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
