### PR TITLE
march: fix goroutine leak on successful march

### DIFF
--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -263,11 +263,18 @@ func (m *March) Run(ctx context.Context) error {
 		dstDepth:  dstDepth - 1,
 		noDst:     m.NoCheckDest,
 	}
+	done := make(chan struct{})
+	defer close(done)
 	go func() {
-		// when the context is cancelled discard the remaining jobs
-		<-m.Ctx.Done()
-		for range in {
-			traversing.Done()
+		// when the context is cancelled discard the remaining jobs, but
+		// exit unconditionally once the march finishes so a successful
+		// march (whose context is never cancelled) doesn't strand us
+		select {
+		case <-m.Ctx.Done():
+			for range in {
+				traversing.Done()
+			}
+		case <-done:
 		}
 	}()
 	traversing.Wait()

--- a/fs/march/march_test.go
+++ b/fs/march/march_test.go
@@ -6,9 +6,11 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	_ "github.com/rclone/rclone/backend/local"
 	"github.com/rclone/rclone/fs"
@@ -272,6 +274,53 @@ func TestMarch(t *testing.T) {
 			fstest.CompareItems(t, mt.match, match, test.dirMatch, precision, "match")
 		})
 	}
+}
+
+// countMarchRunGoroutines counts goroutines currently executing inside a
+// March.Run closure
+func countMarchRunGoroutines() int {
+	buf := make([]byte, 1<<20)
+	n := runtime.Stack(buf, true)
+	return strings.Count(string(buf[:n]), "fs/march.(*March).Run.func")
+}
+
+// TestMarchNoGoroutineLeak checks that a successful march leaves no goroutine
+// behind even when its context is never cancelled, as happens for an
+// asynchronous rc job (see issue #9620).
+func TestMarchNoGoroutineLeak(t *testing.T) {
+	r := fstest.NewRun(t)
+
+	// A background context, never cancelled - mirrors an async rc job.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel() // cleanup AFTER the assertion below
+
+	r.WriteFile("file1", "hello world", t1)
+	r.WriteFile("sub dir/file2", "hello world", t1)
+
+	ctx, _ = fs.AddConfig(ctx)
+	fi := filter.GetConfig(ctx)
+	mt := &marchTester{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	m := &March{
+		Ctx:           ctx,
+		Fdst:          r.Fremote,
+		Fsrc:          r.Flocal,
+		Dir:           "",
+		Callback:      mt,
+		DstIncludeAll: fi.Opt.DeleteExcluded,
+	}
+
+	require.NoError(t, m.Run(ctx))
+
+	// The janitor goroutine must have exited even though ctx was never
+	// cancelled. Eventually covers scheduling lag for the workers and
+	// producers, which also match ".Run.func" but exit promptly once Run
+	// returns.
+	require.Eventually(t, func() bool {
+		return countMarchRunGoroutines() == 0
+	}, 5*time.Second, 10*time.Millisecond, "march goroutine leaked")
 }
 
 func TestMarchNoProcessDstOnly(t *testing.T) {


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes a goroutine leak in `fs/march`. `(*March).Run` starts a janitor goroutine whose only exit is context cancellation:

```go
go func() {
	// when the context is cancelled discard the remaining jobs
	<-m.Ctx.Done()
	for range in {
		traversing.Done()
	}
}()
```

The janitor exists to drain the jobs still buffered in `in` when a march is cancelled (the checkers return immediately on `<-m.Ctx.Done()` and stop reading `in`, so without the janitor `traversing.Wait()` would hang). But on a march that completes **successfully** nothing cancels the context, so the janitor parks on `<-m.Ctx.Done()` forever. Its closure pins the `*March` and, through `m.Callback`, the file listings.

This only bites callers that hand `march.New` a context that never gets cancelled. `fs/sync` derives its own cancellable context and defers the cancel, so it is immune. `cmd/bisync` passes the raw job context; an asynchronous rc job's context descends from `context.Background()` (`fs/rc/jobs/job.go`) and is never cancelled on normal completion, so a long-running `rcd` driven with `_async=true sync/bisync` leaks one goroutine and its listings per run — heap grows without bound (reported at ~7.9 GB RSS after ~35 hours in #9620).

The fix gives the janitor a second exit via a `done` channel closed when `Run` returns, so it always terminates. The cancellation path is unchanged.

#### Was the change discussed in an issue or in the forum before?

Fixes #9620

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this set of changes. `TestMarchNoGoroutineLeak` runs a march with a context that is never cancelled and asserts no `Run` goroutine survives; it fails against the current code (the janitor parks and `require.Eventually` times out) and passes with the fix. The existing `TestMarch` did not catch the leak because it cancels the context immediately after `Run` returns, which is exactly what lets the janitor exit.
- [x] I have added documentation where applicable. *(none needed — internal fix, no user-facing flags or behaviour change.)*
- [x] I have run `go build`, `make quicktest` and `go test -race ./fs/march/` and they pass.

#### Notes

An alternative fix would be to add `defer cancel()` to `Job.run` in `fs/rc/jobs/job.go`, releasing the context for every completed rc job. That is broader (it cancels every finished job's context, with side-effect risk on anything reading the context after `job.finish()`) and unnecessary once the janitor is self-terminating, so this PR takes the conservative march-local change. Happy to do the `job.go` change instead/as well if maintainers prefer.

Unrelated but adjacent: #9567 fixed a sibling `accounting.averageLoop` leak in the same rcd/async family; this is independent (after `job/stop`, march goroutines are reclaimed while `averageLoop` ones historically were not).
