### PR TITLE
smb: reuse the upload connection for SetModTime - fixes #9675

### DIFF
--- a/backend/smb/smb.go
+++ b/backend/smb/smb.go
@@ -836,6 +836,11 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		return fmt.Errorf("Update Close failed: %w", err)
 	}
 
+	// Return the connection so the SetModTime below can reuse it rather than
+	// dialling a second one - the file is closed so remove() no longer needs
+	// it. This nils cn out, making the deferred putConnection a no-op.
+	o.fs.putConnection(&cn, nil)
+
 	// Set the modified time and also o.statResult
 	err = o.SetModTime(ctx, src.ModTime(ctx))
 	if err != nil {

--- a/backend/smb/smb_internal_test.go
+++ b/backend/smb/smb_internal_test.go
@@ -3,11 +3,18 @@ package smb
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"net"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/object"
+	"github.com/rclone/rclone/fstest"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,6 +51,46 @@ func TestDialClosesConnectionOnSetupError(t *testing.T) {
 	n, err := result.conn.Read(buffer)
 	require.Zero(t, n)
 	require.ErrorIs(t, err, io.EOF)
+}
+
+// TestUploadConnectionReuse checks an upload leaves only one connection in the
+// pool, ie the connection it used is available again for the SetModTime which
+// follows it rather than a second one being dialled.
+//
+// This needs a real SMB server so it is skipped if one isn't configured.
+func TestUploadConnectionReuse(t *testing.T) {
+	ctx := context.Background()
+	fstest.Initialise()
+	remoteName := *fstest.RemoteName
+	if remoteName == "" {
+		remoteName = "TestSMB:rclone"
+	}
+	remote, err := fs.NewFs(ctx, remoteName)
+	if errors.Is(err, fs.ErrorNotFoundInConfigFile) {
+		t.Skipf("skipping as %q is not configured", remoteName)
+	}
+	require.NoError(t, err)
+	f, ok := remote.(*Fs)
+	if !ok {
+		t.Skipf("skipping as %q is not an SMB remote", remoteName)
+	}
+
+	defer func() { require.NoError(t, f.Shutdown(ctx)) }()
+
+	// Empty the pool so the connections counted below are only the upload's
+	require.NoError(t, f.drainPool(ctx))
+
+	const contents = "connection reuse test"
+	remotePath := fmt.Sprintf("rclone-test-connection-reuse-%d.txt", time.Now().UnixNano())
+	src := object.NewStaticObjectInfo(remotePath, time.Now(), int64(len(contents)), true, nil, nil)
+	o, err := f.Put(ctx, strings.NewReader(contents), src)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, o.Remove(ctx)) }()
+
+	f.poolMu.Lock()
+	pooled := len(f.pool)
+	f.poolMu.Unlock()
+	assert.Equal(t, 1, pooled, "upload should leave exactly one connection in the pool")
 }
 
 // TestIsPathDir tests the isPathDir function logic


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes #9675.

`(*Object).Update` acquires a connection and only releases it via `defer o.fs.putConnection(&cn, err)` at function exit. The upload itself is finished once `fl.Close()` returns, but the connection stays checked out while `o.SetModTime(ctx, src.ModTime(ctx))` runs, and `SetModTime` does its own `getConnection`/`putConnection` for the `Chtimes` and `Stat`. `getConnection` has no cap, so with an empty pool that second call dials a brand new SMB session, and the pool grows to roughly 2N sessions for N transfers.

This returns the connection immediately after the successful `Close()`, so `SetModTime` takes the same one back out of the pool.

The reason it could not simply be released earlier is `remove()`, the cleanup closure that captures `cn` and calls `cn.smbShare.Remove(filename)`. Both of its call sites, the `ReadFrom` failure and the `Close` failure, precede this point, so once `Close` has succeeded nothing else needs the connection.

`putConnection` sets `*pc = nil` and returns early on a nil connection, so the existing deferred `putConnection(&cn, err)` becomes a no-op. There is no double return and no use after return. Calling `putConnection` explicitly rather than only via defer is the pattern already used elsewhere in this file (see `(*Object).Open`).

One behaviour nuance worth a reviewer's eye: previously, if `SetModTime` failed, the deferred `putConnection(&cn, err)` would `Echo` the upload connection and close it if dead. Now the upload connection is returned with a nil error, so it is not health checked, and the `SetModTime` failure is handled against the connection that actually saw it. That seems right, since the upload connection completed `ReadFrom` and `Close` successfully, but it is a real change and I would rather flag it than hide it.

#### Was the change discussed in an issue or in the forum before?

Yes, #9675. @ncw confirmed it and suggested returning the upload connection after the `Close()`, and noted there is no deadlock risk.

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#contributing-to-rclone).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review ::

#### Testing

Verified against a real Samba server (`dperson/samba` in Docker, same image and arguments as `fstest/testserver/init.d/TestSMB`). Before the change one `Put` left **2** connections in the pool; after it leaves **1**.

`TestUploadConnectionReuse` in `backend/smb/smb_internal_test.go` asserts exactly that. It reverts to failing (`expected: 1, actual: 2`) if the production change is removed. Like other backend tests it needs a configured SMB remote and skips without one, so it will not run under plain `make quicktest`.

Also run against that server:
- full SMB backend suite, clean tree 112 pass / 32 skip / 0 fail, with the change 113 pass / 32 skip / 0 fail (the extra one is the new test)
- same suite with `-race`, no data races

`go build ./...` is clean, `gofmt -l backend/smb/` is empty and `golangci-lint run ./backend/smb/...` reports 0 issues. `make quicktest` passes apart from `cmd/gitannex`, `cmd/nfsmount` and `TestS3Minio`, which fail identically on a clean checkout of master here for want of git-annex, NFS mount support and minio.