### PR TITLE
azureblob: fix directory rename failing with InvalidUri on HNS accounts

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -1599,6 +1599,16 @@ func (f *Fs) deleteContainer(ctx context.Context, containerName string) error {
 	})
 }
 
+// isInvalidURI reports whether err is the InvalidUri error Azure Storage
+// returns when a request addresses a blob by a syntactically invalid URI.
+func isInvalidURI(err error) bool {
+	var storageErr *azcore.ResponseError
+	if errors.As(err, &storageErr) {
+		return storageErr.ErrorCode == string(bloberror.InvalidURI)
+	}
+	return false
+}
+
 // Rmdir deletes the container if the fs is at the root
 //
 // Returns an error if it isn't empty
@@ -1612,6 +1622,15 @@ func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 		}
 		fs.Debugf(o, "Removing directory marker")
 		err := o.Remove(ctx)
+		if err != nil && isInvalidURI(err) {
+			// Hierarchical namespace (HNS/ADLS Gen2) accounts can reject a delete
+			// addressed with a trailing slash on the directory marker blob name
+			// with InvalidUri, even though the same name is accepted when the
+			// marker is created - retry once against the same path without the
+			// trailing slash.
+			o.remote = dir
+			err = o.Remove(ctx)
+		}
 		if err != nil {
 			return fmt.Errorf("removing directory marker failed: %w", err)
 		}

