### PR TITLE
vfs: make writeback uploads carry the item's modtime

### DIFF
--- a/vfs/read_write_test.go
+++ b/vfs/read_write_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -758,4 +759,227 @@ func TestRWCacheUpdate(t *testing.T) {
 		assert.Equal(t, int64(len(contents)), fi.Size())
 		fstest.AssertTimeEqualWithPrecision(t, filename, modTime, fi.ModTime(), r.Fremote.Precision())
 	}
+}
+
+// recordingFs wraps an fs.Fs and records the modtime of every source
+// passed to Put. This lets tests see exactly what modtime the upload
+// carries to the server, instead of the final state after the remote's
+// SetModTime fallback has had a chance to correct it (which masks the
+// issue - see #9637 where Nextcloud cannot fall back at all).
+type recordingFs struct {
+	fs.Fs
+	mu   sync.Mutex
+	puts []time.Time
+}
+
+func (f *recordingFs) record(mt time.Time) {
+	f.mu.Lock()
+	f.puts = append(f.puts, mt)
+	f.mu.Unlock()
+}
+
+func (f *recordingFs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	f.record(src.ModTime(ctx))
+	return f.Fs.Put(ctx, in, src, options...)
+}
+
+func (f *recordingFs) putTimes() []time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]time.Time(nil), f.puts...)
+}
+
+// Features strips the server-side copy and move features so uploads go
+// through Put, which is where the modtime is recorded. Server-side
+// copies bypass Put entirely.
+func (f *recordingFs) Features() *fs.Features {
+	features := *f.Fs.Features()
+	cp, mv := features.Copy, features.Move
+	features.Copy = func(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
+		f.record(src.ModTime(ctx))
+		return cp(ctx, src, remote)
+	}
+	features.Move = func(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
+		f.record(src.ModTime(ctx))
+		return mv(ctx, src, remote)
+	}
+	return &features
+}
+
+// newRecordingVFS creates a VFS backed by a recordingFs so tests can
+// observe the modtime each upload carries to the remote.
+func newRecordingVFS(t *testing.T, opt *vfscommon.Options) (r *fstest.Run, vfs *VFS, rec *recordingFs) {
+	r = fstest.NewRun(t)
+	rec = &recordingFs{Fs: r.Fremote}
+	vfs = New(context.Background(), rec, opt)
+	t.Cleanup(func() {
+		cleanupVFS(t, vfs)
+	})
+	return r, vfs, rec
+}
+
+// Test that the modtime set by a writer (e.g. an editor calling
+// utimens) is the one which reaches the remote, not the old modtime
+// of the file - see issue #9637
+func TestRWFileHandleModTimeAfterRewrite(t *testing.T) {
+	r, vfs, rec := newRecordingVFS(t, &vfscommon.Options{
+		CacheMode: vfscommon.CacheModeFull,
+		WriteBack: writeBackDelay,
+	})
+	ctx := context.Background()
+
+	// Create the file with some content and let it settle on the remote
+	fh, err := vfs.OpenFile("file1", os.O_WRONLY|os.O_CREATE, 0777)
+	require.NoError(t, err)
+	_, err = fh.Write([]byte("old content"))
+	require.NoError(t, err)
+	require.NoError(t, fh.Close())
+	vfs.WaitForWriters(waitForWritersDelay)
+
+	// Give the remote object an old modtime, like a file which has
+	// been on the remote for a while
+	oldTime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	obj, err := r.Fremote.NewObject(ctx, "file1")
+	require.NoError(t, err)
+	require.NoError(t, obj.SetModTime(ctx, oldTime))
+
+	// Reopen the file for read-write like an editor would, write new
+	// content and set a fresh modtime (as the kernel does for utimens)
+	h, err := vfs.OpenFile("file1", os.O_RDWR, 0777)
+	require.NoError(t, err)
+	rw, ok := h.(*RWFileHandle)
+	require.True(t, ok)
+
+	_, err = rw.Write([]byte("new content"))
+	require.NoError(t, err)
+
+	newTime := time.Now().Truncate(time.Second)
+	require.NoError(t, rw.file.SetModTime(newTime))
+
+	require.NoError(t, rw.Close())
+	vfs.WaitForWriters(waitForWritersDelay)
+
+	// The upload which carried the new content must have carried the
+	// new modtime as well
+	puts := rec.putTimes()
+	require.NotEmpty(t, puts)
+	got := puts[len(puts)-1]
+	assert.False(t, got.Equal(oldTime), "upload carried modtime %v instead of the new time %v", got, newTime)
+	assert.WithinDuration(t, newTime, got, time.Second)
+}
+
+// TestRWFileHandleModTimeAfterRewriteReopen reproduces the LibreOffice
+// save flow from issue #9637: write the file, close it (which queues the
+// writeback), then reopen it without writing and close again while the
+// upload is still pending. The second close must not clobber the cache
+// file modtime with the old remote modtime, otherwise the pending upload
+// pushes the stale time to the server.
+func TestRWFileHandleModTimeAfterRewriteReopen(t *testing.T) {
+	r, vfs, _ := newRecordingVFS(t, &vfscommon.Options{
+		CacheMode: vfscommon.CacheModeFull,
+		WriteBack: fs.Duration(5 * time.Second),
+	})
+	ctx := context.Background()
+
+	// 1. Create the file, let the first upload settle on the remote
+	fh, err := vfs.OpenFile("file1", os.O_WRONLY|os.O_CREATE, 0777)
+	require.NoError(t, err)
+	_, err = fh.Write([]byte("old content"))
+	require.NoError(t, err)
+	require.NoError(t, fh.Close())
+	vfs.WaitForWriters(waitForWritersDelay)
+
+	// 2. Give the remote object an old modtime, like a file which has
+	// been on the remote for a while
+	oldTime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	obj, err := r.Fremote.NewObject(ctx, "file1")
+	require.NoError(t, err)
+	require.NoError(t, obj.SetModTime(ctx, oldTime))
+
+	// 3. Rewrite the file: write new content, set a fresh modtime (as
+	// the kernel does for utimens) and close. This queues the writeback
+	// which fires in 5s.
+	h, err := vfs.OpenFile("file1", os.O_RDWR, 0777)
+	require.NoError(t, err)
+	rw, ok := h.(*RWFileHandle)
+	require.True(t, ok)
+	_, err = rw.Write([]byte("new content"))
+	require.NoError(t, err)
+	newTime := time.Now().Truncate(time.Second)
+	require.NoError(t, rw.file.SetModTime(newTime))
+	require.NoError(t, rw.Close())
+
+	// 4. Reopen without writing and close again (LibreOffice reopens the
+	// file to verify it after saving). This must not clobber the pending
+	// upload's modtime.
+	h2, err := vfs.OpenFile("file1", os.O_RDWR, 0777)
+	require.NoError(t, err)
+	rw2, ok := h2.(*RWFileHandle)
+	require.True(t, ok)
+	require.NoError(t, rw2.Close())
+	vfs.WaitForWriters(waitForWritersDelay)
+
+	// 5. The upload which carried the new content to the remote must
+	// have carried the new modtime as well - the remote must not be
+	// left with the old modtime (issue #9637).
+	obj, err = r.Fremote.NewObject(ctx, "file1")
+	require.NoError(t, err)
+	got := obj.ModTime(ctx)
+	assert.False(t, got.Equal(oldTime), "remote modtime is %v instead of the new time %v", got, newTime)
+	assert.WithinDuration(t, newTime, got, time.Second)
+}
+
+// Same as above but with a rename in between, like LibreOffice's
+// safe-save: write the new content into a temp file, then rename it over
+// the target while the writeback is still queued.
+func TestRWFileHandleModTimeAfterRewriteRename(t *testing.T) {
+	r, vfs, _ := newRecordingVFS(t, &vfscommon.Options{
+		CacheMode: vfscommon.CacheModeFull,
+		WriteBack: fs.Duration(5 * time.Second),
+	})
+	ctx := context.Background()
+
+	// 1. Target file on the remote with an old modtime
+	fh, err := vfs.OpenFile("file1", os.O_WRONLY|os.O_CREATE, 0777)
+	require.NoError(t, err)
+	_, err = fh.Write([]byte("old content"))
+	require.NoError(t, err)
+	require.NoError(t, fh.Close())
+	vfs.WaitForWriters(waitForWritersDelay)
+	oldTime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	obj, err := r.Fremote.NewObject(ctx, "file1")
+	require.NoError(t, err)
+	require.NoError(t, obj.SetModTime(ctx, oldTime))
+
+	// 2. Write the new content into a temp file, set a fresh modtime
+	// and close (queues the writeback in 5s)
+	h, err := vfs.OpenFile("file1.tmp", os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0777)
+	require.NoError(t, err)
+	rw, ok := h.(*RWFileHandle)
+	require.True(t, ok)
+	_, err = rw.Write([]byte("new content"))
+	require.NoError(t, err)
+	newTime := time.Now().Truncate(time.Second)
+	require.NoError(t, rw.file.SetModTime(newTime))
+	require.NoError(t, rw.Close())
+
+	// 3. Rename the temp file over the target (safe save)
+	require.NoError(t, vfs.Rename("file1.tmp", "file1"))
+
+	// 4. Reopen the renamed file without writing and close again
+	h2, err := vfs.OpenFile("file1", os.O_RDWR, 0777)
+	require.NoError(t, err)
+	rw2, ok := h2.(*RWFileHandle)
+	require.True(t, ok)
+	require.NoError(t, rw2.Close())
+	vfs.WaitForWriters(waitForWritersDelay)
+
+	// 5. The upload which carried the renamed file to the remote must
+	// have carried the new modtime as well - the remote must not be
+	// left with the old modtime (issue #9637).
+	obj, err = r.Fremote.NewObject(ctx, "file1")
+	require.NoError(t, err)
+	got := obj.ModTime(ctx)
+	assert.False(t, got.Equal(oldTime), "remote modtime is %v instead of the new time %v", got, newTime)
+	assert.WithinDuration(t, newTime, got, time.Second)
 }

