### PR TITLE
azureblob: fix Entra ID server-side copy source authentication

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -70,6 +70,7 @@ const (
 	defaultChunkSize      = 4 * fs.Mebi
 	defaultAccessTier     = blob.AccessTier("") // FIXME AccessTierNone
 	sasCopyValidity       = time.Hour           // how long SAS should last when doing server side copy
+	sasCopyStartSkew      = 15 * time.Minute    // how far back SAS should start to allow for clock skew
 )
 
 // setAcceptEncodingGzip is a per-call policy that sets Accept-Encoding: gzip
@@ -1827,7 +1828,7 @@ func (f *Fs) getUserDelegation(ctx context.Context) (*service.UserDelegationCred
 	}
 
 	// Validity window
-	start := time.Now().UTC()
+	start := time.Now().UTC().Add(-sasCopyStartSkew)
 	expiry := start.Add(2 * sasCopyValidity)
 	startStr := start.Format(time.RFC3339)
 	expiryStr := expiry.Format(time.RFC3339)
@@ -1876,7 +1877,7 @@ func (o *Object) getAuth(ctx context.Context, noAuth bool) (srcURL string, err e
 		// Build the SAS values
 		perms := sas.BlobPermissions{Read: true}
 		container, containerPath := o.split()
-		start := time.Now().UTC()
+		start := time.Now().UTC().Add(-sasCopyStartSkew)
 		expiry := start.Add(sasCopyValidity)
 		vals := sas.BlobSignatureValues{
 			StartTime:     start,

--- a/backend/azureblob/azureblob_internal_test.go
+++ b/backend/azureblob/azureblob_internal_test.go
@@ -54,6 +54,11 @@ func TestBlockIDCreator(t *testing.T) {
 	assert.ErrorContains(t, bic2.checkID(chunkNumber, got), "random bytes")
 }
 
+func TestCopySASTimingConstants(t *testing.T) {
+	require.Greater(t, sasCopyStartSkew, time.Duration(0))
+	require.Greater(t, sasCopyValidity, sasCopyStartSkew)
+}
+
 func (f *Fs) testFeatures(t *testing.T) {
 	// Check first feature flags are set on this remote
 	enabled := f.Features().SetTier


### PR DESCRIPTION
<!--
Thank you for contributing to rclone!

Please discuss anything more than a trivial fix in an issue FIRST - see the
"Linked issue" section below. Then fill in the questions to help us review.
-->

# Summary

Fix Azure Blob server-side copy failures when using Microsoft Entra ID authentication.

Azure Blob to Azure Blob sync jobs were failing with `CannotVerifyCopySource` during rclone multipart server-side copy. Debug logs showed that rclone generated a user delegation SAS URL for the copy source with `st` equal to the local request time. Azure Storage then validated the copy source from the service side with a timestamp a few seconds earlier than `st`, causing the SAS to be treated as not yet valid.

This PR makes the generated copy-source SAS valid 15 minutes before the current time.

This follows Microsoft’s SAS clock-skew guidance:

https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview#best-practices-when-using-sas

> Be careful with SAS start time. If you set the start time for a SAS to the current time, failures might occur intermittently for the first few minutes. This is due to different machines having slightly different current times (known as clock skew). In general, set the start time to be at least 15 minutes in the past. Or, don't set it at all, which will make it valid immediately in all cases. The same generally applies to expiry time as well--remember that you may observe up to 15 minutes of clock skew in either direction on any request. For clients using a REST version prior to 2012-02-12, the maximum duration for a SAS that does not reference a stored access policy is 1 hour. Any policies that specify a longer term than 1 hour will fail.

# Details

Affected workloads:

- Azure Blob to Azure Blob server-side copy
- Microsoft Entra ID authenticated remotes
- Workload Identity / user delegation SAS copy source auth
- Cross-account private blob copies

The issue does not affect normal upload/download paths.

# Root Cause

For Entra-authenticated Azure Blob server-side copy, rclone creates a user delegation SAS URL for the private copy source.

Previously, the SAS validity window started at `time.Now().UTC()`.

That is too strict for service-side validation because:

- rclone generates the SAS using the client clock.
- Azure Storage validates the `x-ms-copy-source` URL on the service side.
- The service-side timestamp can be earlier than the client timestamp.
- Azure treats a SAS with a future `st` as invalid.
- The resulting error is surfaced as `403 CannotVerifyCopySource`.

# Why This Changed In rclone 1.70+

This behavior changed in rclone 1.70.0 with:

```text
3a5ddfcd3c1fd686 azureblob: implement multipart server side copy
```

That change was introduced to make Azure Blob server-side copies much faster, especially across Azure regions. It added multipart copy using the Azure Blob PutBlockFromURL / PutBlockList APIs, enabled ServerSideAcrossConfigs, and made cross-config Azure Blob copies use server-side copy more broadly.

For Microsoft Entra ID authenticated remotes, this changed the copy path from the older Copy Blob behavior to multipart server-side copy for cross-account copies.

A later fix addressed the first Entra ID issue from that change:
```
c6e1f5941542d1f4 azureblob: fix server side copy error "requires exactly one scope"
```
That fix replaced direct bearer-token copy source auth with a temporary user delegation SAS URL for the private copy source. 

This solved the ManagedIdentityCredential.GetToken() requires exactly one scope error, but the generated SAS started at exactly time.Now().UTC().

This PR fixes the next issue in that path: Azure Storage can validate the copy-source SAS a few seconds behind the client timestamp, so a SAS starting at the exact local time can be rejected as not yet valid.

# Sanitized Log Evidence

The failing operation was a multipart server-side copy from one private Azure Blob account to another.

```text
2026-08-05T08:58:53Z DEBUG : <file-a.csv>: size = <source-size> (Azure container <source-account> path <source/path>)
2026-08-05T08:58:53Z DEBUG : <file-a.csv>: size = <destination-size> (Azure container <destination-account> path <destination/path>)
2026-08-05T08:58:53Z DEBUG : <file-a.csv>: Sizes differ
2026-08-05T08:58:53Z DEBUG : <file-a.csv>: Starting multipart copy with 1 parts of size 4Mi
2026-08-05T08:58:53Z DEBUG : <file-a.csv>: multipart copy: starting chunk 0 size <chunk-size> offset 0/<object-size>
2026-08-05T08:58:53Z DEBUG : PUT /<destination-container>/<destination/path>/<file-a.csv>?blockid=<redacted>&comp=block HTTP/1.1
2026-08-05T08:58:53Z DEBUG : x-ms-copy-source: https://<source-account>.blob.core.windows.net/<source-container>/<source/path>/<file-a.csv>?se=2026-08-05T09%3A58%3A53Z&sig=<redacted>&ske=2026-08-05T10%3A57%3A20Z&skoid=<redacted>&sks=b&skt=2026-08-05T08%3A57%3A20Z&sktid=<redacted>&skv=2026-02-06&sp=r&sr=b&st=2026-08-05T08%3A58%3A53Z&sv=2026-02-06
2026-08-05T08:58:53Z DEBUG : X-Ms-Copy-Source-Error-Code: AuthenticationFailed
2026-08-05T08:58:53Z DEBUG : X-Ms-Error-Code: CannotVerifyCopySource
2026-08-05T08:58:53Z ERROR : <file-a.csv>: Failed to copy: multipart copy: failed to copy chunk 1 with -1 bytes: PUT https://<destination-account>.blob.core.windows.net/<destination-container>/<destination/path>/<file-a.csv>
2026-08-05T08:58:53Z ERROR CODE: CannotVerifyCopySource
Azure response:
<Error>
  <Code>CannotVerifyCopySource</Code>
  <Message>
    Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
    RequestId:<redacted>
    Time:2026-08-05T08:58:50.5693140Z
  </Message>
  <CopySourceStatusCode>403</CopySourceStatusCode>
  <CopySourceErrorCode>AuthenticationFailed</CopySourceErrorCode>
  <CopySourceErrorMessage>
    Server failed to authenticate the request. Make sure the value of Authorization header is formed correctly including the signature.
  </CopySourceErrorMessage>
</Error>
```

The important timing relationship was:
- copy-source SAS st:  `2026-08-05T08:58:53Z`
- Azure error Time:    `2026-08-05T08:58:50.5693140Z`
- Difference:          Azure evaluated the SAS about 2.4 seconds before its configured start time

This indicates Azure Storage evaluated the source SAS before its configured start time.

# Fix

Start the copy-source user delegation SAS 15 minutes in the past.

This matches Microsoft’s SAS best-practice guidance to set SAS start times at least 15 minutes in the past, or omit them, to account for clock skew.

# Linked issue

Fixes #8694

# For new or changed backends

## PASS: All tests finished OK in 16m43.312848052s

| Property | Value |
|---|---|
| Version | v1.76.0-DEV |
| Test | [2026-08-05-122425](https://pub.rclone.org/integration-tests/2026-08-05-122425/index.html) |
| Branch | [fix-azureblob-entra-copy-source-sas-skew](https://github.com/rclone/rclone/tree/fix-azureblob-entra-copy-source-sas-skew) |
| Commit | [825fdee7b6f82493b1f0c0f1abdcfef49ba0fb16](https://github.com/rclone/rclone/commit/825fdee7b6f82493b1f0c0f1abdcfef49ba0fb16) |
| Go | go1.26.1 linux/amd64 |
| Duration | 16m43.312848052s |
| Previous | 2026-08-05-115535 |
| Up | Older Tests |

## Passed: 16

| Backend | Remote | Test | FastList | Failed | Logs |
|---|---|---|:---:|---|---|
| azureblob | TestAzureBlob,directory_markers: | backend/azureblob | false | | #0 |
| azureblob | TestAzureBlob,directory_markers: | cmd/bisync | false | | #0 |
| azureblob | TestAzureBlob,directory_markers: | cmd/gitannex | false | | #0 |
| azureblob | TestAzureBlob,directory_markers: | fs/operations | false | | #0 |
| azureblob | TestAzureBlob,directory_markers: | fs/operations | **true** | | #0 |
| azureblob | TestAzureBlob,directory_markers: | fs/sync | false | | #0 |
| azureblob | TestAzureBlob,directory_markers: | fs/sync | **true** | | #0 |
| azureblob | TestAzureBlob,directory_markers: | vfs | false | | #0 |
| azureblob | TestAzureBlob: | backend/azureblob | false | | #0 |
| azureblob | TestAzureBlob: | cmd/bisync | false | | #0 |
| azureblob | TestAzureBlob: | cmd/gitannex | false | | #0 |
| azureblob | TestAzureBlob: | fs/operations | false | | #0 |
| azureblob | TestAzureBlob: | fs/operations | **true** | | #0 |
| azureblob | TestAzureBlob: | fs/sync | false | | #0 |
| azureblob | TestAzureBlob: | fs/sync | **true** | | #0 |
| azureblob | TestAzureBlob: | vfs | false | | #0 |


#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate. **- N/A**
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
