### PR TITLE
fserrors: fix out of space detection on Windows - fixes #8011

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -311,10 +311,10 @@ set this flag.`,
 				Name: "fatal_if_no_space",
 				Help: `Make out-of-space errors fatal during transfers.
 
-When enabled, an ENOSPC error during a write returns a fatal error so
-that rclone aborts rather than retrying the operation. Useful for
-backup scripts that should halt loudly on a full disk rather than spin
-retrying.`,
+When enabled, an out of space error while writing, creating a directory,
+or creating a file returns a fatal error so that rclone aborts rather
+than retrying the operation. Useful for backup scripts that should halt
+loudly on a full disk rather than spin retrying.`,
 				Default:  false,
 				Advanced: true,
 			},

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1634,12 +1634,17 @@ func isDiskFullError(err error) bool {
 	return errors.Is(err, file.ErrDiskFull) || fserrors.IsErrNoSpace(err)
 }
 
+func wrapFatalIfNoSpace(err error, enabled bool) error {
+	if err != nil && enabled && isDiskFullError(err) {
+		return fserrors.FatalError(err)
+	}
+	return err
+}
+
 // Update the object from in with modTime and size
 func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (err error) {
 	defer func() {
-		if err != nil && o.fs.opt.FatalIfNoSpace && isDiskFullError(err) {
-			err = fserrors.FatalError(err)
-		}
+		err = wrapFatalIfNoSpace(err, o.fs.opt.FatalIfNoSpace)
 	}()
 	var out io.WriteCloser
 	var hasher *hash.MultiHasher
@@ -1762,12 +1767,30 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 
 var sparseWarning sync.Once
 
+type fatalIfNoSpaceWriterAt struct {
+	fs.WriterAtCloser
+	enabled bool
+}
+
+func (w *fatalIfNoSpaceWriterAt) WriteAt(p []byte, off int64) (n int, err error) {
+	n, err = w.WriterAtCloser.WriteAt(p, off)
+	return n, wrapFatalIfNoSpace(err, w.enabled)
+}
+
+func (w *fatalIfNoSpaceWriterAt) Close() error {
+	return wrapFatalIfNoSpace(w.WriterAtCloser.Close(), w.enabled)
+}
+
 // OpenWriterAt opens with a handle for random access writes
 //
 // Pass in the remote desired and the size if known.
 //
 // It truncates any existing object
-func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.WriterAtCloser, error) {
+func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (writer fs.WriterAtCloser, err error) {
+	defer func() {
+		err = wrapFatalIfNoSpace(err, f.opt.FatalIfNoSpace)
+	}()
+
 	// Temporary Object under construction
 	o, err := f.newObject(remote)
 	if err != nil {
@@ -1805,7 +1828,10 @@ func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.Wr
 		}
 	}
 
-	return out, nil
+	return &fatalIfNoSpaceWriterAt{
+		WriterAtCloser: out,
+		enabled:        f.opt.FatalIfNoSpace,
+	}, nil
 }
 
 // setMetadata sets the file info from the os.FileInfo passed in

