### PR TITLE
serve dlna: bound SOAP request bodies

### DIFF
--- a/cmd/serve/dlna/dlna.go
+++ b/cmd/serve/dlna/dlna.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/xml"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -148,6 +149,7 @@ const (
 	rootDescPath      = "/rootDesc.xml"
 	resPath           = "/r/"
 	serviceControlURL = "/ctl"
+	maxSOAPBodySize   = 1 << 20
 )
 
 type server struct {
@@ -303,7 +305,13 @@ func (s *server) serviceControlHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	var env soap.Envelope
+	r.Body = http.MaxBytesReader(w, r.Body, maxSOAPBodySize)
 	if err := xml.NewDecoder(r.Body).Decode(&env); err != nil {
+		var maxBytesErr *http.MaxBytesError
+		if errors.As(err, &maxBytesErr) {
+			http.Error(w, "SOAP request body too large", http.StatusRequestEntityTooLarge)
+			return
+		}
 		serveError(ctx, s, w, "Could not parse SOAP request body", err)
 		return
 	}

--- a/cmd/serve/dlna/dlna_test.go
+++ b/cmd/serve/dlna/dlna_test.go
@@ -57,6 +57,20 @@ func TestInit(t *testing.T) {
 	startServer(t, f)
 }
 
+func TestServiceControlRejectsOversizedBody(t *testing.T) {
+	body := `<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"><s:Body>` +
+		`<u:RegisterDevice xmlns:u="urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1">` +
+		strings.Repeat("x", maxSOAPBodySize) +
+		`</u:RegisterDevice></s:Body></s:Envelope>`
+	req, err := http.NewRequest("POST", baseURL+serviceControlURL, strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("SOAPACTION", `"urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1#RegisterDevice"`)
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
+}
+
 // Make sure that it serves rootDesc.xml (SCPD in uPnP parlance).
 func TestRootSCPD(t *testing.T) {
 	req, err := http.NewRequest("GET", baseURL+rootDescPath, nil)

--- a/cmd/serve/dlna/dlna_test.go
+++ b/cmd/serve/dlna/dlna_test.go
@@ -67,7 +67,9 @@ func TestServiceControlRejectsOversizedBody(t *testing.T) {
 	req.Header.Set("SOAPACTION", `"urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1#RegisterDevice"`)
 	resp, err := http.DefaultClient.Do(req)
 	require.NoError(t, err)
-	defer resp.Body.Close()
+	defer func() {
+		require.NoError(t, resp.Body.Close())
+	}()
 	assert.Equal(t, http.StatusRequestEntityTooLarge, resp.StatusCode)
 }
 


### PR DESCRIPTION
DLNA control requests are decoded into an in-memory SOAP action. A peer on the reachable DLNA network can send a large request body and consume server memory.

Limit request bodies to 1 MiB before XML decoding and return 413 when the limit is exceeded.

Validated with go test ./cmd/serve/dlna -count=1 and go test -race ./cmd/serve/dlna -count=1.