### PR TITLE
sync: allow --transfers to be changed while syncing

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -2902,6 +2902,10 @@ of timeouts or bigger if you have lots of bandwidth and a fast remote.
 
 The default is to run 4 file transfers in parallel.
 
+This can be changed while rclone is running with the
+[options/set](/rc/#options-set) rc command which will adjust the
+number of transfers of syncs in progress too.
+
 Look at --multi-thread-streams if you would like to control single file transfers.
 
 ### -u, --update

--- a/docs/content/rc.md
+++ b/docs/content/rc.md
@@ -2054,6 +2054,15 @@ And this sets NOTICE level logs (normal without -v)
 
     rclone rc options/set --json '{"main": {"LogLevel": "NOTICE"}}'
 
+And this sets the number of transfers to 10
+
+    rclone rc options/set --json '{"main": {"Transfers": 10}}'
+
+This will change the number of transfers for syncs which are already
+running as well as new syncs. When scaling up new transfers will start
+immediately and when scaling down transfers over the limit will stop
+after they have finished the file they are transferring.
+
 ### pluginsctl/addPlugin: Add a plugin using url {#pluginsctl-addPlugin}
 
 Used for adding a plugin to the webgui.

--- a/fs/config.go
+++ b/fs/config.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 )
 
@@ -749,7 +750,68 @@ func (ci *ConfigInfo) Reload(ctx context.Context) error {
 	nonZero(&ci.Transfers)
 	nonZero(&ci.Checkers)
 
-	return LogReload(ci)
+	if err := LogReload(ci); err != nil {
+		return err
+	}
+
+	// Tell anyone interested that the config has changed
+	ci.callReloadCallbacks()
+
+	return nil
+}
+
+// Reload callbacks are called when a ConfigInfo is reloaded, eg after
+// it has been changed by the rc options/set command.
+var (
+	reloadCallbacksMu sync.Mutex
+	reloadCallbacks   = map[*ConfigInfo]map[int]func(*ConfigInfo){}
+	reloadCallbackKey int
+)
+
+// AddReloadCallback registers fn to be called whenever ci is reloaded,
+// eg after it has been changed by the rc options/set command.
+//
+// This can be used to adjust long running operations when the config
+// changes.
+//
+// The callback is called from the goroutine which reloaded the config
+// so it should not block.
+//
+// It returns a function which should be called to remove the callback
+// when it is no longer needed.
+func (ci *ConfigInfo) AddReloadCallback(fn func(*ConfigInfo)) (remove func()) {
+	reloadCallbacksMu.Lock()
+	defer reloadCallbacksMu.Unlock()
+	callbacks := reloadCallbacks[ci]
+	if callbacks == nil {
+		callbacks = map[int]func(*ConfigInfo){}
+		reloadCallbacks[ci] = callbacks
+	}
+	key := reloadCallbackKey
+	reloadCallbackKey++
+	callbacks[key] = fn
+	return func() {
+		reloadCallbacksMu.Lock()
+		defer reloadCallbacksMu.Unlock()
+		delete(callbacks, key)
+		if len(callbacks) == 0 {
+			delete(reloadCallbacks, ci)
+		}
+	}
+}
+
+// callReloadCallbacks calls any callbacks registered for ci with
+// AddReloadCallback.
+func (ci *ConfigInfo) callReloadCallbacks() {
+	reloadCallbacksMu.Lock()
+	fns := make([]func(*ConfigInfo), 0, len(reloadCallbacks[ci]))
+	for _, fn := range reloadCallbacks[ci] {
+		fns = append(fns, fn)
+	}
+	reloadCallbacksMu.Unlock()
+	for _, fn := range fns {
+		fn(ci)
+	}
 }
 
 // InitialLogLevel performs a simple check for debug flags to enable