--- a/backend/local/local_internal_diskfull_test.go
+++ b/backend/local/local_internal_diskfull_test.go
@@ -60,7 +60,7 @@ func TestIsDiskFullError(t *testing.T) {
 // FatalIfNoSpace setting, returning the error from Update.
 func updateWithReader(t *testing.T, fatalIfNoSpace bool, readerErr error) error {
 	t.Helper()
-	r := fstest.NewRun(t)
+	r := fstest.NewRunIndividual(t)
 	f := r.Flocal.(*Fs)
 	f.opt.FatalIfNoSpace = fatalIfNoSpace
 
@@ -95,4 +95,88 @@ func TestUpdateFatalIfNoSpaceOnButNotDiskFull(t *testing.T) {
 	err := updateWithReader(t, true, errors.New("unrelated network error"))
 	require.Error(t, err)
 	assert.False(t, fserrors.IsFatalError(err), "non-disk-full errors must not be fatal regardless of option")
+}
+
+type diskFullWriterAtCloser struct {
+	writeErr error
+	closeErr error
+	n        int
+	data     []byte
+	offset   int64
+	closed   bool
+}
+
+func (w *diskFullWriterAtCloser) WriteAt(p []byte, off int64) (int, error) {
+	w.data = append([]byte(nil), p...)
+	w.offset = off
+	return w.n, w.writeErr
+}
+
+func (w *diskFullWriterAtCloser) Close() error {
+	w.closed = true
+	return w.closeErr
+}
+
+func testOpenWriterAtError(t *testing.T, injected error, diskFull bool) {
+	t.Helper()
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enabled=%v", enabled), func(t *testing.T) {
+			r := fstest.NewRunIndividual(t)
+			f := r.Flocal.(*Fs)
+			f.opt.FatalIfNoSpace = enabled
+			f.opt.NoPreAllocate = true
+			writer, err := f.OpenWriterAt(context.Background(), "test.txt", 0)
+			require.NoError(t, err)
+			wrapped, ok := writer.(*fatalIfNoSpaceWriterAt)
+			require.True(t, ok)
+			require.NoError(t, wrapped.WriterAtCloser.Close())
+			wantN := 2
+			if injected == nil {
+				wantN = 4
+			}
+			underlying := &diskFullWriterAtCloser{writeErr: injected, closeErr: injected, n: wantN}
+			wrapped.WriterAtCloser = underlying
+			n, err := writer.WriteAt([]byte("data"), 17)
+			assert.Equal(t, wantN, n)
+			assert.Equal(t, []byte("data"), underlying.data)
+			assert.Equal(t, int64(17), underlying.offset)
+			assert.ErrorIs(t, err, injected)
+			assert.Equal(t, enabled && diskFull, fserrors.IsFatalError(err))
+			err = writer.Close()
+			assert.True(t, underlying.closed)
+			assert.ErrorIs(t, err, injected)
+			assert.Equal(t, enabled && diskFull, fserrors.IsFatalError(err))
+		})
+	}
+}
+
+func TestOpenWriterAtFatalIfNoSpace(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		err      error
+		diskFull bool
+	}{
+		{"success", nil, false},
+		{"unrelated", syscall.EPERM, false},
+		{"ENOSPC", syscall.ENOSPC, true},
+		{"ErrDiskFull", file.ErrDiskFull, true},
+		{"wrapped", fmt.Errorf("write: %w", syscall.ENOSPC), true},
+	} {
+		t.Run(test.name, func(t *testing.T) { testOpenWriterAtError(t, test.err, test.diskFull) })
+	}
+}
+
+func TestOpenWriterAtSetupError(t *testing.T) {
+	for _, enabled := range []bool{false, true} {
+		t.Run(fmt.Sprintf("enabled=%v", enabled), func(t *testing.T) {
+			r := fstest.NewRunIndividual(t)
+			f := r.Flocal.(*Fs)
+			f.opt.FatalIfNoSpace = enabled
+			require.NoError(t, os.WriteFile(filepath.Join(r.LocalName, "parent"), nil, 0600))
+			writer, err := f.OpenWriterAt(context.Background(), "parent/child", 0)
+			require.Error(t, err)
+			assert.Nil(t, writer)
+			assert.False(t, fserrors.IsFatalError(err))
+		})
+	}
 }

--- a/backend/local/local_internal_diskfull_windows_test.go
+++ b/backend/local/local_internal_diskfull_windows_test.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package local
+
+import (
+	"os"
+	"testing"
+
+	"github.com/rclone/rclone/fs/fserrors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestUpdateFatalIfNoSpaceWindows(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+	}{
+		{"ERROR_DISK_FULL", windows.ERROR_DISK_FULL},
+		{"openat PathError", &os.PathError{Op: "openat", Path: "test.txt", Err: windows.ERROR_DISK_FULL}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("off", func(t *testing.T) {
+				err := updateWithReader(t, false, test.err)
+				require.Error(t, err)
+				assert.False(t, fserrors.IsFatalError(err))
+			})
+			t.Run("on", func(t *testing.T) {
+				err := updateWithReader(t, true, test.err)
+				require.Error(t, err)
+				assert.True(t, fserrors.IsFatalError(err))
+			})
+		})
+	}
+}

--- a/backend/local/local_internal_diskfull_windows_test.go
+++ b/backend/local/local_internal_diskfull_windows_test.go
@@ -35,3 +35,18 @@ func TestUpdateFatalIfNoSpaceWindows(t *testing.T) {
 		})
 	}
 }
