### PR TITLE
dropbox: preserve Paper export paths on lookup

### DIFF
--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -693,7 +693,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 
 	// See if the root is actually an object
 	if f.root != "" {
-		_, err = f.getFileMetadata(ctx, f.slashRoot)
+		_, _, err = f.getFileMetadata(ctx, f.slashRoot)
 		if err == nil {
 			newRoot := path.Dir(f.root)
 			if newRoot == "." {
@@ -728,9 +728,10 @@ func (f *Fs) setRoot(root string) {
 }
 
 type getMetadataResult struct {
-	entry    files.IsMetadata
-	notFound bool
-	err      error
+	entry              files.IsMetadata
+	remoteIsExportPath bool
+	notFound           bool
+	err                error
 }
 
 // getMetadata gets the metadata for a file or directory
@@ -779,6 +780,7 @@ func (f *Fs) getMetadataForExt(ctx context.Context, filePath string, wantExportE
 				ch <- getMetadataResult{notFound: true}
 				return
 			}
+			res.remoteIsExportPath = true
 		}
 
 		// Return our real result or error
@@ -824,7 +826,7 @@ func (f *Fs) possibleMetadatas(ctx context.Context, filePath string) (ret []<-ch
 }
 
 // getFileMetadata gets the metadata for a file
-func (f *Fs) getFileMetadata(ctx context.Context, filePath string) (*files.FileMetadata, error) {
+func (f *Fs) getFileMetadata(ctx context.Context, filePath string) (*files.FileMetadata, bool, error) {
 	var res getMetadataResult
 
 	// Try all possible metadatas
@@ -833,7 +835,7 @@ func (f *Fs) getFileMetadata(ctx context.Context, filePath string) (*files.FileM
 		res = <-ch
 
 		if res.err != nil {
-			return nil, res.err
+			return nil, false, res.err
 		}
 		if !res.notFound {
 			break
@@ -841,17 +843,17 @@ func (f *Fs) getFileMetadata(ctx context.Context, filePath string) (*files.FileM
 	}
 
 	if res.notFound {
-		return nil, fs.ErrorObjectNotFound
+		return nil, false, fs.ErrorObjectNotFound
 	}
 
 	fileInfo, ok := res.entry.(*files.FileMetadata)
 	if !ok {
 		if _, ok = res.entry.(*files.FolderMetadata); ok {
-			return nil, fs.ErrorIsDir
+			return nil, false, fs.ErrorIsDir
 		}
-		return nil, fs.ErrorNotAFile
+		return nil, false, fs.ErrorNotAFile
 	}
-	return fileInfo, nil
+	return fileInfo, res.remoteIsExportPath, nil
 }
 
 // getDirMetadata gets the metadata for a directory
@@ -1851,7 +1853,7 @@ func (o *Object) Size() int64 {
 	return o.bytes
 }
 
-func (o *Object) setMetadataForExport(info *files.FileMetadata) {
+func (o *Object) setMetadataForExport(info *files.FileMetadata, remoteIsExportPath bool) {
 	o.bytes = -1
 	o.hash = ""
 
@@ -1872,8 +1874,10 @@ func (o *Object) setMetadataForExport(info *files.FileMetadata) {
 		o.exportType = exportExportable
 		// get rid of any paper extension, if present
 		o.remote = strings.TrimSuffix(o.remote, paperExtension)
-		// add the export extension
-		o.remote += "." + string(exportExt)
+		if !remoteIsExportPath {
+			// add the export extension
+			o.remote += "." + string(exportExt)
+		}
 	}
 }
 
@@ -1881,19 +1885,23 @@ func (o *Object) setMetadataForExport(info *files.FileMetadata) {
 //
 // This isn't a complete set of metadata and has an inaccurate date
 func (o *Object) setMetadataFromEntry(info *files.FileMetadata) error {
+	return o.setMetadataFromEntryWithExportPath(info, false)
+}
+
+func (o *Object) setMetadataFromEntryWithExportPath(info *files.FileMetadata, remoteIsExportPath bool) error {
 	o.id = info.Id
 	o.bytes = int64(info.Size)
 	o.modTime = time.Time(info.ClientModified)
 	o.hash = info.ContentHash
 
 	if !info.IsDownloadable {
-		o.setMetadataForExport(info)
+		o.setMetadataForExport(info, remoteIsExportPath)
 	}
 	return nil
 }
 
 // Reads the entry for a file from dropbox
-func (o *Object) readEntry(ctx context.Context) (*files.FileMetadata, error) {
+func (o *Object) readEntry(ctx context.Context) (*files.FileMetadata, bool, error) {
 	return o.fs.getFileMetadata(ctx, o.remotePath())
 }
 
@@ -1903,11 +1911,11 @@ func (o *Object) readEntryAndSetMetadata(ctx context.Context) error {
 	if !o.modTime.IsZero() {
 		return nil
 	}
-	entry, err := o.readEntry(ctx)
+	entry, remoteIsExportPath, err := o.readEntry(ctx)
 	if err != nil {
 		return err
 	}
-	return o.setMetadataFromEntry(entry)
+	return o.setMetadataFromEntryWithExportPath(entry, remoteIsExportPath)
 }
 
 // Returns the remote path for the object

--- a/backend/dropbox/dropbox_internal_test.go
+++ b/backend/dropbox/dropbox_internal_test.go
@@ -8,10 +8,32 @@ import (
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fstest/fstests"
+	"github.com/rclone/rclone/lib/pacer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type paperMetadataClient struct {
+	files.Client
+	info *files.FileMetadata
+}
+
+func (c paperMetadataClient) GetMetadata(arg *files.GetMetadataArg) (files.IsMetadata, error) {
+	if arg.Path == "document" {
+		return c.info, nil
+	}
+	return nil, files.GetMetadataAPIError{
+		APIError: dropbox.APIError{ErrorSummary: "path/not_found/"},
+		EndpointError: &files.GetMetadataError{
+			Tagged: dropbox.Tagged{Tag: files.GetMetadataErrorPath},
+			Path: &files.LookupError{
+				Tagged: dropbox.Tagged{Tag: files.LookupErrorNotFound},
+			},
+		},
+	}
+}
 
 func TestInternalCheckPathLength(t *testing.T) {
 	rep := func(n int, r rune) (out string) {
@@ -48,6 +70,30 @@ func TestInternalCheckPathLength(t *testing.T) {
 		err := checkPathLength(test.in)
 		assert.Equal(t, test.ok, err == nil, test.in)
 	}
+}
+
+func TestPaperExportRemote(t *testing.T) {
+	ctx := context.Background()
+	info := &files.FileMetadata{
+		ExportInfo: &files.ExportInfo{ExportAs: "markdown"},
+	}
+	f := &Fs{
+		exportExts: []exportExtension{"md"},
+		pacer:      fs.NewPacer(ctx, pacer.NewDefault()),
+		srv:        paperMetadataClient{info: info},
+	}
+
+	direct, err := f.NewObject(ctx, "document.md")
+	require.NoError(t, err)
+	assert.Equal(t, "document.md", direct.Remote())
+
+	listed, err := f.newObjectWithInfo(ctx, "document.md", info)
+	require.NoError(t, err)
+	assert.Equal(t, "document.md.md", listed.Remote())
+
+	legacy, err := f.newObjectWithInfo(ctx, "document.paper", info)
+	require.NoError(t, err)
+	assert.Equal(t, "document.md", legacy.Remote())
 }
 
 func (f *Fs) importPaperForTest(t *testing.T) {


### PR DESCRIPTION
#### What does this change do?

Preserves the caller-visible export extension when a Dropbox Paper document is resolved through a direct lookup. This prevents paths such as `document.md` from becoming `document.md.md`, while retaining the existing extension behavior for directory listings and legacy `.paper` paths.

The regression test uses a path-aware fake Dropbox client to cover direct export-path lookup, normal listing of an underlying name that already ends in `.md`, and legacy `.paper` listing.

Validation performed:

- `RCLONE_CONFIG=/notfound go test ./backend/dropbox -run TestPaperExportRemote -count=1`
- `RCLONE_CONFIG=/notfound go test ./backend/dropbox -count=1`
- `RCLONE_CONFIG=/notfound go test -race ./backend/dropbox -count=1`
- `go vet ./backend/dropbox`
- `go build`
- `RCLONE_CONFIG=/notfound make quicktest`

A real Dropbox integration remote was not used.

#### Linked issue

Fixes #9691

#### For new or changed backends

This fixes behavior in the existing Dropbox backend. The regression is covered by a path-aware fake client; real-remote `test_all` was not run.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.