### PR TITLE
serve http: add --disable-dir-list flag to disable HTML directory listing

### DIFF
--- a/cmd/serve/http/http.go
+++ b/cmd/serve/http/http.go
@@ -36,6 +36,10 @@ import (
 
 // OptionsInfo describes the Options in use
 var OptionsInfo = fs.Options{{
+	Name:    "disable_dir_list",
+	Default: false,
+	Help:    "Disable HTML directory list on GET request for a directory",
+}, {
 	Name:    "disable_zip",
 	Default: false,
 	Help:    "Disable zip download of directories",
@@ -46,10 +50,11 @@ var OptionsInfo = fs.Options{{
 
 // Options required for http server
 type Options struct {
-	Auth       libhttp.AuthConfig
-	HTTP       libhttp.Config
-	Template   libhttp.TemplateConfig
-	DisableZip bool `config:"disable_zip"`
+	Auth           libhttp.AuthConfig
+	HTTP           libhttp.Config
+	Template       libhttp.TemplateConfig
+	DisableDirList bool `config:"disable_dir_list"`
+	DisableZip     bool `config:"disable_zip"`
 }
 
 // DefaultOpt is the default values used for Options
@@ -268,6 +273,10 @@ func (s *HTTP) handler(w http.ResponseWriter, r *http.Request) {
 
 // serveDir serves a directory index at dirRemote
 func (s *HTTP) serveDir(w http.ResponseWriter, r *http.Request, dirRemote string) {
+	if s.opt.DisableDirList {
+		http.Error(w, "Directory listing disabled", http.StatusForbidden)
+		return
+	}
 	ctx := r.Context()
 	VFS, err := s.getVFS(r.Context())
 	if err != nil {

--- a/cmd/serve/http/http_test.go
+++ b/cmd/serve/http/http_test.go
@@ -448,3 +448,51 @@ func TestRc(t *testing.T) {
 		"vfs_cache_mode": "off",
 	})
 }
+
+func TestDisableDirList(t *testing.T) {
+	ctx := context.Background()
+	f, err := fs.NewFs(ctx, "testdata/files")
+	require.NoError(t, err)
+
+	opts := Options{
+		HTTP:           libhttp.DefaultCfg(),
+		DisableDirList: true,
+	}
+	opts.HTTP.ListenAddr = []string{testBindAddress}
+	if proxy.Opt.AuthProxy == "" {
+		opts.Auth.BasicUser = testUser
+		opts.Auth.BasicPass = testPass
+	}
+
+	s, err := newServer(ctx, f, &opts, &vfscommon.Opt, &proxy.Opt)
+	require.NoError(t, err, "failed to start server")
+	go func() {
+		_ = s.Serve()
+	}()
+	defer func() { assert.NoError(t, s.server.Shutdown()) }()
+
+	urls := s.server.URLs()
+	require.Len(t, urls, 1)
+	testURL := urls[0]
+
+	pause := time.Millisecond
+	for range 10 {
+		resp, err := http.Head(testURL)
+		if err == nil {
+			_ = resp.Body.Close()
+			break
+		}
+		time.Sleep(pause)
+		pause *= 2
+	}
+
+	req, err := http.NewRequest("GET", testURL, nil)
+	require.NoError(t, err)
+	req.SetBasicAuth(testUser, testPass)
+
+	resp, err := http.DefaultClient.Do(req)
+	require.NoError(t, err)
+	defer func() { _ = resp.Body.Close() }()
+
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}


### PR DESCRIPTION
## Description
Currently, `rclone serve webdav` supports a `--disable-dir-list` option to disable HTML directory listing on GET requests for directories, but `rclone serve http` lacked this functionality.

This PR adds `--disable-dir-list` to `rclone serve http`:
- Added `disable_dir_list` option in `OptionsInfo` and `DisableDirList` field in `Options` struct.
- Updated `serveDir` to check `s.opt.DisableDirList` and return `HTTP 403 Forbidden` when directory listing is disabled.
- Added unit test `TestDisableDirList` in `cmd/serve/http/http_test.go`.

Fixes #4000