### PR TITLE
smb: reuse Kerberos client cache across connections

### DIFF
--- a/backend/smb/connpool.go
+++ b/backend/smb/connpool.go
@@ -38,7 +38,7 @@ func (f *Fs) dial(ctx context.Context, network, addr string) (*conn, error) {
 
 	d := &smb2.Dialer{}
 	if f.opt.UseKerberos {
-		cl, err := NewKerberosFactory().GetClient(f.opt.KerberosCCache)
+		cl, err := getKerberosClient(f.opt.KerberosCCache)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/smb/kerberos.go
+++ b/backend/smb/kerberos.go
@@ -16,6 +16,8 @@ import (
 
 // KerberosFactory encapsulates dependencies and caches for Kerberos clients.
 type KerberosFactory struct {
+	mu sync.Mutex
+
 	// clientCache caches Kerberos clients keyed by resolved ccache path.
 	// Clients are reused unless the associated ccache file changes.
 	clientCache sync.Map // map[string]*client.Client
@@ -42,12 +44,20 @@ func NewKerberosFactory() *KerberosFactory {
 	}
 }
 
+var kerberosFactory = NewKerberosFactory()
+
+func getKerberosClient(ccachePath string) (*client.Client, error) {
+	return kerberosFactory.GetClient(ccachePath)
+}
+
 // GetClient returns a cached Kerberos client or creates a new one if needed.
 func (kf *KerberosFactory) GetClient(ccachePath string) (*client.Client, error) {
 	resolvedPath, err := resolveCcachePath(ccachePath)
 	if err != nil {
 		return nil, err
 	}
+	kf.mu.Lock()
+	defer kf.mu.Unlock()
 
 	stat, err := os.Stat(resolvedPath)
 	if err != nil {

--- a/backend/smb/kerberos_test.go
+++ b/backend/smb/kerberos_test.go
@@ -3,6 +3,8 @@ package smb
 import (
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -139,4 +141,53 @@ func TestKerberosFactory_GetClient_ReloadOnCcacheChange(t *testing.T) {
 	_, err = factory.GetClient(ccachePath)
 	assert.NoError(t, err)
 	assert.Equal(t, 2, loadCallCount, "expected reload on changed ccache")
+}
+
+func TestSharedKerberosFactoryCachesClients(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "krb5cc_test")
+	assert.NoError(t, err)
+	assert.NoError(t, tmpFile.Close())
+
+	var loadCallCount atomic.Int32
+	loadBlocked := make(chan struct{})
+	originalFactory := kerberosFactory
+	t.Cleanup(func() { kerberosFactory = originalFactory })
+	kerberosFactory = &KerberosFactory{
+		loadCCache: func(string) (*credentials.CCache, error) {
+			loadCallCount.Add(1)
+			<-loadBlocked
+			return &credentials.CCache{}, nil
+		},
+		newClient: func(*credentials.CCache, *config.Config, ...func(*client.Settings)) (*client.Client, error) {
+			return &client.Client{}, nil
+		},
+		loadConfig: func() (*config.Config, error) {
+			return &config.Config{}, nil
+		},
+	}
+
+	ccachePath := "FILE:" + filepath.ToSlash(tmpFile.Name())
+	const clientCount = 8
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	errs := make(chan error, clientCount)
+	for range clientCount {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := getKerberosClient(ccachePath)
+			errs <- err
+		}()
+	}
+
+	close(start)
+	assert.Never(t, func() bool { return loadCallCount.Load() > 1 }, 100*time.Millisecond, 5*time.Millisecond)
+	close(loadBlocked)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, int32(1), loadCallCount.Load(), "expected concurrent dials to share one cached client")
 }


### PR DESCRIPTION
## What changed

Use one package-level Kerberos factory for SMB connections so its client, error, and ccache modification-time caches survive beyond a single dial.

The factory now serializes each cache check/load/publish transaction. This prevents concurrent dials from constructing duplicate clients or publishing mismatched client and modification-time entries.

## Testing

- go test -race ./backend/smb -run Test(NewFilePool|FilePool|ResolveCcachePath|KerberosFactory|SharedKerberosFactory|IsPathDir) -count=10
- go vet ./backend/smb
- go build
- make quicktest: all packages passed except cmd/serve/s3 TestS3Minio, whose local test-server script requires Linux flock (not available on this macOS host)
- credentialed TestSMB integration remotes were not available locally

Fixes #9674