### PR TITLE
http: directory listing is empty when the first path segment contains a colon

### DIFF
--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -393,7 +393,8 @@ func (f *Fs) url(remote string) string {
 		return f.endpointURL + trimmedRemote
 	}
 	// Default behavior
-	return f.endpointURL + rest.URLPathEscape(trimmedRemote)
+	escaped := rest.URLPathEscape(trimmedRemote)
+	return f.endpointURL + strings.TrimPrefix(escaped, "./")
 }
 
 // Errors returned by parseName


### PR DESCRIPTION
<!--
Template checkboxes (all required, tick them once you've genuinely done them):
  [x] I have searched the forum and the existing issues for this problem.
  [x] I have tested with the latest beta or stable release and can still reproduce.
  [x] This is a reproducible bug, not a usage question.

Prior issues that look related but are NOT this bug:
  #1331 - CLI argument parser treating "remote:path" colons as a separator (closed, doc fix)
  #1613 - crash on colons in HTTP remote filenames, "first path segment in URL cannot contain colon" (closed)
  #1555 - --http-url containing a colon
This one is a silent empty listing with no error, and is still present on master.
-->

## What is the problem you are having with rclone?

Listing a directory whose name contains a colon returns zero entries, if that directory is the **first path segment** relative to the backend root. The directory shows up in its parent's listing, but descending into it shows nothing. Nothing is logged, even at `-vv`, and the exit status is 0.

### Reproduction

Self-contained, no special server needed — Python's `http.server` escapes hrefs
correctly, so this is not a server-side escaping problem:

```bash
mkdir -p "repro/Sub:Dir" "repro/plain/Sub:Dir"
echo hello > "repro/Sub:Dir/file.txt"
echo hello > "repro/plain/Sub:Dir/file.txt"
(cd repro && python3 -m http.server 8801 --bind 127.0.0.1 &)

rclone lsf :http: --http-url http://127.0.0.1:8801/ -R
```

Actual:

```
Sub:Dir/
plain/
plain/Sub:Dir/
plain/Sub:Dir/file.txt
```

Expected — `Sub:Dir/file.txt` is missing, while the identical directory one
level down lists fine:

```
Sub:Dir/
Sub:Dir/file.txt          <-- missing
plain/
plain/Sub:Dir/
plain/Sub:Dir/file.txt
```

### Cause

`Fs.url` builds sub-paths with `rest.URLPathEscape`, which is `url.URL.String()`.
Per RFC 3986 §4.2 that prepends `./` when the first path segment contains a
colon, so the segment cannot be mistaken for a scheme. Requests as seen by the
server:

```
"GET / HTTP/1.1"
"GET /./Sub:Dir/ HTTP/1.1"        <-- dot-segment
"GET /plain/ HTTP/1.1"
"GET /plain/Sub:Dir/ HTTP/1.1"    <-- no dot-segment, works
```

The server normalises that away and returns the correct listing, so the request
succeeds with a 200. But the unnormalised URL is reused as the base for parsing,
so `base.Path` keeps the dot-segment while hrefs resolved against it through
`url.ResolveReference` have dot-segments removed:

```
base.Path       /./Sub:Dir/
resolved href   /Sub:Dir/file.txt
```

`parseName`'s under-root check is a `strings.HasPrefix` of one against the other,
so every entry is rejected with `errNotUnderRoot`. `parse()` discards `parseName`
errors, which is why the failure is completely silent.

`Fs.url` appends to an absolute endpoint URL that already ends in `/`, so the
dot-segment is never needed there.

I have a patch and a regression test for this and am happy to open a PR.

## rclone version

```
rclone v1.75.0-DEV
- os/version: debian forky/sid (64 bit)
- os/kernel: 7.0.10+deb14-amd64 (x86_64)
- os/type: linux
- os/arch: amd64
- go/version: go1.26.5
- go/linking: dynamic
- go/tags: none
```

Built from master at c10eb47b. Originally hit on the v1.60.1 packaged in Debian;
the relevant line is byte-identical on both.

## Which OS you are using and how many bits

Linux, 64 bit.

## Which cloud storage system are you using?

HTTP (`:http:`). Originally hit against nginx `autoindex`; the reproducer above
uses Python's `http.server` to show it is not server-specific.

## The command you were trying to run

```
rclone lsf :http: --http-url http://127.0.0.1:8801/ -R
```

Originally hit via `rclone mount`, where the symptom is a directory that opens
but appears empty:

```
rclone mount :http: /mnt/data --http-url http://192.0.2.1/ --read-only
ls "/mnt/data/Sub:Dir/"     # empty
```

## A log from the command with the -vv flag

```
DEBUG : rclone: Version "v1.75.0-DEV" starting with parameters ["rclone" "lsf" ":http:" "--http-url" "http://127.0.0.1:8801/" "-R" "-vv"]
DEBUG : Creating backend with remote ":http:"
DEBUG : :http: detected overridden config - adding "{VPVGH}" suffix to name
DEBUG : Root: http://127.0.0.1:8801/
DEBUG : fs cache: renaming cache item ":http:" to be canonical ":http{VPVGH}:"
Sub:Dir/
plain/
plain/Sub:Dir/
plain/Sub:Dir/file.txt
DEBUG : 3 go routines active
```

Note there is no error anywhere in the log — the dropped entries are invisible
at any log level, which is arguably a second bug in `parse()`.

## Output of rclone config redacted

No config file — the backend is configured entirely on the command line with
`:http:` and `--http-url`.

```
[none]
```