### PR TITLE
webdav: validate ranged download responses

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -1546,6 +1546,18 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	}
 	err = o.fs.pacer.Call(func() (bool, error) {
 		resp, err = o.fs.srv.Call(ctx, &opts)
+		if err == nil {
+			err = rest.CheckContentRange(resp, options, o.size)
+			if err != nil {
+				if resp != nil && resp.Body != nil {
+					_ = resp.Body.Close()
+				}
+				if errors.Is(err, fs.ErrorRangeIgnored) {
+					return false, err
+				}
+				return true, fserrors.RetryError(err)
+			}
+		}
 		return o.fs.shouldRetry(ctx, resp, err)
 	})
 	if err != nil {

--- a/backend/webdav/webdav_internal_test.go
+++ b/backend/webdav/webdav_internal_test.go
@@ -3,9 +3,11 @@ package webdav_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	"github.com/rclone/rclone/backend/webdav"
@@ -150,4 +152,91 @@ func TestReservedCharactersInPathAreEscaped(t *testing.T) {
 	// The semicolon must be percent-encoded as %3B
 	assert.Contains(t, capturedPath, "my%3Btest", "semicolons in path should be percent-encoded")
 	assert.NotContains(t, capturedPath, "my;test", "raw semicolons should not appear in path")
+}
+
+const fileInfoResponse = `<d:multistatus xmlns:d="DAV:">
+<d:response>
+ <d:href>/file.txt</d:href>
+ <d:propstat>
+  <d:prop>
+   <d:getcontentlength>10</d:getcontentlength>
+   <d:resourcetype/>
+  </d:prop>
+  <d:status>HTTP/1.1 200 OK</d:status>
+ </d:propstat>
+</d:response>
+</d:multistatus>`
+
+func prepareFileObject(ctx context.Context, t *testing.T, getHandler http.HandlerFunc) (fs.Object, func()) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == "PROPFIND" {
+			w.WriteHeader(http.StatusMultiStatus)
+			_, err := fmt.Fprint(w, fileInfoResponse)
+			require.NoError(t, err)
+			return
+		}
+		if r.Method == http.MethodGet {
+			getHandler(w, r)
+			return
+		}
+		http.Error(w, "unexpected method", http.StatusMethodNotAllowed)
+	})
+	ts := httptest.NewServer(handler)
+
+	configfile.Install()
+	f, err := webdav.NewFs(ctx, remoteName, "", configmap.Simple{
+		"type": "webdav",
+		"url":  ts.URL,
+	})
+	require.NoError(t, err)
+	o, err := f.NewObject(ctx, "file.txt")
+	require.NoError(t, err)
+	return o, ts.Close
+}
+
+func TestOpenDoesNotRetryIgnoredRange(t *testing.T) {
+	var getRequests atomic.Int32
+	o, tidy := prepareFileObject(context.Background(), t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "bytes=2-4", r.Header.Get("Range"))
+		getRequests.Add(1)
+		w.Header().Set("Content-Length", "10")
+		w.WriteHeader(http.StatusOK)
+		_, err := io.WriteString(w, "abcdefghij")
+		require.NoError(t, err)
+	})
+	defer tidy()
+
+	in, err := o.Open(context.Background(), &fs.RangeOption{Start: 2, End: 4})
+	assert.Nil(t, in)
+	assert.ErrorIs(t, err, fs.ErrorRangeIgnored)
+	assert.Equal(t, int32(1), getRequests.Load())
+}
+
+func TestOpenRetriesMismatchedContentRange(t *testing.T) {
+	var getRequests atomic.Int32
+	o, tidy := prepareFileObject(context.Background(), t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "bytes=2-4", r.Header.Get("Range"))
+		if getRequests.Add(1) == 1 {
+			w.Header().Set("Content-Length", "3")
+			w.Header().Set("Content-Range", "bytes 0-2/10")
+			w.WriteHeader(http.StatusPartialContent)
+			_, err := io.WriteString(w, "abc")
+			require.NoError(t, err)
+			return
+		}
+		w.Header().Set("Content-Length", "3")
+		w.Header().Set("Content-Range", "bytes 2-4/10")
+		w.WriteHeader(http.StatusPartialContent)
+		_, err := io.WriteString(w, "cde")
+		require.NoError(t, err)
+	})
+	defer tidy()
+
+	in, err := o.Open(context.Background(), &fs.RangeOption{Start: 2, End: 4})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, in.Close()) }()
+	contents, err := io.ReadAll(in)
+	require.NoError(t, err)
+	assert.Equal(t, "cde", string(contents))
+	assert.Equal(t, int32(2), getRequests.Load())
 }