--- a/fs/config_test.go
+++ b/fs/config_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetConfig(t *testing.T) {
@@ -28,6 +29,47 @@ func TestGetConfig(t *testing.T) {
 	// Check can get config back
 	config2ctx := GetConfig(ctx2)
 	assert.Equal(t, config2, config2ctx)
+}
+
+func TestAddReloadCallback(t *testing.T) {
+	ctx := context.Background()
+	_, ci := AddConfig(ctx)
+
+	var calls int
+	var gotCi *ConfigInfo
+	remove := ci.AddReloadCallback(func(ci *ConfigInfo) {
+		calls++
+		gotCi = ci
+	})
+
+	// Check the callback is called on Reload with the right ConfigInfo
+	require.NoError(t, ci.Reload(ctx))
+	assert.Equal(t, 1, calls)
+	assert.Equal(t, ci, gotCi)
+
+	// Check a reload of a different ConfigInfo doesn't call the callback
+	_, ci2 := AddConfig(ctx)
+	require.NoError(t, ci2.Reload(ctx))
+	assert.Equal(t, 1, calls)
+
+	// Check multiple callbacks are called
+	var calls2 int
+	remove2 := ci.AddReloadCallback(func(*ConfigInfo) {
+		calls2++
+	})
+	require.NoError(t, ci.Reload(ctx))
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, 1, calls2)
+
+	// Check the callbacks aren't called after remove
+	remove()
+	remove2()
+	require.NoError(t, ci.Reload(ctx))
+	assert.Equal(t, 2, calls)
+	assert.Equal(t, 1, calls2)
+
+	// Check remove is safe to call twice
+	remove()
 }
 
 // The rc request marker must survive CopyConfig, which is how rclone

--- a/fs/rc/config.go
+++ b/fs/rc/config.go
@@ -174,6 +174,15 @@ And this sets INFO level logs (-v)
 And this sets NOTICE level logs (normal without -v)
 
     rclone rc options/set --json '{"main": {"LogLevel": "NOTICE"}}'
