### PR TITLE
operations: add cryptcheck to rc API

### DIFF
--- a/cmd/cryptcheck/cryptcheck.go
+++ b/cmd/cryptcheck/cryptcheck.go
@@ -65,53 +65,21 @@ After it has run it will log the status of the ` + "`encryptedremote:`" + `.
 
 // cryptCheck checks the integrity of an encrypted remote
 func cryptCheck(ctx context.Context, fdst, fsrc fs.Fs) error {
-	// Check to see fcrypt is a crypt
 	fcrypt, ok := fdst.(*crypt.Fs)
 	if !ok {
 		return fmt.Errorf("%s:%s is not a crypt remote", fdst.Name(), fdst.Root())
 	}
-	// Find a hash to use
 	funderlying := fcrypt.UnWrap()
-	hashType := funderlying.Hashes().GetOne()
-	if hashType == hash.None {
+	if funderlying.Hashes().GetOne() == hash.None {
 		return fmt.Errorf("%s:%s does not support any hashes", funderlying.Name(), funderlying.Root())
 	}
-	fs.Infof(nil, "Using %v for hash comparisons", hashType)
 
-	opt, close, err := check.GetCheckOpt(fsrc, fcrypt)
+	opt, close, err := check.GetCheckOpt(fsrc, fdst)
 	if err != nil {
 		return err
 	}
 	defer close()
 
-	// checkIdentical checks to see if dst and src are identical
-	//
-	// it returns true if differences were found
-	// it also returns whether it couldn't be hashed
-	opt.Check = func(ctx context.Context, dst, src fs.Object) (differ bool, noHash bool, err error) {
-		cryptDst := dst.(*crypt.Object)
-		underlyingDst := cryptDst.UnWrap()
-		underlyingHash, err := underlyingDst.Hash(ctx, hashType)
-		if err != nil {
-			return true, false, fmt.Errorf("error reading hash from underlying %v: %w", underlyingDst, err)
-		}
-		if underlyingHash == "" {
-			return false, true, nil
-		}
-		cryptHash, err := fcrypt.ComputeHash(ctx, cryptDst, src, hashType)
-		if err != nil {
-			return true, false, fmt.Errorf("error computing hash: %w", err)
-		}
-		if cryptHash == "" {
-			return false, true, nil
-		}
-		if cryptHash != underlyingHash {
-			err = fmt.Errorf("hashes differ (%s:%s) %q vs (%s:%s) %q", fdst.Name(), fdst.Root(), cryptHash, fsrc.Name(), fsrc.Root(), underlyingHash)
-			fs.Errorf(src, "%s", err.Error())
-			return true, false, nil
-		}
-		return false, false, nil
-	}
-
-	return operations.CheckFn(ctx, opt)
+	_, err = operations.CryptCheck(ctx, opt)
+	return err
 }

--- a/cmd/cryptcheck/cryptcheck_test.go
+++ b/cmd/cryptcheck/cryptcheck_test.go
@@ -1,0 +1,41 @@
+package cryptcheck
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	_ "github.com/rclone/rclone/backend/local"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/operations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCryptCheckValidatesBeforeOpeningReports(t *testing.T) {
+	ctx := context.Background()
+	fsrc, err := fs.TemporaryLocalFs(ctx)
+	require.NoError(t, err)
+	fdst, err := fs.TemporaryLocalFs(ctx)
+	require.NoError(t, err)
+	require.NoError(t, fsrc.Mkdir(ctx, ""))
+	require.NoError(t, fdst.Mkdir(ctx, ""))
+	t.Cleanup(func() {
+		require.NoError(t, operations.Purge(ctx, fsrc, ""))
+		require.NoError(t, operations.Purge(ctx, fdst, ""))
+	})
+
+	report := t.TempDir() + "/combined.txt"
+	require.NoError(t, os.WriteFile(report, []byte("keep"), 0o600))
+	combinedFlag := commandDefinition.Flags().Lookup("combined")
+	require.NotNil(t, combinedFlag)
+	oldCombined := combinedFlag.Value.String()
+	require.NoError(t, combinedFlag.Value.Set(report))
+	t.Cleanup(func() { require.NoError(t, combinedFlag.Value.Set(oldCombined)) })
+
+	err = cryptCheck(ctx, fdst, fsrc)
+	require.Error(t, err)
+	contents, readErr := os.ReadFile(report)
+	require.NoError(t, readErr)
+	assert.Equal(t, "keep", string(contents))
+}

--- a/fs/operations/check.go
+++ b/fs/operations/check.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"sync/atomic"
 
+	"github.com/rclone/rclone/backend/crypt"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/accounting"
 	"github.com/rclone/rclone/fs/filter"
@@ -291,6 +292,60 @@ func Check(ctx context.Context, opt *CheckOpt) error {
 	}
 
 	return CheckFn(ctx, &optCopy)
+}
+
+// CryptCheck checks the integrity of an encrypted destination.
+func CryptCheck(ctx context.Context, opt *CheckOpt) (hashType hash.Type, err error) {
+	fcrypt, ok := opt.Fdst.(*crypt.Fs)
+	if !ok {
+		return hash.None, fmt.Errorf("%s:%s is not a crypt remote", opt.Fdst.Name(), opt.Fdst.Root())
+	}
+	funderlying := fcrypt.UnWrap()
+	hashType = funderlying.Hashes().GetOne()
+	if hashType == hash.None {
+		return hash.None, fmt.Errorf("%s:%s does not support any hashes", funderlying.Name(), funderlying.Root())
+	}
+	fs.Infof(nil, "Using %v for hash comparisons", hashType)
+
+	optCopy := *opt
+	var checkErrors atomic.Int32
+	optCopy.Check = func(ctx context.Context, dst, src fs.Object) (differ bool, noHash bool, err error) {
+		cryptDst, ok := dst.(*crypt.Object)
+		if !ok {
+			checkErrors.Add(1)
+			return true, false, fmt.Errorf("expected crypt object, got %T", dst)
+		}
+		underlyingDst := cryptDst.UnWrap()
+		underlyingHash, err := underlyingDst.Hash(ctx, hashType)
+		if err != nil {
+			checkErrors.Add(1)
+			return true, false, fmt.Errorf("error reading hash from underlying %v: %w", underlyingDst, err)
+		}
+		if underlyingHash == "" {
+			return false, true, nil
+		}
+		cryptHash, err := fcrypt.ComputeHash(ctx, cryptDst, src, hashType)
+		if err != nil {
+			checkErrors.Add(1)
+			return true, false, fmt.Errorf("error computing hash: %w", err)
+		}
+		if cryptHash == "" {
+			return false, true, nil
+		}
+		if cryptHash != underlyingHash {
+			err = fmt.Errorf("hashes differ (%s:%s) %q vs (%s:%s) %q", opt.Fdst.Name(), opt.Fdst.Root(), cryptHash, opt.Fsrc.Name(), opt.Fsrc.Root(), underlyingHash)
+			fs.Errorf(src, "%s", err.Error())
+			return true, false, nil
+		}
+		return false, false, nil
+	}
+
+	err = CheckFn(ctx, &optCopy)
+	if errors := checkErrors.Load(); errors > 0 {
+		err = fserrors.FsError(fmt.Errorf("%d errors while checking", errors))
+		fserrors.Count(err)
+	}
+	return hashType, err
 }
 
 // CheckEqualReaders checks to see if in1 and in2 have the same

