### PR TITLE
vfs: synchronize poll updates with shutdown

### DIFF
--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -288,6 +288,32 @@ func getStatus(vfs *VFS, in rc.Params) (out rc.Params, err error) {
 	}, nil
 }
 
+func setPollInterval(vfs *VFS, interval, timeout time.Duration) (timeoutHit bool, err error) {
+	vfs.pollMu.Lock()
+	defer vfs.pollMu.Unlock()
+	if vfs.ctx.Err() != nil {
+		return false, errors.New("VFS is shutting down")
+	}
+	if vfs.pollChan == nil {
+		return false, errors.New("poll-interval is not supported by this remote")
+	}
+	var timeoutChan <-chan time.Time
+	if timeout > 0 {
+		timer := time.NewTimer(timeout)
+		defer timer.Stop()
+		timeoutChan = timer.C
+	}
+	select {
+	case vfs.pollChan <- interval:
+		vfs.Opt.PollInterval = fs.Duration(interval)
+	case <-timeoutChan:
+		timeoutHit = true
+	case <-vfs.ctx.Done():
+		return false, errors.New("VFS is shutting down")
+	}
+	return timeoutHit, nil
+}
+
 func init() {
 	rc.Add(rc.Call{
 		Path:  "vfs/poll-interval",
@@ -334,33 +360,19 @@ func rcPollInterval(ctx context.Context, in rc.Params) (out rc.Params, err error
 	for k, v := range in {
 		return nil, fmt.Errorf("invalid parameter: %s=%s", k, v)
 	}
-	vfs.pollMu.Lock()
-	if vfs.pollChan == nil {
-		vfs.pollMu.Unlock()
-		return nil, errors.New("poll-interval is not supported by this remote")
-	}
-
 	if !intervalPresent {
+		vfs.pollMu.Lock()
+		supported := vfs.pollChan != nil
 		vfs.pollMu.Unlock()
+		if !supported {
+			return nil, errors.New("poll-interval is not supported by this remote")
+		}
 		return getStatus(vfs, in)
 	}
-	var timeoutHit bool
-	var timeoutChan <-chan time.Time
-	if timeout > 0 {
-		timer := time.NewTimer(timeout)
-		defer timer.Stop()
-		timeoutChan = timer.C
+	timeoutHit, err := setPollInterval(vfs, interval, timeout)
+	if err != nil {
+		return nil, err
 	}
-	select {
-	case vfs.pollChan <- interval:
-		vfs.Opt.PollInterval = fs.Duration(interval)
-	case <-timeoutChan:
-		timeoutHit = true
-	case <-vfs.ctx.Done():
-		vfs.pollMu.Unlock()
-		return nil, errors.New("VFS is shutting down")
-	}
-	vfs.pollMu.Unlock()
 	out, err = getStatus(vfs, in)
 	if out != nil {
 		out["timeout"] = timeoutHit

--- a/vfs/rc.go
+++ b/vfs/rc.go
@@ -275,6 +275,8 @@ func getStatus(vfs *VFS, in rc.Params) (out rc.Params, err error) {
 	for k, v := range in {
 		return nil, fmt.Errorf("invalid parameter: %s=%s", k, v)
 	}
+	vfs.pollMu.Lock()
+	defer vfs.pollMu.Unlock()
 	return rc.Params{
 		"enabled":   vfs.Opt.PollInterval != 0,
 		"supported": vfs.pollChan != nil,
@@ -332,11 +334,14 @@ func rcPollInterval(ctx context.Context, in rc.Params) (out rc.Params, err error
 	for k, v := range in {
 		return nil, fmt.Errorf("invalid parameter: %s=%s", k, v)
 	}
+	vfs.pollMu.Lock()
 	if vfs.pollChan == nil {
+		vfs.pollMu.Unlock()
 		return nil, errors.New("poll-interval is not supported by this remote")
 	}
 
 	if !intervalPresent {
+		vfs.pollMu.Unlock()
 		return getStatus(vfs, in)
 	}
 	var timeoutHit bool
@@ -351,7 +356,11 @@ func rcPollInterval(ctx context.Context, in rc.Params) (out rc.Params, err error
 		vfs.Opt.PollInterval = fs.Duration(interval)
 	case <-timeoutChan:
 		timeoutHit = true
+	case <-vfs.ctx.Done():
+		vfs.pollMu.Unlock()
+		return nil, errors.New("VFS is shutting down")
 	}
+	vfs.pollMu.Unlock()
 	out, err = getStatus(vfs, in)
 	if out != nil {
 		out["timeout"] = timeoutHit

--- a/vfs/rc_test.go
+++ b/vfs/rc_test.go
@@ -3,6 +3,7 @@ package vfs
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/rc"
@@ -99,6 +100,75 @@ func TestRcPollInterval(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, rc.Params{}, out)
 	// FIXME needs more tests
+}
+
+func TestRcPollIntervalShutdown(t *testing.T) {
+	r := fstest.NewRun(t)
+	features := r.Fremote.Features()
+	originalChangeNotify := features.ChangeNotify
+	t.Cleanup(func() {
+		features.ChangeNotify = originalChangeNotify
+	})
+
+	initialIntervalReceived := make(chan struct{})
+	features.ChangeNotify = func(_ context.Context, _ func(string, fs.EntryType), pollInterval <-chan time.Duration) {
+		go func() {
+			<-pollInterval
+			close(initialIntervalReceived)
+		}()
+	}
+
+	vfs := New(context.Background(), r.Fremote, nil)
+	t.Cleanup(func() {
+		if vfs.inUse.Load() > 0 {
+			vfs.Shutdown()
+		}
+	})
+	<-initialIntervalReceived
+
+	call := rc.Calls.Get("vfs/poll-interval")
+	require.NotNil(t, call)
+	originalInterval := vfs.Opt.PollInterval
+
+	type result struct {
+		out rc.Params
+		err error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		out, err := call.Fn(context.Background(), rc.Params{
+			"fs":       fs.ConfigString(r.Fremote),
+			"interval": "1h",
+		})
+		resultCh <- result{out: out, err: err}
+	}()
+
+	select {
+	case got := <-resultCh:
+		t.Fatalf("poll interval update returned before shutdown: out=%v err=%v", got.out, got.err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	shutdownDone := make(chan struct{})
+	go func() {
+		vfs.Shutdown()
+		close(shutdownDone)
+	}()
+
+	select {
+	case <-shutdownDone:
+	case <-time.After(time.Second):
+		t.Fatal("VFS shutdown blocked behind poll interval update")
+	}
+
+	select {
+	case got := <-resultCh:
+		require.EqualError(t, got.err, "VFS is shutting down")
+		assert.Nil(t, got.out)
+	case <-time.After(time.Second):
+		t.Fatal("poll interval update did not return after shutdown")
+	}
+	assert.Equal(t, originalInterval, vfs.Opt.PollInterval)
 }
 
 func TestRcList(t *testing.T) {

--- a/vfs/rc_test.go
+++ b/vfs/rc_test.go
@@ -90,6 +90,26 @@ func TestRcRefresh(t *testing.T) {
 	// FIXME needs more tests
 }
 
+func newTestPollVFS(t *testing.T, changeNotify func(context.Context, func(string, fs.EntryType), <-chan time.Duration)) (*fstest.Run, *VFS, *rc.Call) {
+	t.Helper()
+	r := fstest.NewRun(t)
+	features := r.Fremote.Features()
+	originalChangeNotify := features.ChangeNotify
+	features.ChangeNotify = changeNotify
+	t.Cleanup(func() {
+		features.ChangeNotify = originalChangeNotify
+	})
+	vfs := New(context.Background(), r.Fremote, nil)
+	t.Cleanup(func() {
+		if vfs.inUse.Load() > 0 {
+			vfs.Shutdown()
+		}
+	})
+	call := rc.Calls.Get("vfs/poll-interval")
+	require.NotNil(t, call)
+	return r, vfs, call
+}
+
 func TestRcPollInterval(t *testing.T) {
 	r, vfs, call := rcNewRun(t, "vfs/poll-interval")
 	_ = vfs
@@ -103,31 +123,15 @@ func TestRcPollInterval(t *testing.T) {
 }
 
 func TestRcPollIntervalShutdown(t *testing.T) {
-	r := fstest.NewRun(t)
-	features := r.Fremote.Features()
-	originalChangeNotify := features.ChangeNotify
-	t.Cleanup(func() {
-		features.ChangeNotify = originalChangeNotify
-	})
-
 	initialIntervalReceived := make(chan struct{})
-	features.ChangeNotify = func(_ context.Context, _ func(string, fs.EntryType), pollInterval <-chan time.Duration) {
+	r, vfs, call := newTestPollVFS(t, func(_ context.Context, _ func(string, fs.EntryType), pollInterval <-chan time.Duration) {
 		go func() {
 			<-pollInterval
 			close(initialIntervalReceived)
 		}()
-	}
-
-	vfs := New(context.Background(), r.Fremote, nil)
-	t.Cleanup(func() {
-		if vfs.inUse.Load() > 0 {
-			vfs.Shutdown()
-		}
 	})
 	<-initialIntervalReceived
 
-	call := rc.Calls.Get("vfs/poll-interval")
-	require.NotNil(t, call)
 	originalInterval := vfs.Opt.PollInterval
 
 	type result struct {
@@ -169,6 +173,66 @@ func TestRcPollIntervalShutdown(t *testing.T) {
 		t.Fatal("poll interval update did not return after shutdown")
 	}
 	assert.Equal(t, originalInterval, vfs.Opt.PollInterval)
+}
+
+func TestRcPollIntervalUpdate(t *testing.T) {
+	intervals := make(chan time.Duration, 2)
+	r, vfs, call := newTestPollVFS(t, func(_ context.Context, _ func(string, fs.EntryType), pollInterval <-chan time.Duration) {
+		go func() {
+			for interval := range pollInterval {
+				intervals <- interval
+			}
+		}()
+	})
+
+	assert.Equal(t, time.Duration(vfs.Opt.PollInterval), <-intervals)
+	status, err := call.Fn(context.Background(), rc.Params{
+		"fs": fs.ConfigString(r.Fremote),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, true, status["supported"])
+	assert.Equal(t, vfs.Opt.PollInterval != 0, status["enabled"])
+
+	out, err := call.Fn(context.Background(), rc.Params{
+		"fs":       fs.ConfigString(r.Fremote),
+		"interval": "1h",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, time.Hour, <-intervals)
+	assert.Equal(t, fs.Duration(time.Hour), vfs.Opt.PollInterval)
+	assert.Equal(t, false, out["timeout"])
+}
+
+func TestRcPollIntervalTimeout(t *testing.T) {
+	initialIntervalReceived := make(chan struct{})
+	r, vfs, call := newTestPollVFS(t, func(_ context.Context, _ func(string, fs.EntryType), pollInterval <-chan time.Duration) {
+		go func() {
+			<-pollInterval
+			close(initialIntervalReceived)
+		}()
+	})
+	<-initialIntervalReceived
+	originalInterval := vfs.Opt.PollInterval
+
+	out, err := call.Fn(context.Background(), rc.Params{
+		"fs":       fs.ConfigString(r.Fremote),
+		"interval": "1h",
+		"timeout":  "10ms",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, true, out["timeout"])
+	assert.Equal(t, originalInterval, vfs.Opt.PollInterval)
+}
+
+func TestRcPollIntervalUnsupported(t *testing.T) {
+	r, vfs, call := newTestPollVFS(t, nil)
+	out, err := call.Fn(context.Background(), rc.Params{
+		"fs":       fs.ConfigString(r.Fremote),
+		"interval": "1h",
+	})
+	require.EqualError(t, err, "poll-interval is not supported by this remote")
+	assert.Nil(t, out)
+	assert.Nil(t, vfs.pollChan)
 }
 
 func TestRcList(t *testing.T) {

--- a/vfs/rc_test.go
+++ b/vfs/rc_test.go
@@ -2,6 +2,7 @@ package vfs
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 
@@ -110,6 +111,20 @@ func newTestPollVFS(t *testing.T, changeNotify func(context.Context, func(string
 	return r, vfs, call
 }
 
+func waitForPollLock(t *testing.T, vfs *VFS) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if vfs.pollMu.TryLock() {
+			vfs.pollMu.Unlock()
+			runtime.Gosched()
+			continue
+		}
+		return
+	}
+	t.Fatal("poll interval update did not acquire poll lock")
+}
+
 func TestRcPollInterval(t *testing.T) {
 	r, vfs, call := rcNewRun(t, "vfs/poll-interval")
 	_ = vfs
@@ -147,11 +162,7 @@ func TestRcPollIntervalShutdown(t *testing.T) {
 		resultCh <- result{out: out, err: err}
 	}()
 
-	select {
-	case got := <-resultCh:
-		t.Fatalf("poll interval update returned before shutdown: out=%v err=%v", got.out, got.err)
-	case <-time.After(100 * time.Millisecond):
-	}
+	waitForPollLock(t, vfs)
 
 	shutdownDone := make(chan struct{})
 	go func() {
@@ -173,6 +184,24 @@ func TestRcPollIntervalShutdown(t *testing.T) {
 		t.Fatal("poll interval update did not return after shutdown")
 	}
 	assert.Equal(t, originalInterval, vfs.Opt.PollInterval)
+}
+
+func TestSetPollIntervalAfterShutdown(t *testing.T) {
+	initialIntervalReceived := make(chan struct{})
+	_, vfs, _ := newTestPollVFS(t, func(_ context.Context, _ func(string, fs.EntryType), pollInterval <-chan time.Duration) {
+		go func() {
+			<-pollInterval
+			close(initialIntervalReceived)
+			for range pollInterval {
+			}
+		}()
+	})
+	<-initialIntervalReceived
+	vfs.Shutdown()
+
+	timeoutHit, err := setPollInterval(vfs, time.Hour, 0)
+	require.EqualError(t, err, "VFS is shutting down")
+	assert.False(t, timeoutHit)
 }
 
 func TestRcPollIntervalUpdate(t *testing.T) {

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -188,6 +188,7 @@ type VFS struct {
 	usageMu     sync.Mutex
 	usageTime   time.Time
 	usage       *fs.Usage
+	pollMu      sync.Mutex
 	pollChan    chan time.Duration
 	inUse       atomic.Int32 // count of number of opens
 }
@@ -409,13 +410,15 @@ func (vfs *VFS) Shutdown() {
 
 	vfs.shutdownCache()
 
+	// Cancel any background go routines
+	vfs.cancel()
+
+	vfs.pollMu.Lock()
 	if vfs.pollChan != nil {
 		close(vfs.pollChan)
 		vfs.pollChan = nil
 	}
-
-	// Cancel any background go routines
-	vfs.cancel()
+	vfs.pollMu.Unlock()
 }
 
 // CleanUp deletes the contents of the on disk cache


### PR DESCRIPTION
#### What does this change do?

Synchronizes `vfs/poll-interval` updates with VFS shutdown.

The RC handler now holds a VFS-local mutex while checking and sending on the poll interval channel. Shutdown cancels the VFS context before waiting for that mutex, so a blocked update returns `VFS is shutting down` and releases the lock before the channel is closed. The existing backend contract—closing the interval channel to stop change notification—remains unchanged.

Regression tests cover the original send/close race, an update that resumes after shutdown, normal interval delivery and status, timeout behavior, and remotes without change notification support.

#### Linked issue

Fixes #9689

#### For new or changed backends

Not applicable; this changes the shared VFS lifecycle only.

#### Verification

- RED on unmodified master: the deterministic shutdown test reports the `rcPollInterval`/`VFS.Shutdown` data race and panics with `send on closed channel`.
- `go test -race -run '^(TestRcPollIntervalShutdown|TestSetPollIntervalAfterShutdown)$' -count=200 ./vfs` (400/400 passed)
- `go test -race -run '^(TestRcPollInterval|TestSetPollInterval)' -count=20 ./vfs` (100/100 passed)
- `go test -race ./vfs` (474 tests passed)
- `go vet ./vfs`
- `go build`
- `make rclone`
- `make quicktest` with the built worktree binary on `PATH`
- Independent review found no Critical or Important issues after the review fixes.

OpenAI Codex assisted with tracing the channel lifecycle, designing the deterministic concurrency tests, implementing the synchronization, and running the verification commands. I reviewed the complete diff and test output and take responsibility for the change.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests). (Not applicable.)
- [x] This Pull Request is ready for review.