--- a/backend/webdav/webdav_internal_test.go
+++ b/backend/webdav/webdav_internal_test.go
@@ -10,11 +10,13 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/rclone/rclone/backend/local"
 	"github.com/rclone/rclone/backend/webdav"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/configfile"
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/obscure"
+	"github.com/rclone/rclone/fs/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -239,4 +241,46 @@ func TestOpenRetriesMismatchedContentRange(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "cde", string(contents))
 	assert.Equal(t, int32(2), getRequests.Load())
+}
+
+func TestCopyFallsBackWhenRangeIgnored(t *testing.T) {
+	var rangeRequests atomic.Int32
+	var fullRequests atomic.Int32
+	ctx, ci := fs.AddConfig(context.Background())
+	ci.LowLevelRetries = 2
+	ci.MultiThreadStreams = 2
+	ci.MultiThreadSet = true
+	ci.MultiThreadCutoff = 1
+	ci.MultiThreadChunkSize = 4
+
+	src, tidy := prepareFileObject(ctx, t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Range") == "" {
+			fullRequests.Add(1)
+		} else {
+			rangeRequests.Add(1)
+		}
+		w.Header().Set("Content-Length", "10")
+		w.WriteHeader(http.StatusOK)
+		_, err := io.WriteString(w, "abcdefghij")
+		require.NoError(t, err)
+	})
+	defer tidy()
+
+	dstFs, err := local.NewFs(ctx, "local", t.TempDir(), configmap.Simple{
+		"no_preallocate": "true",
+		"no_sparse":      "true",
+	})
+	require.NoError(t, err)
+	dst, err := operations.Copy(ctx, dstFs, nil, "file.txt", src)
+	require.NoError(t, err)
+
+	in, err := dst.Open(ctx)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, in.Close()) }()
+	contents, err := io.ReadAll(in)
+	require.NoError(t, err)
+	assert.Equal(t, "abcdefghij", string(contents))
+	assert.Positive(t, rangeRequests.Load())
+	assert.LessOrEqual(t, rangeRequests.Load(), int32(3))
+	assert.Equal(t, int32(1), fullRequests.Load())
 }

--- a/fs/fs.go
+++ b/fs/fs.go
@@ -53,6 +53,7 @@ var (
 	ErrorFileNameTooLong             = errors.New("file name too long")
 	ErrorCantListRoot                = errors.New("can't list root")
 	ErrorFileTooSmall                = errors.New("file too small for multipart upload")
+	ErrorRangeIgnored                = errors.New("server ignored requested range")
 )
 
 // FileTooSmallError is returned by OpenChunkWriter when a file is below the

--- a/fs/operations/copy.go
+++ b/fs/operations/copy.go
@@ -266,7 +266,12 @@ func (c *copy) manualCopy(ctx context.Context) (actionTaken string, newDst fs.Ob
 	}
 
 	if doMultiThreadCopy(ctx, c.f, c.src) {
-		return c.multiThreadCopy(ctx, uploadOptions)
+		actionTaken, newDst, err = c.multiThreadCopy(ctx, uploadOptions)
+		if !errors.Is(err, fs.ErrorRangeIgnored) {
+			return actionTaken, newDst, err
+		}
+		fs.Logf(c.src, "multi-thread copy: %v: downloading in a single stream", err)
+		c.tr.Reset(ctx)
 	}
 
 	var in io.ReadCloser

