### PR TITLE
iclouddrive: fix 2FA failing with 409 even when the code is valid

### DIFF
--- a/backend/iclouddrive/api/session.go
+++ b/backend/iclouddrive/api/session.go
@@ -194,6 +194,22 @@ func (s *Session) Request(ctx context.Context, opts rest.Opts, request any, resp
 	return resp, nil
 }
 
+// acceptedDespiteConflict returns true when Apple signals a successful code
+// validation with HTTP 409. Since ~mid-2026, idmsa returns 409 on the
+// securitycode endpoints even when the code is accepted (body carries
+// securityCode.valid=true), but it still issues X-Apple-Session-Token on
+// success. Treat token issuance as ground truth and absorb the headers so
+// TrustSession can proceed.
+func (s *Session) acceptedDespiteConflict(resp *http.Response) bool {
+	if resp == nil || resp.StatusCode != 409 || resp.Header.Get("X-Apple-Session-Token") == "" {
+		return false
+	}
+	s.mu.Lock()
+	s.extractHeaders(resp)
+	s.mu.Unlock()
+	return true
+}
+
 // Requires2FA returns true if the session requires 2FA
 func (s *Session) Requires2FA() bool {
 	if s.needs2FA {
@@ -660,7 +676,10 @@ func (s *Session) Validate2FACode(ctx context.Context, code string) error {
 		NoResponse:   true,
 	}
 
-	_, err = s.Request(ctx, opts, nil, nil)
+	resp, err := s.Request(ctx, opts, nil, nil)
+	if err != nil && s.acceptedDespiteConflict(resp) {
+		err = nil
+	}
 	if err == nil {
 		if err := s.TrustSession(ctx); err != nil {
 			return err
@@ -788,7 +807,10 @@ func (s *Session) ValidateSMSCode(ctx context.Context, code string, phoneID int,
 		Body:         body,
 		NoResponse:   true,
 	}
-	_, err = s.Request(ctx, opts, nil, nil)
+	resp, err := s.Request(ctx, opts, nil, nil)
+	if err != nil && s.acceptedDespiteConflict(resp) {
+		err = nil
+	}
 	if err == nil {
 		if err := s.TrustSession(ctx); err != nil {
 			return err


### PR DESCRIPTION
#### What is the problem you are trying to fix?

Configuring an `iclouddrive` remote fails after entering the 2FA code (both trusted-device push and SMS paths) with:

```
validate2FACode failed: HTTP error 409 (409 ) returned body: "{... \"securityCode\": {\"code\": \"...\", \"valid\": true} ...}"
```

Note the body says the code is **valid** — yet rclone reports failure. Reported in #9324 and #9359 (and several forum threads).

#### What is the root cause?

Apple changed the semantics of the idmsa validation endpoints (observed ~mid-2026): `POST /verify/trusteddevice/securitycode` and `POST /verify/phone/securitycode` now return **HTTP 409 even on successful validation**. A `--dump headers` trace shows the 409 response carries everything a success used to carry:

- `X-Apple-Session-Token: …` (only issued on successful validation)
- fresh `Scnt` and `X-Apple-Auth-Attributes`
- `X-Apple-ID-Account-Country`
- body: `"securityCode": {…, "valid": true}`

rclone's `Session.Request` treats any non-2xx as an error, so both validate paths abort before `TrustSession` — discarding the session token Apple just issued.

#### What is your fix?

Add `Session.acceptedDespiteConflict(resp)`: if the response is a 409 **and** carries `X-Apple-Session-Token`, absorb the session headers (`extractHeaders`) and treat validation as successful, then continue to `TrustSession` as before. Applied to both `Validate2FACode` and `ValidateSMSCode`. A plain 409 without the token (e.g. a genuinely wrong/expired code) still fails as before.

#### How was it tested?

Built from master (`c99b2d11e`) and verified against a live account (2FA, 13 trusted devices, ADP off, standard recovery): before the patch, config failed with the exact error above on every attempt (device-push and SMS codes, all reported `valid:true`); with the patch, `rclone config create` completes the 2FA step, the trust token is persisted, and `lsd` / `lsjson -R` / `copy` against the remote work.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix)
- [x] I have added tests for all changes in this PR if appropriate (not appropriate — requires live Apple auth endpoints)
- [x] I have added documentation for the changes if appropriate (no user-facing behaviour change)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages)
- [x] I'm done, this Pull Request is ready for review :-)

🤖 Generated with [Claude Code](https://claude.com/claude-code)