### PR TITLE
lib/transform: fix panic in truncate_keep_extension

### DIFF
--- a/lib/transform/transform.go
+++ b/lib/transform/transform.go
@@ -165,13 +165,13 @@ func transformPathSegment(s string, t transform) (string, error) {
 		if err != nil {
 			return s, err
 		}
-		return truncateChars(s, max, false), nil
+		return truncateChars(s, max, false)
 	case ConvTruncateKeepExtension:
 		max, err := strconv.Atoi(t.value)
 		if err != nil {
 			return s, err
 		}
-		return truncateChars(s, max, true), nil
+		return truncateChars(s, max, true)
 	case ConvTruncateBytes:
 		max, err := strconv.Atoi(t.value)
 		if err != nil {
@@ -266,19 +266,23 @@ func splitExtension(remote string) (base, exts string) {
 	return base, exts
 }
 
-func truncateChars(s string, max int, keepExtension bool) string {
+func truncateChars(s string, max int, keepExtension bool) (string, error) {
 	if max <= 0 {
-		return s
+		return s, nil
 	}
 	if utf8.RuneCountInString(s) <= max {
-		return s
+		return s, nil
 	}
 	exts := ""
 	if keepExtension {
 		s, exts = splitExtension(s)
 	}
+	keep := max - utf8.RuneCountInString(exts)
+	if keep <= 0 {
+		return "", errors.New("extension is longer than the truncation limit")
+	}
 	runes := []rune(s)
-	return string(runes[:max-utf8.RuneCountInString(exts)]) + exts
+	return string(runes[:keep]) + exts, nil
 }
 
 // truncateBytes is like truncateChars but counts the number of bytes, not UTF-8 characters

--- a/lib/transform/transform_test.go
+++ b/lib/transform/transform_test.go
@@ -134,6 +134,9 @@ func TestVarious(t *testing.T) {
 		{"stories/Вот русское предложение, в котором байтов больше, чем символов.txt", "stories/Вот русское предложение, в котором бай", []string{"truncate_bytes=70"}},
 		{"stories/Вот русское предложение, в котором байтов больше, чем символов.txt", "stories/Вот русское предложение, в котором байтов больше, чем си.txt", []string{"truncate_keep_extension=60"}},
 		{"stories/Вот русское предложение, в котором байтов больше, чем символов.txt", "stories/Вот русское предложение, в котором б.txt", []string{"truncate_bytes_keep_extension=70"}},
+		// the extension alone exceeds the limit, so there is nothing valid to return
+		{"stories/photo.jpeg", "stories/photo.jpeg", []string{"all,truncate_keep_extension=3"}},
+		{"stories/a.tar.gz", "stories/a.tar.gz", []string{"all,truncate_keep_extension=2"}},
 		{"stories/The Quick Brown Fox!.txt", "stories/The Quick Brown Fox!.txt", []string{"all,command=echo"}},
 		{"stories/The Quick Brown Fox!.txt", "stories/The Quick Brown Fox!.txt-" + time.Now().Local().Format("20060102"), []string{"date=-{YYYYMMDD}"}},
 		{"stories/The Quick Brown Fox!.txt", "stories/The Quick Brown Fox!.txt-" + time.Now().Local().Format("2006-01-02 0304PM"), []string{"date=-{macfriendlytime}"}},


### PR DESCRIPTION
#### What does this change do?

`--name-transform truncate_keep_extension=N` panics when the extension alone is at least as long as `N`.

```
$ touch src/photo.jpeg
$ rclone copy src dst --name-transform "all,truncate_keep_extension=3"
panic: runtime error: slice bounds out of range [:-2]

goroutine 45 [running]:
github.com/rclone/rclone/lib/transform.truncateChars({0xc00090e030, 0xa}, 0x3, 0x1)
	lib/transform/transform.go:281
```

`truncateChars` computes `runes[:max-utf8.RuneCountInString(exts)]`. Once the extension is longer than the limit that index is negative, so a `.jpeg` file with `truncate_keep_extension=3` takes down the whole command rather than reporting a bad transform.

`truncateBytes`, directly below it, already handles the same situation by returning an error. This makes the rune version agree with it: `truncateChars` gains an `error` return, and the two call sites in `transformPathSegment` pass it through the same way the byte versions already do.

After, the run reports the transform failure and leaves the name alone:

```
$ rclone copy src dst --name-transform "all,truncate_keep_extension=3"
ERROR : Failed to transform: extension is longer than the truncation limit
```

Ordinary truncation is untouched. Same tree, before and after, `truncate_keep_extension=12`:

```
before: a_long_.jpeg   short.txt
after:  a_long_.jpeg   short.txt
```

#### Linked issue

None. This is a small obvious bug fix, so I have not opened an issue for it, per the template's note. Happy to file one if you would rather.

Fixes #

#### For new or changed backends

Not a backend change. `lib/transform` runs before any backend is involved.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate. No doc change: the flag's behaviour on a valid input is unchanged, and `transform.md` is generated.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** Not a backend change.
- [x] This Pull Request is ready for review.

#### Testing

Two rows added to the existing `TestVarious` table in `lib/transform/transform_test.go`, next to the truncation rows already there: a single extension whose length exceeds the limit, and a double extension (`.tar.gz`) where the combined extension does. Both assert the path comes back unchanged, which is what `Path` does when a transform errors.

Restoring the old slice expression makes `TestVarious` panic rather than fail:

```
--- FAIL: TestVarious (0.00s)
panic: runtime error: slice bounds out of range [:-2] [recovered, repanicked]
FAIL	github.com/rclone/rclone/lib/transform	0.016s
```

`go build ./...` is clean and `go test ./lib/transform/` passes. Across `./fs/... ./lib/...` the only failure is `fs/logger`, which fails identically on a stashed clean tree here.

*AI disclosure, per CONTRIBUTING: I used Claude Code while working on this. I built rclone from master, reproduced the panic myself with the command above, and ran the before and after comparisons and the revert check by hand. I understand the change and can explain it.*
