### PR TITLE
sync: replace conflicting files and directories

### DIFF
--- a/fs/list/sorter.go
+++ b/fs/list/sorter.go
@@ -97,7 +97,9 @@ func (ls *Sorter) entryToKey(entry fs.DirEntry) string {
 
 // Turn an exsort key back into a directory entry
 func (ls *Sorter) keyToEntry(ctx context.Context, key string) (entry fs.DirEntry, err error) {
-	null := strings.IndexRune(key, '\x00')
+	// The final NUL separates the sort key from the remote so KeyFn may
+	// use NUL to delimit parts of its own key.
+	null := strings.LastIndex(key, "\x00")
 	if null < 0 {
 		return nil, errors.New("sorter: failed to deserialize: missing null")
 	}

--- a/fs/list/sorter_test.go
+++ b/fs/list/sorter_test.go
@@ -107,6 +107,26 @@ func TestSorterKeyFn(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestSorterKeyFnWithNull(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	ci.ListCutoff = 1
+	object := mockobject.Object("a")
+	f := &testFs{t: t, entriesMap: map[string]fs.DirEntry{"a": object}}
+	callback := func(entries fs.DirEntries) error {
+		require.Equal(t, fs.DirEntries{object}, entries)
+		return nil
+	}
+	keyFn := func(fs.DirEntry) string { return "a\x00F" }
+
+	ls, err := NewSorter(ctx, f, callback, keyFn)
+	require.NoError(t, err)
+	defer ls.CleanUp()
+	require.NoError(t, ls.Add(fs.DirEntries{object}))
+	require.True(t, ls.extSort)
+	require.NoError(t, ls.Send())
+}
+
 // testFs implements enough of the fs.Fs interface for Sorter
 type testFs struct {
 	t          *testing.T

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -95,8 +95,9 @@ func (m *March) srcOrDstKey(entry fs.DirEntry, isSrc bool) string {
 	if entry == nil {
 		return name
 	}
-	// Suffix entries to make identically named files and
-	// directories sort consistently with directories first.
+	// Delimit the type so entries sort by name before type, with
+	// directories first for identically named entries.
+	name += "\x00"
 	if _, isDirectory := entry.(fs.Directory); isDirectory {
 		name += "D"
 	} else {
@@ -407,34 +408,42 @@ func (m *March) matchListings(srcChan, dstChan <-chan fs.DirEntry, dstCancel fun
 }
 
 type entryGroupReader struct {
-	entries <-chan fs.DirEntry
-	key     func(fs.DirEntry) string
-	pending fs.DirEntry
-	more    bool
-	started bool
+	entries     <-chan fs.DirEntry
+	key         func(fs.DirEntry) string
+	sortKey     func(fs.DirEntry) string
+	side        string
+	pending     fs.DirEntry
+	previousKey string
+}
+
+func (r *entryGroupReader) read() (entry fs.DirEntry, ok bool) {
+	if r.pending != nil {
+		entry = r.pending
+		r.pending = nil
+		return entry, true
+	}
+	entry, ok = <-r.entries
+	if !ok {
+		return nil, false
+	}
+	sortKey := r.sortKey(entry)
+	if r.previousKey != "" && sortKey < r.previousKey {
+		panic("Out of order listing in " + r.side)
+	}
+	r.previousKey = sortKey
+	return entry, true
 }
 
 func (r *entryGroupReader) next() (key string, entries fs.DirEntries, ok bool) {
-	var entry fs.DirEntry
-	if r.started {
-		if !r.more {
-			return "", nil, false
-		}
-		entry = r.pending
-	} else {
-		entry, r.more = <-r.entries
-		r.started = true
-		if !r.more {
-			return "", nil, false
-		}
+	entry, ok := r.read()
+	if !ok {
+		return "", nil, false
 	}
-
 	key = r.key(entry)
 	entries = append(entries, entry)
 	for {
-		entry, r.more = <-r.entries
-		if !r.more {
-			r.pending = nil
+		entry, ok = r.read()
+		if !ok {
 			return key, entries, true
 		}
 		if r.key(entry) != key {
@@ -483,10 +492,10 @@ func firstEntryGroup(entries map[string]fs.DirEntry) fs.DirEntry {
 func (m *March) matchListingGroups(srcChan, dstChan <-chan fs.DirEntry, dstCancel func(), srcOnly, dstOnly func(fs.DirEntry), match func(dst, src fs.DirEntry)) error {
 	srcReader := entryGroupReader{entries: srcChan, key: func(entry fs.DirEntry) string {
 		return m.srcOrDstBaseKey(entry, true)
-	}}
+	}, sortKey: m.srcKey, side: "source"}
 	dstReader := entryGroupReader{entries: dstChan, key: func(entry fs.DirEntry) string {
 		return m.srcOrDstBaseKey(entry, false)
-	}}
+	}, sortKey: m.dstKey, side: "destination"}
 	srcKey, srcEntries, srcMore := srcReader.next()
 	if !srcMore && m.NoProcessDstOnly {
 		dstCancel()

--- a/fs/march/march.go
+++ b/fs/march/march.go
@@ -45,6 +45,7 @@ type March struct {
 	NoCheckDest            bool            // transfer all objects regardless without checking dst
 	NoUnicodeNormalization bool            // don't normalize unicode characters in filenames
 	NoProcessDstOnly       bool            // if set, when source listing finishes, cancel the dst listing
+	MatchFileAndDirectory  bool            // match identically named files and directories when no same-type match exists
 	// internal state
 	srcListDir   listDirFn // function to call to list a directory in the src
 	dstListDir   listDirFn // function to call to list a directory in the dst
@@ -90,6 +91,22 @@ func (m *March) init(ctx context.Context) {
 
 // srcOrDstKey turns a directory entry into a sort key using the defined transforms.
 func (m *March) srcOrDstKey(entry fs.DirEntry, isSrc bool) string {
+	name := m.srcOrDstBaseKey(entry, isSrc)
+	if entry == nil {
+		return name
+	}
+	// Suffix entries to make identically named files and
+	// directories sort consistently with directories first.
+	if _, isDirectory := entry.(fs.Directory); isDirectory {
+		name += "D"
+	} else {
+		name += "F"
+	}
+	return name
+}
+
+// srcOrDstBaseKey turns a directory entry into a comparison key without its type.
+func (m *March) srcOrDstBaseKey(entry fs.DirEntry, isSrc bool) string {
 	if entry == nil {
 		return ""
 	}
@@ -100,13 +117,6 @@ func (m *March) srcOrDstKey(entry fs.DirEntry, isSrc bool) string {
 	}
 	for _, transform := range m.transforms {
 		name = transform(name)
-	}
-	// Suffix entries to make identically named files and
-	// directories sort consistently with directories first.
-	if isDirectory {
-		name += "D"
-	} else {
-		name += "F"
 	}
 	return name
 }
@@ -304,6 +314,9 @@ func (m *March) aborting() bool {
 //
 // This checks for duplicates and checks the list is sorted.
 func (m *March) matchListings(srcChan, dstChan <-chan fs.DirEntry, dstCancel func(), srcOnly, dstOnly func(fs.DirEntry), match func(dst, src fs.DirEntry)) error {
+	if m.MatchFileAndDirectory && !m.NoTraverse {
+		return m.matchListingGroups(srcChan, dstChan, dstCancel, srcOnly, dstOnly, match)
+	}
 	var (
 		srcPrev, dstPrev         fs.DirEntry
 		srcPrevName, dstPrevName string
@@ -388,6 +401,134 @@ func (m *March) matchListings(srcChan, dstChan <-chan fs.DirEntry, dstCancel fun
 		case dst == nil:
 			srcOnly(src)
 			srcDone()
+		}
+	}
+	return nil
+}
+
+type entryGroupReader struct {
+	entries <-chan fs.DirEntry
+	key     func(fs.DirEntry) string
+	pending fs.DirEntry
+	more    bool
+	started bool
+}
+
+func (r *entryGroupReader) next() (key string, entries fs.DirEntries, ok bool) {
+	var entry fs.DirEntry
+	if r.started {
+		if !r.more {
+			return "", nil, false
+		}
+		entry = r.pending
+	} else {
+		entry, r.more = <-r.entries
+		r.started = true
+		if !r.more {
+			return "", nil, false
+		}
+	}
+
+	key = r.key(entry)
+	entries = append(entries, entry)
+	for {
+		entry, r.more = <-r.entries
+		if !r.more {
+			r.pending = nil
+			return key, entries, true
+		}
+		if r.key(entry) != key {
+			r.pending = entry
+			return key, entries, true
+		}
+		entries = append(entries, entry)
+	}
+}
+
+func deduplicateEntryGroup(entries fs.DirEntries, side string) map[string]fs.DirEntry {
+	unique := make(map[string]fs.DirEntry, len(entries))
+	for _, entry := range entries {
+		switch entry.(type) {
+		case fs.Object, fs.Directory:
+		default:
+			panic("Bad object in DirEntries")
+		}
+		entryType := fs.DirEntryType(entry)
+		if _, found := unique[entryType]; found {
+			fs.Logf(entry, "Duplicate %s found in %s - ignoring", entryType, side)
+			continue
+		}
+		unique[entryType] = entry
+	}
+	return unique
+}
+
+func forEachEntryGroup(entries map[string]fs.DirEntry, fn func(fs.DirEntry)) {
+	for _, entryType := range []string{"directory", "object"} {
+		if entry, found := entries[entryType]; found {
+			fn(entry)
+		}
+	}
+}
+
+func firstEntryGroup(entries map[string]fs.DirEntry) fs.DirEntry {
+	for _, entryType := range []string{"directory", "object"} {
+		if entry, found := entries[entryType]; found {
+			return entry
+		}
+	}
+	return nil
+}
+
+func (m *March) matchListingGroups(srcChan, dstChan <-chan fs.DirEntry, dstCancel func(), srcOnly, dstOnly func(fs.DirEntry), match func(dst, src fs.DirEntry)) error {
+	srcReader := entryGroupReader{entries: srcChan, key: func(entry fs.DirEntry) string {
+		return m.srcOrDstBaseKey(entry, true)
+	}}
+	dstReader := entryGroupReader{entries: dstChan, key: func(entry fs.DirEntry) string {
+		return m.srcOrDstBaseKey(entry, false)
+	}}
+	srcKey, srcEntries, srcMore := srcReader.next()
+	if !srcMore && m.NoProcessDstOnly {
+		dstCancel()
+		return nil
+	}
+	dstKey, dstEntries, dstMore := dstReader.next()
+
+	for srcMore || dstMore {
+		if m.aborting() {
+			return m.Ctx.Err()
+		}
+		if !srcMore && m.NoProcessDstOnly {
+			dstCancel()
+			break
+		}
+		switch {
+		case !dstMore || srcMore && srcKey < dstKey:
+			forEachEntryGroup(deduplicateEntryGroup(srcEntries, "source"), srcOnly)
+			srcKey, srcEntries, srcMore = srcReader.next()
+		case !srcMore || dstKey < srcKey:
+			forEachEntryGroup(deduplicateEntryGroup(dstEntries, "destination"), dstOnly)
+			dstKey, dstEntries, dstMore = dstReader.next()
+		default:
+			srcByType := deduplicateEntryGroup(srcEntries, "source")
+			dstByType := deduplicateEntryGroup(dstEntries, "destination")
+			for _, entryType := range []string{"directory", "object"} {
+				src, srcOK := srcByType[entryType]
+				dst, dstOK := dstByType[entryType]
+				if srcOK && dstOK {
+					match(dst, src)
+					delete(srcByType, entryType)
+					delete(dstByType, entryType)
+				}
+			}
+			if len(srcByType) == 1 && len(dstByType) == 1 {
+				match(firstEntryGroup(dstByType), firstEntryGroup(srcByType))
+			} else {
+				forEachEntryGroup(srcByType, srcOnly)
+				forEachEntryGroup(dstByType, dstOnly)
+			}
+			srcKey, srcEntries, srcMore = srcReader.next()
+			dstKey, dstEntries, dstMore = dstReader.next()
 		}
 	}
 	return nil

--- a/fs/march/march_test.go
+++ b/fs/march/march_test.go
@@ -451,12 +451,13 @@ func TestMatchListings(t *testing.T) {
 	)
 
 	for _, test := range []struct {
-		what       string
-		input      fs.DirEntries // pairs of input src, dst
-		srcOnly    fs.DirEntries
-		dstOnly    fs.DirEntries
-		matches    []matchPair // pairs of output
-		transforms []matchTransformFn
+		what                  string
+		input                 fs.DirEntries // pairs of input src, dst
+		srcOnly               fs.DirEntries
+		dstOnly               fs.DirEntries
+		matches               []matchPair // pairs of output
+		transforms            []matchTransformFn
+		matchFileAndDirectory bool
 	}{
 		{
 			what: "only src or dst",
@@ -597,6 +598,40 @@ func TestMatchListings(t *testing.T) {
 			},
 		},
 		{
+			what: "File replaces directory",
+			input: fs.DirEntries{
+				A, dirA,
+			},
+			matches: []matchPair{
+				{A, dirA},
+			},
+			matchFileAndDirectory: true,
+		},
+		{
+			what: "Directory replaces file",
+			input: fs.DirEntries{
+				dirA, A,
+			},
+			matches: []matchPair{
+				{dirA, A},
+			},
+			matchFileAndDirectory: true,
+		},
+		{
+			what: "Same type match takes precedence",
+			input: fs.DirEntries{
+				A, dirA,
+				nil, A,
+			},
+			dstOnly: fs.DirEntries{
+				dirA,
+			},
+			matches: []matchPair{
+				{A, A},
+			},
+			matchFileAndDirectory: true,
+		},
+		{
 			what: "Sync with directory #1",
 			input: fs.DirEntries{
 				dirA, nil,
@@ -653,8 +688,9 @@ func TestMatchListings(t *testing.T) {
 
 			// Skeleton March for testing
 			m := March{
-				Ctx:        context.Background(),
-				transforms: test.transforms,
+				Ctx:                   context.Background(),
+				transforms:            test.transforms,
+				MatchFileAndDirectory: test.matchFileAndDirectory,
 			}
 
 			// Make a channel to send the source (0) or dest (1) using a list.Sorter

--- a/fs/march/march_test.go
+++ b/fs/march/march_test.go
@@ -882,3 +882,20 @@ func TestMatchListingsNoProcessDstOnly(t *testing.T) {
 		})
 	}
 }
+
+func TestMatchListingGroupsRejectsOutOfOrderEntries(t *testing.T) {
+	m := March{
+		Ctx:                   context.Background(),
+		MatchFileAndDirectory: true,
+	}
+	src := make(chan fs.DirEntry, 2)
+	src <- mockobject.Object("b")
+	src <- mockobject.Object("a")
+	close(src)
+	dst := make(chan fs.DirEntry)
+	close(dst)
+
+	require.PanicsWithValue(t, "Out of order listing in source", func() {
+		_ = m.matchListings(src, dst, func() {}, func(fs.DirEntry) {}, func(fs.DirEntry) {}, func(fs.DirEntry, fs.DirEntry) {})
+	})
+}

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/march"
 	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fs/walk"
 	"github.com/rclone/rclone/lib/errcount"
 	"github.com/rclone/rclone/lib/transform"
 	"golang.org/x/sync/errgroup"
@@ -961,6 +962,7 @@ func (s *syncCopyMove) run() error {
 		NoCheckDest:            s.noCheckDest,
 		NoUnicodeNormalization: s.noUnicodeNormalization,
 		NoProcessDstOnly:       s.deleteMode == fs.DeleteModeOff && !s.usingLogger,
+		MatchFileAndDirectory:  s.deleteMode != fs.DeleteModeOff && s.deleteMode != fs.DeleteModeOnly && !s.noTraverse,
 	}
 	s.processError(m.Run(s.ctx))
 
@@ -1232,49 +1234,90 @@ func (s *syncCopyMove) setDelayedDirModTimes(ctx context.Context) error {
 	return errCount.Err("failed to set directory modtime")
 }
 
-// SrcOnly have an object which is in the source only
+func (s *syncCopyMove) copySrcOnlyObject(src fs.Object) {
+	s.logger(s.ctx, operations.MissingOnDst, src, nil, nil)
+	s.markParentNotEmpty(src)
+
+	if s.trackRenames {
+		select {
+		case <-s.ctx.Done():
+			return
+		case s.trackRenamesCh <- src:
+		}
+		return
+	}
+
+	noNeedTransfer, err := operations.CompareOrCopyDest(s.ctx, s.fdst, nil, src, s.compareCopyDest, s.backupDir)
+	if err != nil {
+		s.processError(err)
+		s.logger(s.ctx, operations.TransferError, src, nil, err)
+	}
+	if noNeedTransfer {
+		return
+	}
+
+	fs.Debugf(src, "Need to transfer - File not found at Destination")
+	s.markDirModifiedObject(src)
+	if !s.toBeUploaded.Put(s.inCtx, fs.ObjectPair{Src: src, Dst: nil}) {
+		return
+	}
+}
+
+func (s *syncCopyMove) copySrcOnlyDirectory(src fs.Directory) bool {
+	s.markParentNotEmpty(src)
+	s.logger(s.ctx, operations.MissingOnDst, src, nil, fs.ErrorIsDir)
+	dir := transform.Path(s.ctx, src.Remote(), true)
+	s.copyDirMetadata(s.ctx, s.fdst, nil, dir, src)
+	s.markDirModified(dir)
+	return true
+}
+
+func (s *syncCopyMove) removeConflictingDirectory(ctx context.Context, dst fs.Directory) error {
+	if !s.fi.InActive() && !s.fi.Opt.DeleteExcluded {
+		return fserrors.NoRetryError(errors.New("can't replace directory with file while filters are active without --delete-excluded"))
+	}
+	if s.backupDir == nil {
+		return operations.Purge(ctx, s.fdst, dst.Remote())
+	}
+
+	tree, err := walk.NewDirTree(ctx, s.fdst, dst.Remote(), true, -1)
+	if err != nil {
+		return err
+	}
+	var objects []fs.Object
+	for _, entries := range tree {
+		entries.ForObject(func(object fs.Object) {
+			objects = append(objects, object)
+		})
+	}
+	toDelete := make(fs.ObjectsChan, len(objects))
+	for _, object := range objects {
+		toDelete <- object
+	}
+	close(toDelete)
+	if err := operations.DeleteFilesWithBackupDir(ctx, toDelete, s.backupDir); err != nil {
+		return err
+	}
+
+	dirs := tree.Dirs()
+	for i := len(dirs) - 1; i >= 0; i-- {
+		if err := operations.Rmdir(ctx, s.fdst, dirs[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SrcOnly has an object which is in the source only
 func (s *syncCopyMove) SrcOnly(src fs.DirEntry) (recurse bool) {
 	if s.deleteMode == fs.DeleteModeOnly {
 		return false
 	}
 	switch x := src.(type) {
 	case fs.Object:
-		s.logger(s.ctx, operations.MissingOnDst, x, nil, nil)
-		s.markParentNotEmpty(src)
-
-		if s.trackRenames {
-			// Save object to check for a rename later
-			select {
-			case <-s.ctx.Done():
-				return
-			case s.trackRenamesCh <- x:
-			}
-		} else {
-			// Check CompareDest && CopyDest
-			NoNeedTransfer, err := operations.CompareOrCopyDest(s.ctx, s.fdst, nil, x, s.compareCopyDest, s.backupDir)
-			if err != nil {
-				s.processError(err)
-				s.logger(s.ctx, operations.TransferError, x, nil, err)
-			}
-			if !NoNeedTransfer {
-				// No need to check since doesn't exist
-				fs.Debugf(src, "Need to transfer - File not found at Destination")
-				s.markDirModifiedObject(x)
-				ok := s.toBeUploaded.Put(s.inCtx, fs.ObjectPair{Src: x, Dst: nil})
-				if !ok {
-					return
-				}
-			}
-		}
+		s.copySrcOnlyObject(x)
 	case fs.Directory:
-		// Do the same thing to the entire contents of the directory
-		s.markParentNotEmpty(src)
-		s.logger(s.ctx, operations.MissingOnDst, src, nil, fs.ErrorIsDir)
-
-		// Create the directory and make sure the Metadata/ModTime is correct
-		s.copyDirMetadata(s.ctx, s.fdst, nil, transform.Path(s.ctx, x.Remote(), true), x)
-		s.markDirModified(transform.Path(s.ctx, x.Remote(), true))
-		return true
+		return s.copySrcOnlyDirectory(x)
 	default:
 		panic("Bad object in DirEntries")
 	}
@@ -1298,14 +1341,30 @@ func (s *syncCopyMove) Match(ctx context.Context, dst, src fs.DirEntry) (recurse
 				return false
 			}
 		} else {
-			// FIXME src is file, dst is directory
-			err := errors.New("can't overwrite directory with file")
-			fs.Errorf(dst, "%v", err)
-			s.processError(err)
-			s.logger(ctx, operations.TransferError, srcX, dstX, err)
+			dstDir, ok := dst.(fs.Directory)
+			if !ok {
+				panic("Bad object in DirEntries")
+			}
+			if s.ci.Immutable {
+				err := fserrors.NoRetryError(fs.ErrorImmutableModified)
+				fs.Errorf(dst, "Source is file and destination is directory: %v", err)
+				s.processError(err)
+				s.logger(ctx, operations.TransferError, srcX, nil, err)
+				return false
+			}
+			s.logger(ctx, operations.MissingOnSrc, nil, dstDir, fs.ErrorIsDir)
+			err := s.removeConflictingDirectory(ctx, dstDir)
+			if err != nil {
+				fs.Errorf(dst, "Failed to remove directory before replacing it with a file: %v", err)
+				s.processError(err)
+				s.logger(ctx, operations.TransferError, srcX, nil, err)
+				return false
+			}
+			s.copySrcOnlyObject(srcX)
 		}
 	case fs.Directory:
 		// Do the same thing to the entire contents of the directory
+		srcOriginal := srcX
 		srcX = fs.NewOverrideDirectory(srcX, transform.Path(ctx, src.Remote(), true))
 		src = srcX
 		if !transform.Transforming(ctx) || src.Remote() != dst.Remote() {
@@ -1331,11 +1390,25 @@ func (s *syncCopyMove) Match(ctx context.Context, dst, src fs.DirEntry) (recurse
 
 			return true
 		}
-		// FIXME src is dir, dst is file
-		err := errors.New("can't overwrite file with directory")
-		fs.Errorf(dst, "%v", err)
-		s.processError(err)
-		s.logger(ctx, operations.TransferError, src.(fs.ObjectInfo), dst.(fs.ObjectInfo), err)
+		dstObject, ok := dst.(fs.Object)
+		if !ok {
+			panic("Bad object in DirEntries")
+		}
+		if s.ci.Immutable {
+			err := fserrors.NoRetryError(fs.ErrorImmutableModified)
+			fs.Errorf(dst, "Source is directory and destination is file: %v", err)
+			s.processError(err)
+			s.logger(ctx, operations.TransferError, srcX, dstObject, err)
+			return false
+		}
+		s.logger(ctx, operations.MissingOnSrc, nil, dstObject, nil)
+		err := operations.DeleteFileWithBackupDir(ctx, dstObject, s.backupDir)
+		if err != nil {
+			s.processError(err)
+			s.logger(ctx, operations.TransferError, srcX, dstObject, err)
+			return false
+		}
+		return s.copySrcOnlyDirectory(srcOriginal)
 	default:
 		panic("Bad object in DirEntries")
 	}

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/march"
 	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fs/walk"
 	"github.com/rclone/rclone/lib/errcount"
 	"github.com/rclone/rclone/lib/transform"
 	"golang.org/x/sync/errgroup"
@@ -962,6 +963,7 @@ func (s *syncCopyMove) run() error {
 		NoCheckDest:            s.noCheckDest,
 		NoUnicodeNormalization: s.noUnicodeNormalization,
 		NoProcessDstOnly:       s.deleteMode == fs.DeleteModeOff && !s.usingLogger,
+		MatchFileAndDirectory:  s.deleteMode != fs.DeleteModeOff && s.deleteMode != fs.DeleteModeOnly && !s.noTraverse,
 	}
 	s.processError(m.Run(s.ctx))
 
@@ -1233,49 +1235,90 @@ func (s *syncCopyMove) setDelayedDirModTimes(ctx context.Context) error {
 	return errCount.Err("failed to set directory modtime")
 }
 
-// SrcOnly have an object which is in the source only
+func (s *syncCopyMove) copySrcOnlyObject(src fs.Object) {
+	s.logger(s.ctx, operations.MissingOnDst, src, nil, nil)
+	s.markParentNotEmpty(src)
+
+	if s.trackRenames {
+		select {
+		case <-s.ctx.Done():
+			return
+		case s.trackRenamesCh <- src:
+		}
+		return
+	}
+
+	noNeedTransfer, err := operations.CompareOrCopyDest(s.ctx, s.fdst, nil, src, s.compareCopyDest, s.backupDir)
+	if err != nil {
+		s.processError(err)
+		s.logger(s.ctx, operations.TransferError, src, nil, err)
+	}
+	if noNeedTransfer {
+		return
+	}
+
+	fs.Debugf(src, "Need to transfer - File not found at Destination")
+	s.markDirModifiedObject(src)
+	if !s.toBeUploaded.Put(s.inCtx, fs.ObjectPair{Src: src, Dst: nil}) {
+		return
+	}
+}
+
+func (s *syncCopyMove) copySrcOnlyDirectory(src fs.Directory) bool {
+	s.markParentNotEmpty(src)
+	s.logger(s.ctx, operations.MissingOnDst, src, nil, fs.ErrorIsDir)
+	dir := transform.Path(s.ctx, src.Remote(), true)
+	s.copyDirMetadata(s.ctx, s.fdst, nil, dir, src)
+	s.markDirModified(dir)
+	return true
+}
+
+func (s *syncCopyMove) removeConflictingDirectory(ctx context.Context, dst fs.Directory) error {
+	if !s.fi.InActive() && !s.fi.Opt.DeleteExcluded {
+		return fserrors.NoRetryError(errors.New("can't replace directory with file while filters are active without --delete-excluded"))
+	}
+	if s.backupDir == nil {
+		return operations.Purge(ctx, s.fdst, dst.Remote())
+	}
+
+	tree, err := walk.NewDirTree(ctx, s.fdst, dst.Remote(), true, -1)
+	if err != nil {
+		return err
+	}
+	var objects []fs.Object
+	for _, entries := range tree {
+		entries.ForObject(func(object fs.Object) {
+			objects = append(objects, object)
+		})
+	}
+	toDelete := make(fs.ObjectsChan, len(objects))
+	for _, object := range objects {
+		toDelete <- object
+	}
+	close(toDelete)
+	if err := operations.DeleteFilesWithBackupDir(ctx, toDelete, s.backupDir); err != nil {
+		return err
+	}
+
+	dirs := tree.Dirs()
+	for i := len(dirs) - 1; i >= 0; i-- {
+		if err := operations.Rmdir(ctx, s.fdst, dirs[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// SrcOnly has an object which is in the source only
 func (s *syncCopyMove) SrcOnly(src fs.DirEntry) (recurse bool) {
 	if s.deleteMode == fs.DeleteModeOnly {
 		return false
 	}
 	switch x := src.(type) {
 	case fs.Object:
-		s.logger(s.ctx, operations.MissingOnDst, x, nil, nil)
-		s.markParentNotEmpty(src)
-
-		if s.trackRenames {
-			// Save object to check for a rename later
-			select {
-			case <-s.ctx.Done():
-				return
-			case s.trackRenamesCh <- x:
-			}
-		} else {
-			// Check CompareDest && CopyDest
-			NoNeedTransfer, err := operations.CompareOrCopyDest(s.ctx, s.fdst, nil, x, s.compareCopyDest, s.backupDir)
-			if err != nil {
-				s.processError(err)
-				s.logger(s.ctx, operations.TransferError, x, nil, err)
-			}
-			if !NoNeedTransfer {
-				// No need to check since doesn't exist
-				fs.Debugf(src, "Need to transfer - File not found at Destination")
-				s.markDirModifiedObject(x)
-				ok := s.toBeUploaded.Put(s.inCtx, fs.ObjectPair{Src: x, Dst: nil})
-				if !ok {
-					return
-				}
-			}
-		}
+		s.copySrcOnlyObject(x)
 	case fs.Directory:
-		// Do the same thing to the entire contents of the directory
-		s.markParentNotEmpty(src)
-		s.logger(s.ctx, operations.MissingOnDst, src, nil, fs.ErrorIsDir)
-
-		// Create the directory and make sure the Metadata/ModTime is correct
-		s.copyDirMetadata(s.ctx, s.fdst, nil, transform.Path(s.ctx, x.Remote(), true), x)
-		s.markDirModified(transform.Path(s.ctx, x.Remote(), true))
-		return true
+		return s.copySrcOnlyDirectory(x)
 	default:
 		panic("Bad object in DirEntries")
 	}
@@ -1299,14 +1342,30 @@ func (s *syncCopyMove) Match(ctx context.Context, dst, src fs.DirEntry) (recurse
 				return false
 			}
 		} else {
-			// FIXME src is file, dst is directory
-			err := errors.New("can't overwrite directory with file")
-			fs.Errorf(dst, "%v", err)
-			s.processError(err)
-			s.logger(ctx, operations.TransferError, srcX, dstX, err)
+			dstDir, ok := dst.(fs.Directory)
+			if !ok {
+				panic("Bad object in DirEntries")
+			}
+			if s.ci.Immutable {
+				err := fserrors.NoRetryError(fs.ErrorImmutableModified)
+				fs.Errorf(dst, "Source is file and destination is directory: %v", err)
+				s.processError(err)
+				s.logger(ctx, operations.TransferError, srcX, nil, err)
+				return false
+			}
+			s.logger(ctx, operations.MissingOnSrc, nil, dstDir, fs.ErrorIsDir)
+			err := s.removeConflictingDirectory(ctx, dstDir)
+			if err != nil {
+				fs.Errorf(dst, "Failed to remove directory before replacing it with a file: %v", err)
+				s.processError(err)
+				s.logger(ctx, operations.TransferError, srcX, nil, err)
+				return false
+			}
+			s.copySrcOnlyObject(srcX)
 		}
 	case fs.Directory:
 		// Do the same thing to the entire contents of the directory
+		srcOriginal := srcX
 		srcX = fs.NewOverrideDirectory(srcX, transform.Path(ctx, src.Remote(), true))
 		src = srcX
 		if !transform.Transforming(ctx) || src.Remote() != dst.Remote() {
@@ -1332,11 +1391,25 @@ func (s *syncCopyMove) Match(ctx context.Context, dst, src fs.DirEntry) (recurse
 
 			return true
 		}
-		// FIXME src is dir, dst is file
-		err := errors.New("can't overwrite file with directory")
-		fs.Errorf(dst, "%v", err)
-		s.processError(err)
-		s.logger(ctx, operations.TransferError, src.(fs.ObjectInfo), dst.(fs.ObjectInfo), err)
+		dstObject, ok := dst.(fs.Object)
+		if !ok {
+			panic("Bad object in DirEntries")
+		}
+		if s.ci.Immutable {
+			err := fserrors.NoRetryError(fs.ErrorImmutableModified)
+			fs.Errorf(dst, "Source is directory and destination is file: %v", err)
+			s.processError(err)
+			s.logger(ctx, operations.TransferError, srcX, dstObject, err)
+			return false
+		}
+		s.logger(ctx, operations.MissingOnSrc, nil, dstObject, nil)
+		err := operations.DeleteFileWithBackupDir(ctx, dstObject, s.backupDir)
+		if err != nil {
+			s.processError(err)
+			s.logger(ctx, operations.TransferError, srcX, dstObject, err)
+			return false
+		}
+		return s.copySrcOnlyDirectory(srcOriginal)
 	default:
 		panic("Bad object in DirEntries")
 	}

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fs/walk"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/lib/transform"
 	"github.com/stretchr/testify/assert"
@@ -1192,6 +1193,119 @@ func testSyncAfterRemovingAFileAndAddingAFile(ctx context.Context, t *testing.T)
 
 func TestSyncAfterRemovingAFileAndAddingAFile(t *testing.T) {
 	testSyncAfterRemovingAFileAndAddingAFile(context.Background(), t)
+}
+
+func testSyncReplacesFileAndDirectory(t *testing.T, sourceIsDirectory, useListR bool) {
+	t.Helper()
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	r := fstest.NewRun(t)
+	ci.UseListR = useListR
+	if useListR && r.Fremote.Features().ListR == nil {
+		r.Fremote.Features().ListR = func(ctx context.Context, dir string, callback fs.ListRCallback) error {
+			r.Fremote.Features().ListR = nil
+			return walk.ListR(ctx, r.Fremote, dir, true, -1, walk.ListAll, callback)
+		}
+		defer func() {
+			r.Fremote.Features().ListR = nil
+		}()
+	}
+
+	var file fstest.Item
+	if sourceIsDirectory {
+		file = r.WriteFile("item/new", "new contents", t1)
+		r.WriteObject(ctx, "item", "old contents", t2)
+	} else {
+		file = r.WriteFile("item", "new contents", t1)
+		r.WriteObject(ctx, "item/old", "old contents", t2)
+	}
+
+	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
+
+	r.CheckLocalItems(t, file)
+	r.CheckRemoteItems(t, file)
+}
+
+func TestSyncReplacesFileAndDirectory(t *testing.T) {
+	for _, useListR := range []bool{false, true} {
+		mode := "list"
+		if useListR {
+			mode = "listR"
+		}
+		t.Run("directory with file/"+mode, func(t *testing.T) {
+			testSyncReplacesFileAndDirectory(t, false, useListR)
+		})
+		t.Run("file with directory/"+mode, func(t *testing.T) {
+			testSyncReplacesFileAndDirectory(t, true, useListR)
+		})
+	}
+}
+
+func TestSyncReplacesFileAndDirectoryWithBackupDir(t *testing.T) {
+	for _, sourceIsDirectory := range []bool{false, true} {
+		name := "directory with file"
+		if sourceIsDirectory {
+			name = "file with directory"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx, ci := fs.AddConfig(ctx)
+			r := fstest.NewRun(t)
+			if !operations.CanServerSideMove(r.Fremote) {
+				t.Skip("Skipping test as remote does not support server-side move")
+			}
+			ci.BackupDir = r.FremoteName + "/backup"
+			fdst, err := fs.NewFs(ctx, r.FremoteName+"/dst")
+			require.NoError(t, err)
+
+			var file, old fstest.Item
+			if sourceIsDirectory {
+				file = r.WriteFile("item/new", "new contents", t1)
+				old = r.WriteObject(ctx, "dst/item", "old contents", t2)
+				file.Path = "dst/item/new"
+				old.Path = "backup/item"
+			} else {
+				file = r.WriteFile("item", "new contents", t1)
+				old = r.WriteObject(ctx, "dst/item/old", "old contents", t2)
+				file.Path = "dst/item"
+				old.Path = "backup/item/old"
+			}
+
+			require.NoError(t, Sync(ctx, fdst, r.Flocal, false))
+
+			r.CheckRemoteItems(t, file, old)
+		})
+	}
+}
+
+func TestSyncReplaceDirectorySafetyChecks(t *testing.T) {
+	t.Run("immutable", func(t *testing.T) {
+		ctx := context.Background()
+		ctx, ci := fs.AddConfig(ctx)
+		ci.Immutable = true
+		r := fstest.NewRun(t)
+		r.WriteFile("item", "new contents", t1)
+		old := r.WriteObject(ctx, "item/old", "old contents", t2)
+
+		err := Sync(ctx, r.Fremote, r.Flocal, false)
+		require.ErrorIs(t, err, fs.ErrorImmutableModified)
+		r.CheckRemoteItems(t, old)
+	})
+
+	t.Run("active filters", func(t *testing.T) {
+		ctx := context.Background()
+		r := fstest.NewRun(t)
+		r.WriteFile("item", "new contents", t1)
+		old := r.WriteObject(ctx, "item/old", "old contents", t2)
+		flt, err := filter.NewFilter(nil)
+		require.NoError(t, err)
+		require.NoError(t, flt.AddRule("+ *"))
+		ctx = filter.ReplaceConfig(ctx, flt)
+
+		err = Sync(ctx, r.Fremote, r.Flocal, false)
+		require.ErrorContains(t, err, "filters are active")
+		r.CheckRemoteItems(t, old)
+	})
 }
 
 // Sync after removing a file and adding a file

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1241,6 +1241,20 @@ func TestSyncReplacesFileAndDirectory(t *testing.T) {
 	}
 }
 
+func TestSyncDeleteAfterMatchesNamesBeforeTypeSuffix(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	require.Equal(t, fs.DeleteModeAfter, ci.DeleteMode)
+	r := fstest.NewRun(t)
+
+	file := r.WriteFile("a", "new contents", t1)
+	fileWithSuffix := r.WriteFile("a-", "other contents", t1)
+	r.WriteObject(ctx, "a", "old contents", t2)
+
+	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
+	r.CheckRemoteItems(t, file, fileWithSuffix)
+}
+
 func TestSyncReplacesFileAndDirectoryWithBackupDir(t *testing.T) {
 	for _, sourceIsDirectory := range []bool{false, true} {
 		name := "directory with file"

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
+	"github.com/rclone/rclone/fs/walk"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/lib/transform"
 	"github.com/stretchr/testify/assert"
@@ -1192,6 +1193,119 @@ func testSyncAfterRemovingAFileAndAddingAFile(ctx context.Context, t *testing.T)
 
 func TestSyncAfterRemovingAFileAndAddingAFile(t *testing.T) {
 	testSyncAfterRemovingAFileAndAddingAFile(context.Background(), t)
+}
+
+func testSyncReplacesFileAndDirectory(t *testing.T, sourceIsDirectory, useListR bool) {
+	t.Helper()
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	r := fstest.NewRun(t)
+	ci.UseListR = useListR
+	if useListR && r.Fremote.Features().ListR == nil {
+		r.Fremote.Features().ListR = func(ctx context.Context, dir string, callback fs.ListRCallback) error {
+			r.Fremote.Features().ListR = nil
+			return walk.ListR(ctx, r.Fremote, dir, true, -1, walk.ListAll, callback)
+		}
+		defer func() {
+			r.Fremote.Features().ListR = nil
+		}()
+	}
+
+	var file fstest.Item
+	if sourceIsDirectory {
+		file = r.WriteFile("item/new", "new contents", t1)
+		r.WriteObject(ctx, "item", "old contents", t2)
+	} else {
+		file = r.WriteFile("item", "new contents", t1)
+		r.WriteObject(ctx, "item/old", "old contents", t2)
+	}
+
+	require.NoError(t, Sync(ctx, r.Fremote, r.Flocal, false))
+
+	r.CheckLocalItems(t, file)
+	r.CheckRemoteItems(t, file)
+}
+
+func TestSyncReplacesFileAndDirectory(t *testing.T) {
+	for _, useListR := range []bool{false, true} {
+		mode := "list"
+		if useListR {
+			mode = "listR"
+		}
+		t.Run("directory with file/"+mode, func(t *testing.T) {
+			testSyncReplacesFileAndDirectory(t, false, useListR)
+		})
+		t.Run("file with directory/"+mode, func(t *testing.T) {
+			testSyncReplacesFileAndDirectory(t, true, useListR)
+		})
+	}
+}
+
+func TestSyncReplacesFileAndDirectoryWithBackupDir(t *testing.T) {
+	for _, sourceIsDirectory := range []bool{false, true} {
+		name := "directory with file"
+		if sourceIsDirectory {
+			name = "file with directory"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			ctx, ci := fs.AddConfig(ctx)
+			r := fstest.NewRun(t)
+			if !operations.CanServerSideMove(r.Fremote) {
+				t.Skip("Skipping test as remote does not support server-side move")
+			}
+			ci.BackupDir = r.FremoteName + "/backup"
+			fdst, err := fs.NewFs(ctx, r.FremoteName+"/dst")
+			require.NoError(t, err)
+
+			var file, old fstest.Item
+			if sourceIsDirectory {
+				file = r.WriteFile("item/new", "new contents", t1)
+				old = r.WriteObject(ctx, "dst/item", "old contents", t2)
+				file.Path = "dst/item/new"
+				old.Path = "backup/item"
+			} else {
+				file = r.WriteFile("item", "new contents", t1)
+				old = r.WriteObject(ctx, "dst/item/old", "old contents", t2)
+				file.Path = "dst/item"
+				old.Path = "backup/item/old"
+			}
+
+			require.NoError(t, Sync(ctx, fdst, r.Flocal, false))
+
+			r.CheckRemoteItems(t, file, old)
+		})
+	}
+}
+
+func TestSyncReplaceDirectorySafetyChecks(t *testing.T) {
+	t.Run("immutable", func(t *testing.T) {
+		ctx := context.Background()
+		ctx, ci := fs.AddConfig(ctx)
+		ci.Immutable = true
+		r := fstest.NewRun(t)
+		r.WriteFile("item", "new contents", t1)
+		old := r.WriteObject(ctx, "item/old", "old contents", t2)
+
+		err := Sync(ctx, r.Fremote, r.Flocal, false)
+		require.ErrorIs(t, err, fs.ErrorImmutableModified)
+		r.CheckRemoteItems(t, old)
+	})
+
+	t.Run("active filters", func(t *testing.T) {
+		ctx := context.Background()
+		r := fstest.NewRun(t)
+		r.WriteFile("item", "new contents", t1)
+		old := r.WriteObject(ctx, "item/old", "old contents", t2)
+		flt, err := filter.NewFilter(nil)
+		require.NoError(t, err)
+		require.NoError(t, flt.AddRule("+ *"))
+		ctx = filter.ReplaceConfig(ctx, flt)
+
+		err = Sync(ctx, r.Fremote, r.Flocal, false)
+		require.ErrorContains(t, err, "filters are active")
+		r.CheckRemoteItems(t, old)
+	})
 }
 
 // Sync after removing a file and adding a file


### PR DESCRIPTION
#### What does this change do?

`sync` now replaces a destination directory with a source file, or a destination file with a source directory, when they have the same transformed name.

The traversal groups entries by transformed basename but still prefers same-type matches. This preserves the behavior of backends such as Drive that can expose a file and directory with the same name. Only a remaining cross-type pair is treated as a replacement.

For a real type conflict, sync removes the destination before continuing. If `--backup-dir` is configured, files from the conflicting directory are moved into the backup tree before its directories are removed. `--immutable` still refuses the replacement, and an active filtered sync refuses to purge a directory unless `--delete-excluded` is set.

The root cause was that file and directory sort keys included their type. A same-name cross-type pair therefore arrived as separate source-only and destination-only entries, so delete-after queued the upload before removing the conflicting destination.

Tests cover both replacement directions with normal listing and `ListR`, backup-directory preservation, same-type precedence, immutable mode, and filtered-sync safety.

#### Linked issue

Fixes #2231

#### For new or changed backends

Not applicable; this changes core sync traversal only.

#### Verification

- `go build`
- `RCLONE_CONFIG=/notfound go test ./fs/march ./fs/sync`
- `RCLONE_CONFIG=/notfound go test -race ./fs/march ./fs/sync`
- `PATH="$PWD:$PATH" RCLONE_CONFIG=/notfound make quicktest BRANCH=codex-fix-sync-file-dir-replacement`
- `golangci-lint run ./fs/march/... ./fs/sync/...` (0 issues)

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate (not applicable for this bug fix).
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** Not applicable.
- [ ] This Pull Request is ready for review.