--- a/lib/rest/headers.go
+++ b/lib/rest/headers.go
@@ -1,10 +1,160 @@
 package rest
 
 import (
+	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/rclone/rclone/fs"
 )
+
+type contentRange struct {
+	start int64
+	end   int64
+	size  int64
+}
+
+func parseContentRange(value string) (contentRange, error) {
+	const prefix = "bytes "
+	if !strings.HasPrefix(value, prefix) {
+		return contentRange{}, fmt.Errorf("doesn't start with %q", prefix)
+	}
+
+	rangeAndSize := strings.Split(value[len(prefix):], "/")
+	if len(rangeAndSize) != 2 {
+		return contentRange{}, errors.New("must contain one '/'")
+	}
+	bounds := strings.Split(rangeAndSize[0], "-")
+	if len(bounds) != 2 {
+		return contentRange{}, errors.New("must contain one '-'")
+	}
+
+	start, err := strconv.ParseInt(bounds[0], 10, 64)
+	if err != nil || start < 0 {
+		return contentRange{}, errors.New("invalid start")
+	}
+	end, err := strconv.ParseInt(bounds[1], 10, 64)
+	if err != nil || end < start {
+		return contentRange{}, errors.New("invalid end")
+	}
+
+	size := int64(-1)
+	if rangeAndSize[1] != "*" {
+		size, err = strconv.ParseInt(rangeAndSize[1], 10, 64)
+		if err != nil || size < 0 || end >= size {
+			return contentRange{}, errors.New("invalid complete length")
+		}
+	}
+
+	return contentRange{start: start, end: end, size: size}, nil
+}
+
+// CheckContentRange checks that a response satisfies a Range open option.
+// The size is the expected size of the complete representation, or -1 if it is
+// unknown. Calls without a Range option are ignored.
+func CheckContentRange(resp *http.Response, options []fs.OpenOption, size int64) error {
+	var requestRange string
+	for _, option := range options {
+		key, value := option.Header()
+		if strings.EqualFold(key, "Range") {
+			requestRange = value
+		}
+	}
+	if requestRange == "" {
+		return nil
+	}
+
+	requested, err := fs.ParseRangeOption(requestRange)
+	if err != nil {
+		return fmt.Errorf("invalid requested range %q: %w", requestRange, err)
+	}
+	if requested.Start < 0 && requested.End < 0 {
+		return fmt.Errorf("invalid requested range %q", requestRange)
+	}
+	if requested.Start >= 0 && requested.End >= 0 && requested.End < requested.Start {
+		return fmt.Errorf("invalid requested range %q", requestRange)
+	}
+	if resp == nil {
+		return errors.New("nil response to range request")
+	}
+
+	if resp.StatusCode == http.StatusOK {
+		responseSize := size
+		if resp.ContentLength >= 0 {
+			if size >= 0 && resp.ContentLength != size {
+				return fmt.Errorf("Content-Length %d does not match expected size %d", resp.ContentLength, size)
+			}
+			responseSize = resp.ContentLength
+		}
+		if responseSize >= 0 {
+			offset, limit := requested.Decode(responseSize)
+			if limit < 0 {
+				limit = responseSize - offset
+			}
+			if offset == 0 && limit >= responseSize {
+				return nil
+			}
+		} else if requested.Start == 0 && requested.End < 0 {
+			return nil
+		}
+		return fmt.Errorf("%w %q", fs.ErrorRangeIgnored, requestRange)
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("response status %d does not satisfy requested range %q", resp.StatusCode, requestRange)
+	}
+
+	responseRange := resp.Header.Get("Content-Range")
+	got, err := parseContentRange(responseRange)
+	if err != nil {
+		return fmt.Errorf("invalid Content-Range %q: %w", responseRange, err)
+	}
+
+	if size >= 0 && got.size >= 0 && got.size != size {
+		return fmt.Errorf("Content-Range %q does not match expected size %d", responseRange, size)
+	}
+
+	rangeSize := size
+	if rangeSize < 0 {
+		rangeSize = got.size
+	}
+	expectedStart := requested.Start
+	expectedEnd := requested.End
+	if requested.Start >= 0 {
+		if rangeSize >= 0 && (expectedEnd < 0 || expectedEnd >= rangeSize) {
+			expectedEnd = rangeSize - 1
+		}
+	} else if rangeSize >= 0 {
+		expectedStart = rangeSize - requested.End
+		if expectedStart < 0 {
+			expectedStart = 0
+		}
+		expectedEnd = rangeSize - 1
+	}
+
+	var matches bool
+	if requested.Start < 0 && rangeSize < 0 {
+		matches = got.end-got.start+1 <= requested.End
+	} else {
+		matches = got.start == expectedStart
+		if expectedEnd >= 0 {
+			matches = matches && got.end == expectedEnd
+		}
+	}
+	if !matches {
+		return fmt.Errorf("Content-Range %q does not match requested range %q", responseRange, requestRange)
+	}
+
+	contentLength := got.end - got.start + 1
+	if contentLength <= 0 {
+		return fmt.Errorf("invalid Content-Range %q: length overflows", responseRange)
+	}
+	if resp.ContentLength >= 0 && resp.ContentLength != contentLength {
+		return fmt.Errorf("Content-Length %d does not match Content-Range %q", resp.ContentLength, responseRange)
+	}
+	return nil
+}
 
 // ParseSizeFromHeaders parses HTTP response headers to get the full file size.
 // Returns -1 if the headers did not exist or were invalid.

