### PR TITLE
http: add Prefer to CORS Access-Control-Allow-Headers header

### DIFF
--- a/lib/http/middleware.go
+++ b/lib/http/middleware.go
@@ -189,7 +189,7 @@ func MiddlewareCORS(allowOrigin string) Middleware {
 
 			if allowOrigin != "" {
 				w.Header().Add("Access-Control-Allow-Origin", allowOrigin)
-				w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, TimeOut, Translate")
+				w.Header().Add("Access-Control-Allow-Headers", "Authorization, Content-Type, Depth, Destination, If, Lock-Token, Overwrite, Prefer, TimeOut, Translate")
 				w.Header().Add("Access-Control-Allow-Methods", "COPY, DELETE, GET, HEAD, LOCK, MKCOL, MOVE, OPTIONS, POST, PROPFIND, PROPPATCH, PUT, TRACE, UNLOCK")
 				w.Header().Add("Access-Control-Max-Age", "86400")
 			}


### PR DESCRIPTION
#### What is the purpose of this change?

Fix the rclone web GUI remote access failing on copy operations due to CORS preflight rejection of the `Prefer` header.

Fixes #9614

#### Briefly describe your PR.

The CORS middleware in `lib/http/middleware.go` enumerates allowed request headers in the preflight `Access-Control-Allow-Headers` response. The `Prefer` header — sent by the web GUI `sync/copy` endpoint — was missing from this list, causing the browser to block cross-origin copy requests with:

```
Request header field prefer is not allowed by Access-Control-Allow-Headers in preflight response.
```

This is a one-line addition of `Prefer` to the existing comma-separated allowlist.

#### Was the change discussed in an issue or in the forum before?

Reported in #9614

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/main/CONTRIBUTING.md).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] Run `go test ./...` if appropriate.
- [x] All commit messages are in the house style.
- [x] Minor change — single header addition in well-understood code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)