### PR TITLE
fix(onedrive): do not retry multipart upload chunk on 404 (upload session not found)

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -2678,9 +2678,8 @@ func (o *Object) uploadFragment(ctx context.Context, url string, start int64, to
 			}
 			return true, fmt.Errorf("retry this chunk skipping %d bytes: %w", skip, err)
 		} else if err != nil && resp != nil && resp.StatusCode == http.StatusNotFound {
-			fs.Debugf(o, "Received 404 error: assuming eventual consistency problem with session - retrying chunk: %v", err)
-			time.Sleep(5 * time.Second) // a little delay to help things along
-			return true, err
+			fs.Debugf(o, "Received 404 error: upload session not found - not retrying: %v", err)
+			return false, fserrors.NoLowLevelRetryError(err)
 		}
 		if err != nil {
 			return shouldRetry(ctx, resp, err)


### PR DESCRIPTION
When a file is edited on OneDrive/SharePoint via the web UI and then re-uploaded by rclone, the multipart upload session is already consumed by the server-side edit. The chunk PUT returns HTTP 404 "The upload session was not found".

The code currently assumes this is an eventual consistency issue and retries the chunk with a 5-second sleep, up to `--low-level-retries` (default 10) times per chunk. This creates a nested retry storm:
- Inner loop: up to 10 chunk retries × ~5s sleep ≈ 50s per chunk
- Outer loop: the whole create-session → upload → fail → cancel cycle retried up to 10 more times

Effectively up to ~100 retry cycles, causing a single 5KB file upload to block for 10-20+ minutes before failing.

**Fix**: When the chunk PUT returns 404, treat it as a non-retryable error. The upload session does not exist — retrying cannot succeed. Use `fserrors.NoLowLevelRetryError` to prevent both the pacer-level retry and the outer low-level retry loop.

Fixes #9767