### PR TITLE
operations: fix Move godoc to note Copy fallback is accounted as a transfer - fixes #8799

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -416,7 +416,9 @@ func SameObject(src, dst fs.Object) bool {
 // It returns the destination object if possible.  Note that this may
 // be nil.
 //
-// This is accounted as a check.
+// This is accounted as a check, unless Move falls back to Copy + Delete
+// (on backends without server-side move), in which case the Copy is
+// accounted as a transfer.
 func Move(ctx context.Context, fdst fs.Fs, dst fs.Object, remote string, src fs.Object) (newDst fs.Object, err error) {
 	return move(ctx, fdst, dst, remote, src, false)
 }


### PR DESCRIPTION
### What

Fixes the misleading godoc comment on `operations.Move`, as discussed in #8799.

`Move` is documented as "accounted as a check", but when a backend cannot
server-side move (e.g. S3 can `Copy` but not `Move`), `move` falls back to
`Copy` + `DeleteFile` (`operations.go` line 512). `Copy` calls
`accounting.Stats(ctx).NewTransfer`, so the operation is in fact accounted
as a transfer in that case — not a check.

This updates the comment to state that explicitly, so callers reading the
godoc are not misled about the stats behaviour.

### Why

The old comment (`// This is accounted as a check.`) was inaccurate for the
fallback path. As noted by @nielash in #8799, the simplest correct fix is to
clarify the comment rather than change the accounting semantics (which ncw
noted is "partly a philosophical question").

No code or behaviour change — comment-only fix.

### AI assistance

This pull request was prepared with the assistance of an AI coding tool.
The change has been reviewed and understood: it is a single comment edit
in `fs/operations/operations.go` that clarifies the accounting behaviour
of `Move` when it falls back to `Copy + Delete`. No compilation or test
output is affected by a comment-only change.
