### PR TITLE
lsf: document Google Drive shortcut IDs

### DIFF
--- a/cmd/lsf/lsf.go
+++ b/cmd/lsf/lsf.go
@@ -80,6 +80,12 @@ T - tier of storage if known, e.g. "Hot" or "Cool"
 M - Metadata of object in JSON blob format, eg {"key":"value"}
 ` + "```" + `
 
+Some backends use composite IDs. In particular, Google Drive shortcuts are
+normally dereferenced, and their "i" field contains the target object's ID
+followed by the shortcut's ID, separated by a tab. This tab is part of the ID
+field and is not changed by ` + "`--separator`" + `. Use ` + "`--drive-skip-shortcuts`" + ` to omit
+shortcut entries.
+
 So if you wanted the path, size and modification time, you would use
 ` + "`--format \"pst\"`, or maybe `--format \"tsp\"`" + ` to put the path last.
 

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -499,6 +499,10 @@ used to create shortcuts.
 Shortcuts can be completely ignored with the `--drive-skip-shortcuts` flag
 or the corresponding `skip_shortcuts` configuration setting.
 
+When `rclone lsf --format i` lists a file shortcut, the ID field contains the
+target file ID followed by the shortcut ID, separated by a tab. This internal
+tab is not changed by `--separator`.
+
 If you have a folder shortcut that points at one of its own parent folders it
 would lead to an infinite recursion. Rclone detects this, leaves the offending
 shortcut out of the listing and logs an ERROR, so the rest of the drive can


### PR DESCRIPTION
## What this changes

Documents the composite ID returned by `rclone lsf --format i` for Google Drive shortcuts:

- The target object's ID is first.
- The shortcut's ID is second.
- The two IDs are separated by a tab inside the ID field.
- `--separator` does not change that internal tab.
- `--drive-skip-shortcuts` omits shortcut entries.

The wording is added to the command's source help so it appears in both `rclone lsf --help` and generated command documentation.

## Verification

- `go test ./cmd/lsf -count=1`
- `go vet ./cmd/lsf`
- `golangci-lint run ./cmd/lsf/...` with zero findings
- `git diff --check`
- Built and inspected `rclone lsf --help` to verify the explanation appears.

Fixes #7863
