### PR TITLE
bisync: fix memory leak when running via the rc

### DIFF
--- a/cmd/bisync/queue.go
+++ b/cmd/bisync/queue.go
@@ -247,7 +247,9 @@ func (b *bisyncRun) fastCopy(ctx context.Context, fsrc, fdst fs.Fs, files bilib.
 
 	b.SyncCI = fs.GetConfig(ctxCopy)                       // allows us to request graceful shutdown
 	accounting.Stats(ctxCopy).SetMaxCompletedTransfers(-1) // we need a complete list in the event of graceful shutdown
-	ctxCopy, b.CancelSync = context.WithCancel(ctxCopy)
+	ctxCopy, cancel := context.WithCancel(ctxCopy)
+	defer cancel()
+	b.CancelSync = cancel
 	b.testFn()
 	err := sync.Sync(ctxCopy, fdst, fsrc, b.opt.CreateEmptySrcDirs)
 	prettyprint(b.queueOpt.logger, "b.queueOpt.logger", fs.LogLevelDebug)


### PR DESCRIPTION
#### What does this change do?

Before this change, `fastCopy` created a cancellable context for the sync and stored its cancel func on the `bisyncRun`, but only ever called it when gracefully shutting down. On a normal run, it was never called, and until it is cancelled, a context from `context.WithCancel` stays registered with its nearest cancellable ancestor.

For an rc job, that ancestor is the job's own context, which the job registry retains for `--rc-job-expire-duration`. The sync context carries bisync's `LoggerOpt`, whose `LoggerFn` is a method value on `*bisyncRun`, so a finished run was kept alive -- including the Path1 and Path2 listings -- for as long as the job was.

This change fixes the issue by cancelling the sync context when `fastCopy` returns. The cancel func is still stored on the `bisyncRun`, so a graceful shutdown can still interrupt a sync that is in progress.

#### Linked issue

none (small obvious bug fix)

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