--- a/backend/azureblob/azureblob_internal_test.go
+++ b/backend/azureblob/azureblob_internal_test.go
@@ -8,23 +8,77 @@ import (
 	"context"
 	"crypto/md5"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/object"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/fstest/fstests"
+	"github.com/rclone/rclone/lib/encoder"
 	"github.com/rclone/rclone/lib/random"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// defaultTestEnc mirrors the default value of the "encoding" config option
+// declared in the Options spec in azureblob.go.
+var defaultTestEnc = encoder.EncodeInvalidUtf8 |
+	encoder.EncodeSlash |
+	encoder.EncodeCtl |
+	encoder.EncodeDel |
+	encoder.EncodeBackSlash |
+	encoder.EncodeRightPeriod
+
+// TestSplitDirectoryMarkerPath pins the path rclone builds for a directory
+// marker's DELETE request in Rmdir - see https://github.com/rclone/rclone/issues/9577.
+//
+// f.split retains a single trailing slash on the container path for a
+// directory marker remote ("dir/"), which is the form that hierarchical
+// namespace (HNS/ADLS Gen2) accounts reject with InvalidUri when deleting.
+// It also checks that stripping the trailing slash from the remote before
+// splitting - what Rmdir's InvalidUri fallback does - yields the same
+// container with a path that has no trailing slash.
+func TestSplitDirectoryMarkerPath(t *testing.T) {
+	f := &Fs{
+		root: "container",
+		opt: Options{
+			DirectoryMarkers: true,
+			Enc:              defaultTestEnc,
+		},
+	}
+
+	dir := "it/New folder (5)"
+
+	container, withSlash := f.split(dir + "/")
+	assert.Equal(t, "container", container)
+	assert.Equal(t, "it/New folder (5)/", withSlash)
+
+	container, withoutSlash := f.split(dir)
+	assert.Equal(t, "container", container)
+	assert.Equal(t, "it/New folder (5)", withoutSlash)
+	assert.Equal(t, strings.TrimSuffix(withSlash, "/"), withoutSlash)
+}
+
+// TestIsInvalidURI checks the classification of the InvalidUri storage
+// error that HNS/ADLS Gen2 accounts return when deleting a directory
+// marker addressed with a trailing slash - see
+// https://github.com/rclone/rclone/issues/9577.
+func TestIsInvalidURI(t *testing.T) {
+	assert.True(t, isInvalidURI(&azcore.ResponseError{ErrorCode: string(bloberror.InvalidURI)}))
+	assert.False(t, isInvalidURI(&azcore.ResponseError{ErrorCode: string(bloberror.BlobNotFound)}))
+	assert.False(t, isInvalidURI(errors.New("some other error")))
+	assert.False(t, isInvalidURI(nil))
+}
 
 func TestBlockIDCreator(t *testing.T) {
 	// Check creation and random number


### PR DESCRIPTION
#### What does this change do?

Fixes a `Dir.Rename` failure on the `azureblob` backend for Hierarchical
Namespace (HNS/ADLS Gen2) storage accounts using `--azureblob-directory-markers`.

Root cause: `Fs.Rmdir` (`backend/azureblob/azureblob.go`) removes a
directory's marker blob by constructing an `Object` whose remote is
`dir + "/"` — the same trailing-slash form used when the marker is
*created* (`Fs.createDirectoryMarker` → `Object.Update` → `Object.prepareUpload`,
which goes through the same `Fs.split`). On HNS/ADLS Gen2 accounts, Azure
accepts a blob PUT addressed this way when creating the marker, but rejects
the equivalent DELETE with an `InvalidUri` error. Since `azureblob` does not
implement the `DirMove` feature, `fs/operations.DirMove` falls back to
move-then-`Rmdir`-each-source-directory, so every directory rename on an
HNS account with directory markers enabled hits this and fails.

The fix retries the marker delete once, without the trailing slash, only
when the first attempt fails with `InvalidUri`. Accounts that already
accept the trailing-slash delete (i.e. everything except this HNS case,
as far as I can tell) never take the retry path, so this should not
change behaviour anywhere else.

I could not get a HNS/ADLS Gen2 Azure account to verify the fix end-to-end
against the real service — see "For new or changed backends" below for what
this means for review. The root-cause trace (which two call paths in the
backend build the same trailing-slash blob path, and that only one is
reported to fail) is inferred from the code plus the reporter's own log and
analysis in the issue, not from an independent live reproduction.

#### Linked issue

Fixes #9577

Thanks to @korey-fried for the very thorough bug report, including the
`-vv` log showing the exact `DELETE .../it/New folder (5)/` request and
`InvalidUri` response, and for tracing it to the same family of issue as
#7047.

#### For new or changed backends

- [ ] `go run ./fstest/test_all -backends azureblob` — **not run**. I do not
  have an Azure Blob Storage account (HNS or otherwise) configured, so I
  could not run the integration suite or reproduce the original `InvalidUri`
  error against a real account.
- What I *did* verify without live Azure:
  - `backend/azureblob/azureblob_internal_test.go`: `TestSplitDirectoryMarkerPath`
    pins the path-construction bug — `Fs.split` on a directory-marker remote
    ("dir/") keeps a single trailing slash in the container path (the exact
    form in the issue's failing DELETE request), and confirms that dropping
    the trailing slash before splitting (what the fallback does) yields the
    same container with a clean, non-slash-terminated path.
  - `TestIsInvalidURI` unit-tests the new `isInvalidURI` error classifier
    against `*azcore.ResponseError` values, including the exact
    `bloberror.InvalidURI` ("InvalidUri") code from the issue's log.
  - Confirmed via `git stash` that both new tests fail to compile/pass
    without the fix, and pass with it.
  - `go build ./backend/azureblob/...`, `go vet ./backend/azureblob/...`,
    `gofmt -l` on changed files, and `go test ./backend/azureblob/...`
    (unit tests only, no configured test remote) all pass.
- What still needs a real HNS/ADLS Gen2 account: confirming that (a) the
  original repro (`--azureblob-directory-markers` + rename a freshly created
  folder) actually reproduces `InvalidUri` today, and (b) the no-trailing-slash
  retry actually succeeds against Azure rather than e.g. returning
  `BlobNotFound` — my reasoning that HNS silently normalizes away the
  trailing slash on the server side for the directory entity is inferred
  from the issue's evidence, not independently confirmed.

#### Checklist

- [ ] This change is trivial **OR** it has been discussed and agreed in the linked issue.
  - Not yet discussed with a maintainer — flagging this explicitly since the
    PR template asks for that before anything beyond a trivial fix. Given the
    root cause is inferred rather than independently reproduced against a
    live HNS account, this may need maintainer input on whether the
    retry-on-InvalidUri approach is preferred over the reporter's suggested
    alternative (switching directory rename to the ADLS Gen2 DFS rename API).
- [x] I have read the contribution guidelines.
- [x] (AI tools were used to help write this code) I have read and understood
  the AI-assisted contributions guidance, and I have tested and take
  ownership of this change myself — with the live-Azure caveat noted above.
- [x] I have added tests for all changes in this PR if appropriate (unit
  tests only; see integration-test caveat above).
- [ ] I have added documentation for the changes if appropriate — not
  applicable, no user-facing option/flag change.
- [x] All commit messages are in house style.
- [ ] (Backend changes only) `test_all` passes for this backend — not run,
  no test account available (see above).
- [ ] This Pull Request is ready for review. — Draft only; holding for human
  review/approval and, ideally, confirmation against a real HNS account
  before this is actually opened upstream.
