### PR TITLE
docs: fix reference to the removed --dump-auth flag in the SFTP docs

### DIFF
--- a/docs/content/sftp.md
+++ b/docs/content/sftp.md
@@ -1442,7 +1442,7 @@ SFTP isn't supported under plan9 until [this
 issue](https://github.com/pkg/sftp/issues/156) is fixed.
 
 Note that since SFTP isn't HTTP based the following flags don't work
-with it: `--dump-headers`, `--dump-bodies`, `--dump-auth`.
+with it: `--dump headers`, `--dump bodies`, `--dump auth`.
 
 Note that `--timeout` and `--contimeout` are both supported.
 

--- a/docs/content/swift.md
+++ b/docs/content/swift.md
@@ -709,7 +709,7 @@ Request" error rather than a more sensible error when the
 authentication fails for Swift.
 
 So this most likely means your username / password is wrong.  You can
-investigate further with the `--dump-bodies` flag.
+investigate further with the `--dump bodies` flag.
 
 This may also be caused by specifying the region when you shouldn't
 have (e.g. OVH).


### PR DESCRIPTION
### What is the purpose of this change?

`docs/content/sftp.md` lists the HTTP-only dump flags that have no effect on SFTP:

> Note that since SFTP isn't HTTP based the following flags don't work with it: `--dump-headers`, `--dump-bodies`, `--dump-auth`.

`--dump-auth` no longer exists. It was removed when `--dump` was introduced — from the changelog:

> Add --dump flag, introduce --dump requests, responses and remove --dump-auth, --dump-filters

Today the equivalent is `--dump auth`, backed by the `auth` dump flag in `fs/dump.go`. A reader who looks up `--dump-auth` finds nothing in `rclone help flags` or in the docs.

`--dump-headers` and `--dump-bodies` do still exist as separate flags, so those two are left untouched.

### Was the change discussed in an issue or in the forum before?

No, this was found by comparing the changelog against the current documentation.

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate. *(documentation only, no code changes)*
- [x] I have added documentation for the changes if appropriate. *(this is the documentation change)*
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).