### PR TITLE
operations: speed up checksum by hashing files in parallel - fixes #9727

### DIFF
--- a/fs/operations/check.go
+++ b/fs/operations/check.go
@@ -481,24 +481,16 @@ func (c *checkMarch) checkSum(ctx context.Context, obj fs.Object, download bool,
 		return
 	}
 
-	var err error
 	tr := accounting.Stats(ctx).NewCheckingTransfer(obj, "hashing")
-	defer tr.Done(ctx, err)
 
 	if !sumFound {
-		err = errors.New("sum not found")
+		err := errors.New("sum not found")
 		_ = fs.CountError(ctx, err)
 		fs.Errorf(obj, "%v", err)
 		c.differences.Add(1)
 		c.srcFilesMissing.Add(1)
 		c.report(obj, c.opt.MissingOnSrc, '-')
-		return
-	}
-
-	if !download {
-		var objHash string
-		objHash, err = obj.Hash(ctx, hashType)
-		c.matchSum(ctx, sumHash, objHash, obj, err, hashType)
+		tr.Done(ctx, nil)
 		return
 	}
 
@@ -512,16 +504,21 @@ func (c *checkMarch) checkSum(ctx context.Context, obj fs.Object, download bool,
 		)
 		defer func() {
 			c.matchSum(ctx, sumHash, objHash, obj, err, hashType)
+			tr.Done(ctx, nil)
 			<-c.tokens // get the token back to free up a slot
 			c.wg.Done()
 		}()
+		if !download {
+			objHash, err = obj.Hash(ctx, hashType)
+			return
+		}
 		if in, err = Open(ctx, obj); err != nil {
 			return
 		}
