### PR TITLE
progress: write progress output to stderr not stdout

### DIFF
--- a/cmd/progress.go
+++ b/cmd/progress.go
@@ -60,7 +60,7 @@ func startProgress() func() {
 					log.Handler.ResetOutput()
 				}
 				operations.SyncPrintf = oldSyncPrint
-				fmt.Fprintln(config.PasswordPromptOutput, "")
+				_, _ = fmt.Fprintln(config.PasswordPromptOutput, "")
 				return
 			}
 		}

--- a/cmd/progress.go
+++ b/cmd/progress.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/rclone/rclone/fs/accounting"
+	"github.com/rclone/rclone/fs/config"
 	"github.com/rclone/rclone/fs/log"
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/lib/terminal"
@@ -59,7 +60,7 @@ func startProgress() func() {
 					log.Handler.ResetOutput()
 				}
 				operations.SyncPrintf = oldSyncPrint
-				fmt.Println("")
+				fmt.Fprintln(config.PasswordPromptOutput, "")
 				return
 			}
 		}
@@ -115,5 +116,5 @@ func printProgress(logMessage string) {
 			out("\n")
 		}
 	}
-	terminal.Write(buf.Bytes())
+	_, _ = config.PasswordPromptOutput.Write(buf.Bytes())
 }

--- a/cmd/progress_test.go
+++ b/cmd/progress_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs/config"
+)
+
+// TestPrintProgressOutputTarget verifies that progress output written by
+// printProgress goes to config.PasswordPromptOutput (the terminal attached
+// to stderr, preserved even when --log-file redirects stderr) and NOT to
+// stdout, so data written to stdout by commands like "cat" is never
+// intermixed with the progress display.
+func TestPrintProgressOutputTarget(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	defer func() {
+		_ = r.Close()
+		_ = w.Close()
+	}()
+
+	old := config.PasswordPromptOutput
+	config.PasswordPromptOutput = w
+	defer func() { config.PasswordPromptOutput = old }()
+
+	readDone := make(chan int, 1)
+	go func() {
+		buf := make([]byte, 4096)
+		n, _ := r.Read(buf)
+		readDone <- n
+	}()
+
+	printProgress("some log message")
+
+	select {
+	case n := <-readDone:
+		if n == 0 {
+			t.Errorf("printProgress wrote no output to PasswordPromptOutput")
+		}
+	case <-time.After(2 * time.Second):
+		t.Errorf("printProgress wrote nothing to PasswordPromptOutput (still writing progress to stdout?)")
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fixes progress output being mixed into the command's data stream on stdout.

The `--progress` option renders a dynamic progress bar in the terminal (via `terminal.Write`, which writes to stdout). For commands that write data to stdout — like `cat`, `ls`, `checksum` — this interleaved the progress bar (with its terminal escape codes) into the actual output, corrupting the stream. E.g. `rclone --progress cat file | tool` would feed the progress text into `tool`.

Progress output now goes to `config.PasswordPromptOutput`: the dup'ed terminal attached to stderr, preserved even when `--log-file` redirects stderr (see `fs/log/redirect_stderr_unix.go`). This keeps the progress display on the terminal while leaving stdout clean for piping, consistent with the convention noted in #3743 (progress/status info belongs on stderr).

### Repro before

```sh
$ rclone --progress cat small.txt > out.txt; wc -c out.txt
168     # expected 5 (file is 5 bytes)
$ rclone --progress cat big.bin | md5sum
# hash differs; progress text leaked into pipeline
```

### After

```sh
$ rclone --progress cat big.bin | md5sum
b477217a4e80d5d32f523ac5f402f318  -   # matches source file exactly
```

### Tests

- Added `cmd/progress_test.go` (TDD RED→GREEN): asserts `printProgress` writes to `config.PasswordPromptOutput` and not to stdout.
- `go test ./cmd/`, `./fs/accounting/`, `./fs/log/` all pass.
- Verified `GOOS=windows` build still compiles.

Fixes #3743