### PR TITLE
fserrors: make http2 "server sent GOAWAY" a retriable error - fixes #9664

### DIFF
--- a/fs/fserrors/error.go
+++ b/fs/fserrors/error.go
@@ -386,6 +386,7 @@ var retriableErrorStrings = []string{
 	"server closed idle connection",    // net/http/transport.go
 	"bad record MAC",                   // crypto/tls/alert.go
 	"stream error:",                    // net/http/h2_bundle.go
+	"http2: server sent GOAWAY",        // net/http/h2_bundle.go
 	"tls: use of closed connection",    // crypto/tls/conn.go
 }
 

--- a/fs/fserrors/error_test.go
+++ b/fs/fserrors/error_test.go
@@ -38,6 +38,8 @@ func wrap(err error, message string) error {
 
 var errUseOfClosedNetworkConnection = errors.New("use of closed network connection")
 
+var errHTTP2GoAway = errors.New(`http2: server sent GOAWAY and closed the connection; LastStreamID=19999, ErrCode=NO_ERROR, debug=""`)
+
 type myError1 struct {
 	Err error
 }
@@ -135,6 +137,8 @@ func TestShouldRetry(t *testing.T) {
 		{&url.Error{Op: "post", URL: "/", Err: io.EOF}, true},
 		{&url.Error{Op: "post", URL: "/", Err: errUseOfClosedNetworkConnection}, true},
 		{&url.Error{Op: "post", URL: "/", Err: fmt.Errorf("net/http: HTTP/1.x transport connection broken: %v", fmt.Errorf("http: ContentLength=%d with Body length %d", 100663336, 99590598))}, true},
+		{errHTTP2GoAway, true},
+		{fmt.Errorf("operation error S3: ListObjectsV2, deserialization failed, failed to decode response body: %w", errHTTP2GoAway), true},
 	} {
 		got := ShouldRetry(test.err)
 		assert.Equal(t, test.want, got, fmt.Sprintf("test #%d: %v", i, test.err))


### PR DESCRIPTION
When an HTTP/2 server retires a connection with GOAWAY after it has already sent successful response headers, Go's http2 transport fails the read of the response body with

    http2: server sent GOAWAY and closed the connection; LastStreamID=..., ErrCode=NO_ERROR, debug=""

This was not recognised as a retriable networking error, so a transient connection retirement aborted the whole command instead of consuming a low level retry. It was reported against a large S3 check, where an interrupted ListObjectsV2 page made rclone report destination objects as missing and exit unsuccessfully.

The concrete error type is unexported by net/http, so match on the message as we already do for the other http2 transport errors.

<!--
Thank you for contributing to rclone!

Please discuss anything more than a trivial fix in an issue FIRST - see the
"Linked issue" section below. Then fill in the questions to help us review.
-->

#### What does this change do?

<!-- Describe the change here. -->

#### Linked issue

<!--
Put `Fixes #1234` here if this closes an issue, or `#1234` to link without closing.

IMPORTANT: Anything beyond a trivial fix (typo, doc tweak, small obvious bug fix)
should be discussed and agreed in an issue BEFORE you open a pull request.
Pull requests for larger changes that have not been discussed in an issue first
may be closed. This saves everyone's time if the change needs a different approach
or isn't a good fit.
-->

Fixes #9664 

#### For new or changed backends

<!--
Backend pull requests are often sent without the integration tests having been run.
We cannot merge a backend change until it passes the integration tests.

To be merged, a backend change REQUIRES:
  1. A clean run of `go run ./fstest/test_all -backends <remote>` (summarise the
     result below or paste a screenshot of the test_all output in the web browser).
  2. A test account so the maintainers can run the integration tests daily against
     the backend on the integration test server.

If the tests aren't quite passing yet and you need help getting them
to pass, then submit the PR and we can help getting you over the line.

See https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#writing-a-new-backend
and https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests
-->

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [ ] This Pull Request is ready for review.