-		tr := accounting.Stats(ctx).NewTransfer(obj, nil)
-		in = tr.Account(ctx, in).WithBuffer() // account and buffer the transfer
+		dlTr := accounting.Stats(ctx).NewTransfer(obj, nil)
+		in = dlTr.Account(ctx, in).WithBuffer() // account and buffer the transfer
 		defer func() {
-			tr.Done(ctx, nil) // will close the stream
+			dlTr.Done(ctx, nil) // will close the stream
 		}()
 		hashVals, err2 := hash.StreamTypes(in, hash.NewHashSet(hashType))
 		if err2 != nil {

--- a/fs/operations/check_test.go
+++ b/fs/operations/check_test.go
@@ -8,7 +8,9 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/rclone/rclone/cmd/bisync/bilib"
 	"github.com/rclone/rclone/fs"
@@ -16,6 +18,8 @@ import (
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fstest"
+	"github.com/rclone/rclone/fstest/mockfs"
+	"github.com/rclone/rclone/fstest/mockobject"
 	"github.com/rclone/rclone/lib/readers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -539,6 +543,120 @@ func TestCheckSum(t *testing.T) {
 
 func TestCheckSumDownload(t *testing.T) {
 	testCheckSum(t, true)
+}
+
+// hashProbe records how many hashing operations are running at once. Each
+// operation blocks until want of them are in flight, or until the deadline
+// expires so a serial implementation finishes instead of deadlocking.
+type hashProbe struct {
+	mu       sync.Mutex
+	inFlight int
+	max      int
+	want     int
+	once     sync.Once
+	reached  chan struct{}
+	timedOut chan struct{}
+}
+
+func newHashProbe(t *testing.T, want int, deadline time.Duration) *hashProbe {
+	p := &hashProbe{
+		want:     want,
+		reached:  make(chan struct{}),
+		timedOut: make(chan struct{}),
+	}
+	timer := time.AfterFunc(deadline, func() { close(p.timedOut) })
+	t.Cleanup(func() { timer.Stop() })
+	return p
+}
+
+func (p *hashProbe) enter() {
+	p.mu.Lock()
+	p.inFlight++
+	p.max = max(p.max, p.inFlight)
+	full := p.inFlight >= p.want
+	p.mu.Unlock()
+	if full {
+		p.once.Do(func() { close(p.reached) })
+	}
+	select {
+	case <-p.reached:
+	case <-p.timedOut:
+	}
+}
+
+func (p *hashProbe) leave() {
+	p.mu.Lock()
+	p.inFlight--
+	p.mu.Unlock()
+}
+
+func (p *hashProbe) maxInFlight() int {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	return p.max
+}
+
+// probeObject is an object whose hashing is instrumented by a hashProbe
+type probeObject struct {
+	*mockobject.ContentMockObject
+	probe *hashProbe
+}
+
+func (o *probeObject) Hash(ctx context.Context, ht hash.Type) (string, error) {
+	o.probe.enter()
+	defer o.probe.leave()
+	return o.ContentMockObject.Hash(ctx, ht)
+}
+
+func (o *probeObject) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
+	o.probe.enter()
+	defer o.probe.leave()
+	return o.ContentMockObject.Open(ctx, options...)
+}
+
+func testCheckSumConcurrency(t *testing.T, download bool) {
+	const (
+		checkers = 2
+		numFiles = 4
+		sumFile  = "test.sum"
+	)
+	hashType := hash.MD5
+
+	ctx, ci := fs.AddConfig(context.Background())
+	ci.Checkers = checkers
+	probe := newHashProbe(t, checkers, 10*time.Second)
+
+	f, err := mockfs.NewFs(ctx, "checkSum", "checkSum", nil)
+	require.NoError(t, err)
+	fsrc := f.(*mockfs.Fs)
+	fsrc.SetHashes(hash.NewHashSet(hashType))
+
+	sums := &bytes.Buffer{}
+	for i := range numFiles {
+		remote := fmt.Sprintf("file%d", i)
+		o := mockobject.New(remote).WithContent([]byte("contents of "+remote), mockobject.SeekModeNone)
+		sum, err := o.Hash(ctx, hashType)
+		require.NoError(t, err)
+		_, _ = fmt.Fprintf(sums, "%s  %s\n", sum, remote)
+		fsrc.AddObject(&probeObject{ContentMockObject: o, probe: probe})
+	}
+
+	f, err = mockfs.NewFs(ctx, "sums", "sums", nil)
+	require.NoError(t, err)
+	fsum := f.(*mockfs.Fs)
+	fsum.AddObject(mockobject.New(sumFile).WithContent(sums.Bytes(), mockobject.SeekModeNone))
+
+	opt := operations.CheckOpt{Combined: new(bytes.Buffer)}
+	require.NoError(t, operations.CheckSum(ctx, fsrc, fsum, sumFile, hashType, &opt, download))
+	assert.Equal(t, checkers, probe.maxInFlight(), "hashing was not run --checkers at a time")
+}
+
+func TestCheckSumConcurrency(t *testing.T) {
+	testCheckSumConcurrency(t, false)
+}
+
+func TestCheckSumDownloadConcurrency(t *testing.T) {
+	testCheckSumConcurrency(t, true)
 }
 
 func TestApplyTransforms(t *testing.T) {


### PR DESCRIPTION
#### What does this change do?

`rclone checksum` and `rclone check --checkfile` hash one file at a time unless
`--download` is given.

In `operations.CheckSum` the objects are walked with `ListFn` and each one is
handed to `checkMarch.checkSum`. The `--download` branch there puts a token in
`c.tokens` (sized to `--checkers`) and does its work in a goroutine, but the
non-download branch calls `obj.Hash()` synchronously, inline in the listing
callback, so `--checkers` has no effect on it at all. On a backend where
`Hash()` actually reads the file — local, and anything wrapping it — that makes
the command serial.

Reproducer, 40 x 64 MiB of local files against a `sha256sum` manifest:

```
$ time rclone checksum sha256 manifest.txt . --one-way --checkers 8
# master
real  0m1.70s   user  0m1.48s   sys  0m0.25s
# this branch
real  0m0.31s   user  0m1.80s   sys  0m0.33s
```

`user` is unchanged (same hashing work) while `real` drops by ~5x, i.e. before
this change the eight checkers were never used.

The fix moves the `!download` case into the same goroutine the download case
already uses, so both branches are bounded by `--checkers` and `--checkers`
means the same thing with and without `--download`. That is the right layer for
it: the token pool, the `hashes` map locking and the result bookkeeping all
already live in `checkMarch`, and `matchSum` is already called concurrently by
the download path, so nothing new has to become thread safe. There is nothing
backend specific about it either — every backend gets it for free.

One consequential detail: the `"hashing"` checking transfer is now finished by
the goroutine rather than when `checkSum` returns, so it covers the hashing work
in both branches instead of disappearing immediately after the download
goroutine is started. The inner download transfer is renamed `dlTr` so that it
no longer shadows it.

#### Verification

New test `TestCheckSumConcurrency` / `TestCheckSumDownloadConcurrency` in
`fs/operations/check_test.go`. Rather than timing anything (which would be
flaky), it builds a `mockfs` of objects whose `Hash()`/`Open()` block until
`--checkers` of them are in flight at once, and asserts on the maximum number
seen concurrently. It has a deadline so a serial implementation fails the
assertion instead of deadlocking.

Before the change:

```
=== RUN   TestCheckSumConcurrency
    check_test.go:651:
        	Error:      	Not equal:
        	            	expected: 2
        	            	actual  : 1
        	Messages:   	hashing was not run --checkers at a time
--- FAIL: TestCheckSumConcurrency (10.00s)
=== RUN   TestCheckSumDownloadConcurrency
--- PASS: TestCheckSumDownloadConcurrency (0.00s)
```

(the `--download` half already passed, and is there to keep it that way)

After:

```
--- PASS: TestCheckSum (0.02s)
--- PASS: TestCheckSumDownload (0.03s)
--- PASS: TestCheckSumConcurrency (0.00s)
--- PASS: TestCheckSumDownloadConcurrency (0.00s)
ok  	github.com/rclone/rclone/fs/operations	0.999s
```

Also run:

- `go test -race ./fs/operations/` — `ok ... 40.235s`, no races.
- `go test -race -count=10 ./fs/operations/ -run TestCheckSum` — ok, not flaky.
- `RCLONE_CONFIG=/notfound go test ./cmd/... ./fs/...` — pass, apart from
  `cmd/gitannex` and `cmd/nfsmount`, which fail identically on a clean checkout
  of master here (missing `git-annex` / mount support in my environment).
- `go build ./...`, `gofmt -l`, `golangci-lint run ./fs/operations/...` — clean.

#### Not changed

- No flag, no doc and no command change: `--checkers` already documents this
  behaviour, the commands just weren't honouring it here.
- `CheckFn`/`Check` (the two-Fs path) already parallelises correctly and is
  untouched.

#### Linked issue

Fixes #9727

The issue asks for exactly this (parallelise the non-download path, bounded by
`--checkers`) but hasn't been commented on yet — happy to rework or drop it if
you'd rather it were done differently.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