--- a/fs/operations/check.go
+++ b/fs/operations/check.go
@@ -342,7 +342,7 @@ func CryptCheck(ctx context.Context, opt *CheckOpt) (hashType hash.Type, err err
 
 	err = CheckFn(ctx, &optCopy)
 	if errors := checkErrors.Load(); errors > 0 {
-		err = fserrors.FsError(fmt.Errorf("%d errors while checking", errors))
+		err = fserrors.FsError(fmt.Errorf("%d errors while checking (last error %w)", errors, err))
 		fserrors.Count(err)
 	}
 	return hashType, err

--- a/fs/operations/rc.go
+++ b/fs/operations/rc.go
@@ -692,6 +692,40 @@ func rcDu(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 
 func init() {
 	rc.Add(rc.Call{
+		Path:  "operations/cryptcheck",
+		Fn:    rcCryptCheck,
+		Title: "check an unencrypted source against an encrypted destination",
+		Help: `Checks the integrity of an encrypted destination against an unencrypted source.
+
+This takes the following parameters:
+
+- srcFs - a remote name string e.g. "drive:" for the unencrypted source, "/" for local filesystem
+- dstFs - a crypt remote name string e.g. "encrypted:"
+- oneWay - check one way only, source files must exist on destination
+- combined - make a combined report of changes (default false)
+- missingOnSrc - report all files missing from the source (default true)
+- missingOnDst - report all files missing from the destination (default true)
+- match - report all matching files (default false)
+- differ - report all non-matching files (default true)
+- error - report all files with errors (hashing or reading) (default true)
+
+Returns:
+
+- success - true if no error, false otherwise
+- status - textual summary of check, OK or text string
+- hashType - hash used in check, may be missing
+- combined - array of strings of combined report of changes
+- missingOnSrc - array of strings of all files missing from the source
+- missingOnDst - array of strings of all files missing from the destination
+- match - array of strings of all matching files
+- differ - array of strings of all non-matching files
+- error - array of strings of all files with errors (hashing or reading)
+
+See the [cryptcheck](/commands/rclone_cryptcheck/) command for more information.
+`,
+	})
+
+	rc.Add(rc.Call{
 		Path:  "operations/check",
 		Fn:    rcCheck,
 		Title: "check the source and destination are the same",
@@ -812,36 +846,8 @@ func rcCheck(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 		return nil, rc.NewErrParamInvalid(errors.New("need srcFs parameter when not using checkFileHash"))
 	}
 
-	oneway, _ := in.GetBool("oneWay")
 	download, _ := in.GetBool("download")
-
-	opt := &CheckOpt{
-		Fsrc:   srcFs,
-		Fdst:   dstFs,
-		OneWay: oneway,
-	}
-
-	out = rc.Params{}
-
-	getOutput := func(name string, Default bool) io.Writer {
-		active, err := in.GetBool(name)
-		if err != nil {
-			active = Default
-		}
-		if !active {
-			return nil
-		}
-		result := []string{}
-		out[name] = &result
-		return stringWriter{&result}
-	}
-
-	opt.Combined = getOutput("combined", false)
-	opt.MissingOnSrc = getOutput("missingOnSrc", true)
-	opt.MissingOnDst = getOutput("missingOnDst", true)
-	opt.Match = getOutput("match", false)
-	opt.Differ = getOutput("differ", true)
-	opt.Error = getOutput("error", true)
+	out, opt, _ := rcMakeCheckOpt(in, srcFs, dstFs, false)
 
 	if checkFileHash != "" {
 		out["hashType"] = checkFileHashType.String()
@@ -854,6 +860,84 @@ func rcCheck(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 			err = Check(ctx, opt)
 		}
 	}
+	return rcCheckResult(out, err), nil
+}
+
+func rcCryptCheck(ctx context.Context, in rc.Params) (out rc.Params, err error) {
+	srcFs, err := rc.GetFsNamed(ctx, in, "srcFs")
+	if err != nil {
+		return nil, err
+	}
+	dstFs, err := rc.GetFsNamed(ctx, in, "dstFs")
+	if err != nil {
+		return nil, err
+	}
+	out, opt, err := rcMakeCheckOpt(in, srcFs, dstFs, true)
+	if err != nil {
+		return nil, err
+	}
+	hashType, err := CryptCheck(ctx, opt)
+	if hashType != hash.None {
+		out["hashType"] = hashType.String()
+	}
+	return rcCheckResult(out, err), nil
+}
+
+func rcMakeCheckOpt(in rc.Params, srcFs, dstFs fs.Fs, strict bool) (out rc.Params, opt *CheckOpt, err error) {
+	getBool := func(name string, Default bool) (bool, error) {
+		active, err := in.GetBool(name)
+		if rc.IsErrParamNotFound(err) || (!strict && err != nil) {
+			return Default, nil
+		}
+		return active, err
+	}
+
+	oneway, err := getBool("oneWay", false)
+	if err != nil {
+		return nil, nil, err
+	}
+	opt = &CheckOpt{
+		Fsrc:   srcFs,
+		Fdst:   dstFs,
+		OneWay: oneway,
+	}
+	out = rc.Params{}
+
+	getOutput := func(name string, Default bool) (io.Writer, error) {
+		active, err := getBool(name, Default)
+		if err != nil {
+			return nil, err
+		}
+		if !active {
+			return nil, nil
+		}
+		result := []string{}
+		out[name] = &result
+		return stringWriter{&result}, nil
+	}
+
+	outputs := []struct {
+		name    string
+		Default bool
+		writer  *io.Writer
+	}{
+		{"combined", false, &opt.Combined},
+		{"missingOnSrc", true, &opt.MissingOnSrc},
+		{"missingOnDst", true, &opt.MissingOnDst},
+		{"match", false, &opt.Match},
+		{"differ", true, &opt.Differ},
+		{"error", true, &opt.Error},
+	}
+	for _, output := range outputs {
+		*output.writer, err = getOutput(output.name, output.Default)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	return out, opt, nil
+}
+
+func rcCheckResult(out rc.Params, err error) rc.Params {
 	if err != nil {
 		out["status"] = err.Error()
 		out["success"] = false
@@ -861,7 +945,7 @@ func rcCheck(ctx context.Context, in rc.Params) (out rc.Params, err error) {
 		out["status"] = "OK"
 		out["success"] = true
 	}
-	return out, nil
+	return out
 }
 
 func init() {

--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -13,9 +13,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rclone/rclone/backend/crypt"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/cache"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/rclone/rclone/fs/config/obscure"
 	"github.com/rclone/rclone/fs/hash"
+	"github.com/rclone/rclone/fs/object"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fs/rc"
 	"github.com/rclone/rclone/fstest"
@@ -664,6 +668,106 @@ func TestRcDu(t *testing.T) {
 	assert.True(t, info.Total > info.Free)
 	assert.True(t, info.Total > info.Available)
 	assert.True(t, info.Free >= info.Available)
+}
+
+func TestRcCryptCheck(t *testing.T) {
+	ctx := context.Background()
+	r, call := rcNewRun(t, "operations/cryptcheck")
+	r.Mkdir(ctx, r.Fremote)
+
+	cryptName := "TestCryptRc:"
+	fcrypt, err := crypt.NewFs(ctx, "TestCryptRc", "", configmap.Simple{
+		"remote":              r.FremoteName,
+		"password":            obscure.MustObscure("test-password"),
+		"filename_encryption": "standard",
+		"filename_encoding":   "base32",
+	})
+	require.NoError(t, err)
+	cache.Put(cryptName, fcrypt)
+
+	writeCrypt := func(remote, contents string) {
+		src := object.NewStaticObjectInfo(remote, t1, int64(len(contents)), true, nil, nil)
+		_, err := fcrypt.Put(ctx, strings.NewReader(contents), src)
+		require.NoError(t, err)
+	}
+
+	file1 := r.WriteFile("file1", "file1 contents", t1)
+	writeCrypt(file1.Path, "file1 contents")
+
+	out, err := call.Fn(ctx, rc.Params{
+		"srcFs": r.LocalName,
+		"dstFs": cryptName,
+		"match": true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, &[]string{"file1"}, out["match"])
+	assert.Equal(t, r.Fremote.Hashes().GetOne().String(), out["hashType"])
+	assert.Equal(t, "OK", out["status"])
+	assert.Equal(t, true, out["success"])
+
+	cryptObject, err := fcrypt.NewObject(ctx, file1.Path)
+	require.NoError(t, err)
+	underlyingObject := cryptObject.(*crypt.Object).UnWrap()
+	corruptContents := strings.Repeat("\x00", int(underlyingObject.Size()))
+	corruptInfo := object.NewStaticObjectInfo(underlyingObject.Remote(), t1, int64(len(corruptContents)), true, nil, nil)
+	require.NoError(t, underlyingObject.Update(ctx, strings.NewReader(corruptContents), corruptInfo))
+
+	out, err = call.Fn(ctx, rc.Params{
+		"srcFs": r.LocalName,
+		"dstFs": cryptName,
+		"error": true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, &[]string{"file1"}, out["error"])
+	assert.Equal(t, "1 errors while checking", out["status"])
+	assert.Equal(t, false, out["success"])
+	writeCrypt(file1.Path, "file1 contents")
+
+	file2 := r.WriteFile("file2", "file2 contents", t1)
+	file4 := r.WriteFile("file4", "source contents", t1)
+	writeCrypt("file3", "file3 contents")
+	writeCrypt(file4.Path, "remote contents")
+
+	in := rc.Params{
+		"srcFs":        r.LocalName,
+		"dstFs":        cryptName,
+		"combined":     true,
+		"missingOnSrc": true,
+		"missingOnDst": true,
+		"match":        true,
+		"differ":       true,
+		"error":        true,
+	}
+	out, err = call.Fn(ctx, in)
+	require.NoError(t, err)
+
+	combined := *out["combined"].(*[]string)
+	sort.Strings(combined)
+	assert.Equal(t, []string{"* file4", "+ file2", "- file3", "= file1"}, combined)
+	assert.Equal(t, &[]string{"file3"}, out["missingOnSrc"])
+	assert.Equal(t, &[]string{file2.Path}, out["missingOnDst"])
+	assert.Equal(t, &[]string{"file1"}, out["match"])
+	assert.Equal(t, &[]string{"file4"}, out["differ"])
+	assert.Equal(t, &[]string{}, out["error"])
+	assert.Equal(t, r.Fremote.Hashes().GetOne().String(), out["hashType"])
+	assert.Equal(t, "3 differences found", out["status"])
+	assert.Equal(t, false, out["success"])
+
+	out, err = call.Fn(ctx, rc.Params{
+		"srcFs": r.LocalName,
+		"dstFs": r.FremoteName,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, out["status"], "is not a crypt remote")
+	assert.Equal(t, false, out["success"])
+
+	_, err = call.Fn(ctx, rc.Params{
+		"srcFs":  r.LocalName,
+		"dstFs":  cryptName,
+		"oneWay": "invalid",
+	})
+	require.Error(t, err)
+	assert.True(t, rc.IsErrParamInvalid(err))
 }
 
 // operations/check: check the source and destination are the same

--- a/fs/operations/rc_test.go
+++ b/fs/operations/rc_test.go
@@ -681,6 +681,7 @@ func TestRcCryptCheck(t *testing.T) {
 		"password":            obscure.MustObscure("test-password"),
 		"filename_encryption": "standard",
 		"filename_encoding":   "base32",
+		"suffix":              ".bin",
 	})
 	require.NoError(t, err)
 	cache.Put(cryptName, fcrypt)
@@ -719,7 +720,7 @@ func TestRcCryptCheck(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, &[]string{"file1"}, out["error"])
-	assert.Equal(t, "1 errors while checking", out["status"])
+	assert.Contains(t, out["status"], "1 errors while checking")
 	assert.Equal(t, false, out["success"])
 	writeCrypt(file1.Path, "file1 contents")
 


### PR DESCRIPTION
#### What does this change do?

Adds `operations/cryptcheck` to the RC API with the same structured result reports as `operations/check`.

The crypt comparison now lives in `fs/operations` so the CLI and RC endpoint use one implementation. The endpoint returns `success`, `status`, the selected `hashType`, and requested match/difference/error reports. It also:

- rejects malformed boolean parameters;
- reports per-file hash/read failures as unsuccessful checks;
- supports normal RC async jobs through `_async=true`;
- preserves existing CLI validation ordering so invalid destinations cannot truncate report files.

#### Linked issue

Fixes #6664

#### Validation

- `RCLONE_CONFIG=/notfound go test -race ./fs/operations ./cmd/cryptcheck` (focused endpoint, CLI safety, and existing check tests)
- `RCLONE_CONFIG=/notfound go test ./fs/operations ./cmd/cryptcheck ./backend/crypt`
- `go vet ./fs/operations ./cmd/cryptcheck ./backend/crypt`
- `go build`
- `PATH="$PWD:$PATH" RCLONE_CONFIG=/notfound make quicktest`

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] This is not a backend change, so backend integration testing is not applicable.
- [x] This Pull Request is ready for review.
