### PR TITLE
dropbox: cancel API requests when operations stop

### DIFF
--- a/backend/dropbox/batcher.go
+++ b/backend/dropbox/batcher.go
@@ -19,7 +19,7 @@ func (f *Fs) finishBatch(ctx context.Context, items []*files.UploadSessionFinish
 		Entries: items,
 	}
 	err = f.pacer.Call(func() (bool, error) {
-		complete, err = f.srv.UploadSessionFinishBatchV2(arg)
+		complete, err = f.srv.UploadSessionFinishBatchV2Context(ctx, arg)
 		if retry, err := shouldRetryExclude(ctx, err); !retry {
 			return retry, err
 		}

--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -382,20 +382,20 @@ type Options struct {
 
 // Fs represents a remote dropbox server
 type Fs struct {
-	name           string         // name of this remote
-	root           string         // the path we are working on
-	opt            Options        // parsed options
-	ci             *fs.ConfigInfo // global config
-	features       *fs.Features   // optional features
-	srv            files.Client   // the connection to the dropbox server
-	svc            files.Client   // the connection to the dropbox server (unauthorized)
-	sharing        sharing.Client // as above, but for generating sharing links
-	users          users.Client   // as above, but for accessing user information
-	team           team.Client    // for the Teams API
-	slashRoot      string         // root with "/" prefix, lowercase
-	slashRootSlash string         // root with "/" prefix and postfix, lowercase
-	pacer          *fs.Pacer      // To pace the API calls
-	ns             string         // The namespace we are using or "" for none
+	name           string                // name of this remote
+	root           string                // the path we are working on
+	opt            Options               // parsed options
+	ci             *fs.ConfigInfo        // global config
+	features       *fs.Features          // optional features
+	srv            files.ContextClient   // the connection to the dropbox server
+	svc            files.ContextClient   // the connection to the dropbox server (unauthorized)
+	sharing        sharing.ContextClient // as above, but for generating sharing links
+	users          users.ContextClient   // as above, but for accessing user information
+	team           team.ContextClient    // for the Teams API
+	slashRoot      string                // root with "/" prefix, lowercase
+	slashRootSlash string                // root with "/" prefix and postfix, lowercase
+	pacer          *fs.Pacer             // To pace the API calls
+	ns             string                // The namespace we are using or "" for none
 	batcher        *batcher.Batcher[*files.UploadSessionFinishArg, *files.FileMetadata]
 	exportExts     []exportExtension
 }
@@ -577,7 +577,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	}
 
 	// NOTE: needs to be created pre-impersonation so we can look up the impersonated user
-	f.team = team.New(cfg)
+	f.team = team.NewContext(cfg)
 
 	if opt.Impersonate != "" {
 		user := team.UserSelectorArg{
@@ -588,7 +588,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		members := []*team.UserSelectorArg{&user}
 		args := team.NewMembersGetInfoArgs(members)
 
-		memberIDs, err := f.team.MembersGetInfo(args)
+		memberIDs, err := f.team.MembersGetInfoContext(ctx, args)
 		if err != nil {
 			return nil, fmt.Errorf("invalid dropbox team member: %q: %w", opt.Impersonate, err)
 		}
@@ -603,10 +603,10 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		cfg.AsAdminID = opt.ImpersonateAdmin
 	}
 
-	f.srv = files.New(cfg)
-	f.svc = files.New(ucfg)
-	f.sharing = sharing.New(cfg)
-	f.users = users.New(cfg)
+	f.srv = files.NewContext(cfg)
+	f.svc = files.NewContext(ucfg)
+	f.sharing = sharing.NewContext(cfg)
+	f.users = users.NewContext(cfg)
 	f.features = (&fs.Features{
 		CaseInsensitive:         true,
 		ReadMimeType:            false,
@@ -673,7 +673,7 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		// If root starts with / then use the actual root
 		var acc *users.FullAccount
 		err = f.pacer.Call(func() (bool, error) {
-			acc, err = f.users.GetCurrentAccount()
+			acc, err = f.users.GetCurrentAccountContext(ctx)
 			return shouldRetry(ctx, err)
 		})
 		if err != nil {
@@ -736,7 +736,7 @@ type getMetadataResult struct {
 // getMetadata gets the metadata for a file or directory
 func (f *Fs) getMetadata(ctx context.Context, objPath string) (res getMetadataResult) {
 	res.err = f.pacer.Call(func() (bool, error) {
-		res.entry, res.err = f.srv.GetMetadata(&files.GetMetadataArg{
+		res.entry, res.err = f.srv.GetMetadataContext(ctx, &files.GetMetadataArg{
 			Path: f.opt.Enc.FromStandardPath(objPath),
 		})
 		return shouldRetry(ctx, res.err)
@@ -910,7 +910,7 @@ func (f *Fs) listSharedFolders(ctx context.Context, callback func(fs.DirEntry) e
 				Limit: 100,
 			}
 			err := f.pacer.Call(func() (bool, error) {
-				res, err = f.sharing.ListFolders(&arg)
+				res, err = f.sharing.ListFoldersContext(ctx, &arg)
 				return shouldRetry(ctx, err)
 			})
 			if err != nil {
@@ -922,7 +922,7 @@ func (f *Fs) listSharedFolders(ctx context.Context, callback func(fs.DirEntry) e
 				Cursor: res.Cursor,
 			}
 			err := f.pacer.Call(func() (bool, error) {
-				res, err = f.sharing.ListFoldersContinue(&arg)
+				res, err = f.sharing.ListFoldersContinueContext(ctx, &arg)
 				return shouldRetry(ctx, err)
 			})
 			if err != nil {
@@ -971,7 +971,7 @@ func (f *Fs) mountSharedFolder(ctx context.Context, id string) error {
 		SharedFolderId: id,
 	}
 	err := f.pacer.Call(func() (bool, error) {
-		_, err := f.sharing.MountFolder(&arg)
+		_, err := f.sharing.MountFolderContext(ctx, &arg)
 		return shouldRetry(ctx, err)
 	})
 	return err
@@ -988,7 +988,7 @@ func (f *Fs) listReceivedFiles(ctx context.Context, callback func(fs.DirEntry) e
 				Limit: 100,
 			}
 			err := f.pacer.Call(func() (bool, error) {
-				res, err = f.sharing.ListReceivedFiles(&arg)
+				res, err = f.sharing.ListReceivedFilesContext(ctx, &arg)
 				return shouldRetry(ctx, err)
 			})
 			if err != nil {
@@ -1000,7 +1000,7 @@ func (f *Fs) listReceivedFiles(ctx context.Context, callback func(fs.DirEntry) e
 				Cursor: res.Cursor,
 			}
 			err := f.pacer.Call(func() (bool, error) {
-				res, err = f.sharing.ListReceivedFilesContinue(&arg)
+				res, err = f.sharing.ListReceivedFilesContinueContext(ctx, &arg)
 				return shouldRetry(ctx, err)
 			})
 			if err != nil {
@@ -1107,7 +1107,7 @@ func (f *Fs) ListP(ctx context.Context, dir string, callback fs.ListRCallback) (
 				arg.Path = "" // Specify root folder as empty string
 			}
 			err = f.pacer.Call(func() (bool, error) {
-				res, err = f.srv.ListFolder(arg)
+				res, err = f.srv.ListFolderContext(ctx, arg)
 				return shouldRetry(ctx, err)
 			})
 			if err != nil {
@@ -1125,7 +1125,7 @@ func (f *Fs) ListP(ctx context.Context, dir string, callback fs.ListRCallback) (
 				Cursor: res.Cursor,
 			}
 			err = f.pacer.Call(func() (bool, error) {
-				res, err = f.srv.ListFolderContinue(&arg)
+				res, err = f.srv.ListFolderContinueContext(ctx, &arg)
 				return shouldRetry(ctx, err)
 			})
 			if err != nil {
@@ -1162,7 +1162,7 @@ func (f *Fs) ListP(ctx context.Context, dir string, callback fs.ListRCallback) (
 						var sfMeta *sharing.SharedFolderMetadata
 						err = f.pacer.Call(func() (bool, error) {
 							var apiErr error
-							sfMeta, apiErr = f.sharing.GetFolderMetadata(sharing.NewGetMetadataArgs(folderInfo.SharingInfo.SharedFolderId))
+							sfMeta, apiErr = f.sharing.GetFolderMetadataContext(ctx, sharing.NewGetMetadataArgs(folderInfo.SharingInfo.SharedFolderId))
 							return shouldRetry(ctx, apiErr)
 						})
 						if err != nil {
@@ -1249,7 +1249,7 @@ func (f *Fs) Mkdir(ctx context.Context, dir string) error {
 		return cErr
 	}
 	err = f.pacer.Call(func() (bool, error) {
-		_, err = f.srv.CreateFolderV2(&arg2)
+		_, err = f.srv.CreateFolderV2Context(ctx, &arg2)
 		return shouldRetry(ctx, err)
 	})
 	return err
@@ -1277,7 +1277,7 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) (err error)
 		}
 		var res *files.ListFolderResult
 		err = f.pacer.Call(func() (bool, error) {
-			res, err = f.srv.ListFolder(arg)
+			res, err = f.srv.ListFolderContext(ctx, arg)
 			return shouldRetry(ctx, err)
 		})
 		if err != nil {
@@ -1301,7 +1301,7 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) (err error)
 
 	// remove it
 	err = f.pacer.Call(func() (bool, error) {
-		_, err = f.srv.DeleteV2(&files.DeleteArg{Path: encRoot})
+		_, err = f.srv.DeleteV2Context(ctx, &files.DeleteArg{Path: encRoot})
 		return shouldRetry(ctx, err)
 	})
 	return err
@@ -1360,7 +1360,7 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (dst fs.Obj
 	}
 	var result *files.RelocationResult
 	err = f.pacer.Call(func() (bool, error) {
-		result, err = f.srv.CopyV2(&arg)
+		result, err = f.srv.CopyV2Context(ctx, &arg)
 		return shouldRetry(ctx, err)
 	})
 	if err != nil {
@@ -1421,7 +1421,7 @@ func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object,
 	var err error
 	var result *files.RelocationResult
 	err = f.pacer.Call(func() (bool, error) {
-		result, err = f.srv.MoveV2(&arg)
+		result, err = f.srv.MoveV2Context(ctx, &arg)
 		switch e := err.(type) {
 		case files.MoveV2APIError:
 			// There seems to be a bit of eventual consistency here which causes this to
@@ -1475,7 +1475,7 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 
 	var linkRes sharing.IsSharedLinkMetadata
 	err = f.pacer.Call(func() (bool, error) {
-		linkRes, err = f.sharing.CreateSharedLinkWithSettings(&createArg)
+		linkRes, err = f.sharing.CreateSharedLinkWithSettingsContext(ctx, &createArg)
 		return shouldRetry(ctx, err)
 	})
 
@@ -1484,7 +1484,7 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 		fs.Debugf(absPath, "can't create link with expiry, trying without")
 		createArg.Settings.Expires = nil
 		err = f.pacer.Call(func() (bool, error) {
-			linkRes, err = f.sharing.CreateSharedLinkWithSettings(&createArg)
+			linkRes, err = f.sharing.CreateSharedLinkWithSettingsContext(ctx, &createArg)
 			return shouldRetry(ctx, err)
 		})
 	}
@@ -1498,7 +1498,7 @@ func (f *Fs) PublicLink(ctx context.Context, remote string, expire fs.Duration, 
 		}
 		var listRes *sharing.ListSharedLinksResult
 		err = f.pacer.Call(func() (bool, error) {
-			listRes, err = f.sharing.ListSharedLinks(&listArg)
+			listRes, err = f.sharing.ListSharedLinksContext(ctx, &listArg)
 			return shouldRetry(ctx, err)
 		})
 		if err != nil {
@@ -1559,7 +1559,7 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 		},
 	}
 	err = f.pacer.Call(func() (bool, error) {
-		_, err = f.srv.MoveV2(&arg)
+		_, err = f.srv.MoveV2Context(ctx, &arg)
 		return shouldRetry(ctx, err)
 	})
 	if err != nil {
@@ -1573,7 +1573,7 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 func (f *Fs) About(ctx context.Context) (usage *fs.Usage, err error) {
 	var q *users.SpaceUsage
 	err = f.pacer.Call(func() (bool, error) {
-		q, err = f.users.GetSpaceUsage()
+		q, err = f.users.GetSpaceUsageContext(ctx)
 		return shouldRetry(ctx, err)
 	})
 	if err != nil {
@@ -1660,7 +1660,7 @@ func (f *Fs) changeNotifyCursor(ctx context.Context) (cursor string, err error) 
 			arg.Path = ""
 		}
 
-		startCursor, err = f.srv.ListFolderGetLatestCursor(arg)
+		startCursor, err = f.srv.ListFolderGetLatestCursorContext(ctx, arg)
 
 		return shouldRetry(ctx, err)
 	})
@@ -1693,7 +1693,7 @@ func (f *Fs) changeNotifyRunner(ctx context.Context, notifyFunc func(string, fs.
 			Timeout: timeout,
 		}
 
-		res, err = f.svc.ListFolderLongpoll(&args)
+		res, err = f.svc.ListFolderLongpollContext(ctx, &args)
 		return shouldRetry(ctx, err)
 	})
 	if err != nil {
@@ -1716,7 +1716,7 @@ func (f *Fs) changeNotifyRunner(ctx context.Context, notifyFunc func(string, fs.
 			Cursor: cursor,
 		}
 		err = f.pacer.Call(func() (bool, error) {
-			changeList, err = f.srv.ListFolderContinue(&arg)
+			changeList, err = f.srv.ListFolderContinueContext(ctx, &arg)
 			return shouldRetry(ctx, err)
 		})
 		if err != nil {
@@ -1961,7 +1961,7 @@ func (o *Object) export(ctx context.Context) (in io.ReadCloser, err error) {
 	arg := files.ExportArg{Path: o.id, ExportFormat: string(o.exportAPIFormat)}
 	var exportResult *files.ExportResult
 	err = o.fs.pacer.Call(func() (bool, error) {
-		exportResult, in, err = o.fs.srv.Export(&arg)
+		exportResult, in, err = o.fs.srv.ExportContext(ctx, &arg)
 		return shouldRetry(ctx, err)
 	})
 	if err != nil {
@@ -1983,7 +1983,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 			Url: o.url,
 		}
 		err = o.fs.pacer.Call(func() (bool, error) {
-			_, in, err = o.fs.sharing.GetSharedLinkFile(&arg)
+			_, in, err = o.fs.sharing.GetSharedLinkFileContext(ctx, &arg)
 			return shouldRetry(ctx, err)
 		})
 		if err != nil {
@@ -2003,7 +2003,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 		ExtraHeaders: headers,
 	}
 	err = o.fs.pacer.Call(func() (bool, error) {
-		_, in, err = o.fs.srv.Download(&arg)
+		_, in, err = o.fs.srv.DownloadContext(ctx, &arg)
 		return shouldRetry(ctx, err)
 	})
 
@@ -2027,7 +2027,7 @@ func (o *Object) uploadChunked(ctx context.Context, in0 io.Reader, commitInfo *f
 	// start upload
 	var res *files.UploadSessionStartResult
 	err = o.fs.pacer.Call(func() (bool, error) {
-		res, err = o.fs.srv.UploadSessionStart(&files.UploadSessionStartArg{}, nil)
+		res, err = o.fs.srv.UploadSessionStartContext(ctx, &files.UploadSessionStartArg{}, nil)
 		return shouldRetry(ctx, err)
 	})
 	if err != nil {
@@ -2073,7 +2073,7 @@ func (o *Object) uploadChunked(ctx context.Context, in0 io.Reader, commitInfo *f
 			if _, err = chunk.Seek(skip, io.SeekStart); err != nil {
 				return false, err
 			}
-			err = o.fs.srv.UploadSessionAppendV2(&appendArg, chunk)
+			err = o.fs.srv.UploadSessionAppendV2Context(ctx, &appendArg, chunk)
 			// after session is started, we retry everything
 			if err != nil {
 				// Check for incorrect offset error and retry with new offset
@@ -2132,7 +2132,7 @@ func (o *Object) uploadChunked(ctx context.Context, in0 io.Reader, commitInfo *f
 	}
 
 	err = o.fs.pacer.Call(func() (bool, error) {
-		entry, err = o.fs.srv.UploadSessionFinish(args, nil)
+		entry, err = o.fs.srv.UploadSessionFinishContext(ctx, args, nil)
 		if retry, err := shouldRetryExclude(ctx, err); !retry {
 			return retry, err
 		}
@@ -2200,7 +2200,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		entry, err = o.uploadChunked(ctx, in, commitInfo, size)
 	} else {
 		err = o.fs.pacer.CallNoRetry(func() (bool, error) {
-			entry, err = o.fs.srv.Upload(&files.UploadArg{CommitInfo: *commitInfo}, in)
+			entry, err = o.fs.srv.UploadContext(ctx, &files.UploadArg{CommitInfo: *commitInfo}, in)
 			return shouldRetry(ctx, err)
 		})
 	}
@@ -2225,7 +2225,7 @@ func (o *Object) Remove(ctx context.Context) (err error) {
 		return errNotSupportedInSharedMode
 	}
 	err = o.fs.pacer.Call(func() (bool, error) {
-		_, err = o.fs.srv.DeleteV2(&files.DeleteArg{
+		_, err = o.fs.srv.DeleteV2Context(ctx, &files.DeleteArg{
 			Path: o.fs.opt.Enc.FromStandardPath(o.remotePath()),
 		})
 		return shouldRetry(ctx, err)

--- a/backend/dropbox/dropbox_internal_test.go
+++ b/backend/dropbox/dropbox_internal_test.go
@@ -3,15 +3,55 @@ package dropbox
 import (
 	"context"
 	"io"
+	"net/http"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fstest/fstests"
+	"github.com/rclone/rclone/lib/pacer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestGetMetadataPropagatesContext(t *testing.T) {
+	requestStarted := make(chan struct{}, 1)
+	client := &http.Client{
+		Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			requestStarted <- struct{}{}
+			select {
+			case <-req.Context().Done():
+				return nil, req.Context().Err()
+			case <-time.After(time.Second):
+				return nil, context.DeadlineExceeded
+			}
+		}),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	f := &Fs{
+		srv:   files.NewContext(dropbox.Config{Client: client}),
+		pacer: fs.NewPacer(ctx, pacer.NewDefault()),
+	}
+
+	result := make(chan getMetadataResult, 1)
+	go func() {
+		result <- f.getMetadata(ctx, "/test")
+	}()
+
+	<-requestStarted
+	cancel()
+	require.ErrorIs(t, (<-result).err, context.Canceled)
+}
 
 func TestInternalCheckPathLength(t *testing.T) {
 	rep := func(n int, r rune) (out string) {
@@ -64,7 +104,7 @@ Lorem ipsum __dolor__ sit amet
 	var err error
 	err = f.pacer.Call(func() (bool, error) {
 		reader := strings.NewReader(content)
-		_, err = f.srv.PaperCreate(&arg, reader)
+		_, err = f.srv.PaperCreateContext(context.Background(), &arg, reader)
 		return shouldRetry(context.Background(), err)
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
#### What does this change do?

Use the Dropbox SDK's context-aware clients and `*Context` methods for every caller-scoped API request. This lets Ctrl-C, `rc job/stop`, `--max-duration`, and other cancellation paths abort an in-flight Dropbox request instead of waiting for the request or `--timeout` to finish.

The upload batcher keeps its independently owned lifetime: its existing background commit context is now passed through to the SDK. A regression test uses a blocking HTTP transport to verify that cancelling an rclone operation cancels the underlying Dropbox request.

AI assistance: Codex was used to help implement and audit this mechanical change. The SDK v6.4.0 interfaces and every Dropbox call site were checked, the failure was reproduced before the fix, and the resulting code was built, linted, and tested.

#### Linked issue

Fixes #9688

#### For new or changed backends

This changes an existing backend. A live `test_all` run was not possible because this environment has no configured Dropbox test remote. The backend unit tests and repository-wide quick test pass.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.

Tests:

- `go test ./backend/dropbox -count=1`
- `go build -o /tmp/rclone-pr9688 .`
- `/home/milad/go/bin/golangci-lint run ./backend/dropbox/...`
- `PATH="$PWD:$PATH" XDG_RUNTIME_DIR=<writable-temp-dir> make quicktest`
