### PR TITLE
vfs: invalidate the kernel cache on vfs/forget, vfs/refresh, ChangeNotify

### DIFF
--- a/cmd/mount/dir.go
+++ b/cmd/mount/dir.go
@@ -262,6 +262,7 @@ func (d *Dir) Symlink(ctx context.Context, req *fuse.SymlinkRequest) (node fusef
 	}
 
 	node = &File{n.(*vfs.File), d.fsys}
+	n.SetSys(node) // cache the FUSE node for later
 	return node, nil
 }
 

--- a/cmd/mount/fs.go
+++ b/cmd/mount/fs.go
@@ -45,7 +45,29 @@ func (f *FS) Root() (node fusefs.Node, err error) {
 	if err != nil {
 		return nil, translateError(err)
 	}
-	return &Dir{root, f}, nil
+	d := &Dir{root, f}
+	root.SetSys(d) // cache the FUSE node for later
+	return d, nil
+}
+
+// Called from the VFS's invalidation goroutine.
+func (f *FS) invalidateKernelCacheForEntry(parent vfs.Node, name string, node vfs.Node) {
+	// Drop the parent's cached dir entry so the next access re-LOOKUPs and
+	// picks up the fresh size.
+	if parentNode, ok := parent.Sys().(fusefs.Node); ok {
+		if err := f.server.InvalidateEntry(parentNode, name); err != nil && err != fuse.ErrNotCached {
+			fs.Debugf(parent.Path(), "Failed to invalidate kernel dir entry %q: %v", name, err)
+		}
+	}
+	// For an already-open file, InvalidateEntry doesn't help - also drop its
+	// cached attributes and page cache.
+	if node != nil && node.IsFile() {
+		if fuseNode, ok := node.Sys().(fusefs.Node); ok {
+			if err := f.server.InvalidateNodeData(fuseNode); err != nil && err != fuse.ErrNotCached {
+				fs.Debugf(node.Path(), "Failed to invalidate kernel node data: %v", err)
+			}
+		}
+	}
 }
 
 // Check interface satisfied

