### PR TITLE
lsd: respect --max-depth with --recursive

### DIFF
--- a/cmd/lsd/lsd.go
+++ b/cmd/lsd/lsd.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/rclone/rclone/cmd"
 	"github.com/rclone/rclone/cmd/ls/lshelp"
-	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/flags"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/spf13/cobra"
@@ -56,14 +55,10 @@ If you just want the directory names use ` + "`rclone lsf --dirs-only`" + `.
 		"groups": "Filter,Listing",
 	},
 	Run: func(command *cobra.Command, args []string) {
-		ci := fs.GetConfig(context.Background())
 		cmd.CheckArgs(1, 1, command, args)
-		if recurse {
-			ci.MaxDepth = 0
-		}
 		fsrc := cmd.NewFsSrc(args)
 		cmd.Run(false, false, command, func() error {
-			return operations.ListDir(context.Background(), fsrc, os.Stdout)
+			return operations.ListDir(context.Background(), fsrc, os.Stdout, recurse)
 		})
 	},
 }

--- a/cmdtest/cmdtest_test.go
+++ b/cmdtest/cmdtest_test.go
@@ -205,7 +205,7 @@ func TestCmdTest(t *testing.T) {
 
 	// Test creation of simple test data
 	createSimpleTestData(t)
-	out, err = rclone("config", "create", "myCombine", "combine", "upstreams", "root=myLocal:"+testFolder)
+	_, err = rclone("config", "create", "myCombine", "combine", "upstreams", "root=myLocal:"+testFolder)
 	assert.NoError(t, err)
 
 	// Test access to config file and simple test data

--- a/cmdtest/cmdtest_test.go
+++ b/cmdtest/cmdtest_test.go
@@ -205,6 +205,8 @@ func TestCmdTest(t *testing.T) {
 
 	// Test creation of simple test data
 	createSimpleTestData(t)
+	out, err = rclone("config", "create", "myCombine", "combine", "upstreams", "root=myLocal:"+testFolder)
+	assert.NoError(t, err)
 
 	// Test access to config file and simple test data
 	out, err = rclone("lsl", "myLocal:"+testFolder)
@@ -212,6 +214,27 @@ func TestCmdTest(t *testing.T) {
 	if assert.NoError(t, err) {
 		assert.Contains(t, out, "rclone.config")
 		assert.Contains(t, out, "testdata/folderA/fileA1.txt")
+	}
+
+	// Test recursive lsd with backend ListR enabled
+	out, err = rclone("lsd", "-R", "myCombine:")
+	if assert.NoError(t, err) {
+		assert.Contains(t, out, "root/testdata/folderA/folderAA")
+		assert.Len(t, strings.Split(strings.TrimSpace(out), "\n"), 5)
+	}
+
+	// Test recursive lsd with backend ListR disabled
+	out, err = rclone("lsd", "-R", "--disable", "ListR", "myCombine:")
+	if assert.NoError(t, err) {
+		assert.Contains(t, out, "root/testdata/folderA/folderAA")
+		assert.Len(t, strings.Split(strings.TrimSpace(out), "\n"), 5)
+	}
+
+	// Test recursive lsd with a maximum depth
+	out, err = rclone("lsd", "-R", "--max-depth", "2", "myLocal:"+testFolder)
+	if assert.NoError(t, err) {
+		assert.Contains(t, out, "testdata/folderA")
+		assert.NotContains(t, out, "testdata/folderA/folderAA")
 	}
 
 }

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -1042,10 +1042,11 @@ func ConfigMaxDepth(ctx context.Context, recursive bool) int {
 	return depth
 }
 
-// ListDir lists the directories/buckets/containers in the Fs to the supplied writer
-func ListDir(ctx context.Context, f fs.Fs, w io.Writer) error {
+// ListDir lists the directories/buckets/containers in the Fs to the supplied writer.
+// Recursive controls the default depth; an explicit --max-depth takes precedence.
+func ListDir(ctx context.Context, f fs.Fs, w io.Writer, recursive bool) error {
 	ci := fs.GetConfig(ctx)
-	return walk.ListR(ctx, f, "", false, ConfigMaxDepth(ctx, false), walk.ListDirs, func(entries fs.DirEntries) error {
+	return walk.ListR(ctx, f, "", false, ConfigMaxDepth(ctx, recursive), walk.ListDirs, func(entries fs.DirEntries) error {
 		entries.ForDir(func(dir fs.Directory) {
 			if dir != nil {
 				SyncFprintf(w, "%s %13s %s %s\n", SizeStringField(dir.Size(), ci.HumanReadable, 12), dir.ModTime(ctx).Local().Format("2006-01-02 15:04:05"), CountStringField(dir.Items(), ci.HumanReadable, 9), dir.Remote())

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -77,14 +77,23 @@ func TestLsd(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)
 	file1 := r.WriteObject(ctx, "sub dir/hello world", "hello world", t1)
+	file2 := r.WriteObject(ctx, "sub dir/sub sub dir/hello world", "hello world", t1)
 
-	r.CheckRemoteItems(t, file1)
+	r.CheckRemoteItems(t, file1, file2)
 
 	var buf bytes.Buffer
-	err := operations.ListDir(ctx, r.Fremote, &buf)
+	err := operations.ListDir(ctx, r.Fremote, &buf, false)
 	require.NoError(t, err)
 	res := buf.String()
 	assert.Contains(t, res, "sub dir\n")
+	assert.NotContains(t, res, "sub dir/sub sub dir\n")
+
+	buf.Reset()
+	err = operations.ListDir(ctx, r.Fremote, &buf, true)
+	require.NoError(t, err)
+	res = buf.String()
+	assert.Contains(t, res, "sub dir\n")
+	assert.Contains(t, res, "sub dir/sub sub dir\n")
 }
 
 func TestLs(t *testing.T) {


### PR DESCRIPTION
## What changed

- Pass the `lsd` recursive setting through `operations.ListDir` to the existing depth resolver.
- Preserve explicit `--max-depth` values while retaining unlimited recursion for a bare `-R`.
- Add a compact end-to-end regression check to the existing command test.

## Why

`operations.ListDir` always resolved its depth as a non-recursive listing, so `lsd -R` was implemented by unconditionally changing the shared `MaxDepth` configuration to `0`. This overwrote an explicit `--max-depth` and made the listing recurse without a limit.

`lsd` now passes its recursion setting to `ListDir`, which uses `ConfigMaxDepth` just as `lsf` does. This removes the shared configuration mutation and avoids relying on a zero depth to request unlimited recursion.

## Verification

- `go build`
- `go test -race -count=1 ./fs/operations ./cmdtest`
- Verified default and bounded recursive listings against a nested local directory tree.
