### PR TITLE
sync: don't let a stale error in a shared rc group block later deletes

### DIFF
--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -74,6 +74,7 @@ type syncCopyMove struct {
 	err                    error                  // normal error from copy process
 	noRetryErr             error                  // error with NoRetry set
 	fatalErr               error                  // fatal error
+	startErrors            int64                  // accounting.Stats(ctx).GetErrors() when this sync/copy/move started
 	commonHash             hash.Type              // common hash type between src and dst
 	modifyWindow           time.Duration          // modify window between fsrc, fdst
 	renameMapMu            sync.Mutex             // mutex to protect the below
@@ -164,6 +165,7 @@ func newSyncCopyMove(ctx context.Context, fdst, fsrc fs.Fs, deleteMode fs.Delete
 		setDirModTimeAfter:     !ci.NoUpdateDirModTime && (!copyEmptySrcDirs || fsrc.Features().CanHaveEmptyDirectories && fdst.Features().DirModTimeUpdatesOnWrite),
 		modifiedDirs:           make(map[string]struct{}),
 		allowOverlap:           allowOverlap,
+		startErrors:            accounting.Stats(ctx).GetErrors(),
 	}
 
 	s.logger, s.usingLogger = operations.GetLogger(ctx)
@@ -363,6 +365,27 @@ func (s *syncCopyMove) currentError() error {
 		return s.err
 	}
 	return s.noRetryErr
+}
+
+// erroredThisRun reports whether this sync/copy/move should be treated as
+// having hit an error for the purposes of the delete-on-error safety check.
+//
+// An explicit stats group (set with the rc "_group" parameter) is
+// long-lived and can be shared between separate, unrelated rc calls, so for
+// a grouped context we only count errors recorded since this run started -
+// otherwise an unrelated error from an earlier operation sharing the group
+// would permanently block deletion for every later, error-free operation
+// that reuses it. The default (ungrouped) stats are scoped to a single
+// process invocation, so any error recorded there is treated as belonging
+// to this run, same as before.
+func (s *syncCopyMove) erroredThisRun() bool {
+	if _, hasGroup := accounting.StatsGroupFromContext(s.ctx); !hasGroup {
+		return accounting.Stats(s.ctx).Errored()
+	}
+	if accounting.Stats(s.ctx).GetErrors() > s.startErrors {
+		return true
+	}
+	return s.currentError() != nil
 }
 
 // pairChecker reads Objects~s on in send to out if they need transferring.
