### PR TITLE
Fix doubled words in docs

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -2260,7 +2260,7 @@ Most multi-thread transfers do not take additional memory, but some do
 at maximum `--transfers` \* `--multi-thread-chunk-size` \*
 `--multi-thread-streams` or specifically for the s3 backend
 `--transfers` \* `--s3-chunk-size` \* `--s3-concurrency`. However you
-can use the the [--max-buffer-memory](/docs/#max-buffer-memory) flag
+can use the [--max-buffer-memory](/docs/#max-buffer-memory) flag
 to control the maximum memory used here.
 
 **NB** that this **only** works with supported backends as the

--- a/docs/content/http.md
+++ b/docs/content/http.md
@@ -24,7 +24,7 @@ path is resolved from the root of the domain.
 
 If the path following the `remote:` ends with `/` it will be assumed to point
 to a directory. If the path does not end with `/`, then a HEAD request is sent
-and the response used to decide if it it is treated as a file or a directory
+and the response used to decide if it is treated as a file or a directory
 (run with `-vv` to see details). When [--http-no-head](#http-no-head) is
 specified, a path without ending `/` is always assumed to be a file. If rclone
 incorrectly assumes the path is a file, the solution is to specify the path with

--- a/vfs/vfs.md
+++ b/vfs/vfs.md
@@ -61,7 +61,7 @@ at all times. The buffered data is bound to one open file and won't be
 shared.
 
 This flag is a upper limit for the used memory per open file.  The
-buffer will only use memory for data that is downloaded but not not
+buffer will only use memory for data that is downloaded but not
 yet read. If the buffer is empty, only a small amount of memory will
 be used.
 


### PR DESCRIPTION
A few small doubled-word fixes in the docs:

- `docs/content/docs.md`: "use the the [--max-buffer-memory] flag" -> "use the [--max-buffer-memory] flag"
- `docs/content/http.md`: "decide if it it is treated as a file" -> "decide if it is treated as a file"
- `vfs/vfs.md`: "downloaded but not not yet read" -> "downloaded but not yet read"

I edited `vfs/vfs.md` (the source); the same sentence in `MANUAL.md` and the generated `rclone serve` command pages is generated from it, so I left those untouched.
