### PR TITLE
march: fix goroutine leak on completed async rc jobs

### DIFF
--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -263,14 +263,19 @@ func (m *March) Run(ctx context.Context) error {
 		dstDepth:  dstDepth - 1,
 		noDst:     m.NoCheckDest,
 	}
+	// Discard the remaining jobs on cancellation to unblock the senders.
+	done := make(chan struct{})
 	go func() {
-		// when the context is cancelled discard the remaining jobs
-		<-m.Ctx.Done()
-		for range in {
-			traversing.Done()
+		select {
+		case <-m.Ctx.Done():
+			for range in {
+				traversing.Done()
+			}
+		case <-done:
 		}
 	}()
 	traversing.Wait()
+	close(done)
 	close(in)
 	wg.Wait()
 

--- a/fs/march/march_test.go
+++ b/fs/march/march_test.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	_ "github.com/rclone/rclone/backend/local"
 	"github.com/rclone/rclone/fs"
@@ -375,6 +377,58 @@ func TestMarchNoProcessDstOnly(t *testing.T) {
 			assert.Empty(t, mt.dstOnly, "dstOnly should be empty with NoProcessDstOnly")
 			fstest.CompareItems(t, mt.match, match, test.dirMatch, precision, "match")
 		})
+	}
+}
+
+// TestMarchNoGoroutineLeak checks that a march which completes normally (its
+// context is never cancelled, as with an async rc job) does not strand the
+// janitor goroutine that drains the job channel (See #9620)
+func TestMarchNoGoroutineLeak(t *testing.T) {
+	r := fstest.NewRun(t)
+
+	ctx := context.Background()
+	ctx, _ = fs.AddConfig(ctx)
+	// Write to both src and dst so the march lists real directories on both
+	// sides and completes cleanly (no missing-directory listing errors).
+	r.WriteBoth(ctx, "test", "hello world", t1)
+	r.WriteBoth(ctx, "sub dir/test2", "hello world", t1)
+
+	runMarch := func() {
+		mt := &marchTester{ctx: ctx, cancel: func() {}}
+		m := &March{
+			Ctx:      ctx,
+			Fdst:     r.Fremote,
+			Fsrc:     r.Flocal,
+			Dir:      "",
+			Callback: mt,
+		}
+		require.NoError(t, m.Run(ctx))
+	}
+
+	// Warm up so any one-time background goroutines are already started.
+	runMarch()
+	waitForGoroutines := func() int {
+		// Give any exiting goroutines a moment to unwind before counting.
+		var n int
+		for range 20 {
+			runtime.GC()
+			n = runtime.NumGoroutine()
+			time.Sleep(10 * time.Millisecond)
+		}
+		return n
+	}
+	before := waitForGoroutines()
+
+	const runs = 20
+	for range runs {
+		runMarch()
+	}
+	after := waitForGoroutines()
+
+	// The leak stranded one goroutine per run. Allow a small slack for unrelated
+	// runtime goroutines, but well under the number of runs.
+	if after-before >= runs {
+		t.Fatalf("goroutine leak: %d before, %d after %d marches (delta %d)", before, after, runs, after-before)
 	}
 }
 


### PR DESCRIPTION
The march janitor goroutine (started in `(*March).Run`) discards queued jobs when the context is cancelled so the checker senders do not block on a full channel. Its only exit was context cancellation:

```go
go func() {
    <-m.Ctx.Done()
    for range in {
        traversing.Done()
    }
}()
```

A march that finishes normally never cancels its context. For a synchronous rc call this is harmless because the job keeps the HTTP request context, which `net/http` cancels when the handler returns. But an async rc job runs with a context descended from `context.Background()` that is only cancelled via `job/stop`, so on normal completion the janitor parked on `m.Ctx.Done()` forever, leaking one goroutine per run and pinning that runs directory listings in memory. A long-running `rcd` driving async `sync`/`bisync` jobs accumulates these (reported at ~7.9 GB RSS after ~35 hours, one leaked goroutine per lifetime job).

Fix: signal the janitor via a `done` channel closed after the march finishes, so it returns on both normal completion and cancellation. `fs/sync` and one-shot CLI runs were never affected; this only changes the leaked path.

Fixes #9620.

Test plan: added `TestMarchNoGoroutineLeak`, which runs 20 marches to completion (context never cancelled) and asserts the goroutine count does not grow by one per run. Verified it fails before the fix (`goroutine leak: 6 before, 26 after 20 marches`) and passes after. `go test -race ./fs/march/` is green.