### PR TITLE
http: add metadata defaults for --http-no-head

### DIFF
--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -96,19 +96,25 @@ sizes of any files, and some files that don't exist may be in the listing.`,
 			Advanced: true,
 		}, {
 			Name: "no_head_size",
-			Help: `Set a default file size for --http-no-head.
+			Help: `Set the reported file size for --http-no-head.
 
 When HEAD requests are disabled, rclone normally reports an unknown file size.
-Set this option to report the specified size for every file instead.
-Leave it at 0 to keep reporting an unknown size.`,
-			Default:  fs.SizeSuffix(0),
+Set this option to a non-negative value to report that size for every file,
+including 0. Leave it at -1 to keep reporting an unknown size.
+
+The configured size is authoritative. If it does not match the actual file
+size, transfers may fail their size check and retry unless --ignore-size is
+used. It can also make multi-thread transfers request incorrect ranges and
+make mounted files unreadable past the reported size.`,
+			Default:  fs.SizeSuffix(-1),
 			Advanced: true,
 		}, {
 			Name: "no_head_time",
 			Help: `Set a default modification time for --http-no-head.
 
 When HEAD requests are disabled, rclone normally reports an unset modification
-time. Set this option to report the specified time for every file instead.`,
+time. Set this option to report the specified time for every file instead.
+Changing the configured time later makes every file appear modified to a sync.`,
 			Default:  fs.Time{},
 			Advanced: true,
 		}, {
@@ -330,7 +336,9 @@ func (f *Fs) httpConnection(ctx context.Context, opt *Options) (isFile bool, err
 // the host specified in the config file.
 func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, error) {
 	// Parse config into Options struct
-	opt := new(Options)
+	opt := &Options{
+		NoHeadSize: fs.SizeSuffix(-1),
+	}
 	err := configstruct.Set(m, opt)
 	if err != nil {
 		return nil, err
@@ -706,10 +714,7 @@ func (o *Object) url() string {
 // head sends a HEAD request to update info fields in the Object
 func (o *Object) head(ctx context.Context) error {
 	if o.fs.opt.NoHead {
-		o.size = -1
-		if o.fs.opt.NoHeadSize > 0 {
-			o.size = int64(o.fs.opt.NoHeadSize)
-		}
+		o.size = int64(o.fs.opt.NoHeadSize)
 		o.modTime = timeUnset
 		if o.fs.opt.NoHeadTime.IsSet() {
 			o.modTime = time.Time(o.fs.opt.NoHeadTime)

--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -95,6 +95,23 @@ sizes of any files, and some files that don't exist may be in the listing.`,
 			Default:  false,
 			Advanced: true,
 		}, {
+			Name: "no_head_size",
+			Help: `Set a default file size for --http-no-head.
+
+When HEAD requests are disabled, rclone normally reports an unknown file size.
+Set this option to report the specified size for every file instead.
+Leave it at 0 to keep reporting an unknown size.`,
+			Default:  fs.SizeSuffix(0),
+			Advanced: true,
+		}, {
+			Name: "no_head_time",
+			Help: `Set a default modification time for --http-no-head.
+
+When HEAD requests are disabled, rclone normally reports an unset modification
+time. Set this option to report the specified time for every file instead.`,
+			Default:  fs.Time{},
+			Advanced: true,
+		}, {
 			Name:    "no_escape",
 			Help:    "Do not escape URL metacharacters in path names.",
 			Default: false,
@@ -139,11 +156,13 @@ var systemMetadataInfo = map[string]fs.MetadataHelp{
 
 // Options defines the configuration for this backend
 type Options struct {
-	Endpoint string          `config:"url"`
-	NoSlash  bool            `config:"no_slash"`
-	NoHead   bool            `config:"no_head"`
-	Headers  fs.CommaSepList `config:"headers"`
-	NoEscape bool            `config:"no_escape"`
+	Endpoint   string          `config:"url"`
+	NoSlash    bool            `config:"no_slash"`
+	NoHead     bool            `config:"no_head"`
+	NoHeadSize fs.SizeSuffix   `config:"no_head_size"`
+	NoHeadTime fs.Time         `config:"no_head_time"`
+	Headers    fs.CommaSepList `config:"headers"`
+	NoEscape   bool            `config:"no_escape"`
 }
 
 // Fs stores the interface to the remote HTTP files
@@ -688,7 +707,13 @@ func (o *Object) url() string {
 func (o *Object) head(ctx context.Context) error {
 	if o.fs.opt.NoHead {
 		o.size = -1
+		if o.fs.opt.NoHeadSize > 0 {
+			o.size = int64(o.fs.opt.NoHeadSize)
+		}
 		o.modTime = timeUnset
+		if o.fs.opt.NoHeadTime.IsSet() {
+			o.modTime = time.Time(o.fs.opt.NoHeadTime)
+		}
 		o.contentType = fs.MimeType(ctx, o)
 		return nil
 	}

--- a/backend/http/http_internal_test.go
+++ b/backend/http/http_internal_test.go
@@ -314,6 +314,22 @@ func TestOpen(t *testing.T) {
 	}
 }
 
+func TestNoHeadMetadataDefaults(t *testing.T) {
+	m := prepareServer(t)
+	m.Set("no_head", "true")
+	m.Set("no_head_size", "100B")
+	m.Set("no_head_time", "2024-08-05T07:36:07Z")
+
+	f, err := NewFs(context.Background(), remoteName, "", m)
+	require.NoError(t, err)
+	o, err := f.NewObject(context.Background(), "four/under four.txt")
+	require.NoError(t, err)
+
+	assert.Equal(t, int64(100), o.Size())
+	assert.Equal(t, time.Date(2024, 8, 5, 7, 36, 7, 0, time.UTC),
+		o.ModTime(context.Background()))
+}
+
 func TestMimeType(t *testing.T) {
 	f := prepare(t)
 

--- a/backend/http/http_internal_test.go
+++ b/backend/http/http_internal_test.go
@@ -315,19 +315,51 @@ func TestOpen(t *testing.T) {
 }
 
 func TestNoHeadMetadataDefaults(t *testing.T) {
-	m := prepareServer(t)
-	m.Set("no_head", "true")
-	m.Set("no_head_size", "100B")
-	m.Set("no_head_time", "2024-08-05T07:36:07Z")
+	tests := []struct {
+		name        string
+		size        string
+		modTime     string
+		wantSize    int64
+		wantModTime time.Time
+	}{
+		{
+			name:        "defaults",
+			wantSize:    -1,
+			wantModTime: timeUnset,
+		}, {
+			name:        "zero size",
+			size:        "0B",
+			wantSize:    0,
+			wantModTime: timeUnset,
+		}, {
+			name:        "configured metadata",
+			size:        "100B",
+			modTime:     "2024-08-05T07:36:07Z",
+			wantSize:    100,
+			wantModTime: time.Date(2024, 8, 5, 7, 36, 7, 0, time.UTC),
+		},
+	}
 
-	f, err := NewFs(context.Background(), remoteName, "", m)
-	require.NoError(t, err)
-	o, err := f.NewObject(context.Background(), "four/under four.txt")
-	require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			m := prepareServer(t)
+			m.Set("no_head", "true")
+			if test.size != "" {
+				m.Set("no_head_size", test.size)
+			}
+			if test.modTime != "" {
+				m.Set("no_head_time", test.modTime)
+			}
 
-	assert.Equal(t, int64(100), o.Size())
-	assert.Equal(t, time.Date(2024, 8, 5, 7, 36, 7, 0, time.UTC),
-		o.ModTime(context.Background()))
+			f, err := NewFs(context.Background(), remoteName, "", m)
+			require.NoError(t, err)
+			o, err := f.NewObject(context.Background(), "four/under four.txt")
+			require.NoError(t, err)
+
+			assert.Equal(t, test.wantSize, o.Size())
+			assert.Equal(t, test.wantModTime, o.ModTime(context.Background()))
+		})
+	}
 }
 
 func TestMimeType(t *testing.T) {


### PR DESCRIPTION
## What this changes

Adds two advanced HTTP backend options for use with `--http-no-head`:

- `--http-no-head-size` reports a configured size for every file instead of the usual unknown size. Its default is `-1` (unknown), while any non-negative value—including `0`—is reported as authoritative.
- `--http-no-head-time` reports a configured modification time instead of the Unix epoch sentinel.

Both options preserve current behavior when left unset. The values are applied in the common no-HEAD metadata path, so they cover both directory listings and direct object lookup.

The size option's help now calls out that an incorrect fixed size can cause transfer size-check failures/retries, incorrect multi-thread ranges, and mount reads being limited at the reported size. The time option notes that changing it later makes every file appear modified to a sync.

## Verification

- `go test ./backend/http -count=1`
- `go vet ./backend/http`
- `golangci-lint run ./backend/http/...` with zero findings
- `git diff --check`

Focused tests cover the default unknown size, an explicit zero-byte size, and configured size/time metadata.

Fixes #7988
