### PR TITLE
onedrive: restore malware-flagged downloads via Graph Prefer header

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -393,6 +393,16 @@ In this case you will see a message like this
 If you are 100% sure you want to download this file anyway then use
 the --onedrive-av-override flag, or av_override = true in the config
 file.
+
+When set, malware-flagged files are downloaded via Microsoft Graph
+beta APIs with Prefer: forceInfectedDownload (contentStream, then
+/content). Clean files continue to use the stable v1.0 endpoint.
+
+This is a beta API and may change. It works reliably with application
+permissions (client_credentials). With delegated (user) login on
+OneDrive for Business, Microsoft often still blocks the download.
+tenant_url configurations fall back to the legacy AVOverride query
+parameter.
 `,
 			Advanced: true,
 		}, {
@@ -2406,25 +2416,120 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	}
 
 	fs.FixRangeOption(options, o.size)
-	var resp *http.Response
+	// Only malware-flagged files use Graph beta; clean files stay on stable v1.0.
+	if o.fs.opt.AVOverride && o.fs.opt.TenantURL == "" && o.malwareDetected() {
+		return o.openInfected(ctx, options...)
+	}
 	opts := o.fs.newOptsCall(o.id, "GET", "/content")
 	opts.Options = options
 	if o.fs.opt.AVOverride {
+		// SharePoint v2 (tenant_url) or non-flagged objects: keep legacy query.
 		opts.Parameters = url.Values{"AVOverride": {"1"}}
 	}
+	return o.openWithRedirect(ctx, &opts)
+}
+
+// malwareDetected reports whether metadata says this object is malware-flagged.
+func (o *Object) malwareDetected() bool {
+	return o.meta != nil && o.meta.malwareDetected
+}
+
+// openInfected downloads a malware-flagged file using Graph beta APIs.
+// contentStream applies Prefer for the whole transfer (needs application auth on many tenants);
+// beta /content + Prefer is tried next.
+func (o *Object) openInfected(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
+	in, err = o.openContentStream(ctx, options...)
+	if err == nil {
+		return in, nil
+	}
+	fs.Debugf(o, "contentStream download failed, trying beta /content: %v", err)
+	in, err2 := o.openContentPrefer(ctx, options...)
+	if err2 == nil {
+		return in, nil
+	}
+	return nil, fmt.Errorf("%w; beta /content also failed: %v (malware download often requires application permissions / client_credentials, or a tenant admin account)", err, err2)
+}
+
+// openContentStream streams the object via Graph beta contentStream.
+func (o *Object) openContentStream(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
+	var resp *http.Response
+	id, drive, _ := o.fs.parseNormalizedID(o.id)
+	if drive == "" {
+		drive = o.fs.driveID
+	}
+	opts := rest.Opts{
+		Method:  "GET",
+		RootURL: graphAPIEndpoint[o.fs.opt.Region] + "/beta/drives/" + drive,
+		Path:    "/items/" + id + "/contentStream",
+		Options: options,
+		ExtraHeaders: map[string]string{
+			"Prefer": "forceInfectedDownload",
+		},
+	}
+	err = o.fs.pacer.Call(func() (bool, error) {
+		resp, err = o.fs.srv.Call(ctx, &opts)
+		return shouldRetry(ctx, resp, err)
+	})
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode == http.StatusOK && resp.ContentLength > 0 && resp.Header.Get("Content-Range") == "" {
+		o.size = resp.ContentLength
+	}
+	return resp.Body, nil
+}
+
+// openContentPrefer downloads via Graph beta /content with Prefer: forceInfectedDownload.
+func (o *Object) openContentPrefer(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
+	id, drive, _ := o.fs.parseNormalizedID(o.id)
+	if drive == "" {
+		drive = o.fs.driveID
+	}
+	opts := rest.Opts{
+		Method:  "GET",
+		RootURL: graphAPIEndpoint[o.fs.opt.Region] + "/beta/drives/" + drive,
+		Path:    "/items/" + id + "/content",
+		Options: options,
+		ExtraHeaders: map[string]string{
+			"Prefer": "forceInfectedDownload",
+		},
+	}
+	return o.openWithRedirect(ctx, &opts)
+}
+
+// openWithRedirect downloads via /content style endpoints that 302 to a preauthenticated URL.
+func (o *Object) openWithRedirect(ctx context.Context, opts *rest.Opts) (in io.ReadCloser, err error) {
+	var resp *http.Response
 	// Make a note of the redirect target as we need to call it without Auth
 	var redirectReq *http.Request
 	opts.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		if len(via) >= 10 {
 			return errors.New("stopped after 10 redirects")
 		}
-		req.Header.Del("Authorization") // remove Auth header
+		// Preauthenticated download URLs must not carry the Graph Authorization header.
+		req.Header.Del("Authorization")
+		// Keep Prefer on the redirect when forcing infected download; some SharePoint
+		// endpoints honor it only on the final download request.
+		// Do not delete Prefer here: users may set it via --header.
+		if o.fs.opt.AVOverride {
+			if req.Header.Get("Prefer") == "" {
+				req.Header.Set("Prefer", "forceInfectedDownload")
+			}
+			// Append AVOverride without re-encoding tempauth (re-encoding breaks the signature).
+			if !strings.Contains(req.URL.RawQuery, "AVOverride=") {
+				if req.URL.RawQuery == "" {
+					req.URL.RawQuery = "AVOverride=1"
+				} else {
+					req.URL.RawQuery += "&AVOverride=1"
+				}
+			}
+		}
 		redirectReq = req
 		return http.ErrUseLastResponse
 	}
 
 	err = o.fs.pacer.Call(func() (bool, error) {
-		resp, err = o.fs.srv.Call(ctx, &opts)
+		resp, err = o.fs.srv.Call(ctx, opts)
 		if redirectReq != nil {
 			// It is a redirect which we are expecting
 			err = nil

--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -2434,7 +2434,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	if err != nil {
 		if resp != nil {
 			if virus := resp.Header.Get("X-Virus-Infected"); virus != "" {
-				err = fmt.Errorf("server reports this file is infected with a virus - use --onedrive-av-override to download anyway: %s: %w", virus, err)
+				err = malwareDownloadError(o.fs.opt.AVOverride, fmt.Errorf("%s: %w", virus, err))
 			}
 		}
 		return nil, err
@@ -2442,12 +2442,26 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	if redirectReq != nil {
 		err = o.fs.pacer.Call(func() (bool, error) {
 			resp, err = o.fs.unAuth.Do(redirectReq)
+			if err != nil {
+				return shouldRetry(ctx, resp, err)
+			}
+			// unAuth.Do does not check status; treat non-2xx as failure so a malware
+			// JSON body is not written out as file content.
+			if resp.StatusCode < 200 || resp.StatusCode > 299 {
+				body, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+				_ = resp.Body.Close()
+				err = fmt.Errorf("HTTP error %d (%s) %s", resp.StatusCode, resp.Status, strings.TrimSpace(string(body)))
+				if strings.Contains(string(body), "malwareDetected") || resp.Header.Get("X-Virus-Infected") != "" {
+					err = malwareDownloadError(o.fs.opt.AVOverride, err)
+				}
+				return shouldRetry(ctx, resp, err)
+			}
 			return shouldRetry(ctx, resp, err)
 		})
 		if err != nil {
 			if resp != nil {
 				if virus := resp.Header.Get("X-Virus-Infected"); virus != "" {
-					err = fmt.Errorf("server reports this file is infected with a virus - use --onedrive-av-override to download anyway: %s: %w", virus, err)
+					err = malwareDownloadError(o.fs.opt.AVOverride, fmt.Errorf("%s: %w", virus, err))
 				}
 			}
 			return nil, err
@@ -2459,6 +2473,14 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 		o.size = resp.ContentLength
 	}
 	return resp.Body, err
+}
+
+// malwareDownloadError formats an error when the server blocks a malware-flagged file.
+func malwareDownloadError(avOverride bool, err error) error {
+	if avOverride {
+		return fmt.Errorf("server reports this file is infected with a virus: %w (if downloads remain blocked, use application permissions / client_credentials or a tenant admin account)", err)
+	}
+	return fmt.Errorf("server reports this file is infected with a virus - use --onedrive-av-override to download anyway: %w", err)
 }
 
 // createUploadSession creates an upload session for the object


### PR DESCRIPTION
## Summary

- When `--onedrive-av-override` is set, download malware-flagged files using Microsoft Graph **beta** APIs with `Prefer: forceInfectedDownload` (try `contentStream`, then `/content`).
- On the SharePoint preauthenticated redirect for `/content`, keep `Prefer: forceInfectedDownload` and append `AVOverride=1` **without** re-encoding the existing query (re-encoding breaks `tempauth`).
- Treat non-2xx on the final download as an error (previously a 403 malware JSON body could be written as a short “successful” file).
- Document that this path is beta and that **application permissions** are often required on OneDrive for Business.

Fixes the practical failure mode behind #7934 where `?AVOverride=1` alone is ignored by Microsoft.

## What users still need to do

This is **not** a one-flag fix for every auth mode. After this change:

1. Use `--onedrive-av-override` (or `av_override = true`).
2. For **OneDrive for Business / SharePoint**, malware downloads are most reliable with **application (daemon) auth**:
   - Register an Azure AD app.
   - Grant **application** permission `Files.Read.All` (and admin consent).
   - Create a client secret (or certificate).
   - Configure the remote with custom `client_id` / `client_secret`, `tenant`, and `client_credentials = true`, plus the usual `drive_id` / `drive_type`.
3. **Delegated (user) OAuth** often still fails: `contentStream` can return 401 (token audience), and SharePoint `download.aspx` can still return `malwareDetected` even with the Prefer header.
4. Remotes using `tenant_url` (SharePoint v2, non-Graph) keep the legacy `AVOverride=1` query only; there is no Graph beta path there.
5. Tenant policy (`DisallowInfectedFileDownload`) and non-admin delegated accounts can still block downloads per Microsoft’s rules.

## Test plan

- [x] `go test ./backend/onedrive/`
- [x] Manual: OneDrive for Business remote with **application permissions** (`client_credentials`) + `--onedrive-av-override` downloads a malware-flagged file successfully (full size, HTTP 200 on final download).
- [x] Manual: delegated user OAuth still fails as expected with a clear error (not a silent ~65-byte partial).
- [ ] CI / maintainer review

## AI assistance

This change was AI-assisted. It was compiled, unit-tested, and manually verified against a real OneDrive for Business tenant with application permissions before opening this PR.