### PR TITLE
dropbox: make Rmdir use one less API call - fixes #9663

### DIFF
--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -1267,15 +1267,11 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) (err error)
 	encRoot := f.opt.Enc.FromStandardPath(root)
 
 	if check {
-		// check directory exists
-		_, err = f.getDirMetadata(ctx, root)
-		if err != nil {
-			return fmt.Errorf("Rmdir: %w", err)
-		}
-
-		// check directory empty
+		// ListFolder reports a missing path and a path that is a file, so it
+		// checks that the directory exists and is empty in a single request.
 		arg := files.NewListFolderArg(encRoot)
 		arg.Recursive = false
+		arg.Limit = 1
 		if root == "/" {
 			arg.Path = "" // Specify root folder as empty string
 		}
@@ -1285,9 +1281,20 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) (err error)
 			return shouldRetry(ctx, err)
 		})
 		if err != nil {
+			switch e := err.(type) {
+			case files.ListFolderAPIError:
+				if e.EndpointError != nil && e.EndpointError.Path != nil {
+					switch e.EndpointError.Path.Tag {
+					case files.LookupErrorNotFound:
+						err = fs.ErrorDirNotFound
+					case files.LookupErrorNotFolder:
+						err = fs.ErrorIsFile
+					}
+				}
+			}
 			return fmt.Errorf("Rmdir: %w", err)
 		}
-		if len(res.Entries) != 0 {
+		if len(res.Entries) != 0 || res.HasMore {
 			return errors.New("directory not empty")
 		}
 	}


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes #9663.

`Rmdir` called `GetMetadata` to check the directory existed, then `ListFolder` to check it was empty. `ListFolder` already reports both a missing path and a path that is a file, so the first request was redundant and every directory processed by `rclone rmdirs` paid for it.

This drops the `GetMetadata` call and maps the `ListFolder` lookup errors onto the same sentinel errors as before, so a missing directory still returns `fs.ErrorDirNotFound` and a file still returns `fs.ErrorIsFile`. `Limit` is set to 1 since only the presence of an entry matters. `HasMore` is checked alongside `Entries` so that a first page which is full rather than empty is not mistaken for an empty directory.

#### Was the change discussed in an issue or in the forum before?

#9663, opened by @MikeeI, which describes this approach. Not yet acknowledged by a maintainer, so please treat the approach as up for discussion.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [ ] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend.
- [x] This Pull Request is ready for review.

On the two boxes I have left unticked, so a reviewer does not have to guess:

I do not have a Dropbox account, so I have not run the backend integration tests. `go build`, `go vet`, `gofmt` and `go test ./backend/dropbox/` are clean, and I verified the error mapping against the real SDK types in a scratch test (not included here): a `ListFolderAPIError` tagged `not_found` maps to `fs.ErrorDirNotFound`, `not_folder` maps to `fs.ErrorIsFile`, and anything else, including an error with no path detail, passes through untouched. The empty/non-empty/missing/file behaviour against the live API is exactly what I cannot confirm, so please run `test_all` for the dropbox backend before merging.

No tests or docs added: this keeps the existing observable behaviour and only removes a request, and the backend's own tests are the integration suite.

AI disclosure: written with Claude Code (Claude Sonnet 5). I reviewed the diff, checked the SDK constants and the error mapping myself, and take ownership of the change.
