### PR TITLE
smb: test closing failed dial connections

### DIFF
--- a/backend/smb/connpool.go
+++ b/backend/smb/connpool.go
@@ -27,6 +27,12 @@ func (f *Fs) dial(ctx context.Context, network, addr string) (*conn, error) {
 	if err != nil {
 		return nil, err
 	}
+	ownershipTransferred := false
+	defer func() {
+		if !ownershipTransferred {
+			_ = tconn.Close()
+		}
+	}()
 
 	pass := ""
 	if f.opt.Pass != "" {
@@ -66,6 +72,7 @@ func (f *Fs) dial(ctx context.Context, network, addr string) (*conn, error) {
 		return nil, err
 	}
 
+	ownershipTransferred = true
 	return &conn{
 		smbSession: session,
 		conn:       &tconn,

--- a/backend/smb/smb_internal_test.go
+++ b/backend/smb/smb_internal_test.go
@@ -1,7 +1,50 @@
 // Unit tests for internal SMB functions
 package smb
 
-import "testing"
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDialClosesConnectionOnSetupError(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, listener.Close()) }()
+
+	type acceptResult struct {
+		conn net.Conn
+		err  error
+	}
+	accepted := make(chan acceptResult, 1)
+	go func() {
+		conn, err := listener.Accept()
+		accepted <- acceptResult{conn: conn, err: err}
+	}()
+
+	f := &Fs{opt: Options{Pass: "invalid"}}
+	_, err = f.dial(context.Background(), "tcp", listener.Addr().String())
+	require.Error(t, err)
+
+	var result acceptResult
+	select {
+	case result = <-accepted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for server to accept connection")
+	}
+	require.NoError(t, result.err)
+	defer func() { require.NoError(t, result.conn.Close()) }()
+	require.NoError(t, result.conn.SetReadDeadline(time.Now().Add(time.Second)))
+
+	buffer := make([]byte, 1)
+	n, err := result.conn.Read(buffer)
+	require.Zero(t, n)
+	require.ErrorIs(t, err, io.EOF)
+}
 
 // TestIsPathDir tests the isPathDir function logic
 func TestIsPathDir(t *testing.T) {


### PR DESCRIPTION
#### What does this change do?

Adds regression coverage for the TCP connection cleanup implemented on current master by 74f9f182a.

The test opens a local TCP listener, lets SMB dial it, forces password decoding to fail after the connection is accepted, and verifies that the peer immediately observes EOF. Before the production fix, the peer remains open until the read deadline.

The branch has been merged with current master and now differs only by the regression test.

Validation performed:

- RCLONE_CONFIG=/notfound go test ./backend/smb -run TestDialClosesConnectionOnSetupError -count=20
- RCLONE_CONFIG=/notfound go test -race ./backend/smb -run TestDialClosesConnectionOnSetupError -count=5
- RCLONE_CONFIG=/notfound go test -race ./backend/smb -count=1
- go vet ./backend/smb

A real SMB integration remote was not used.

#### Linked issue

Regression coverage for #9678.

#### For new or changed backends

This adds a local TCP regression test to the existing SMB backend. Real-remote test_all was not run.

#### Checklist

- [x] This change is trivial OR it has been discussed and agreed in the linked issue.
- [x] I have read the contribution guidelines.
- [x] I have read and understood the AI-assisted contributions guidance and tested and take ownership of this change.
- [x] I have added tests for all changes if appropriate.
- [x] I have added documentation if appropriate.
- [ ] Backend test_all passes; no integration account was used.
- [x] This Pull Request is ready for review.