### PR TITLE
gui: respect explicit --rc-allow-origin instead of always deriving it from the bind address

### DIFF
--- a/cmd/gui/gui.go
+++ b/cmd/gui/gui.go
@@ -175,20 +175,8 @@ For more help see [the GUI docs](/gui/).
 			}
 		}
 
-		// When the GUI is bound to a wildcard address the bound origin
-		// (e.g. http://[::]:5522) is never what a browser sends in its
-		// Origin header, and the GUI may be reached via any number of
-		// hosts (localhost, a LAN IP, a Docker host), so no single
-		// origin can match them all.
-		switch addr, _ := guiServer.Addr().(*net.TCPAddr); {
-		case addr == nil || !addr.IP.IsUnspecified():
-			opt.HTTP.AllowOrigin = guiOrigin
-		case !opt.NoAuth:
-			opt.HTTP.AllowOrigin = "*"
-		default:
-			opt.HTTP.AllowOrigin = guiOrigin
-			fs.Logf(nil, "GUI bound to a wildcard address with --no-auth: browsers can only use the API from %s. Enable auth or bind --addr to a specific host.", guiOrigin)
-		}
+		addr, _ := guiServer.Addr().(*net.TCPAddr)
+		opt.HTTP.AllowOrigin = resolveAllowOrigin(command.Flags().Changed("rc-allow-origin"), opt.HTTP.AllowOrigin, guiOrigin, addr, opt.NoAuth)
 
 		// Start the RC server (unchanged rcserver.Start)
 		rcServer, err := rcserver.Start(ctx, &opt)
@@ -251,6 +239,28 @@ func originFromURL(rawURL string) string {
 		return strings.TrimRight(rawURL, "/")
 	}
 	return u.Scheme + "://" + u.Host
+}
+
+// resolveAllowOrigin picks the Access-Control-Allow-Origin value for the RC
+// API server. An explicit --rc-allow-origin always wins. Otherwise a value is
+// derived from how the GUI is bound: the bound origin (e.g. http://[::]:5522)
+// is never what a browser sends in its Origin header when the GUI is bound to
+// a wildcard address, and the GUI may be reached via any number of hosts
+// (localhost, a LAN IP, a Docker host), so no single origin can match them
+// all.
+func resolveAllowOrigin(explicitAllowOrigin bool, currentAllowOrigin, guiOrigin string, addr *net.TCPAddr, noAuth bool) string {
+	if explicitAllowOrigin {
+		return currentAllowOrigin
+	}
+	switch {
+	case addr == nil || !addr.IP.IsUnspecified():
+		return guiOrigin
+	case !noAuth:
+		return "*"
+	default:
+		fs.Logf(nil, "GUI bound to a wildcard address with --no-auth: browsers can only use the API from %s. Enable auth or bind --addr to a specific host.", guiOrigin)
+		return guiOrigin
+	}
 }
 
 // guiSourceFS opens the GUI bundle at the given path. An empty path

--- a/cmd/gui/gui_test.go
+++ b/cmd/gui/gui_test.go
@@ -5,6 +5,7 @@ import (
 	"compress/gzip"
 	"io"
 	iofs "io/fs"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -94,6 +95,66 @@ func TestOriginFromURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := originFromURL(tt.url)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestResolveAllowOrigin(t *testing.T) {
+	wildcard := &net.TCPAddr{IP: net.IPv4zero, Port: 5533}
+	specific := &net.TCPAddr{IP: net.ParseIP("127.0.0.1"), Port: 5533}
+
+	tests := []struct {
+		name                string
+		explicitAllowOrigin bool
+		currentAllowOrigin  string
+		guiOrigin           string
+		addr                *net.TCPAddr
+		noAuth              bool
+		want                string
+	}{
+		{
+			name:                "explicit flag wins even on a wildcard bind",
+			explicitAllowOrigin: true,
+			currentAllowOrigin:  "http://192.0.2.10:5522",
+			guiOrigin:           "http://[::]:5580",
+			addr:                wildcard,
+			noAuth:              false,
+			want:                "http://192.0.2.10:5522",
+		},
+		{
+			name:                "explicit flag wins on a specific bind too",
+			explicitAllowOrigin: true,
+			currentAllowOrigin:  "http://192.0.2.10:5522",
+			guiOrigin:           "http://127.0.0.1:5580",
+			addr:                specific,
+			noAuth:              false,
+			want:                "http://192.0.2.10:5522",
+		},
+		{
+			name:      "specific bind falls back to the gui origin",
+			guiOrigin: "http://127.0.0.1:5580",
+			addr:      specific,
+			want:      "http://127.0.0.1:5580",
+		},
+		{
+			name:      "wildcard bind with auth falls back to *",
+			guiOrigin: "http://[::]:5580",
+			addr:      wildcard,
+			noAuth:    false,
+			want:      "*",
+		},
+		{
+			name:      "wildcard bind without auth falls back to the gui origin",
+			guiOrigin: "http://[::]:5580",
+			addr:      wildcard,
+			noAuth:    true,
+			want:      "http://[::]:5580",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveAllowOrigin(tt.explicitAllowOrigin, tt.currentAllowOrigin, tt.guiOrigin, tt.addr, tt.noAuth)
 			assert.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
#### What does this change do?

`rclone gui` derives the RC server's CORS origin from how the GUI is bound (needed since #9603, for the wildcard-bind case), but it does that unconditionally - so an explicitly passed `--rc-allow-origin` gets silently overwritten. That's exactly the Docker/remote-browser setup the flag exists for and that the docs describe: bind to `0.0.0.0` inside the container, browser somewhere else, `--rc-allow-origin` set to the address the browser actually uses. Right now that setup just doesn't work.

Fix is small: only derive the origin when the user hasn't set `--rc-allow-origin` themselves. Pulled the origin-selection logic into its own `resolveAllowOrigin` function (matching how `originFromURL`/`buildLoginURL` are already split out in this file) so it's unit-testable without spinning up real servers.

#### Linked issue

Fixes #9640

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** N/A, not a backend change.
- [x] This Pull Request is ready for review.

---

Used an AI coding assistant (Claude Code) for part of this, per the repo's stated policy - tested it myself, notes below.

Testing: added `TestResolveAllowOrigin` covering both the explicit-flag and auto-derived paths, confirmed it fails on the old code (deleted the guard, two of five cases failed with the exact wrong values you'd see live - `*` instead of the explicit origin). Also did a real end-to-end check: built both the old and new code as actual binaries, ran `rclone gui --addr=0.0.0.0:PORT --rc-allow-origin=http://192.0.2.10:PORT --user=... --pass=...`, then hit the RC API with `curl` and an `Origin` header matching that address. Old binary answered `Access-Control-Allow-Origin: *`, new one answered with the actual `--rc-allow-origin` value. `go build`, `go vet`, and the full `cmd/gui` package test suite all pass.