--- a/vfs/vfscache/item.go
+++ b/vfs/vfscache/item.go
@@ -643,6 +643,14 @@ func (item *Item) _store(ctx context.Context, storeFn StoreFn) (err error) {
 
 	// Object has disappeared if cacheObj == nil
 	if cacheObj != nil {
+		// Make sure the upload carries the item's modtime, not
+		// whatever modtime the cache file happens to have on disk.
+		// A reopen/close since the last write can reset the cache
+		// file's modtime to the remote object's modtime (see
+		// _actualClose), and the upload would then send that stale
+		// time to the server - e.g. Nextcloud can't fix it up
+		// afterwards as SetModTime is not supported.
+		item._setModTime(item.info.ModTime)
 		o, name := item.o, item.name
 		unlockMutexForCall(&item.mu, func() {
 			o, err = operations.Copy(ctx, item.c.fremote, o, name, cacheObj)

--- a/vfs/vfscache/item_test.go
+++ b/vfs/vfscache/item_test.go
@@ -823,3 +823,107 @@ func TestItemHandleCachingReopenDuringGraceClose(t *testing.T) {
 	}
 	item.mu.Unlock()
 }
+
+// recordingFs wraps an fs.Fs and records the modtime of every source
+// passed to Put, Copy or Move, so tests can see what modtime an upload
+// carries to the server.
+type recordingFs struct {
+	fs.Fs
+	mu   sync.Mutex
+	puts []time.Time
+}
+
+func (f *recordingFs) record(mt time.Time) {
+	f.mu.Lock()
+	f.puts = append(f.puts, mt)
+	f.mu.Unlock()
+}
+
+func (f *recordingFs) Put(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (fs.Object, error) {
+	f.record(src.ModTime(ctx))
+	return f.Fs.Put(ctx, in, src, options...)
+}
+
+func (f *recordingFs) putTimes() []time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]time.Time(nil), f.puts...)
+}
+
+// Features wraps the server-side copy and move features so the modtime
+// the upload is about to carry gets recorded. The vfs cache uploads via
+// operations.Copy which takes the server-side copy path for same-config
+// remotes (local test remotes are both local), so recording in Put or
+// Update would miss the upload entirely.
+func (f *recordingFs) Features() *fs.Features {
+	features := *f.Fs.Features()
+	cp, mv := features.Copy, features.Move
+	features.Copy = func(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
+		f.record(src.ModTime(ctx))
+		return cp(ctx, src, remote)
+	}
+	features.Move = func(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
+		f.record(src.ModTime(ctx))
+		return mv(ctx, src, remote)
+	}
+	return &features
+}
+
+// TestItemStoreModTime checks that an upload carries the item's logical
+// modtime (info.ModTime), not whatever modtime the cache file happens
+// to have on disk at upload time. Issue #9637: reopening and closing a
+// file after its writeback has been queued can reset the cache file's
+// modtime to the old remote modtime (_actualClose sets it from
+// item.o.ModTime for non-dirty items), and the pending upload then
+// sends that stale time to the server. Nextcloud in particular cannot
+// fix this up afterwards - its SetModTime returns ErrorCantSetModTime -
+// so the upload itself must carry the right time.
+func TestItemStoreModTime(t *testing.T) {
+	r := fstest.NewRun(t)
+	rec := &recordingFs{Fs: r.Fremote}
+
+	opt := vfscommon.Opt
+	opt.CachePollInterval = 0
+	opt.WriteBack = 0
+
+	ctx, cancel := context.WithCancel(context.Background())
+	c, err := New(ctx, rec, &opt, addVirtual)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := c.CleanUp()
+		require.NoError(t, err)
+		assertPathNotExist(t, c.root)
+		cancel()
+	})
+
+	_, obj, item := newFile(t, r, c, "existing")
+
+	// Give the remote object an old modtime, like a file which has
+	// been on the remote for a while
+	oldTime := time.Now().Add(-time.Hour).Truncate(time.Second)
+	require.NoError(t, obj.SetModTime(ctx, oldTime))
+
+	// Open the item, write new content and set a fresh logical modtime
+	// (what the kernel does for utimens)
+	require.NoError(t, item.Open(obj))
+	_, err = item.WriteAt([]byte("new content"), 0)
+	require.NoError(t, err)
+	newTime := time.Now().Truncate(time.Second)
+	item.setModTime(newTime)
+
+	// Closing stores the file - this upload must carry newTime
+	require.NoError(t, item.Close(nil))
+
+	// Now simulate what a reopen/close does to the cache file in the
+	// buggy scenario (issue #9637): the cache file's OS modtime gets
+	// reset to the old remote modtime while an upload is still pending.
+	// The next store must not be poisoned by it.
+	item._setModTime(oldTime)
+	require.NoError(t, item.store(ctx, nil))
+
+	puts := rec.putTimes()
+	require.GreaterOrEqual(t, len(puts), 2, "expected at least the two uploads to have happened")
+	got := puts[len(puts)-1]
+	assert.False(t, got.Equal(oldTime), "store carried stale modtime %v instead of the new time %v", got, newTime)
+	assert.WithinDuration(t, newTime, got, time.Second)
+}


