### PR TITLE
docs: clarify VFS cache age semantics

### DIFF
--- a/docs/content/commands/rclone_serve_ftp.md
+++ b/docs/content/commands/rclone_serve_ftp.md
@@ -148,8 +148,7 @@ longest. This cache flushing strategy is efficient and more relevant
 files are likely to remain cached.
 
 The `--vfs-cache-max-age` will evict files from the cache
-after the set time since last access has passed; it is based on access time,
-not on when the file was first added to the cache. The default value of
+after the set time since last access has passed. The default value of
 1 hour will start evicting files from cache that haven't been accessed
 for 1 hour. When a cached file is accessed the 1 hour timer is reset to 0
 and will wait for 1 more hour before evicting. Specify the time with

--- a/docs/content/commands/rclone_serve_ftp.md
+++ b/docs/content/commands/rclone_serve_ftp.md
@@ -148,7 +148,8 @@ longest. This cache flushing strategy is efficient and more relevant
 files are likely to remain cached.
 
 The `--vfs-cache-max-age` will evict files from the cache
-after the set time since last access has passed. The default value of
+after the set time since last access has passed; it is based on access time,
+not on when the file was first added to the cache. The default value of
 1 hour will start evicting files from cache that haven't been accessed
 for 1 hour. When a cached file is accessed the 1 hour timer is reset to 0
 and will wait for 1 more hour before evicting. Specify the time with

--- a/vfs/vfs.md
+++ b/vfs/vfs.md
@@ -116,7 +116,8 @@ longest. This cache flushing strategy is efficient and more relevant
 files are likely to remain cached.
 
 The `--vfs-cache-max-age` will evict files from the cache
-after the set time since last access has passed. The default value of
+after the set time since last access has passed; it is based on access time,
+not on when the file was first added to the cache. The default value of
 1 hour will start evicting files from cache that haven't been accessed
 for 1 hour. When a cached file is accessed the 1 hour timer is reset to 0
 and will wait for 1 more hour before evicting. Specify the time with


### PR DESCRIPTION
Clarifies that --vfs-cache-max-age is measured from last access rather than cache insertion, addressing rclone/rclone#5793.

Assisted-by: OpenAI GPT-5