--- a/cmd/mount/mount.go
+++ b/cmd/mount/mount.go
@@ -91,6 +91,8 @@ func mount(VFS *vfs.VFS, mountpoint string, opt *mountlib.Options) (<-chan error
 	filesys := NewFS(VFS, opt)
 	filesys.server = fusefs.New(c, nil)
 
+	removeInvalidateKernelCacheHook := VFS.AddInvalidateKernelCacheHook(filesys.invalidateKernelCacheForEntry)
+
 	// Serve the mount point in the background returning error to errChan
 	errChan := make(chan error, 1)
 	go func() {
@@ -103,6 +105,7 @@ func mount(VFS *vfs.VFS, mountpoint string, opt *mountlib.Options) (<-chan error
 	}()
 
 	unmount := func() error {
+		removeInvalidateKernelCacheHook()
 		// Shutdown the VFS
 		filesys.VFS.Shutdown()
 		return fuse.Unmount(mountpoint)

--- a/cmd/mount2/fs.go
+++ b/cmd/mount2/fs.go
@@ -105,6 +105,27 @@ func (f *FS) setEntryOut(node vfs.Node, out *fuse.EntryOut) {
 	out.SetAttrTimeout(time.Duration(f.opt.AttrTimeout))
 }
 
+// Called from the VFS's invalidation goroutine.
+//
+// The Operations() checks skip nodes which newNode has created but not
+// yet registered with NewInode - notifying on those would panic.
+func (f *FS) invalidateKernelCacheForEntry(parent vfs.Node, name string, node vfs.Node) {
+	// Drop the parent's cached dir entry so the next access re-LOOKUPs.
+	if parentNode, ok := parent.Sys().(*Node); ok && parentNode.Operations() != nil {
+		if errno := parentNode.NotifyEntry(name); errno != 0 && errno != syscall.ENOENT {
+			fs.Debugf(parent.Path(), "Failed to invalidate kernel dir entry %q: %v", name, errno)
+		}
+	}
+	// For an already-open file, also drop its attributes and page cache.
+	if node != nil && node.IsFile() {
+		if fuseNode, ok := node.Sys().(*Node); ok && fuseNode.Operations() != nil {
+			if errno := fuseNode.NotifyContent(0, -1); errno != 0 && errno != syscall.ENOENT {
+				fs.Debugf(node.Path(), "Failed to invalidate kernel node data: %v", errno)
+			}
+		}
+	}
+}
+
 // Translate errors from mountlib into Syscall error numbers
 func translateError(err error) syscall.Errno {
 	if err == nil {

--- a/cmd/mount2/mount.go
+++ b/cmd/mount2/mount.go
@@ -233,6 +233,8 @@ func mount(VFS *vfs.VFS, mountpoint string, opt *mountlib.Options) (<-chan error
 		return nil, nil, "", err
 	}
 
+	removeInvalidateKernelCacheHook := VFS.AddInvalidateKernelCacheHook(fsys.invalidateKernelCacheForEntry)
+
 	//mountOpts := &fuse.MountOptions{}
 	//server, err := fusefs.Mount(mountpoint, fsys, &opts)
 	// server, err := fusefs.Mount(mountpoint, root, &opts)
@@ -241,6 +243,7 @@ func mount(VFS *vfs.VFS, mountpoint string, opt *mountlib.Options) (<-chan error
 	// }
 
 	umount := func() error {
+		removeInvalidateKernelCacheHook()
 		// Shutdown the VFS
 		fsys.VFS.Shutdown()
 		return server.Unmount()

--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -267,6 +267,7 @@ func (d *Dir) forgetDirPath(relativePath string) {
 	if dir == nil {
 		return
 	}
+	dir.invalidateKernelCacheForSubtree()
 	dir.ForgetAll()
 }
 
@@ -296,6 +297,7 @@ func (d *Dir) changeNotify(relativePath string, entryType fs.EntryType) {
 	if entryType == fs.EntryDirectory {
 		d.invalidateDir(absPath)
 	}
+	d.vfs.invalidateKernelCacheForPath(absPath)
 }
 
 // ForgetPath clears the cache for itself and all subdirectories if
@@ -314,6 +316,24 @@ func (d *Dir) ForgetPath(relativePath string, entryType fs.EntryType) {
 	}
 	if entryType == fs.EntryDirectory {
 		d.forgetDirPath(relativePath)
+	}
+	d.vfs.invalidateKernelCacheForPath(absPath)
+}
+
+func (d *Dir) invalidateKernelCacheForSubtree() {
+	if !d.vfs.HasInvalidateKernelCacheHooks() {
+		return
+	}
+	// We run this with RLock only to avoid deadlocks in the recursion
+	d.mu.RLock()
+	defer d.mu.RUnlock()
+	// Note that this does not invalidate d's own entry. Callers invalidate that
+	// via invalidateKernelCacheForPath.
+	for name, node := range d.items {
+		d.vfs.invalidateKernelCacheForEntry(d, name, node)
+		if dir, ok := node.(*Dir); ok {
+			dir.invalidateKernelCacheForSubtree()
+		}
 	}
 }
 

--- a/vfs/invalidate.go
+++ b/vfs/invalidate.go
@@ -1,0 +1,154 @@
+package vfs
+
+import (
+	"path"
+	"strings"
+	"sync"
+)
+
+// InvalidateKernelCacheHook is called by the VFS to tell a mount to drop
+// the kernel's cached directory entry for name in parent, along with the
+// attributes and page cache of the node it refers to. node is nil when
+// the entry is no longer in the VFS cache; only the directory entry can
+// be dropped then.
+//
+// Hooks run on a dedicated goroutine, never on a FUSE handler, so a
+// synchronous kernel notify is safe.
+type InvalidateKernelCacheHook func(parent Node, name string, node Node)
+
+// pendingEntry identifies one kernel directory entry, so a storm of
+// invalidations coalesces to one notify per entry.
+type pendingEntry struct {
+	parent Node
+	name   string
+}
+
+// kernelCacheInvalidator coalesces and dispatches kernel cache
+// invalidations to registered hooks. The zero value is ready for use.
+type kernelCacheInvalidator struct {
+	mu         sync.Mutex // guards the fields below
+	hooks      map[int]InvalidateKernelCacheHook
+	nextID     int
+	pending    map[pendingEntry]Node // entry to invalidate → node (nil if not cached)
+	wake       chan struct{}
+	running    bool       // whether the dispatcher goroutine is running
+	dispatchMu sync.Mutex // held while one entry's hooks run; a barrier for unsubscribe
+}
+
+// AddInvalidateKernelCacheHook registers fn and returns a function to
+// unregister it. A VFS shared by several mounts (see New) calls every
+// hook. The returned remove function does not return while fn is
+// running, so the caller can tear down its mount safely afterwards.
+func (vfs *VFS) AddInvalidateKernelCacheHook(fn InvalidateKernelCacheHook) (remove func()) {
+	k := &vfs.kernelCacheInvalidator
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if k.hooks == nil {
+		k.hooks = map[int]InvalidateKernelCacheHook{}
+		k.pending = map[pendingEntry]Node{}
+		k.wake = make(chan struct{}, 1)
+	}
+	id := k.nextID
+	k.nextID++
+	k.hooks[id] = fn
+	if !k.running && vfs.ctx.Err() == nil {
+		k.running = true
+		go vfs.invalidateKernelCacheDispatcher()
+	}
+	return func() {
+		k.mu.Lock()
+		delete(k.hooks, id)
+		k.mu.Unlock()
+		// Barrier: wait for any in-flight dispatch to finish.
+		k.dispatchMu.Lock()
+		k.dispatchMu.Unlock() //nolint:staticcheck // barrier, not an empty critical section
+	}
+}
+
+// HasInvalidateKernelCacheHooks reports whether any hook is registered.
+func (vfs *VFS) HasInvalidateKernelCacheHooks() bool {
+	vfs.kernelCacheInvalidator.mu.Lock()
+	defer vfs.kernelCacheInvalidator.mu.Unlock()
+	return len(vfs.kernelCacheInvalidator.hooks) > 0
+}
+
+// Queue an invalidation of the directory entry for name in parent, referring to
+// node (which may be nil if the node is no longer cached).
+func (vfs *VFS) invalidateKernelCacheForEntry(parent Node, name string, node Node) {
+	if parent == nil || name == "" {
+		return
+	}
+	k := &vfs.kernelCacheInvalidator
+	k.mu.Lock()
+	if len(k.hooks) == 0 || !k.running {
+		k.mu.Unlock()
+		return
+	}
+	key := pendingEntry{parent: parent, name: name}
+	if existing := k.pending[key]; existing == nil {
+		k.pending[key] = node
+	}
+	k.mu.Unlock()
+	select {
+	case k.wake <- struct{}{}:
+	default:
+	}
+}
+
+// Queue an invalidation of absPath's directory entry. The entry is queued even
+// if the node itself is no longer in the VFS cache (the kernel may still hold
+// it), as long as its parent directory is.
+func (vfs *VFS) invalidateKernelCacheForPath(absPath string) {
+	if !vfs.HasInvalidateKernelCacheHooks() {
+		return
+	}
+	absPath = strings.Trim(absPath, "/")
+	if absPath == "" {
+		return // the root has no parent entry to invalidate
+	}
+	parentPath, name := path.Split(absPath)
+	parent := vfs.root.cachedDir(parentPath)
+	if parent == nil {
+		return
+	}
+	vfs.invalidateKernelCacheForEntry(parent, name, parent.cachedNode(name))
+}
+
+func (vfs *VFS) invalidateKernelCacheDispatcher() {
+	k := &vfs.kernelCacheInvalidator
+	defer func() {
+		k.mu.Lock()
+		k.running = false
+		k.pending = map[pendingEntry]Node{} // release Node references
+		k.mu.Unlock()
+	}()
+	for {
+		select {
+		case <-vfs.ctx.Done():
+			return
+		case <-k.wake:
+		}
+		k.mu.Lock()
+		pending := k.pending
+		k.pending = make(map[pendingEntry]Node, len(pending))
+		k.mu.Unlock()
+		for entry, node := range pending {
+			if vfs.ctx.Err() != nil {
+				return
+			}
+			// dispatchMu is held per entry, not per batch, so an unsubscribing
+			// mount waits for at most one entry's hooks.
+			k.dispatchMu.Lock()
+			k.mu.Lock()
+			hooks := make([]InvalidateKernelCacheHook, 0, len(k.hooks))
+			for _, fn := range k.hooks {
+				hooks = append(hooks, fn)
+			}
+			k.mu.Unlock()
+			for _, fn := range hooks {
+				fn(entry.parent, entry.name, node)
+			}
+			k.dispatchMu.Unlock()
+		}
+	}
+}

--- a/vfs/invalidate_test.go
+++ b/vfs/invalidate_test.go
@@ -1,0 +1,198 @@
+package vfs
+
+import (
+	"context"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/rc"
+	"github.com/rclone/rclone/fstest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// waitForInvalidations reads ch until every path in want has been seen,
+// failing the test on timeout. Extra paths are ignored.
+func waitForInvalidations(t *testing.T, ch <-chan string, want ...string) {
+	need := map[string]bool{}
+	for _, w := range want {
+		need[w] = true
+	}
+	timeout := time.After(5 * time.Second)
+	for len(need) > 0 {
+		select {
+		case p := <-ch:
+			delete(need, p)
+		case <-timeout:
+			t.Fatalf("timed out waiting for invalidation of %v", need)
+		}
+	}
+}
+
+// set up a VFS with dir/file1 and dir/file2 looked up (cached) and a hook
+// feeding invalidated paths into the returned channel.
+func invalidateTestVFS(t *testing.T) (r *fstest.Run, vfs *VFS, ch chan string) {
+	r, vfs = newTestVFS(t)
+	ctx := context.Background()
+	file1 := r.WriteObject(ctx, "dir/file1", "content one", t1)
+	file2 := r.WriteObject(ctx, "dir/file2", "content two two", t1)
+	r.CheckRemoteItems(t, file1, file2)
+
+	// Look them up so they are cached
+	for _, path := range []string{"dir", "dir/file1", "dir/file2"} {
+		_, err := vfs.Stat(path)
+		require.NoError(t, err)
+	}
+
+	ch = make(chan string, 64)
+	vfs.AddInvalidateKernelCacheHook(func(parent Node, name string, node Node) {
+		ch <- path.Join(parent.Path(), name)
+	})
+	return r, vfs, ch
+}
+
+// ForgetPath on a file invalidates that file's kernel entry
+func TestInvalidateForgetPath(t *testing.T) {
+	_, vfs, ch := invalidateTestVFS(t)
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	root.ForgetPath("dir/file1", fs.EntryObject)
+
+	waitForInvalidations(t, ch, "dir/file1")
+}
+
+// ForgetPath on a directory invalidates the directory and everything
+// cached under it
+func TestInvalidateForgetDir(t *testing.T) {
+	_, vfs, ch := invalidateTestVFS(t)
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	root.ForgetPath("dir", fs.EntryDirectory)
+
+	waitForInvalidations(t, ch, "dir", "dir/file1", "dir/file2")
+}
+
+// vfs/forget with no arguments invalidates the whole looked-up tree
+func TestInvalidateForgetAll(t *testing.T) {
+	r, _, ch := invalidateTestVFS(t)
+
+	call := rc.Calls.Get("vfs/forget")
+	require.NotNil(t, call)
+	_, err := call.Fn(context.Background(), rc.Params{"fs": fs.ConfigString(r.Fremote)})
+	require.NoError(t, err)
+
+	waitForInvalidations(t, ch, "dir", "dir/file1", "dir/file2")
+}
+
+// changeNotify invalidates the changed node
+func TestInvalidateChangeNotify(t *testing.T) {
+	_, vfs, ch := invalidateTestVFS(t)
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	root.changeNotify("dir/file1", fs.EntryObject)
+
+	waitForInvalidations(t, ch, "dir/file1")
+}
+
+// changeNotify for a path which is not in the VFS cache still invalidates
+// the kernel's entry (which may be a negative one) via the cached parent
+func TestInvalidateChangeNotifyUncached(t *testing.T) {
+	_, vfs, ch := invalidateTestVFS(t)
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	root.changeNotify("dir/new-file", fs.EntryObject)
+
+	waitForInvalidations(t, ch, "dir/new-file")
+}
+
+// vfs/refresh invalidates the refreshed subtree
+func TestInvalidateRefresh(t *testing.T) {
+	r, _, ch := invalidateTestVFS(t)
+
+	call := rc.Calls.Get("vfs/refresh")
+	require.NotNil(t, call)
+	out, err := call.Fn(context.Background(), rc.Params{"fs": fs.ConfigString(r.Fremote)})
+	require.NoError(t, err)
+	require.Equal(t, rc.Params{"result": map[string]string{"": "OK"}}, out)
+
+	waitForInvalidations(t, ch, "dir/file1", "dir/file2")
+}
+
+// Two hooks both fire (a VFS can be shared by more than one mount), and
+// unsubscribing removes only that hook.
+func TestInvalidateMultipleHooks(t *testing.T) {
+	_, vfs, ch1 := invalidateTestVFS(t)
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	ch2 := make(chan string, 64)
+	remove2 := vfs.AddInvalidateKernelCacheHook(func(parent Node, name string, node Node) {
+		ch2 <- path.Join(parent.Path(), name)
+	})
+
+	root.ForgetPath("dir/file1", fs.EntryObject)
+	waitForInvalidations(t, ch1, "dir/file1")
+	waitForInvalidations(t, ch2, "dir/file1")
+
+	// Remove the second hook - it should stop receiving
+	remove2()
+
+	// Trigger two invalidations in sequence. Dispatches are serial, so by
+	// the time ch1 has seen the second one, any erroneous ch2 delivery of
+	// the first would have happened already.
+	root.ForgetPath("dir/file2", fs.EntryObject)
+	waitForInvalidations(t, ch1, "dir/file2")
+	root.ForgetPath("dir/file1", fs.EntryObject)
+	waitForInvalidations(t, ch1, "dir/file1")
+
+	assert.Empty(t, ch2, "removed hook still fired")
+}
+
+// Unsubscribing waits for an in-flight hook to finish, so a mount can tear
+// down safely.
+func TestInvalidateUnsubscribeBarrier(t *testing.T) {
+	r, vfs := newTestVFS(t)
+	file1 := r.WriteObject(context.Background(), "dir/file1", "content one", t1)
+	r.CheckRemoteItems(t, file1)
+	_, err := vfs.Stat("dir/file1")
+	require.NoError(t, err)
+	root, err := vfs.Root()
+	require.NoError(t, err)
+
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	remove := vfs.AddInvalidateKernelCacheHook(func(parent Node, name string, node Node) {
+		close(entered)
+		<-release
+	})
+
+	// Trigger one invalidation and wait until the hook is running and blocked.
+	root.ForgetPath("dir/file1", fs.EntryObject)
+	<-entered
+
+	removed := make(chan struct{})
+	go func() {
+		remove()
+		close(removed)
+	}()
+
+	// remove() must not return while the hook is still in-flight.
+	select {
+	case <-removed:
+		t.Fatal("remove() returned while a hook was still running")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	close(release)
+	select {
+	case <-removed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("remove() did not return after the hook finished")
+	}
+}

--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -73,6 +73,11 @@ starting with dir will refresh that directory, e.g.
 
 If the parameter recursive=true is given the whole directory tree
 will get refreshed. This refresh will use --fast-list if enabled.
+
+On a mount or mount2 (Linux) this also drops the kernel's cached
+directory entries and attributes for the refreshed paths, so
+out-of-band changes are seen at once; other mount backends (cmount,
+NFS) can't and will wait for --attr-timeout.
 ` + getVFSHelp,
 	})
 }
@@ -132,6 +137,7 @@ func rcRefresh(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 		if err != nil {
 			result[""] = err.Error()
 		} else {
+			root.invalidateKernelCacheForSubtree()
 			result[""] = "OK"
 		}
 	} else {
@@ -153,6 +159,7 @@ func rcRefresh(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 					if err != nil {
 						result[path] = err.Error()
 					} else {
+						dir.invalidateKernelCacheForSubtree()
 						result[path] = "OK"
 					}
 				}
@@ -187,6 +194,11 @@ parameter key starting with file will forget that file and any
 starting with dir will forget that dir, e.g.
 
     rclone rc vfs/forget file=hello file2=goodbye dir=home/junk
+
+On a mount or mount2 (Linux) this also drops the kernel's cached
+directory entries and attributes so an out-of-band change is seen
+at once; other mount backends (cmount, NFS) can't and will wait
+for --attr-timeout.
 ` + getVFSHelp,
 	})
 }
@@ -204,6 +216,7 @@ func rcForget(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 
 	forgotten := []string{}
 	if len(in) == 0 {
+		root.invalidateKernelCacheForSubtree()
 		root.ForgetAll()
 	} else {
 		for k, v := range in {

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -188,6 +188,8 @@ type VFS struct {
 	usage       *fs.Usage
 	pollChan    chan time.Duration
 	inUse       atomic.Int32 // count of number of opens
+
+	kernelCacheInvalidator kernelCacheInvalidator
 }
 
 // Keep track of active VFS keyed on fs.ConfigString(f)

--- a/vfs/vfstest/fs.go
+++ b/vfs/vfstest/fs.go
@@ -108,6 +108,7 @@ func RunTests(t *testing.T, useVFS bool, minimumRequiredCacheMode vfscommon.Cach
 			t.Run("TestWriteFileAppend", TestWriteFileAppend)
 			t.Run("TestSymlinks", TestSymlinks)
 			t.Run("TestMknod", TestMknod)
+			t.Run("TestFileForgetGrown", TestFileForgetGrown)
 		})
 		fs.Logf(nil, "Finished test run with %s (ok=%v)", what, ok)
 		run.Finalise()

--- a/vfs/vfstest/invalidate.go
+++ b/vfs/vfstest/invalidate.go
@@ -1,0 +1,60 @@
+package vfstest
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/cmd/mountlib"
+	"github.com/rclone/rclone/fs/object"
+	"github.com/rclone/rclone/vfs/vfscommon"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestFileForgetGrown checks that a file grown out of band is seen at its new
+// size once forgotten. See https://github.com/rclone/rclone/issues/9617
+func TestFileForgetGrown(t *testing.T) {
+	run.skipIfVFS(t)
+	run.skipIfNoFUSE(t)
+	if !run.hasInvalidateKernelCacheHooks() {
+		t.Skip("mount backend doesn't invalidate the kernel cache on forget")
+	}
+	if run.vfsOpt.CacheMode != vfscommon.CacheModeOff {
+		t.Skip("only meaningful with --vfs-cache-mode off - reads go straight to the remote")
+	}
+
+	const (
+		short = "small"
+		long  = "much longer contents than the original file had"
+	)
+
+	// Create through the mount and stat it so the kernel caches the short size.
+	run.createFile(t, "file", short)
+	fi, err := run.os.Stat(run.path("file"))
+	require.NoError(t, err)
+	require.Equal(t, int64(len(short)), fi.Size())
+
+	// Grow the object out of band, directly on the remote.
+	src := object.NewStaticObjectInfo("file", time.Now(), int64(len(long)), true, nil, nil)
+	_, err = run.fremote.Put(context.Background(), strings.NewReader(long), src)
+	require.NoError(t, err)
+
+	run.forgetFile("file")
+
+	// The kernel must now report the new size before the attr-timeout
+	deadline := time.Now().Add(time.Duration(mountlib.Opt.AttrTimeout) * 3 / 4)
+	var size int64
+	for {
+		fi, err = run.os.Stat(run.path("file"))
+		require.NoError(t, err)
+		if size = fi.Size(); size == int64(len(long)) || time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	assert.Equal(t, int64(len(long)), size)
+
+	run.rm(t, "file")
+}

--- a/vfs/vfstest/submount.go
+++ b/vfs/vfstest/submount.go
@@ -199,6 +199,15 @@ func doMountCommand(vfs *vfs.VFS, rx string) (tx string, exit bool) {
 		} else {
 			root.ForgetPath(command[1], fs.EntryDirectory)
 		}
+	case "forgetFile":
+		root, err := vfs.Root()
+		if err != nil {
+			out = []string{"ERR", err.Error()}
+		} else {
+			root.ForgetPath(command[1], fs.EntryObject)
+		}
+	case "hasInvalidateKernelCacheHooks":
+		out = []string{"OK", fmt.Sprintf("%v", vfs.HasInvalidateKernelCacheHooks())}
 	case "exit":
 		exit = true
 	default:
@@ -207,8 +216,10 @@ func doMountCommand(vfs *vfs.VFS, rx string) (tx string, exit bool) {
 	return strings.Join(out, "\t"), exit
 }
 
-// Send a command to the mount subprocess and await a response
-func (r *Run) sendMountCommand(args ...string) {
+// Send a command to the mount subprocess and await its reply, returned
+// as tab-separated tokens. The first token is always "OK" (errors are
+// fatal), with any result values following it.
+func (r *Run) sendMountCommand(args ...string) []string {
 	r.cmdMu.Lock()
 	defer r.cmdMu.Unlock()
 	tx := strings.Join(args, "\t")
@@ -232,6 +243,7 @@ func (r *Run) sendMountCommand(args ...string) {
 	if in[0] != "OK" {
 		fs.Fatalf(nil, "Error from mount: %q", in[1:])
 	}
+	return in
 }
 
 // wait for any files being written to be released by fuse
@@ -242,6 +254,17 @@ func (r *Run) waitForWriters() {
 // forget the directory passed in
 func (r *Run) forget(dir string) {
 	r.sendMountCommand("forget", dir)
+}
+
+// forget the file passed in
+func (r *Run) forgetFile(path string) {
+	r.sendMountCommand("forgetFile", path)
+}
+
+// check if the VFS has invalidate kernel cache hooks installed
+func (r *Run) hasInvalidateKernelCacheHooks() bool {
+	reply := r.sendMountCommand("hasInvalidateKernelCacheHooks")
+	return len(reply) > 1 && reply[1] == "true"
 }
 
 // Unmount the mount


### PR DESCRIPTION
This PR fixes #9617 by dropping the kernel's cached state whenever the VFS invalidates a node via `vfs/forget`, `vfs/refresh`, or `ChangeNotify`, so out-of-band changes are seen at once instead of waiting for `--attr-timeout`.

Thanks @ncw for the initial feedback! Responding to those comments in order:

**1. Hook registration.** The single slot is now `AddInvalidateKernelCacheHook(fn) (remove func())`. A shared VFS calls every hook, and `remove()` waits for an in-flight call to finish so a mount can tear down safely.

**2. Coverage.** `vfs/forget` with no args invalidates the whole looked-up tree, `dir=X` the directory and everything under it, and `vfs/refresh` the refreshed subtree. `ChangeNotify` invalidates the changed path even if it's no longer in the VFS cache, as long as its parent directory is.

**3. Performance.** Invalidations are captured as `(parent, name, node)` into a pending set at enqueue time, so enqueuing is a non-blocking map insert and a storm coalesces to one notification per entry. A dedicated goroutine runs the hooks — never a FUSE handler. Routine dir-cache aging (`--dir-cache-time` expiry, SIGHUP, renames)
deliberately does **not** notify the kernel.

**4. Mount flavours.** Both `mount` and `mount2` are wired; the `vfs/forget`/`vfs/refresh` help notes that `cmount` and NFS can't do this.

**5. Not just dentries.** For files the hook also drops cached attributes and page cache (`InvalidateEntry` + `InvalidateNodeData` on mount, `NotifyEntry` + `NotifyContent` on mount2), which matters for already-open fds.

### Tests

* `vfs/invalidate_test.go`: file and directory forget, whole-tree forget and refresh through the real rc calls, `changeNotify` for cached and uncached paths, multiple hooks with selective unsubscribe, and the unsubscribe barrier.
* `vfs/vfstest`: `TestFileForgetGrown` grows a file out of band behind a real mount, forgets it, and checks the new size before `--attr-timeout`.

### Known limitations / follow-ups

- **`Sys()` under a shared VFS.** A single slot, so with two mounts on one VFS the last to look up a node wins and the other's invalidation silently no-ops. Needs the `Sys()` rethink you mentioned.
- **Serial dispatch.** A notification that blocks in the kernel delays the rest of the pending set.
- **Parent must be cached.** Paths the VFS has entirely forgotten age out on `--attr-timeout` as before.
- **`mount2` nodes mid-creation** are skipped until registered with the kernel (notifying them would crash go-fuse).

#### Linked issue

Fixes #9617

#### Checklist

- [X] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [X] This Pull Request is ready for review.
