### PR TITLE
deletefile: support --backup-dir when deleting a single file

### DIFF
--- a/cmd/deletefile/deletefile.go
+++ b/cmd/deletefile/deletefile.go
@@ -32,11 +32,16 @@ specified file exists, it will always be removed.`,
 			if fileName == "" {
 				return fmt.Errorf("%s is a directory or doesn't exist: %w", args[0], fs.ErrorObjectNotFound)
 			}
-			fileObj, err := f.NewObject(context.Background(), fileName)
+			ctx := context.Background()
+			fileObj, err := f.NewObject(ctx, fileName)
 			if err != nil {
 				return err
 			}
-			return operations.DeleteFile(context.Background(), fileObj)
+			backupDir, err := operations.BackupDir(ctx, f, "")
+			if err != nil {
+				return err
+			}
+			return operations.DeleteFileWithBackupDir(ctx, fileObj, backupDir)
 		})
 	},
 }


### PR DESCRIPTION
## Description
Previously, `rclone deletefile` invoked `operations.DeleteFile`, which directly removed the specified file without honoring `--backup-dir` configuration.

This PR updates `cmd/deletefile/deletefile.go` to lookup `operations.BackupDir(ctx, f, "")` and invoke `operations.DeleteFileWithBackupDir(ctx, fileObj, backupDir)`, allowing `rclone deletefile` to safely move target files into the configured backup directory instead of permanently deleting them when `--backup-dir` is supplied.

Fixes #7566