### PR TITLE
s3: add Scality (RING / ARTESCA) provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ directories to and from different cloud storage providers.
 - RackCorp Object Storage [:page_facing_up:](https://rclone.org/s3/#RackCorp)
 - rsync.net [:page_facing_up:](https://rclone.org/sftp/#rsync-net)
 - Scaleway [:page_facing_up:](https://rclone.org/s3/#scaleway)
+- Scality (RING / ARTESCA) [:page_facing_up:](https://rclone.org/s3/#scality)
 - Seafile [:page_facing_up:](https://rclone.org/seafile/)
 - Seagate Lyve Cloud [:page_facing_up:](https://rclone.org/s3/#lyve)
 - SeaweedFS [:page_facing_up:](https://rclone.org/s3/#seaweedfs)

--- a/backend/s3/provider/Scality.yaml
+++ b/backend/s3/provider/Scality.yaml
@@ -1,0 +1,8 @@
+name: Scality
+description: Scality (RING / ARTESCA)
+region: {}
+endpoint: {}
+location_constraint: {}
+acl: {}
+quirks:
+  force_path_style: true # RING and ARTESCA support path-style; virtual-hosted style needs wildcard DNS which on-prem clients often lack

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -204,6 +204,7 @@ WebDAV or S3, that work out of the box.)
 {{< provider name="Rclone Serve S3" home="/commands/rclone_serve_s3/" config="/s3/#rclone" >}}
 {{< provider name="rsync.net" home="https://rsync.net/products/rclone.html" config="/sftp/#rsync-net" >}}
 {{< provider name="Scaleway" home="https://www.scaleway.com/object-storage/" config="/s3/#scaleway" >}}
+{{< provider name="Scality (RING / ARTESCA)" home="https://www.scality.com/" config="/s3/#scality" >}}
 {{< provider name="Seafile" home="https://www.seafile.com/" config="/seafile/" >}}
 {{< provider name="Seagate Lyve Cloud" home="https://www.seagate.com/gb/en/services/cloud/storage/" config="/s3/#lyve" >}}
 {{< provider name="SeaweedFS" home="https://github.com/chrislusf/seaweedfs/" config="/s3/#seaweedfs" >}}

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -49,6 +49,7 @@ The S3 backend can be used with a number of different providers:
 {{< provider name="RackCorp Object Storage" home="https://www.rackcorp.com/" config="/s3/#RackCorp" >}}
 {{< provider name="Rclone Serve S3" home="/commands/rclone_serve_s3/" config="/s3/#rclone" >}}
 {{< provider name="Scaleway" home="https://www.scaleway.com/en/object-storage/" config="/s3/#scaleway" >}}
+{{< provider name="Scality (RING / ARTESCA)" home="https://www.scality.com/" config="/s3/#scality" >}}
 {{< provider name="Seagate Lyve Cloud" home="https://www.seagate.com/gb/en/services/cloud/storage/" config="/s3/#lyve" >}}
 {{< provider name="SeaweedFS" home="https://github.com/chrislusf/seaweedfs/" config="/s3/#seaweedfs" >}}
 {{< provider name="Selectel" home="https://selectel.ru/services/cloud/storage/" config="/s3/#selectel" >}}
@@ -8927,6 +8928,131 @@ with the `storage_class = GLACIER` option to upload directly to Scaleway Glacier
 Don't forget that in this state you can't read files back after, you will need
 to restore them to "STANDARD" storage_class first before being able to read
 them (see "restore" section above)
+
+### Scality {#scality}
+
+[Scality](https://www.scality.com/) RING and ARTESCA both expose an
+S3-compatible object storage API that works with rclone using `s3` as the
+type and `Scality` as the provider.
+
+Both products are S3 clones, so you always need to set the `endpoint` to the
+S3 API of your deployment (the S3 Connector service on RING, or the S3
+data-service endpoint on ARTESCA). The `Scality` provider uses path-style
+addressing (`endpoint/bucket/key`) which is supported out of the box and does
+not require any wildcard/virtual-host DNS entries.
+
+Get your access key, secret key and endpoint from your Scality administrator
+(on ARTESCA these are created per account under *Identity > Accounts* in the
+UI; on RING they are created with `vaultclient` or the S3 Console).
+
+Here is an example of making a Scality configuration. First run:
+
+```console
+rclone config
+```
+
+This will guide you through an interactive setup process.
+
+```text
+No remotes found, make a new one?
+n) New remote
+s) Set configuration password
+q) Quit config
+n/s/q> n
+
+Enter name for new remote.
+name> scality
+
+Option Storage.
+Type of storage to configure.
+Choose a number from below, or type in your own value.
+[snip]
+ XX / Amazon S3 Compliant Storage Providers including AWS, ...Scaleway, Scality, SeaweedFS, ...
+   \ (s3)
+[snip]
+Storage> s3
+
+Option provider.
+Choose your S3 provider.
+Choose a number from below, or type in your own value.
+Press Enter to leave empty.
+[snip]
+XX / Scality (RING / ARTESCA)
+   \ (Scality)
+[snip]
+provider> Scality
+
+Option env_auth.
+Get AWS credentials from runtime (environment variables or EC2/ECS meta data if no env vars).
+Only applies if access_key_id and secret_access_key is blank.
+Choose a number from below, or type in your own boolean value (true or false).
+Press Enter for the default (false).
+ 1 / Enter AWS credentials in the next step.
+   \ (false)
+ 2 / Get AWS credentials from the environment (env vars or IAM).
+   \ (true)
+env_auth>
+
+Option access_key_id.
+AWS Access Key ID.
+Leave blank for anonymous access or runtime credentials.
+Enter a value. Press Enter to leave empty.
+access_key_id> S3_ACCESS_KEY
+
+Option secret_access_key.
+AWS Secret Access Key (password).
+Leave blank for anonymous access or runtime credentials.
+Enter a value. Press Enter to leave empty.
+secret_access_key> S3_SECRET_KEY
+
+Option region.
+Region to connect to.
+Leave blank if you are using an S3 clone and you don't have a region.
+Choose a number from below, or type in your own value.
+Press Enter to leave empty.
+   / Use this if unsure.
+ 1 | Will use v4 signatures and an empty region.
+   \ ()
+   / Use this only if v4 signatures don't work.
+ 2 | E.g. pre Jewel/v10 CEPH.
+   \ (other-v2-signature)
+region>
+
+Option endpoint.
+Endpoint for S3 API.
+Required when using an S3 clone.
+Enter a value. Press Enter to leave empty.
+endpoint> https://s3.example.com
+
+Edit advanced config?
+y) Yes
+n) No (default)
+y/n>
+
+Configuration complete.
+Options:
+- type: s3
+- provider: Scality
+- access_key_id: S3_ACCESS_KEY
+- secret_access_key: S3_SECRET_KEY
+- endpoint: https://s3.example.com
+Keep this "scality" remote?
+y) Yes this is OK (default)
+e) Edit this remote
+d) Delete this remote
+y/e/d> y
+```
+
+This will leave the config file looking like this.
+
+```ini
+[scality]
+type = s3
+provider = Scality
+access_key_id = S3_ACCESS_KEY
+secret_access_key = S3_SECRET_KEY
+endpoint = https://s3.example.com
+```
 
 ### Seagate Lyve Cloud {#lyve}
 


### PR DESCRIPTION
### What

Adds Scality as an S3 provider (`provider = Scality`), covering both Scality RING (S3 Connector) and ARTESCA, which share the same CloudServer + Vault S3 implementation. A single provider is used deliberately since both behave identically in testing.

Follows the guide in `backend/s3/README.md`: a new provider YAML plus documentation, with no autogenerated docs regenerated.

### Quirks

Only `force_path_style: true`. Both products support path-style addressing, and virtual-hosted style needs wildcard DNS that on-prem deployments usually don't have. Single-part and multipart ETags both come back as real MD5s, so no ETag-related quirks are required.

### Testing

Ran the S3 integration suite (`go test -v ./backend/s3 -remote <remote>:`) against a 3-node ARTESCA deployment and a RING / S3 Connector 9.5.2.0 cluster. Identical results on both: 168 pass, 15 skip, 15 fail.

The 15 failures are the same on both and are expected:

- 14 are object keys containing control characters or leading/trailing whitespace, which CloudServer rejects with `400 InvalidInput: object keys cannot contain non-printable characters`. The provider guide says to ignore these when the backend can't store such names.
- 1 is the `content-language` metadata field not being echoed back on GET.