### PR TITLE
dropbox: fix ChangeNotify paths with mismatched root casing

### DIFF
--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -392,8 +392,8 @@ type Fs struct {
 	sharing        sharing.ContextClient // as above, but for generating sharing links
 	users          users.ContextClient   // as above, but for accessing user information
 	team           team.ContextClient    // for the Teams API
-	slashRoot      string                // root with "/" prefix, lowercase
-	slashRootSlash string                // root with "/" prefix and postfix, lowercase
+	slashRoot      string                // root with "/" prefix
+	slashRootSlash string                // root with "/" prefix and postfix
 	pacer          *fs.Pacer             // To pace the API calls
 	ns             string                // The namespace we are using or "" for none
 	batcher        *batcher.Batcher[*files.UploadSessionFinishArg, *files.FileMetadata]
@@ -725,6 +725,13 @@ func (f *Fs) setRoot(root string) {
 	if f.root != "" {
 		f.slashRootSlash += "/"
 	}
+}
+
+func trimPrefixFold(s, prefix string) string {
+	if len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix) {
+		return s[len(prefix):]
+	}
+	return s
 }
 
 type getMetadataResult struct {
@@ -1731,13 +1738,13 @@ func (f *Fs) changeNotifyRunner(ctx context.Context, notifyFunc func(string, fs.
 			switch info := entry.(type) {
 			case *files.FolderMetadata:
 				entryType = fs.EntryDirectory
-				entryPath = strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)
+				entryPath = trimPrefixFold(info.PathDisplay, f.slashRootSlash)
 			case *files.FileMetadata:
 				entryType = fs.EntryObject
-				entryPath = strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)
+				entryPath = trimPrefixFold(info.PathDisplay, f.slashRootSlash)
 			case *files.DeletedMetadata:
 				entryType = fs.EntryObject
-				entryPath = strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)
+				entryPath = trimPrefixFold(info.PathDisplay, f.slashRootSlash)
 			default:
 				fs.Errorf(entry, "dropbox ChangeNotify: ignoring unknown EntryType %T", entry)
 				continue

--- a/backend/dropbox/dropbox_internal_test.go
+++ b/backend/dropbox/dropbox_internal_test.go
@@ -268,6 +268,24 @@ func TestUploadChunkedCancel(t *testing.T) {
 	assert.False(t, client.finishCalled)
 }
 
+func TestTrimPrefixFold(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		path   string
+		prefix string
+		want   string
+	}{
+		{name: "MatchingCase", path: "/Root/File.txt", prefix: "/Root/", want: "File.txt"},
+		{name: "DifferentCase", path: "/ROOT/File.txt", prefix: "/root/", want: "File.txt"},
+		{name: "NoMatch", path: "/Other/File.txt", prefix: "/root/", want: "/Other/File.txt"},
+		{name: "Root", path: "/File.txt", prefix: "/", want: "File.txt"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, trimPrefixFold(test.path, test.prefix))
+		})
+	}
+}
+
 func (f *Fs) importPaperForTest(t *testing.T) {
 	content := `# test doc
 


### PR DESCRIPTION
#### What does this change do?

Dropbox can return `PathDisplay` with casing that differs from the configured remote root. ChangeNotify previously used a case-sensitive prefix trim, so those events could be emitted as absolute Dropbox paths instead of paths relative to the remote root.

This change trims the root prefix case-insensitively while preserving the display casing of the remaining path. It also removes stale comments that incorrectly described the stored root as lowercase and adds unit coverage for matching, mismatched-case, unrelated, and root paths.

Tests:
- `go test ./backend/dropbox/ -count=1`
- `go build ./`
- `go test ./...` was also run; Dropbox and the rest of the unit packages passed, but the overall command fails on Windows where integration-style packages require Unix `fstest/testserver/init.d` executables and `fs/logger` requires the external `diff` command.

A live Dropbox integration run was not performed because no `TestDropbox:` remote is configured locally.

#### Linked issue

Fixes #9692

#### For new or changed backends

This is a focused fix to the existing Dropbox backend and does not change its configuration or API. The Dropbox package unit tests pass; a live backend integration test was not run locally.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.