### PR TITLE
drive: don't list trashed files when removing a directory into the trash - fixes #9681

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -2766,7 +2766,12 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 	}
 	trashedFiles := false
 	if check {
-		found, err := f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, true, func(item *drive.File) bool {
+		// trashedFiles is only consulted to decide between trashing and hard deleting
+		// below, so when the directory is going to be trashed anyway there is no reason
+		// to enumerate trashed children: let the server filter them out instead of
+		// paging through them. Hard deletes still need to see them (#1040).
+		includeAll := !f.opt.UseTrash || f.opt.TrashedOnly
+		found, err := f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, includeAll, func(item *drive.File) bool {
 			if !item.Trashed {
 				fs.Debugf(dir, "Rmdir: contains file: %q", item.Name)
 				return true


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes #9681.

`purgeCheck` listed a directory's children with `includeAll` set, so the Drive API returned trashed children as well as live ones. The only thing that came of that was the `trashedFiles` flag, and that flag is consulted in exactly one place:

```go
err = f.delete(ctx, directoryID, trashedFiles || f.opt.UseTrash)
```

So when `use_trash` is on (the default) the directory is trashed either way and the flag cannot change the outcome. The listing that produced it is wasted work, and it is wasted in the case this behaviour creates itself: after trashing N files in a directory, removing the now empty directory pages through all N trashed entries, roughly one API call and pacer delay per 1000, instead of a single query that returns nothing.

This asks the server to filter trashed children out when the directory is going to be trashed anyway:

```go
includeAll := !f.opt.UseTrash || f.opt.TrashedOnly
```

Hard deletes keep the existing behaviour, since there `trashedFiles` genuinely decides whether the directory can be removed permanently (#1040 / 33c2873).

`--drive-trashed-only` is also left on the old path deliberately. With `includeAll` false, `list` builds its query as `(mimeType='<folder>' or trashed=true)` in that mode rather than a plain `trashed=false`, so it is a different query and not the no-op filter this optimisation relies on. @ncw scoped the suggestion in the issue to `use_trash=true` and not `trashed_only`, and this keeps to that.

No behaviour change is intended: the decision `trashedFiles || f.opt.UseTrash` evaluates the same, because the branch that skips the trashed listing is exactly the branch where `f.opt.UseTrash` is already true.

#### Was the change discussed in an issue or in the forum before?

Yes, #9681. @ncw confirmed it against master and suggested this fix.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#contributing-to-rclone).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review ::

#### Testing

`go build ./...`, `go vet ./backend/drive/` and `go test ./backend/drive/` all pass. `make quicktest` passes apart from `cmd/gitannex`, `cmd/nfsmount` and `TestS3Minio`, which fail identically on a clean checkout of master here because this machine has no git-annex, NFS mount support or minio.

I have not run the Drive integration tests against a real remote, as I do not have a Drive account set up for that. The change is one boolean on an existing call, and no new test is added because the observable behaviour is unchanged. If you would like `TestIntegration` for `TestDrive:` run before merging, I am happy to set that up.