### PR TITLE
vfs/vfscache: fix reader deadlock when the item size drops below the read offset

### DIFF
--- a/vfs/vfscache/downloaders/downloaders.go
+++ b/vfs/vfscache/downloaders/downloaders.go
@@ -394,7 +394,11 @@ func (dls *Downloaders) _dispatchWaiters() {
 		// Clip the size against the actual size in case it has shrunk
 		r := waiter.r
 		r.Clip(dls.src.Size())
-		if dls.item.HasRange(r) {
+		// Wake the waiter if its data has arrived, or if there is nothing
+		// left to download for it. _ensureDownloader starts a downloader
+		// only when FindMissing is non empty, so a waiter with nothing
+		// missing would otherwise never be woken by anything.
+		if dls.item.HasRange(r) || dls.item.FindMissing(waiter.r).IsEmpty() {
 			waiter.errChan <- nil
 		} else {
 			newWaiters = append(newWaiters, waiter)

--- a/vfs/vfscache/downloaders/downloaders_test.go
+++ b/vfs/vfscache/downloaders/downloaders_test.go
@@ -126,4 +126,29 @@ func TestDownloaders(t *testing.T) {
 			return item.HasRange(r)
 		}, 10*time.Second, 10*time.Millisecond)
 	})
+
+	// A waiter for a range beyond the item's size but within the source
+	// object's size must still be dispatched. _ensureDownloader will not
+	// start a downloader for it, so nothing else would ever wake it.
+	t.Run("DownloadBeyondItemSize", func(t *testing.T) {
+		item := &testItem{
+			t:    t,
+			size: 1024 * 1024,
+		}
+		opt := vfscommon.Opt
+		dls := New(ctx, item, &opt, remote, src)
+		defer cancel(dls)
+
+		done := make(chan error, 1)
+		go func() {
+			done <- dls.Download(ranges.Range{Pos: 40 * 1024 * 1024, Size: 250})
+		}()
+
+		select {
+		case err := <-done:
+			assert.NoError(t, err)
+		case <-time.After(30 * time.Second):
+			t.Fatal("Download did not return: the waiter was never dispatched")
+		}
+	})
 }

--- a/vfs/vfscache/item_waiter_test.go
+++ b/vfs/vfscache/item_waiter_test.go
@@ -1,0 +1,72 @@
+package vfscache
+
+import (
+	"os"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/lib/ranges"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestItemWaiterBeyondItemSize checks that a reader waiting for a range past
+// the item's size, but within the size of the source object the downloaders
+// hold, is still released.
+//
+// Download is called directly because _ensure clips the range against
+// info.Size before it can reach the waiter queue. In the field the waiter is
+// queued while info.Size is still full and info.Size shrinks afterwards.
+func TestItemWaiterBeyondItemSize(t *testing.T) {
+	r, c := newItemTestCache(t)
+
+	const (
+		remote     = "waiter.bin"
+		fileSize   = 64 * 1024 * 1024
+		headLen    = 64 * 1024
+		shrunkSize = 1024 * 1024
+		tailOffset = 48 * 1024 * 1024
+	)
+
+	_, obj, item := newFileLength(t, r, c, remote, fileSize)
+	require.NoError(t, item.Open(obj))
+	defer func() { _ = item.Close(nil) }()
+
+	buf := make([]byte, headLen)
+	n, err := item.ReadAt(buf, 0)
+	require.NoError(t, err)
+	require.Equal(t, headLen, n)
+
+	osPath := c.toOSPath(remote)
+	apparent := func() int64 {
+		fi, statErr := os.Stat(osPath)
+		require.NoError(t, statErr)
+		return fi.Size()
+	}
+	require.Equal(t, int64(fileSize), obj.Size())
+	require.Equal(t, int64(fileSize), apparent())
+
+	head := ranges.Range{Pos: 0, Size: headLen}
+	tail := ranges.Range{Pos: tailOffset, Size: 4096}
+	require.True(t, item.info.Rs.Present(head))
+	require.False(t, item.info.Rs.Present(tail), "tail must not be prefetched")
+
+	// Shrink info.Size below the tail offset, as readAt does when the
+	// remote object and the item disagree about the size.
+	item.mu.Lock()
+	require.NoError(t, item._truncate(shrunkSize))
+	item.mu.Unlock()
+
+	require.Equal(t, int64(shrunkSize), item.info.Size)
+	require.Equal(t, int64(shrunkSize), apparent())
+
+	done := make(chan error, 1)
+	go func() { done <- item.downloaders.Download(tail) }()
+
+	select {
+	case err := <-done:
+		assert.NoError(t, err)
+	case <-time.After(30 * time.Second):
+		t.Fatal("Download did not return: the waiter was never dispatched")
+	}
+}


### PR DESCRIPTION
#### What is the purpose of this change?

Fixes #9769.

With `--vfs-cache-mode full` a reader can block forever in `Downloaders.Download`. No downloader is started, no request reaches the backend, no error is produced and nothing is logged at any level. On a mount the reading process sits in D state and cannot be killed.

`_dispatchWaiters` decides whether a waiter is satisfied by clipping its range against `dls.src.Size()`, the `fs.Object` snapshot frozen when the `Downloaders` was created. `_ensureDownloader` decides whether to download from `Item.FindMissing`, which clips against `item.info.Size`. When

    item.info.Size < readOffset <= dls.src.Size()

the download side collapses the range to empty and starts nothing, while the wake side does not collapse it and never releases the waiter. Since no downloader ever runs, no error is ever counted, so `maxErrorCount` never trips and `_closeWaiters` is never reached. The 5s background kicker re-evaluates both every 5s and changes nothing.

The two sizes drift because `dls.src` is frozen at construction while `item.info.Size` is re-derived later, notably by the shrink check in `Item.readAt` and by `_checkObject`/`_getSize` on reopen. `Item.open` calls `_checkObject` before the `item.opens != 1` early return but only rebuilds `item.downloaders` when `opens == 1`, so a second open refreshes `item.o` and `item.info.Size` while leaving the old `dls.src` in place.

This was introduced by f3f743c3f, which added both halves of the asymmetry in one commit. That commit correctly fixed the case where `src` itself shrinks and opened this one.

#### Was the change discussed in an issue or in the forum before?

#9769

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-pull-request).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added a note to `docs/content/changelog.md` if appropriate. (Not applicable, changelog is generated at release.)
- [x] I have added a note to the relevant docs if appropriate. (Not applicable, no user visible option changed.)

#### The fix

Wake a waiter when `FindMissing` reports nothing left to download for it, as well as when its data has arrived. `_ensureDownloader` starts a downloader only when `FindMissing` is non empty, so a waiter with nothing missing has nothing that could ever wake it. The new condition is purely additive, so it cannot regress the shrink case f3f743c3f fixed.

#### Tests

Two regression tests, both on the local backend, no special remote required. I verified both directions: each fails on unpatched master with `Download did not return: the waiter was never dispatched` and passes with the fix.

- `TestDownloaders/DownloadBeyondItemSize` covers the `Downloaders` layer directly.
- `TestItemWaiterBeyondItemSize` drives the real `vfscache.Item` through the lifecycle: open at full size, cache the head, shrink `info.Size` via `_truncate`, then park a reader on a tail range.

`go test ./vfs/vfscache/...` is green.