### PR TITLE
s3: fix server side copy failing with --s3-no-head-object

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -3249,6 +3249,16 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 		return nil, err
 	}
 
+	// With NoHeadObject no metadata was read for the new object, so carry
+	// the size and MD5 over from the source as a server-side copy produces
+	// an object with identical content.
+	if f.opt.NoHeadObject {
+		if dstObject, ok := dstObj.(*Object); ok {
+			dstObject.bytes = srcObj.bytes
+			dstObject.md5 = srcObj.md5
+		}
+	}
+
 	// Set Object Lock via separate API calls if requested
 	if f.opt.ObjectLockSetAfterUpload {
 		if dstObject, ok := dstObj.(*Object); ok {

--- a/backend/s3/s3_internal_test.go
+++ b/backend/s3/s3_internal_test.go
@@ -144,6 +144,33 @@ func (f *Fs) InternalTestNoHead(t *testing.T) {
 
 }
 
+func (f *Fs) InternalTestNoHeadObjectCopy(t *testing.T) {
+	ctx := context.Background()
+	contents := random.String(1000)
+	item := fstest.NewItem("test-no-head-object-copy-src", contents, fstest.Time("2001-05-06T04:05:06.499999999Z"))
+	src := fstests.PutTestContents(ctx, t, f, &item, contents, true)
+	defer func() {
+		assert.NoError(t, src.Remove(ctx))
+	}()
+	// Set NoHeadObject for this test so the copied object's metadata is not read back
+	f.opt.NoHeadObject = true
+	defer func() {
+		f.opt.NoHeadObject = false
+	}()
+	dst, err := f.Copy(ctx, src, "test-no-head-object-copy-dst")
+	require.NoError(t, err)
+	defer func() {
+		assert.NoError(t, dst.Remove(ctx))
+	}()
+	assert.Equal(t, src.Size(), dst.Size())
+	srcHash, err := src.Hash(ctx, hash.MD5)
+	require.NoError(t, err)
+	dstHash, err := dst.Hash(ctx, hash.MD5)
+	require.NoError(t, err)
+	assert.Equal(t, srcHash, dstHash)
+	assert.NotEqual(t, "", dstHash)
+}
+
 func (f *Fs) InternalTestHasChildren(t *testing.T) {
 	ctx := context.Background()
 	contents := random.String(100)
@@ -810,6 +837,7 @@ func (f *Fs) InternalTestObjectLock(t *testing.T) {
 func (f *Fs) InternalTest(t *testing.T) {
 	t.Run("Metadata", f.InternalTestMetadata)
 	t.Run("NoHead", f.InternalTestNoHead)
+	t.Run("NoHeadObjectCopy", f.InternalTestNoHeadObjectCopy)
 	t.Run("HasChildren", f.InternalTestHasChildren)
 	t.Run("Versions", f.InternalTestVersions)
 	t.Run("ObjectLock", f.InternalTestObjectLock)


### PR DESCRIPTION
#### What does this change do?

Fixes server side copy on the S3 backend when `--s3-no-head-object` is set. With the flag, `NewObject` skips `readMetaData` entirely, so the destination object returned by `Copy` had a size of 0 and no MD5. The generic post-copy verification then failed with `corrupted on transfer: sizes differ N vs 0` and deleted the (healthy) destination object. Since `Move` is implemented as server side copy + delete, this also broke every rename, including through `rclone mount`.

The fix populates the destination object's size and MD5 from the source object after the server side copy — the content is identical by definition of `CopyObject`, so no extra API call is needed. As requested in the issue discussion, the population is done only when `no_head_object` is set; the normal path is untouched.

Includes a regression test (`InternalTestNoHeadObjectCopy`, mirroring the existing `InternalTestNoHead` pattern) which fails on master with `expected: 1000, actual: 0` and passes with this change.

#### Linked issue

Fixes #9629

Approach confirmed by @ncw in https://github.com/rclone/rclone/issues/9629#issuecomment-5016197908 ("This is what we've done elsewhere in the code. The population of data should only be done on no_head_object").

#### For new or changed backends

Not a new backend, but tested against the S3 backend integration suite:

- `go test -v -remote TestS3Minio: ./backend/s3/` against a local MinIO — all tests pass (`ok github.com/rclone/rclone/backend/s3 21.9s`), including the new regression test.
- Regression test confirmed to fail on unpatched master.
- `make quicktest` equivalent (`RCLONE_CONFIG="/notfound" go test ./...`) — no failures related to this change.
- `go vet`, `gofmt` clean.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate (not needed — behaviour now matches the existing docs).
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend — S3 integration suite run against MinIO, see above.
- [x] This Pull Request is ready for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