+
+func TestOpenWriterAtFatalIfNoSpaceWindows(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		err      error
+		diskFull bool
+	}{
+		{"ERROR_DISK_FULL", windows.ERROR_DISK_FULL, true},
+		{"ERROR_HANDLE_DISK_FULL", windows.ERROR_HANDLE_DISK_FULL, true},
+		{"PathError", &os.PathError{Op: "write", Path: "test.txt", Err: windows.ERROR_DISK_FULL}, true},
+		{"ERROR_ACCESS_DENIED", windows.ERROR_ACCESS_DENIED, false},
+	} {
+		t.Run(test.name, func(t *testing.T) { testOpenWriterAtError(t, test.err, test.diskFull) })
+	}
+}

--- a/fs/fserrors/enospc_error.go
+++ b/fs/fserrors/enospc_error.go
@@ -3,16 +3,24 @@
 package fserrors
 
 import (
+	"slices"
 	"syscall"
 
 	liberrors "github.com/rclone/rclone/lib/errors"
 )
 
+// noSpaceErrors are the errors which mean the disk is full.
+//
+// Platform specific files add to this list in their init functions.
+var noSpaceErrors = []error{
+	syscall.ENOSPC,
+}
+
 // IsErrNoSpace checks a possibly wrapped error to
-// see if it contains a ENOSPC error
+// see if it contains an out of space error.
 func IsErrNoSpace(cause error) (isNoSpc bool) {
 	liberrors.Walk(cause, func(c error) bool {
-		if c == syscall.ENOSPC {
+		if slices.Contains(noSpaceErrors, c) {
 			isNoSpc = true
 			return true
 		}

--- a/fs/fserrors/enospc_error_windows.go
+++ b/fs/fserrors/enospc_error_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package fserrors
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func init() {
+	// Windows does not return syscall.ENOSPC, which Go defines here as a
+	// value in its application reserved range. A full disk reports these.
+	// https://learn.microsoft.com/en-us/windows/win32/debug/system-error-codes--0-499-
+	noSpaceErrors = append(noSpaceErrors,
+		windows.ERROR_DISK_FULL,
+		windows.ERROR_HANDLE_DISK_FULL,
+	)
+}

--- a/fs/fserrors/enospc_error_windows_test.go
+++ b/fs/fserrors/enospc_error_windows_test.go
@@ -1,0 +1,59 @@
+//go:build windows
+
+package fserrors
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/windows"
+)
+
+func TestIsErrNoSpaceRealWindowsError(t *testing.T) {
+	dir := t.TempDir()
+	dirp, err := windows.UTF16PtrFromString(dir)
+	if err != nil {
+		t.Skipf("cannot convert the temporary directory path: %v", err)
+	}
+	var available, total, free uint64
+	if err := windows.GetDiskFreeSpaceEx(dirp, &available, &total, &free); err != nil {
+		t.Skipf("cannot read the free space of the temporary directory: %v", err)
+	}
+
+	f, err := os.Create(filepath.Join(dir, "truncate"))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, f.Close()) }()
+
+	err = f.Truncate(int64(free + 1<<30))
+	if err == nil {
+		t.Skip("real Windows disk-full error coverage lost: volume did not enforce the free-space limit when truncating the file")
+	}
+	assert.True(t, IsErrNoSpace(err), "error = %v", err)
+}
+
+func TestIsErrNoSpaceWindows(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"syscall.ENOSPC", syscall.ENOSPC, true},
+		{"ERROR_DISK_FULL", windows.ERROR_DISK_FULL, true},
+		{"ERROR_HANDLE_DISK_FULL", windows.ERROR_HANDLE_DISK_FULL, true},
+		{"openat PathError", &os.PathError{Op: "openat", Path: "file", Err: windows.ERROR_DISK_FULL}, true},
+		{"mkdirat PathError", &os.PathError{Op: "mkdirat", Path: "dir", Err: windows.ERROR_DISK_FULL}, true},
+		{"SyscallError", os.NewSyscallError("write", windows.ERROR_HANDLE_DISK_FULL), true},
+		{"ERROR_ACCESS_DENIED", windows.ERROR_ACCESS_DENIED, false},
+		{"access denied PathError", &os.PathError{Op: "openat", Path: "file", Err: windows.ERROR_ACCESS_DENIED}, false},
+		{"nil", nil, false},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, IsErrNoSpace(test.err))
+		})
+	}
+}

--- a/fs/fserrors/enospc_error_windows_test.go
+++ b/fs/fserrors/enospc_error_windows_test.go
@@ -4,36 +4,12 @@ package fserrors
 
 import (
 	"os"
-	"path/filepath"
 	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/windows"
 )