--- a/lib/rest/headers_test.go
+++ b/lib/rest/headers_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -37,5 +38,198 @@ func TestParseSizeFromHeaders(t *testing.T) {
 			headers.Set("Content-Range", testCase.ContentRange)
 		}
 		assert.Equalf(t, testCase.Size, ParseSizeFromHeaders(headers), "%+v", testCase)
+	}
+}
+
+func TestCheckContentRange(t *testing.T) {
+	testCases := []struct {
+		name          string
+		status        int
+		contentRange  string
+		contentLength int64
+		unknownSize   bool
+		options       []fs.OpenOption
+		wantErr       bool
+		wantErrorIs   error
+	}{
+		{
+			name:          "exact range",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-4/10",
+			contentLength: 3,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+		},
+		{
+			name:          "unknown content length",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-4/10",
+			contentLength: -1,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+		},
+		{
+			name:          "unknown complete length",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-4/*",
+			contentLength: 3,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+		},
+		{
+			name:          "open ended range",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-9/10",
+			contentLength: 8,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: -1}},
+		},
+		{
+			name:          "suffix range",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 6-9/10",
+			contentLength: 4,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: -1, End: 4}},
+		},
+		{
+			name:          "suffix range with unknown complete length",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 6-9/*",
+			contentLength: 4,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: -1, End: 4}},
+		},
+		{
+			name:          "suffix range larger than representation",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 0-9/10",
+			contentLength: 10,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: -1, End: 20}},
+		},
+		{
+			name:          "seek option",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-9/10",
+			contentLength: 8,
+			options:       []fs.OpenOption{&fs.SeekOption{Offset: 2}},
+		},
+		{
+			name:          "whole representation range",
+			status:        http.StatusOK,
+			contentLength: 10,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 0, End: 9}},
+		},
+		{
+			name:          "open ended whole representation range with unknown size",
+			status:        http.StatusOK,
+			contentLength: -1,
+			unknownSize:   true,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 0, End: -1}},
+		},
+		{
+			name:          "partial range ignored",
+			status:        http.StatusOK,
+			contentLength: 10,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+			wantErr:       true,
+			wantErrorIs:   fs.ErrorRangeIgnored,
+		},
+		{
+			name:          "whole range response has wrong length",
+			status:        http.StatusOK,
+			contentLength: 9,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 0, End: 9}},
+			wantErr:       true,
+		},
+		{
+			name:          "no range requested",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-4/10",
+			contentLength: 3,
+		},
+		{
+			name:          "missing content range",
+			status:        http.StatusPartialContent,
+			contentLength: 3,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+			wantErr:       true,
+		},
+		{
+			name:          "wrong unit",
+			status:        http.StatusPartialContent,
+			contentRange:  "items 2-4/10",
+			contentLength: 3,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+			wantErr:       true,
+		},
+		{
+			name:          "wrong start",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 0-2/10",
+			contentLength: 3,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+			wantErr:       true,
+		},
+		{
+			name:          "wrong end",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-5/10",
+			contentLength: 4,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+			wantErr:       true,
+		},
+		{
+			name:          "wrong content length",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-4/10",
+			contentLength: 4,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+			wantErr:       true,
+		},
+		{
+			name:          "invalid complete length",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-10/10",
+			contentLength: 9,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 10}},
+			wantErr:       true,
+		},
+		{
+			name:          "wrong complete length",
+			status:        http.StatusPartialContent,
+			contentRange:  "bytes 2-4/11",
+			contentLength: 3,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+			wantErr:       true,
+		},
+		{
+			name:          "unexpected successful status",
+			status:        http.StatusNoContent,
+			contentLength: 0,
+			options:       []fs.OpenOption{&fs.RangeOption{Start: 2, End: 4}},
+			wantErr:       true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			expectedSize := int64(10)
+			if testCase.unknownSize {
+				expectedSize = -1
+			}
+			resp := &http.Response{
+				StatusCode:    testCase.status,
+				Header:        make(http.Header),
+				ContentLength: testCase.contentLength,
+			}
+			if testCase.contentRange != "" {
+				resp.Header.Set("Content-Range", testCase.contentRange)
+			}
+
+			err := CheckContentRange(resp, testCase.options, expectedSize)
+			if testCase.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			if testCase.wantErrorIs != nil {
+				assert.ErrorIs(t, err, testCase.wantErrorIs)
+			}
+		})
 	}
 }


### PR DESCRIPTION
#### What does this change do?

WebDAV range reads currently expose any successful response body without checking whether it contains the requested bytes. If a server or proxy ignores `Range` and returns the complete representation, a multi-threaded copy can put bytes from the start of the source into later destination chunks. Some chunk-writer paths truncate each response to the requested chunk size, so the final object can have the expected length while containing incorrect data.

This change:

- adds a reusable `lib/rest` validator for responses to rclone range options;
- verifies `206 Partial Content` boundaries, complete size, and known content length;
- rejects `200 OK` for partial ranges, while accepting it when the requested range covers the complete representation;
- returns a distinct error when a server ignores a range, without consuming WebDAV pacer retries;
- aborts the partial multi-thread destination and falls back to a single-stream copy for that file; and
- resets transfer accounting before the fallback so bytes are not counted twice.

Malformed or mismatched partial responses remain retryable. Only the deterministic "range ignored" case selects the single-stream fallback.

#### Linked issue

Fixes #6980

#### Tests

Passed with Go 1.26.5:

- `go test ./lib/rest ./fs/operations -count=1`
- all local `backend/webdav` unit tests (the four external-server integration tests were not run)
- targeted `-race` tests for response validation, retry behavior, and multi-thread-to-single-stream fallback
- `go vet ./lib/rest ./fs/operations ./backend/webdav`

The end-to-end regression test uses a WebDAV server that always ignores ranged GETs. It verifies that the multi-thread destination is aborted, the source is reopened without `Range`, and the final object contains the correct bytes.