+
+And this sets the number of transfers to 10
+
+    rclone rc options/set --json '{"main": {"Transfers": 10}}'
+
+This will change the number of transfers for syncs which are already
+running as well as new syncs. When scaling up new transfers will start
+immediately and when scaling down transfers over the limit will stop
+after they have finished the file they are transferring.
 `,
 	})
 }

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -10,6 +10,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/rclone/rclone/fs"
@@ -69,6 +70,9 @@ type syncCopyMove struct {
 	checkerWg              sync.WaitGroup         // wait for checkers
 	toBeChecked            *pipe                  // checkers channel
 	transfersWg            sync.WaitGroup         // wait for transfers
+	maxTransfers           atomic.Int32           // number of transfer goroutines wanted
+	transfersRunning       atomic.Int32           // number of transfer goroutines running
+	transfersChanged       chan struct{}          // signalled when maxTransfers is changed
 	toBeUploaded           *pipe                  // copiers channel
 	errorMu                sync.Mutex             // Mutex covering the errors variables
 	err                    error                  // normal error from copy process
@@ -144,6 +148,7 @@ func newSyncCopyMove(ctx context.Context, fdst, fsrc fs.Fs, deleteMode fs.Delete
 		copyEmptySrcDirs:       copyEmptySrcDirs,
 		deleteEmptySrcDirs:     deleteEmptySrcDirs,
 		dir:                    "",
+		transfersChanged:       make(chan struct{}, 1),
 		srcFilesChan:           make(chan fs.Object, ci.Checkers+ci.Transfers),
 		srcFilesResult:         make(chan error, 1),
 		dstFilesResult:         make(chan error, 1),
@@ -165,6 +170,8 @@ func newSyncCopyMove(ctx context.Context, fdst, fsrc fs.Fs, deleteMode fs.Delete
 		modifiedDirs:           make(map[string]struct{}),
 		allowOverlap:           allowOverlap,
 	}
+
+	s.maxTransfers.Store(int32(ci.Transfers))
 
 	s.logger, s.usingLogger = operations.GetLogger(ctx)
 
@@ -497,12 +504,19 @@ func (s *syncCopyMove) pairRenamer(in *pipe, out *pipe, fraction int, wg *sync.W
 }
 
 // pairCopyOrMove reads Objects on in and moves or copies them.
-func (s *syncCopyMove) pairCopyOrMove(ctx context.Context, in *pipe, fdst fs.Fs, fraction int, wg *sync.WaitGroup) {
-	defer wg.Done()
+//
+// inCtx is a context cancelled by manageTransfers to make this
+// goroutine stop after it has finished its current transfer.
+//
+// When it finishes it sends true to exited if it stopped because in
+// was closed or the sync was cancelled, or false if it stopped
+// because inCtx was cancelled to reduce the number of transfers.
+func (s *syncCopyMove) pairCopyOrMove(ctx context.Context, in *pipe, fdst fs.Fs, fraction int, inCtx context.Context, exited chan<- bool) {
 	var err error
 	for {
-		pair, ok := in.GetMax(s.inCtx, fraction)
+		pair, ok := in.GetMax(inCtx, fraction)
 		if !ok {
+			exited <- inCtx.Err() == nil || s.inCtx.Err() != nil
 			return
 		}
 		src := pair.Src
@@ -542,10 +556,87 @@ func (s *syncCopyMove) stopCheckers() {
 
 // This starts the background transfers
 func (s *syncCopyMove) startTransfers() {
-	s.transfersWg.Add(s.ci.Transfers)
-	for i := range s.ci.Transfers {
-		fraction := (100 * i) / s.ci.Transfers
-		go s.pairCopyOrMove(s.ctx, s.toBeUploaded, s.fdst, fraction, &s.transfersWg)
+	s.transfersWg.Add(1)
+	go s.manageTransfers()
+}
+
+// manageTransfers maintains the pool of transfer goroutines.
+//
+// It starts s.maxTransfers goroutines and if s.maxTransfers changes
+// (eg by --transfers being changed with the rc options/set command)
+// it starts new goroutines or stops running ones to match.
+//
+// It runs until the transfers pipe has been closed or the sync has
+// been cancelled and all the transfer goroutines have finished.
+func (s *syncCopyMove) manageTransfers() {
+	defer s.transfersWg.Done()
+	var (
+		exited   = make(chan bool)    // transfer goroutines send here when they finish
+		cancels  []context.CancelFunc // cancel functions for the goroutines not asked to stop
+		started  int                  // number of transfer goroutines started so far
+		running  int                  // number of transfer goroutines running
+		stopping int                  // number of transfer goroutines asked to stop
+		closed   bool                 // set when the pipe is closed or the sync is cancelled
+	)
+	defer func() {
+		// Cancel any contexts left to free resources
+		for _, cancel := range cancels {
+			cancel()
+		}
+	}()
+	for {
+		if !closed {
+			// Adjust the number of transfer goroutines to match maxTransfers
+			want := int(s.maxTransfers.Load())
+			if want < 1 {
+				want = 1
+			}
+			for running-stopping < want {
+				ctx, cancel := context.WithCancel(s.inCtx)
+				cancels = append(cancels, cancel)
+				fraction := (100 * (started % want)) / want
+				started++
+				running++
+				s.transfersRunning.Store(int32(running))
+				go s.pairCopyOrMove(s.ctx, s.toBeUploaded, s.fdst, fraction, ctx, exited)
+			}
+			for running-stopping > want {
+				// Ask the most recently started goroutine to stop
+				// once it has finished its current transfer.
+				i := len(cancels) - 1
+				cancels[i]()
+				cancels = cancels[:i]
+				stopping++
+			}
+		}
+		select {
+		case <-s.transfersChanged:
+		case wasClosed := <-exited:
+			running--
+			s.transfersRunning.Store(int32(running))
+			if wasClosed {
+				closed = true
+			} else {
+				stopping--
+			}
+			if closed && running == 0 {
+				return
+			}
+		}
+	}
+}
+
+// configReloaded is called when the config s is using has been
+// reloaded, eg by the rc options/set command. It adjusts the number
+// of transfer goroutines if --transfers has changed.
+func (s *syncCopyMove) configReloaded(ci *fs.ConfigInfo) {
+	newTransfers := int32(ci.Transfers)
+	if s.maxTransfers.Swap(newTransfers) != newTransfers {
+		fs.Infof(s.fdst, "Setting transfers to %d", newTransfers)
+		select {
+		case s.transfersChanged <- struct{}{}:
+		default:
+		}
 	}
 }
 
@@ -938,6 +1029,11 @@ func (s *syncCopyMove) run() error {
 		fs.Errorf(s.fdst, "Nothing to do as source and destination are the same")
 		return nil
 	}
+
+	// Adjust the number of transfers if the config is reloaded, eg
+	// by the rc options/set command
+	removeReloadCallback := s.ci.AddReloadCallback(s.configReloaded)
+	defer removeReloadCallback()
 
 	// Start background checking and transferring pipeline
 	s.startCheckers()

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -3134,3 +3134,50 @@ func blankMissingHashes(logger, lsf *bytes.Buffer) {
 	logger.Reset()
 	logger.Write(bytes.Join(loggerSplit, []byte("\n")))
 }
+
+// Test that the number of transfer goroutines is scaled up and down
+// when the config is reloaded, eg by the rc options/set command.
+func TestSyncScaleTransfers(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	ci.Transfers = 4
+	r := fstest.NewRun(t)
+
+	s, err := newSyncCopyMove(ctx, r.Fremote, r.Flocal, fs.DeleteModeOff, false, false, false, false)
+	require.NoError(t, err)
+	defer func() {
+		s.inCancel()
+		s.cancel()
+	}()
+
+	// Register the callback as run() does
+	removeReloadCallback := s.ci.AddReloadCallback(s.configReloaded)
+	defer removeReloadCallback()
+
+	waitForTransfers := func(want int32) {
+		deadline := time.Now().Add(10 * time.Second)
+		for s.transfersRunning.Load() != want {
+			if time.Now().After(deadline) {
+				t.Fatalf("want %d transfer goroutines but got %d", want, s.transfersRunning.Load())
+			}
+			time.Sleep(time.Millisecond)
+		}
+	}
+
+	s.startTransfers()
+	waitForTransfers(4)
+
+	// Scale up the number of transfers as the rc options/set command would
+	ci.Transfers = 8
+	require.NoError(t, ci.Reload(ctx))
+	waitForTransfers(8)
+
+	// Scale down the number of transfers
+	ci.Transfers = 2
+	require.NoError(t, ci.Reload(ctx))
+	waitForTransfers(2)
+
+	// Check all the transfer goroutines stop when the pipe is closed
+	s.stopTransfers()
+	waitForTransfers(0)
+}


### PR DESCRIPTION
#### What does this change do?

Makes `--transfers` adjustable while a sync is running. `rclone rc options/set --json '{"main": {"Transfers": 10}}'` already worked, but only for syncs started afterwards; running syncs kept their original fixed pool of transfer goroutines.

This follows the callback approach sketched in the issue:

- `fs.ConfigInfo.AddReloadCallback` registers a function called whenever that ConfigInfo is reloaded (as `options/set` does), returning a remove function. The sync registers one for the duration of its run.
- The fixed pool of transfer goroutines in `fs/sync` is replaced by a managed pool. Scaling up starts new goroutines immediately; scaling down cancels the most recently started ones, and each stops once it has finished the file it is transferring. Idle goroutines stop straight away.
- Syncs started with `_config` get their own ConfigInfo copy, so they are unaffected by `options/set` on `main`, same as before.

Docs: `options/set` help and `--transfers` in docs.md now mention this, and the matching section of rc.md is updated.

Verified end to end against a live sync (`--bwlimit` + 30 files): `core/stats` shows `transferring` going 2 → 6 immediately after scaling up, and 6 → 2 after in-flight files complete when scaling down.

#### Linked issue

Fixes #3898

#### Validation

- `go test -race ./fs/sync` (full suite, includes new `TestSyncScaleTransfers`)
- `go test ./fs ./fs/rc/...` (includes new `TestAddReloadCallback`)
- `go vet ./fs ./fs/sync ./fs/rc`
- `go build ./...`

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] This is not a backend change, so backend integration testing is not applicable.
- [x] This Pull Request is ready for review.
