### PR TITLE
sync: add backup-dir deletes-only option

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -892,6 +892,19 @@ with `--suffix $(date +%F)` in bash, and
 
 See `--compare-dest` and `--copy-dest`.
 
+### --backup-dir-deletes-only
+
+When using `sync` with `--backup-dir`, this option moves only files deleted
+from the destination into the backup directory. Files that are updated by the
+source are overwritten in the destination as normal and are not moved into the
+backup directory first.
+
+This is useful with remotes that provide native file versioning: overwritten
+files retain their version history at the destination, while deleted files are
+still collected in the backup directory.
+
+This option has no effect unless `--backup-dir` is set.
+
 ### --bind string
 
 Local address to bind to for outgoing connections.  This can be an

--- a/fs/config.go
+++ b/fs/config.go
@@ -263,6 +263,11 @@ var ConfigOptionsInfo = Options{{
 	Help:    "Make backups into hierarchy based in DIR",
 	Groups:  "Sync",
 }, {
+	Name:    "backup_dir_deletes_only",
+	Default: false,
+	Help:    "Only move deleted files into the backup directory",
+	Groups:  "Sync",
+}, {
 	Name:    "suffix",
 	Default: "",
 	Help:    "Suffix to add to changed files",
@@ -614,6 +619,7 @@ type ConfigInfo struct {
 	CompareDest                []string          `config:"compare_dest"`
 	CopyDest                   []string          `config:"copy_dest"`
 	BackupDir                  string            `config:"backup_dir"`
+	BackupDirDeletesOnly       bool              `config:"backup_dir_deletes_only"`
 	Suffix                     string            `config:"suffix"`
 	SuffixKeepExtension        bool              `config:"suffix_keep_extension"`
 	UseListR                   bool              `config:"fast_list"`

--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -427,7 +427,8 @@ func (s *syncCopyMove) pairChecker(in *pipe, out *pipe, fraction int, wg *sync.W
 						s.markDirModifiedObject(src)
 					}
 					// If destination already exists, then we must move it into --backup-dir if required
-					if pair.Dst != nil && s.backupDir != nil {
+					backupDirDeletesOnly := s.ci.BackupDirDeletesOnly && s.ci.BackupDir != ""
+					if pair.Dst != nil && s.backupDir != nil && !backupDirDeletesOnly {
 						err := operations.MoveBackupDir(s.ctx, s.backupDir, pair.Dst)
 						if err != nil {
 							s.processError(err)

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -2458,6 +2458,65 @@ func TestSyncBackupDir(t *testing.T) {
 	testSyncBackupDir(t, "backup", "", false)
 }
 
+func TestSyncBackupDirDeletesOnly(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	r := fstest.NewRun(t)
+
+	if !operations.CanServerSideMove(r.Fremote) {
+		t.Skip("Skipping test as remote does not support server-side move")
+	}
+	r.Mkdir(ctx, r.Fremote)
+
+	ci.BackupDir = r.FremoteName + "/backup"
+	ci.BackupDirDeletesOnly = true
+
+	r.WriteObject(ctx, "dst/changed", "old", t1)
+	deleted := r.WriteObject(ctx, "dst/deleted", "deleted", t1)
+	newChanged := r.WriteFile("changed", "new", t2)
+
+	fdst, err := fs.NewFs(ctx, r.FremoteName+"/dst")
+	require.NoError(t, err)
+
+	accounting.GlobalStats().ResetCounters()
+	err = Sync(ctx, fdst, r.Flocal, false)
+	require.NoError(t, err)
+
+	newChangedDst := newChanged
+	newChangedDst.Path = "dst/changed"
+	deleted.Path = "backup/deleted"
+	r.CheckRemoteItems(t, newChangedDst, deleted)
+	r.CheckLocalItems(t, newChanged)
+}
+
+func TestSyncBackupDirDeletesOnlyWithoutBackupDir(t *testing.T) {
+	ctx := context.Background()
+	ctx, ci := fs.AddConfig(ctx)
+	r := fstest.NewRun(t)
+
+	if !operations.CanServerSideMove(r.Fremote) {
+		t.Skip("Skipping test as remote does not support server-side move")
+	}
+	r.Mkdir(ctx, r.Fremote)
+
+	ci.BackupDirDeletesOnly = true
+	ci.Suffix = ".bak"
+
+	oldChanged := r.WriteObject(ctx, "dst/changed", "old", t1)
+	newChanged := r.WriteFile("changed", "new", t2)
+
+	fdst, err := fs.NewFs(ctx, r.FremoteName+"/dst")
+	require.NoError(t, err)
+
+	accounting.GlobalStats().ResetCounters()
+	err = Sync(ctx, fdst, r.Flocal, false)
+	require.NoError(t, err)
+
+	oldChanged.Path = "dst/changed.bak"
+	newChanged.Path = "dst/changed"
+	r.CheckRemoteItems(t, oldChanged, newChanged)
+}
+
 func TestSyncBackupDirWithSuffix(t *testing.T) {
 	testSyncBackupDir(t, "backup", ".bak", false)
 }


### PR DESCRIPTION
#### What does this change do?

Adds `--backup-dir-deletes-only` for `sync`. With the option enabled alongside `--backup-dir`, destination-only files are moved to the backup directory, while changed files are overwritten in place so remotes with native versioning can retain their version history.

The option is config-backed, documented, and leaves suffix-only behavior unchanged when no backup directory is configured.

#### Linked issue

Fixes #2352

#### Verification

- `go build`
- `make quicktest BRANCH=backup-dir-deletes-only-2352`
- `go test -race ./fs/sync -count=1`
- `go test ./fs/... -count=1`
- `go vet ./fs ./fs/sync`
- CLI help smoke test

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the contribution guidelines.
- [x] I have read and understood the AI-assisted contributions guidance, tested the change, and take ownership of it.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in house style.
- [x] Backend-only integration-test requirement is not applicable.
- [x] This Pull Request is ready for review.