### PR TITLE
filter: normalise globs and matched paths to NFC

### DIFF
--- a/fs/filter/glob.go
+++ b/fs/filter/glob.go
@@ -9,11 +9,15 @@ import (
 	"strings"
 
 	"github.com/rclone/rclone/fs"
+	"golang.org/x/text/unicode/norm"
 )
 
 // GlobPathToRegexp converts an rsync style glob path to a regexp
+//
+// The glob is normalised to NFC so that paths normalised likewise
+// match regardless of the unicode form they were written in.
 func GlobPathToRegexp(glob string, ignoreCase bool) (*regexp.Regexp, error) {
-	return globToRegexp(glob, true, true, ignoreCase)
+	return globToRegexp(norm.NFC.String(glob), true, true, ignoreCase)
 }
 
 // GlobStringToRegexp converts an rsync style glob string to a regexp

--- a/fs/filter/rules.go
+++ b/fs/filter/rules.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/rclone/rclone/fs"
+	"golang.org/x/text/unicode/norm"
 )
 
 // RulesOpt is configuration for a rule set
@@ -29,8 +30,11 @@ type rule struct {
 }
 
 // Match returns true if rule matches path
+//
+// The path is normalised to NFC before matching so that it matches
+// rules regardless of the unicode form it is in.
 func (r *rule) Match(path string) bool {
-	return r.Regexp.MatchString(path)
+	return r.Regexp.MatchString(norm.NFC.String(path))
 }
 
 // String the rule


### PR DESCRIPTION
#### What does this change do?

Fixes filters silently not matching non-ASCII file names when the pattern and the file name are in different Unicode normalization forms (NFC pattern vs NFD names from macOS, or vice versa).

Filter matching compared raw bytes: `globToRegexp` wrote the pattern's runes verbatim into the regexp and `rule.Match` matched the raw path string. This change normalises the glob to NFC when compiling it (`GlobPathToRegexp`) and the path to NFC before matching (`rule.Match`), so both sides compare in the same form. This is option 1 from the issue discussion (normalise both sides, no new flag); `norm.NFC.String` short-circuits for already-NFC input so the per-match cost is negligible for ASCII/NFC paths.

Affected package tests (`fs/filter`) pass.

#### Linked issue

Fixes #7757

#### For new or changed backends

Not a backend change.
