### PR TITLE
dropbox: fix ChangeNotify leaking absolute paths on root casing mismatch

### DIFF
--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -1672,6 +1672,24 @@ func (f *Fs) changeNotifyCursor(ctx context.Context) (cursor string, err error) 
 	return startCursor.Cursor, nil
 }
 
+// trimRootFromChangeNotifyPath removes the configured root from a
+// ChangeNotify entry's display path.
+//
+// PathDisplay's casing can - in rare instances - fail to match the root's
+// casing (see "The Case folding of PathDisplay problem" above), so the
+// root is matched against the always-lowercase PathLower instead, and the
+// same number of bytes trimmed off PathDisplay - the Dropbox docs say only
+// the casing differs between the two, so they stay the same length.
+func (f *Fs) trimRootFromChangeNotifyPath(pathLower, pathDisplay string) string {
+	if !strings.HasPrefix(pathLower, strings.ToLower(f.slashRootSlash)) {
+		return ""
+	}
+	if len(pathDisplay) < len(f.slashRootSlash) {
+		return ""
+	}
+	return pathDisplay[len(f.slashRootSlash):]
+}
+
 func (f *Fs) changeNotifyRunner(ctx context.Context, notifyFunc func(string, fs.EntryType), startCursor string) (newCursor string, err error) {
 	cursor := startCursor
 	var res *files.ListFolderLongpollResult
@@ -1731,13 +1749,13 @@ func (f *Fs) changeNotifyRunner(ctx context.Context, notifyFunc func(string, fs.
 			switch info := entry.(type) {
 			case *files.FolderMetadata:
 				entryType = fs.EntryDirectory
-				entryPath = strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)
+				entryPath = f.trimRootFromChangeNotifyPath(info.PathLower, info.PathDisplay)
 			case *files.FileMetadata:
 				entryType = fs.EntryObject
-				entryPath = strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)
+				entryPath = f.trimRootFromChangeNotifyPath(info.PathLower, info.PathDisplay)
 			case *files.DeletedMetadata:
 				entryType = fs.EntryObject
-				entryPath = strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)
+				entryPath = f.trimRootFromChangeNotifyPath(info.PathLower, info.PathDisplay)
 			default:
 				fs.Errorf(entry, "dropbox ChangeNotify: ignoring unknown EntryType %T", entry)
 				continue

--- a/backend/dropbox/dropbox_internal_test.go
+++ b/backend/dropbox/dropbox_internal_test.go
@@ -119,6 +119,40 @@ func TestInternalCheckPathLength(t *testing.T) {
 	}
 }
 
+func TestInternalTrimRootFromChangeNotifyPath(t *testing.T) {
+	f := &Fs{}
+	f.setRoot("MyRoot")
+
+	for _, test := range []struct {
+		name        string
+		pathLower   string
+		pathDisplay string
+		want        string
+	}{
+		{
+			name:        "matching case",
+			pathLower:   "/myroot/sub/file.txt",
+			pathDisplay: "/MyRoot/sub/file.txt",
+			want:        "sub/file.txt",
+		},
+		{
+			name:        "root casing differs from PathDisplay",
+			pathLower:   "/myroot/sub/file.txt",
+			pathDisplay: "/myRoot/sub/file.txt", // note lowercase "r" - differs from configured "MyRoot"
+			want:        "sub/file.txt",
+		},
+		{
+			name:        "not under root",
+			pathLower:   "/otherroot/sub/file.txt",
+			pathDisplay: "/OtherRoot/sub/file.txt",
+			want:        "",
+		},
+	} {
+		got := f.trimRootFromChangeNotifyPath(test.pathLower, test.pathDisplay)
+		assert.Equal(t, test.want, got, test.name)
+	}
+}
+
 func TestPaperExportRemote(t *testing.T) {
 	ctx := context.Background()
 	info := &files.FileMetadata{


### PR DESCRIPTION
### What's the problem this fixes?

`changeNotifyRunner` in `backend/dropbox/dropbox.go` strips the configured
root from Dropbox's `PathDisplay` with a case-sensitive
`strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)`
(https://github.com/rclone/rclone/blob/master/backend/dropbox/dropbox.go#L1734-L1740).

`f.slashRootSlash` is set directly from the root the user typed
(`setRoot`, https://github.com/rclone/rclone/blob/master/backend/dropbox/dropbox.go#L720-L728)
and is never lowercased, even though the field's own comment claims it is.

Dropbox's SDK documents `PathDisplay` as display-only, noting that "in rare
instances the casing will not correctly match the user's filesystem" - this
is also called out in rclone's own "Case folding of PathDisplay problem"
comment at the top of the file. When that happens, `TrimPrefix` silently
fails to strip the root (because the casing no longer matches byte-for-byte),
and the *full, untrimmed* Dropbox path gets passed straight to `notifyFunc`
as if it were already relative to the root. The consumer (e.g. VFS
`ChangeNotify` handling) then invalidates the wrong path, and the actually
changed file is left stale until the next `--dir-cache-time` refresh.

This reproduces with a poll-capable mount/serve (`--poll-interval`), a
non-root configured path, and a change reported by Dropbox with different
casing than the configured root.

### The fix

Added `trimRootFromChangeNotifyPath`, which matches the root against
`PathLower` (the field Dropbox's API always returns fully lowercased)
instead of `PathDisplay`, and trims the same number of bytes off
`PathDisplay`. Per the Dropbox docs, only casing differs between
`PathLower` and `PathDisplay`, so the two stay the same length - this
mirrors the existing assumption the file already documents for `List` (see
"Only the last element is reliably cased in PathDisplay").

### Testing

- Added `TestInternalTrimRootFromChangeNotifyPath`, covering: matching
  case, a root-casing mismatch (the bug case), and a path outside the
  configured root.
- `go build ./backend/dropbox/...` and `go vet ./backend/dropbox/...` pass.
- `go test ./backend/dropbox/...` passes (including the new test).
- `golangci-lint run ./backend/dropbox/...` reports no new issues (the 4
  pre-existing `goimports` findings are in files this change doesn't touch).

Fixes #9692