### PR DESCRIPTION
#### What is the problem?

Fixes #9637 - after saving a file via the VFS mount (observed with LibreOffice against Nextcloud), the remote file ends up with a stale modtime: the time the file had before the save, or the time of an earlier write, instead of the save time.

From the reporter's `-vv` log:

```
20:52:48 close → "setting modification time to 20:52:48.168" + "queuing for upload in 5s"
20:52:48 Rename → reopen/close cycles
20:52:52 "setting modification time to 2026-07-20 18:51:26 +0000 GMT"   ← old remote time
20:52:53 upload with X-OC-Mtime = 18:51:26                              ← stale time lands on server
```

The upload itself carries the stale time, so a post-upload `SetModTime` fixup would not help - and Nextcloud's `SetModTime` returns `ErrorCantSetModTime` anyway, so the time stays wrong.

#### Root cause

The writeback upload in `vfscache.Item._store` sends the cache file to the remote, and the modtime the upload carries comes from the cache file's mtime on disk (`operations.Copy` uses `src.ModTime`). Normally the cache file mtime matches the item's logical modtime (`info.ModTime`), but it can be reset between the last write and the upload:

- `_actualClose` sets the cache file mtime from `item.o.ModTime` for **non-dirty** items (item.go:817). A reopen/close while a writeback is queued can hit this path, resetting the cache file to the old remote time.
- The grace-period close added by 0db3e7a (`--vfs-handle-caching`, which fixed #9251) does exactly this: `closeAfterGrace` runs `_actualClose(nil, false)` on the non-dirty path, restoring the remote mtime onto the cache file while the upload is still pending.

#### What this change does

`_store` now sets the cache file's mtime from `item.info.ModTime` right before the upload, so the upload always carries the logical modtime (what the user/kernel last set via utimens), regardless of what happened to the cache file in between.

#### Tests

- `TestItemStoreModTime` (vfs/vfscache) is the discriminating repro: it writes, sets a fresh modtime, then simulates the poisoned cache file mtime (the reset `_actualClose` performs for non-dirty items, as seen in the log) before the second store. On master the upload carries the stale time and the test fails; with the fix it carries the new time and passes.
- `TestRWFileHandleModTimeAfterRewrite{Reopen,Rename}` (vfs) exercise the LibreOffice save flows from #9637 end to end (rewrite, reopen-after-save, safe-save rename) and assert the remote ends up with the new modtime. They pass on master as well: the poisoning needs the cache file mtime to be reset by a non-dirty close after the last write, which can't be arranged while a writeback is pending in the same session. They are regression guards for the flows; the white-box test above pins the bug itself.

Tested with `go test ./vfs/...` (excluding the root-only `TestWriteFileHandleReadonly`).
