### PR TITLE
local: add --local-use-trash to send deletes to the OS trash

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -253,6 +253,26 @@ platforms may be added in the future.)`,
 				Advanced: true,
 			},
 			{
+				Name: "use_trash",
+				Help: `Send deleted files to the OS trash instead of deleting permanently.
+
+When enabled, files and directories deleted by rclone are moved to the
+operating system trash (the Recycle Bin on Windows, ~/.Trash on macOS,
+the freedesktop.org trash on Linux and other Unix systems) rather than
+being deleted permanently. This mirrors the behaviour many cloud
+backends have by default (e.g. --drive-use-trash).
+
+If the platform trash is not available - an unsupported platform or
+architecture, or a file on a different filesystem than the trash
+directory - rclone returns an error instead of falling back to
+permanent deletion.
+
+On Windows this is limited to paths shorter than 260 characters as the
+underlying API does not support extended-length paths.`,
+				Default:  false,
+				Advanced: true,
+			},
+			{
 				Name: "no_preallocate",
 				Help: `Disable preallocation of disk space for transferred files.
 
@@ -393,6 +413,7 @@ type Options struct {
 	Enc                    encoder.MultiEncoder `config:"encoding"`
 	NoClone                bool                 `config:"no_clone"`
 	MetadataRestoreSpecial bool                 `config:"metadata_restore_special_bits"`
+	UseTrash               bool                 `config:"use_trash"`
 }
 
 // Fs represents a local filesystem rooted at root
@@ -940,6 +961,17 @@ func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 	} else if !fi.IsDir() {
 		return fs.ErrorIsFile
 	}
+	if f.opt.UseTrash {
+		// preserve Rmdir semantics: only remove empty directories
+		entries, err := os.ReadDir(localPath)
+		if err != nil {
+			return err
+		}
+		if len(entries) > 0 {
+			return fmt.Errorf("directory not empty: %q", localPath)
+		}
+		return moveToTrash(localPath)
+	}
 	err = os.Remove(localPath)
 	if runtime.GOOS == "windows" && errors.Is(err, iofs.ErrPermission) { // https://github.com/golang/go/issues/26295
 		if os.Chmod(localPath, 0o600) == nil {
@@ -947,6 +979,30 @@ func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 		}
 	}
 	return err
+}
+
+// Purge deletes all the files and the directory
+//
+// Only supported with --local-use-trash where the whole directory is
+// moved to the trash in one operation - otherwise rclone falls back to
+// the standard recursive delete.
+func (f *Fs) Purge(ctx context.Context, dir string) error {
+	if !f.opt.UseTrash {
+		return fs.ErrorCantPurge
+	}
+	localPath, err := f.localPath(dir)
+	if err != nil {
+		return err
+	}
+	if fi, err := os.Stat(localPath); err != nil {
+		if os.IsNotExist(err) {
+			return fs.ErrorDirNotFound
+		}
+		return err
+	} else if !fi.IsDir() {
+		return fs.ErrorIsFile
+	}
+	return moveToTrash(localPath)
 }
 
 // Precision of the file system
