### PR TITLE
size: include source in JSON output - fixes #5429

### DIFF
--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -52,9 +52,10 @@ of the size command.`,
 		cmd.Run(false, false, command, func() error {
 			var err error
 			var results struct {
-				Count    int64 `json:"count"`
-				Bytes    int64 `json:"bytes"`
-				Sizeless int64 `json:"sizeless"`
+				Count    int64  `json:"count"`
+				Bytes    int64  `json:"bytes"`
+				Sizeless int64  `json:"sizeless"`
+				Fs       string `json:"fs"`
 			}
 
 			results.Count, results.Bytes, results.Sizeless, err = operations.Count(context.Background(), fsrc)
@@ -65,6 +66,7 @@ of the size command.`,
 				fs.Logf(fsrc, "Size may be underestimated due to %d objects with unknown size", results.Sizeless)
 			}
 			if jsonOutput {
+				results.Fs = args[0]
 				return json.NewEncoder(os.Stdout).Encode(results)
 			}
 			count := strconv.FormatInt(results.Count, 10)

--- a/cmd/size/size.go
+++ b/cmd/size/size.go
@@ -52,10 +52,12 @@ of the size command.`,
 		cmd.Run(false, false, command, func() error {
 			var err error
 			var results struct {
-				Count    int64 `json:"count"`
-				Bytes    int64 `json:"bytes"`
-				Sizeless int64 `json:"sizeless"`
+				Fs       string `json:"fs"`
+				Count    int64  `json:"count"`
+				Bytes    int64  `json:"bytes"`
+				Sizeless int64  `json:"sizeless"`
 			}
+			results.Fs = args[0]
 
 			results.Count, results.Bytes, results.Sizeless, err = operations.Count(context.Background(), fsrc)
 			if err != nil {


### PR DESCRIPTION
#### What is the purpose of this change?

This adds an `fs` field to `rclone size --json` containing the source exactly as passed on the command line. It follows the JSON-only shape requested when #6047 was closed and leaves the human-readable output unchanged.

Fixes #5429.

#### Verification

- `go test ./cmd/size -count=1`
- `go vet ./cmd/size`
- `go build`
- `make compiletest`
- Built-binary check of JSON output against a local directory
- Built-binary check that human-readable output is unchanged

#### Checklist

- [x] I have read the contribution guidelines.
- [x] The change is limited to the requested JSON output.
- [x] The commit message follows the project style.
- [x] I am done and this pull request is ready for review.