### PR TITLE
accounting: fix memory leaks on long-running rcd

### DIFF
--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -33,7 +33,6 @@ var MaxCompletedTransfers = 100
 // to correctly count the updated fields
 type StatsInfo struct {
 	mu                    sync.RWMutex
-	ctx                   context.Context
 	ci                    *fs.ConfigInfo
 	bytes                 int64
 	errors                int64
@@ -85,7 +84,6 @@ type averageValues struct {
 func NewStats(ctx context.Context) *StatsInfo {
 	ci := fs.GetConfig(ctx)
 	s := &StatsInfo{
-		ctx:                   ctx,
 		ci:                    ci,
 		checking:              newTransferMap(ci.Checkers, "checking"),
 		transferring:          newTransferMap(ci.Transfers, "transferring"),
@@ -518,10 +516,10 @@ func (s *StatsInfo) String() string {
 	// Add per transfer stats if required
 	if !s.ci.StatsOneLine {
 		if !s.checking.empty() {
-			_, _ = fmt.Fprintf(buf, "Checking:\n%s\n", s.checking.String(s.ctx, s.inProgress, s.transferring))
+			_, _ = fmt.Fprintf(buf, "Checking:\n%s\n", s.checking.String(s.ci, s.inProgress, s.transferring))
 		}
 		if !s.transferring.empty() {
-			_, _ = fmt.Fprintf(buf, "Transferring:\n%s\n", s.transferring.String(s.ctx, s.inProgress, nil))
+			_, _ = fmt.Fprintf(buf, "Transferring:\n%s\n", s.transferring.String(s.ci, s.inProgress, nil))
 		}
 	}
 

--- a/fs/accounting/transfer.go
+++ b/fs/accounting/transfer.go
@@ -66,6 +66,7 @@ type Transfer struct {
 	acc         *Account
 	err         error
 	completedAt time.Time
+	doneBytes   int64
 }
 
 // newCheckingTransfer instantiates new checking of the object.
@@ -116,12 +117,20 @@ func (tr *Transfer) Done(ctx context.Context, err error) {
 		}
 		// Signal done with accounting
 		acc.Done()
-		// free the account since we may keep the transfer
-		acc = nil
+	}
+
+	var doneBytes int64
+	if acc != nil {
+		doneBytes, _ = acc.progress()
 	}
 
 	tr.mu.Lock()
 	tr.completedAt = time.Now()
+	if acc != nil {
+		tr.doneBytes = doneBytes
+	}
+	// free the account since we may keep the transfer
+	tr.acc = nil
 	tr.mu.Unlock()
 
 	if tr.checking {
@@ -181,7 +190,7 @@ func (tr *Transfer) Snapshot() TransferSnapshot {
 	tr.mu.RLock()
 	defer tr.mu.RUnlock()
 
-	var s, b int64 = tr.size, 0
+	b, s := tr.doneBytes, tr.size
 	if tr.acc != nil {
 		b, s = tr.acc.progress()
 	}

--- a/fs/accounting/transfer_test.go
+++ b/fs/accounting/transfer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/rclone/rclone/fs/rc"
@@ -54,6 +55,26 @@ func TestTransfer(t *testing.T) {
 		assert.Equal(t, "", snap.Group)
 		assert.Equal(t, "srcFs:srcFs", snap.SrcFs)
 		assert.Equal(t, "dstFs:dstFs", snap.DstFs)
+	})
+
+	t.Run("DoneReleasesAccount", func(t *testing.T) {
+		content := "hello world"
+		o := mockobject.New("obj").WithContent([]byte(content), mockobject.SeekModeNone)
+		tr := newTransfer(s, o, srcFs, dstFs)
+		in := tr.Account(ctx, io.NopCloser(strings.NewReader(content)))
+		_, err := io.Copy(io.Discard, in)
+		require.NoError(t, err)
+
+		tr.Done(ctx, nil)
+
+		tr.mu.RLock()
+		acc := tr.acc
+		tr.mu.RUnlock()
+		assert.Nil(t, acc)
+
+		snap := tr.Snapshot()
+		assert.Equal(t, int64(len(content)), snap.Bytes)
+		assert.Equal(t, int64(len(content)), snap.Size)
 	})
 
 	t.Run("rcStats", func(t *testing.T) {

--- a/fs/accounting/transfermap.go
+++ b/fs/accounting/transfermap.go
@@ -1,7 +1,6 @@
 package accounting
 
 import (
-	"context"
 	"fmt"
 	"maps"
 	"sort"
@@ -91,10 +90,9 @@ func (tm *transferMap) _sortedSlice() []*Transfer {
 
 // String returns string representation of map items excluding any in
 // exclude (if set).
-func (tm *transferMap) String(ctx context.Context, progress *inProgress, exclude *transferMap) string {
+func (tm *transferMap) String(ci *fs.ConfigInfo, progress *inProgress, exclude *transferMap) string {
 	tm.mu.RLock()
 	defer tm.mu.RUnlock()
-	ci := fs.GetConfig(ctx)
 	stringList := make([]string, 0, len(tm.items))
 	for _, tr := range tm._sortedSlice() {
 		var what = tr.what


### PR DESCRIPTION
#### What does this change do?

Fixes two accounting-related memory leaks on a long-running rcd. A third (in bisync) is in a separate PR (#9749).

#### Linked issue

none (small obvious bug fix)

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