@@ -625,7 +648,7 @@ func (s *syncCopyMove) stopDeleters() {
 // checkSrcMap is clear then it assumes that the any source files that
 // have been found have been removed from dstFiles already.
 func (s *syncCopyMove) deleteFiles(checkSrcMap bool) error {
-	if accounting.Stats(s.ctx).Errored() && !s.ci.IgnoreErrors {
+	if s.erroredThisRun() && !s.ci.IgnoreErrors {
 		fs.Errorf(s.fdst, "%v", fs.ErrorNotDeleting)
 		// log all deletes as errors
 		for remote, o := range s.dstFiles {
@@ -671,7 +694,7 @@ func (s *syncCopyMove) deleteEmptyDirectories(ctx context.Context, f fs.Fs, entr
 	if len(entriesMap) == 0 {
 		return nil
 	}
-	if accounting.Stats(ctx).Errored() && !s.ci.IgnoreErrors {
+	if s.erroredThisRun() && !s.ci.IgnoreErrors {
 		fs.Errorf(f, "%v", fs.ErrorNotDeletingDirs)
 		return fs.ErrorNotDeletingDirs
 	}

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1827,6 +1827,37 @@ func TestMoveWithDeleteEmptySrcDirs(t *testing.T) {
 	r.CheckRemoteItems(t, file1, file2)
 }
 
+// Test that --delete-empty-src-dirs still deletes empty source
+// directories when an earlier, unrelated operation recorded an error
+// against the same (long-lived) stats group, as happens on rclone rcd.
+// See: https://github.com/rclone/rclone/issues/9634
+func TestMoveWithDeleteEmptySrcDirsIgnoresUnrelatedStaleGroupError(t *testing.T) {
+	ctx := context.Background()
+	ctx = accounting.WithStatsGroup(ctx, "test-group-9634")
+
+	// Simulate an earlier, unrelated operation (e.g. a failed
+	// operations/copyfile call) having recorded an error against this
+	// group before the move under test ever starts.
+	accounting.Stats(ctx).Error(errors.New("earlier unrelated error"))
+	require.True(t, accounting.Stats(ctx).Errored())
+
+	r := fstest.NewRun(t)
+	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
+	r.Mkdir(ctx, r.Fremote)
+
+	// This move has no errors of its own.
+	ctx = predictDstFromLogger(ctx)
+	err := MoveDir(ctx, r.Fremote, r.Flocal, true, false)
+	require.NoError(t, err)
+	testLoggerVsLsf(ctx, r.Fremote, r.Flocal, operations.GetLoggerOpt(ctx).JSON, t)
+
+	// The empty source directory should still be deleted: the stale error
+	// belongs to an earlier, unrelated operation sharing the same group,
+	// not to this move.
+	r.CheckLocalListing(t, nil, []string{})
+	r.CheckRemoteItems(t, file1)
+}
+
 func TestMoveWithoutDeleteEmptySrcDirs(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)


### PR DESCRIPTION
## What's the bug

On a long-lived `rclone rcd`, when repeated `sync/move` calls reuse the same stats group (`_group=...`) with `deleteEmptySrcDirs=true`, a single transfer error at any earlier point in that group's lifetime permanently disables empty-source-directory deletion for all subsequent operations sharing the group. Every later run logs:

```
ERROR : <source>: not deleting directories as there were IO errors
```

and never removes empty source dirs - even when those later operations transfer successfully and have zero errors of their own. The only recovery is `core/stats-reset group=<group>` or restarting the daemon.

Reproduction (from the issue, using the local backend so no cloud credentials are needed):

```bash
rclone rcd --rc-no-auth --rc-addr :5572 &
mkdir -p /tmp/src/emptydir /tmp/dst

# 1) cause ONE error in group "g" (copy a file that does not exist)
rclone rc --url :5572 operations/copyfile srcFs=/tmp srcRemote=does-not-exist.txt dstFs=/tmp/dst dstRemote=does-not-exist.txt _group=g

# 2) a CLEAN move with --delete-empty-src-dirs in the SAME group
rclone rc --url :5572 sync/move srcFs=/tmp/src dstFs=/tmp/dst deleteEmptySrcDirs=true _group=g
# -> logs "not deleting directories as there were IO errors"
# -> /tmp/src/emptydir is NOT removed, although this move had 0 errors

# 3) reset the group's stats and repeat step 2 -> /tmp/src/emptydir IS now removed
```

## Root cause

`deleteFiles` and `deleteEmptyDirectories` in `fs/sync/sync.go` both gate deletion on `accounting.Stats(ctx).Errored()`:

```go
if accounting.Stats(s.ctx).Errored() && !s.ci.IgnoreErrors {
    fs.Errorf(s.fdst, "%v", fs.ErrorNotDeleting)
    ...
}
```

`Errored()` just checks whether the stats group's cumulative error counter is non-zero (`fs/accounting/stats.go`). An explicit rc stats group (`_group=`) is intentionally long-lived - that's what lets a client poll `core/stats?group=g` for aggregate progress across several separate calls - and `accounting.Stats(ctx)` for a given group returns the *same*, shared `*StatsInfo` on every call that names it (`StatsGroup` in `fs/accounting/stats_groups.go`). So once any call sharing the group records an error, `Errored()` stays true for every later call that reuses the group, regardless of whether that later call had any errors of its own.

## The fix

Add `erroredThisRun()`, and snapshot the group's error count (`accounting.Stats(ctx).GetErrors()`) into a new `startErrors` field when the `syncCopyMove` is constructed. For an **explicit** stats group, only treat errors recorded *since this run started* as relevant - `accounting.Stats(s.ctx).GetErrors() > s.startErrors` - combined with the existing `s.currentError()` (the sync operation's own tracked error, covering error paths that don't go through the shared stats counter). For the **default** (ungrouped) stats, `erroredThisRun()` falls back to the exact original `Errored()` check unchanged, since `GlobalStats()` there is scoped to a single process invocation, not shared between unrelated calls the way an explicit group is.

I initially tried simply swapping the check to `s.currentError() != nil` (the sync operation's own per-run error field), but that turned out to be incomplete: some error paths - e.g. `--name-transform` failures - are recorded via `fs.CountError`/`accounting.Stats(ctx).Error(...)` without ever touching `s.currentError()`, and an existing test (`TestError` in `fs/sync/sync_transform_test.go`) relies on exactly that to correctly block deletion. A pure "ignore anything before this run" approach also conflicts with `TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors`, which intentionally calls `fs.CountError` immediately before `Sync()` on the default (ungrouped) context and expects deletion to still be blocked. The group-scoped delta check above is what let me satisfy the reported bug and both of those pre-existing tests at once.

## Testing

- Added `TestMoveWithDeleteEmptySrcDirsIgnoresUnrelatedStaleGroupError` in `fs/sync/sync_test.go`: records an error against an explicit stats group, then runs an error-free `MoveDir` with `deleteEmptySrcDirs=true` sharing that group, and asserts the empty source directory is still deleted. Verified this fails without the fix, reproducing the exact reported error (`not deleting directories as there were IO errors`).
- Verified (by temporarily reverting just the `sync.go` change) that `TestError` and `TestSyncAfterRemovingAFileAndAddingAFileSubDirWithErrors` both still pass with the fix in place, and that neither is a false pass by confirming they'd fail if the fix incorrectly suppressed their errors too.
- `go build ./...`, `go vet ./fs/...`, and `go test ./fs/sync/... ./fs/accounting/...` all pass. Also ran the broader `go test ./fs/... ./cmd/...`; the only failures there (self-update installer, Docker volume-plugin mount, NFS symlink cache) are unrelated to this change - they need network access, a real Docker daemon socket, or real filesystem symlink support that isn't available in my sandboxed build environment (I don't have a Go toolchain on this machine, so everything was built/tested via Docker).

Fixes #9634