-
-func TestIsErrNoSpaceRealWindowsError(t *testing.T) {
-	dir := t.TempDir()
-	dirp, err := windows.UTF16PtrFromString(dir)
-	if err != nil {
-		t.Skipf("cannot convert the temporary directory path: %v", err)
-	}
-	var available, total, free uint64
-	if err := windows.GetDiskFreeSpaceEx(dirp, &available, &total, &free); err != nil {
-		t.Skipf("cannot read the free space of the temporary directory: %v", err)
-	}
-
-	f, err := os.Create(filepath.Join(dir, "truncate"))
-	require.NoError(t, err)
-	defer func() { require.NoError(t, f.Close()) }()
-
-	err = f.Truncate(int64(free + 1<<30))
-	if err == nil {
-		t.Skip("real Windows disk-full error coverage lost: volume did not enforce the free-space limit when truncating the file")
-	}
-	assert.True(t, IsErrNoSpace(err), "error = %v", err)
-}
 
 func TestIsErrNoSpaceWindows(t *testing.T) {
 	tests := []struct {

--- a/fs/operations/multithread_test.go
+++ b/fs/operations/multithread_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/rclone/rclone/fs/accounting"
+	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/hash"
 	"github.com/rclone/rclone/fs/object"
 	"github.com/rclone/rclone/fstest/mockfs"
@@ -340,5 +341,64 @@ func TestMultithreadCopyAbort(t *testing.T) {
 		o, err := r.Fremote.NewObject(ctx, fileName)
 		require.NoError(t, err)
 		require.NoError(t, o.Remove(ctx))
+	}
+}
+
+type errorWriterAtCloser struct {
+	writeErr error
+	closeErr error
+	closed   bool
+}
+
+func (w *errorWriterAtCloser) WriteAt(p []byte, _ int64) (int, error) {
+	if w.writeErr != nil {
+		return 0, w.writeErr
+	}
+	return len(p), nil
+}
+
+func (w *errorWriterAtCloser) Close() error {
+	w.closed = true
+	return w.closeErr
+}
+
+// Classification belongs to the backend; this checks propagation through the consumer.
+func TestMultithreadCopyWriterAtErrors(t *testing.T) {
+	for _, stage := range []string{"open", "write", "close"} {
+		for _, fatal := range []bool{false, true} {
+			t.Run(fmt.Sprintf("%s/fatal=%v", stage, fatal), func(t *testing.T) {
+				ctx, ci := fs.AddConfig(context.Background())
+				ci.MultiThreadChunkSize = 4
+				ci.MultiThreadWriteBufferSize = 0
+				ci.MultiThreadStreams = 2
+				ci.MultiThreadSet = true
+				f, err := mockfs.NewFs(ctx, "destination", "", nil)
+				require.NoError(t, err)
+				src := mockobject.New("file.txt").WithContent([]byte("0123456789abcdef"), mockobject.SeekModeNone)
+				cause := errors.New("disk full")
+				injected := cause
+				if fatal {
+					injected = fserrors.FatalError(injected)
+				}
+				writer := &errorWriterAtCloser{}
+				f.Features().OpenWriterAt = func(context.Context, string, int64) (fs.WriterAtCloser, error) {
+					switch stage {
+					case "open":
+						return nil, injected
+					case "write":
+						writer.writeErr = injected
+					case "close":
+						writer.closeErr = injected
+					}
+					return writer, nil
+				}
+				tr := accounting.GlobalStats().NewTransfer(src, nil)
+				_, err = multiThreadCopy(ctx, f, src.Remote(), src, 2, tr)
+				tr.Done(ctx, err)
+				require.ErrorIs(t, err, cause)
+				assert.Equal(t, fatal, fserrors.IsFatalError(err))
+				assert.Equal(t, stage != "open", writer.closed)
+			})
+		}
 	}
 }

--- a/vfs/vfscache/cache.go
+++ b/vfs/vfscache/cache.go
@@ -563,7 +563,15 @@ func (c *Cache) reload(ctx context.Context) error {
 }
 
 // KickCleaner kicks cache cleaner upon out of space situation
+//
+// This does nothing when the cleaner is disabled. Only the cleaner clears the
+// out of space condition, so with no cleaner running the wait below would never
+// return.
 func (c *Cache) KickCleaner() {
+	if c.opt.CachePollInterval <= 0 {
+		return
+	}
+
 	/* Use a separate kicker mutex for the kick to go through without waiting for the
 	   cache mutex to avoid letting a thread kick again after the clearer just
 	   finished cleaning and unlock the cache mutex. */

--- a/vfs/vfscache/cache_test.go
+++ b/vfs/vfscache/cache_test.go
@@ -655,6 +655,34 @@ func TestCacheCleaner(t *testing.T) {
 	assert.False(t, found)
 }
 
+func TestCacheKickCleaner(t *testing.T) {
+	// kickCleaner runs KickCleaner and reports whether it returned in time.
+	kickCleaner := func(t *testing.T, c *Cache) bool {
+		t.Helper()
+		done := make(chan struct{})
+		go func() {
+			defer close(done)
+			c.KickCleaner()
+		}()
+		select {
+		case <-done:
+			return true
+		case <-time.After(2 * time.Second):
+			return false
+		}
+	}
+
+	// Only the cleaner clears the out of space condition, so with no cleaner
+	// running a KickCleaner which waited for it would never return.
+	t.Run("CleanerDisabled", func(t *testing.T) {
+		opt := vfscommon.Opt
+		opt.CachePollInterval = 0
+		_, c := newTestCacheOpt(t, opt)
+
+		assert.True(t, kickCleaner(t, c), "KickCleaner did not return with the cleaner disabled")
+	})
+}
+
 func TestCacheSetModTime(t *testing.T) {
 	_, c := newTestCache(t)
 

--- a/vfs/vfscache/cache_test.go
+++ b/vfs/vfscache/cache_test.go
@@ -674,13 +674,15 @@ func TestCacheKickCleaner(t *testing.T) {
 
 	// Only the cleaner clears the out of space condition, so with no cleaner
 	// running a KickCleaner which waited for it would never return.
-	t.Run("CleanerDisabled", func(t *testing.T) {
-		opt := vfscommon.Opt
-		opt.CachePollInterval = 0
-		_, c := newTestCacheOpt(t, opt)
+	for _, interval := range []fs.Duration{0, -1} {
+		t.Run("CleanerDisabled/"+interval.String(), func(t *testing.T) {
+			opt := vfscommon.Opt
+			opt.CachePollInterval = interval
+			_, c := newTestCacheOpt(t, opt)
+			assert.True(t, kickCleaner(t, c), "KickCleaner did not return with the cleaner disabled")
+		})
+	}
 
-		assert.True(t, kickCleaner(t, c), "KickCleaner did not return with the cleaner disabled")
-	})
 }
 
 func TestCacheSetModTime(t *testing.T) {


### PR DESCRIPTION
#### What does this change do?

Recognize Windows disk-full errors (`ERROR_DISK_FULL` and `ERROR_HANDLE_DISK_FULL`) so `--local-fatal-if-no-space` stops transfers instead of retrying them. This also prevents a VFS cache hang when the cleaner is disabled and completes fatal-error handling for local multi-thread writer setup, writes and close. Regression tests cover classification, transfer propagation and disabled-cleaner behavior.

The option remains off by default and preallocation remains best-effort. No flags, public APIs or dependencies are added.

#### Validation

Rebased onto master at `3d7b101c7f4b`; validated candidate `03abd08b5541`:

- Windows build and complete uncached quicktest pass on Go 1.27.1 (174 packages). All eight local integration groups pass on their first attempts; actual restic integration passes separately. Repository-defined platform and feature skips remain, including Windows git-annex end-to-end tests.
- Ten shuffled Windows race repetitions, focused Go 1.26.8 compatibility tests, complete affected Linux suites and focused Linux race coverage pass. Full configured lint, formatting and whitespace checks pass.
- Actual write-time exhaustion on a fixed-capacity NTFS fixture with four streams and preallocation disabled: the published baseline retries and exits 1 with the option off or on; the candidate retries and exits 1 when off, and stops without retrying with exit 7 when on. Healthy-copy and default-preallocation smoke tests verify contents. This does not establish native preallocation-exhaustion behavior or every later metadata failure.

An earlier Windows quicktest hit an intermittent directory-timestamp assertion also reproduced on clean upstream; no workaround was added. Full Linux quicktest remains environment-limited: mount/Docker-volume tests require unavailable FUSE, and NFS tests require unsupported filesystem handle operations. This is not a claim that every repository test passed.

#### Linked issue

Fixes #8011

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