@@ -1804,6 +1860,9 @@ func (o *Object) lstat() error {
 // Remove an object
 func (o *Object) Remove(ctx context.Context) error {
 	o.clearHashCache()
+	if o.fs.opt.UseTrash {
+		return moveToTrash(o.path)
+	}
 	return remove(o.path)
 }
 
@@ -1936,6 +1995,7 @@ func (d *Directory) Hash() {
 // Check the interfaces are satisfied
 var (
 	_ fs.Fs              = &Fs{}
+	_ fs.Purger          = &Fs{}
 	_ fs.PutStreamer     = &Fs{}
 	_ fs.Mover           = &Fs{}
 	_ fs.DirMover        = &Fs{}

--- a/backend/local/trash_darwin.go
+++ b/backend/local/trash_darwin.go
@@ -1,0 +1,46 @@
+//go:build darwin
+
+package local
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+)
+
+// moveToTrash moves the file or directory into the user's ~/.Trash.
+func moveToTrash(path string) error {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	trash := filepath.Join(home, ".Trash")
+	if fi, err := os.Stat(trash); err != nil || !fi.IsDir() {
+		return fmt.Errorf("trash directory %q not usable: %v", trash, err)
+	}
+	base := filepath.Base(path)
+	for i := 1; ; i++ {
+		name := base
+		if i > 1 {
+			ext := filepath.Ext(base)
+			name = fmt.Sprintf("%s %d%s", base[:len(base)-len(ext)], i, ext)
+		}
+		target := filepath.Join(trash, name)
+		if _, err := os.Lstat(target); err == nil {
+			continue
+		} else if !os.IsNotExist(err) {
+			return err
+		}
+		err = os.Rename(path, target)
+		if err != nil && errors.Is(err, syscall.EXDEV) {
+			return fmt.Errorf("%q is on a different filesystem than the trash directory - can't move it to the trash", path)
+		}
+		return err
+	}
+}

--- a/backend/local/trash_test.go
+++ b/backend/local/trash_test.go
@@ -26,7 +26,9 @@ func TestUseTrash(t *testing.T) {
 
 	r := fstest.NewRun(t)
 	f := r.Flocal.(*Fs)
+	// NewRun shares the local Fs between tests - restore the option afterwards
 	f.opt.UseTrash = true
+	t.Cleanup(func() { f.opt.UseTrash = false })
 
 	r.WriteFile("trashme.txt", "content", trashTime)
 	obj, err := f.NewObject(ctx, "trashme.txt")
@@ -64,6 +66,10 @@ func TestUseTrashPurge(t *testing.T) {
 
 	r := fstest.NewRun(t)
 	f := r.Flocal.(*Fs)
+	// NewRun shares the local Fs between tests - set the option explicitly
+	// for both halves and restore it afterwards
+	f.opt.UseTrash = false
+	t.Cleanup(func() { f.opt.UseTrash = false })
 
 	assert.Equal(t, fs.ErrorCantPurge, f.Purge(ctx, "sub"))
 

--- a/backend/local/trash_test.go
+++ b/backend/local/trash_test.go
@@ -1,0 +1,79 @@
+//go:build linux
+
+package local
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fstest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var trashTime = fstest.Time("2011-12-25T12:59:59.123456789Z")
+
+// TestUseTrash checks that Remove with use_trash moves the file into the
+// freedesktop trash instead of deleting it permanently.
+func TestUseTrash(t *testing.T) {
+	ctx := context.Background()
+	// point the freedesktop trash at a temporary directory
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	r := fstest.NewRun(t)
+	f := r.Flocal.(*Fs)
+	f.opt.UseTrash = true
+
+	r.WriteFile("trashme.txt", "content", trashTime)
+	obj, err := f.NewObject(ctx, "trashme.txt")
+	require.NoError(t, err)
+	require.NoError(t, obj.Remove(ctx))
+	fstest.CheckItems(t, r.Flocal)
+
+	// the file must be in the trash with a matching trashinfo
+	trashed := filepath.Join(dataHome, "Trash", "files", "trashme.txt")
+	content, err := os.ReadFile(trashed)
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(content))
+	info, err := os.ReadFile(filepath.Join(dataHome, "Trash", "info", "trashme.txt.trashinfo"))
+	require.NoError(t, err)
+	assert.Contains(t, string(info), "[Trash Info]")
+	assert.Contains(t, string(info), "Path=")
+
+	// a second file with the same name must get a deduplicated name
+	r.WriteFile("trashme.txt", "content2", trashTime)
+	obj, err = f.NewObject(ctx, "trashme.txt")
+	require.NoError(t, err)
+	require.NoError(t, obj.Remove(ctx))
+	content, err = os.ReadFile(filepath.Join(dataHome, "Trash", "files", "trashme.2.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "content2", string(content))
+}
+
+// TestUseTrashPurge checks that Purge with use_trash moves the whole
+// directory into the trash in one go and that Purge without the option
+// reports fs.ErrorCantPurge.
+func TestUseTrashPurge(t *testing.T) {
+	ctx := context.Background()
+	dataHome := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", dataHome)
+
+	r := fstest.NewRun(t)
+	f := r.Flocal.(*Fs)
+
+	assert.Equal(t, fs.ErrorCantPurge, f.Purge(ctx, "sub"))
+
+	f.opt.UseTrash = true
+	r.WriteFile("sub/one.txt", "one", trashTime)
+	r.WriteFile("sub/two.txt", "two", trashTime)
+	require.NoError(t, f.Purge(ctx, "sub"))
+	fstest.CheckItems(t, r.Flocal)
+
+	content, err := os.ReadFile(filepath.Join(dataHome, "Trash", "files", "sub", "one.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "one", string(content))
+}

--- a/backend/local/trash_unix.go
+++ b/backend/local/trash_unix.go
@@ -1,0 +1,83 @@
+//go:build linux || freebsd || netbsd || openbsd
+
+package local
+
+import (
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// trashDir returns the user's freedesktop.org trash directory,
+// creating the files/ and info/ subdirectories if necessary.
+func trashDir() (string, error) {
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		dataHome = filepath.Join(home, ".local", "share")
+	}
+	trash := filepath.Join(dataHome, "Trash")
+	for _, sub := range []string{"files", "info"} {
+		if err := os.MkdirAll(filepath.Join(trash, sub), 0o700); err != nil {
+			return "", err
+		}
+	}
+	return trash, nil
+}
+
+// moveToTrash moves the file or directory to the user's trash following
+// the freedesktop.org Trash specification.
+func moveToTrash(path string) error {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	trash, err := trashDir()
+	if err != nil {
+		return fmt.Errorf("failed to use trash: %w", err)
+	}
+	base := filepath.Base(path)
+	// pick a free name in both files/ and info/, then reserve it by
+	// creating the .trashinfo file with O_EXCL
+	var info *os.File
+	var name string
+	for i := 1; ; i++ {
+		name = base
+		if i > 1 {
+			ext := filepath.Ext(base)
+			name = fmt.Sprintf("%s.%d%s", base[:len(base)-len(ext)], i, ext)
+		}
+		info, err = os.OpenFile(filepath.Join(trash, "info", name+".trashinfo"), os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o600)
+		if err == nil {
+			break
+		}
+		if !os.IsExist(err) {
+			return fmt.Errorf("failed to write trashinfo: %w", err)
+		}
+	}
+	// percent-encode like a URL path, keeping "/" separators
+	escaped := (&url.URL{Path: path}).EscapedPath()
+	_, err = fmt.Fprintf(info, "[Trash Info]\nPath=%s\nDeletionDate=%s\n", escaped, time.Now().Format("2006-01-02T15:04:05"))
+	if closeErr := info.Close(); err == nil {
+		err = closeErr
+	}
+	if err != nil {
+		return fmt.Errorf("failed to write trashinfo: %w", err)
+	}
+	err = os.Rename(path, filepath.Join(trash, "files", name))
+	if err != nil {
+		_ = os.Remove(filepath.Join(trash, "info", name+".trashinfo"))
+		if errors.Is(err, syscall.EXDEV) {
+			return fmt.Errorf("%q is on a different filesystem than the trash directory - can't move it to the trash", path)
+		}
+		return err
+	}
+	return nil
+}

--- a/backend/local/trash_unsupported.go
+++ b/backend/local/trash_unsupported.go
@@ -1,0 +1,10 @@
+//go:build (windows && !amd64 && !arm64) || !(windows || linux || freebsd || netbsd || openbsd || darwin)
+
+package local
+
+import "errors"
+
+// moveToTrash is not supported on this platform or architecture.
+func moveToTrash(path string) error {
+	return errors.New("--local-use-trash is not supported on this platform")
+}

--- a/backend/local/trash_windows.go
+++ b/backend/local/trash_windows.go
@@ -1,0 +1,68 @@
+//go:build windows && (amd64 || arm64)
+
+package local
+
+import (
+	"fmt"
+	"strings"
+	"syscall"
+	"unsafe"
+)
+
+var (
+	shell32          = syscall.NewLazyDLL("shell32.dll")
+	shFileOperationW = shell32.NewProc("SHFileOperationW")
+)
+
+const (
+	foDelete          = 3
+	fofAllowUndo      = 0x0040
+	fofNoConfirmation = 0x0010
+	fofSilent         = 0x0004
+	fofNoErrorUI      = 0x0400
+)
+
+// shFileOpStructW matches SHFILEOPSTRUCTW on 64 bit Windows where the
+// struct uses natural alignment. On 32 bit Windows the struct is byte
+// packed which can't be expressed in Go - hence the build constraint
+// above and the fallback in trash_unsupported.go.
+type shFileOpStructW struct {
+	hwnd                  uintptr
+	wFunc                 uint32
+	pFrom                 *uint16
+	pTo                   *uint16
+	fFlags                uint16
+	fAnyOperationsAborted int32
+	hNameMappings         uintptr
+	lpszProgressTitle     *uint16
+}
+
+// moveToTrash sends the file or directory to the Windows Recycle Bin
+// using SHFileOperationW with FOF_ALLOWUNDO.
+func moveToTrash(path string) error {
+	// SHFileOperation does not accept \\?\ extended-length paths
+	if strings.HasPrefix(path, `\\?\UNC\`) {
+		path = `\\` + strings.TrimPrefix(path, `\\?\UNC\`)
+	} else {
+		path = strings.TrimPrefix(path, `\\?\`)
+	}
+	// pFrom must be double-NUL terminated
+	p, err := syscall.UTF16FromString(path)
+	if err != nil {
+		return err
+	}
+	p = append(p, 0)
+	op := shFileOpStructW{
+		wFunc:  foDelete,
+		pFrom:  &p[0],
+		fFlags: fofAllowUndo | fofNoConfirmation | fofSilent | fofNoErrorUI,
+	}
+	ret, _, _ := shFileOperationW.Call(uintptr(unsafe.Pointer(&op)))
+	if ret != 0 {
+		return fmt.Errorf("failed to move %q to the recycle bin: SHFileOperation error %#x", path, ret)
+	}
+	if op.fAnyOperationsAborted != 0 {
+		return fmt.Errorf("moving %q to the recycle bin was aborted", path)
+	}
+	return nil
+}


### PR DESCRIPTION
#### What is the purpose of this change?

Adds an opt-in `--local-use-trash` option to the local backend that routes file and directory deletions to the platform trash instead of deleting permanently:

- **Windows**: Recycle Bin via `SHFileOperationW` with `FOF_ALLOWUNDO` (amd64/arm64; 32-bit returns a clear error since the byte-packed struct can't be expressed in Go)
- **macOS**: move into `~/.Trash`
- **Linux/BSD**: freedesktop.org Trash specification (`files/` + `info/*.trashinfo`, `XDG_DATA_HOME` honoured)

`Purge` is implemented for the local backend when the option is set, so a directory lands in the trash as a single restorable entry; without the option it returns `fs.ErrorCantPurge` and rclone falls back to the recursive delete exactly as before. When the platform trash is unavailable (unsupported platform, or a path on a different filesystem than the trash directory), rclone returns an error rather than silently hard-deleting.

Motivation (see #9737): in bidirectional setups (`bisync`, scripted two-way syncs) deletions propagated cloud→local are currently irreversible while local→cloud deletions land in a 30-day trash - this closes that asymmetry. I am running this in a production two-way Google Drive sync on Windows.

Fixes #9737

#### Was the change discussed in an issue or in the forum before?

Issue #9737 (opened earlier today, marked as draft pending design feedback - happy to adjust naming/semantics).

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] I have added tests for all changes in this PR if appropriate (freedesktop path; gated to Linux so CI machines' real trash stays clean).
- [x] I have added documentation for the changes if appropriate (option help text; backend docs are generated from it).
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] I'm done, this Pull Request is ready for review :-)