### PR TITLE
vfscache: fix log message growing without bound on repeated write errors

### DIFF
--- a/vfs/vfscache/downloaders/downloaders.go
+++ b/vfs/vfscache/downloaders/downloaders.go
@@ -457,15 +457,18 @@ func (dl *downloader) Write(p []byte) (n int, err error) {
 	// defer log.Trace(dl.dls.src, "p_len=%d", len(p))("n=%d, err=%v", &n, &err)
 
 	// Kick the waiters on exit if some characters received
+	//
+	// Only logs kickWaiters failures rather than returning them as this
+	// Write's own error: kickWaiters can return the downloaders' stale
+	// accumulated lastErr, which would otherwise fail this write (even
+	// when it succeeded) and get wrapped again by download(), growing
+	// unboundedly on every subsequent call while lastErr stays set.
 	defer func() {
 		if n <= 0 {
 			return
 		}
 		if waitErr := dl.dls.kickWaiters(); waitErr != nil {
 			fs.Errorf(dl.dls.src, "vfs cache: download write: failed to kick waiters: %v", waitErr)
-			if err == nil {
-				err = waitErr
-			}
 		}
 	}()
 

--- a/vfs/vfscache/downloaders/downloaders_test.go
+++ b/vfs/vfscache/downloaders/downloaders_test.go
@@ -2,6 +2,8 @@ package downloaders
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"io"
 	"sync"
 	"testing"
@@ -150,5 +152,44 @@ func TestDownloaders(t *testing.T) {
 		case <-time.After(30 * time.Second):
 			t.Fatal("Download did not return: the waiter was never dispatched")
 		}
+	})
+
+	// A successful write must not be turned into a failure by a stale
+	// error left over from a previous problem (e.g. the cache running
+	// out of space earlier). Regression test: this used to make Write
+	// return dls.lastErr even when the write itself succeeded, which
+	// then got wrapped again by download() and stored back as the new
+	// lastErr - causing the wrapped error message to grow without bound
+	// on every subsequent write.
+	t.Run("WriteDoesNotFailOnStaleError", func(t *testing.T) {
+		item, dls := newTest()
+		defer cancel(dls)
+
+		dls.mu.Lock()
+		dls.errorCount = maxErrorCount + 1
+		dls.lastErr = fmt.Errorf("vfs reader: failed to write to cache file: %w", errors.New("no space left on device"))
+		// A waiter for a range that isn't downloaded yet, so kickWaiters
+		// doesn't dispatch it immediately and reaches the errorCount check.
+		dls.waiters = append(dls.waiters, waiter{
+			r:       ranges.Range{Pos: 10 * 1024 * 1024, Size: 250},
+			errChan: make(chan error, 1),
+		})
+		dls.mu.Unlock()
+
+		dl := &downloader{
+			dls:       dls,
+			quit:      make(chan struct{}),
+			kick:      make(chan struct{}, 1),
+			offset:    0,
+			maxOffset: 1024,
+		}
+
+		p := make([]byte, 16)
+		_, err := io.ReadFull(readers.NewPatternReader(item.size), p)
+		require.NoError(t, err)
+
+		n, err := dl.Write(p)
+		require.NoError(t, err, "a successful write must not fail due to unrelated stale state")
+		assert.Equal(t, len(p), n)
 	})
 }


### PR DESCRIPTION
### What is the purpose of this change?

Fixes #4998 — when the VFS cache runs out of space, the error message logged on each retry grows without bound, repeating `vfs reader: failed to write to cache file: ` hundreds of times (243 repeats in the reporter's log).

### Root cause

`downloader.Write()` performs the actual cache write and gets its own error from `WriteAtNoOverwrite` (nil when the write succeeds). Its deferred kick block then calls `kickWaiters()`, which returns the downloaders' accumulated `lastErr` once `errorCount` exceeds `maxErrorCount` (or on out-of-space). That stale error was assigned to `Write`'s named return, so:

1. A write that actually succeeded was reported as failed.
2. `download()` wrapped that returned error in `vfs reader: failed to write to cache file: %w`.
3. `_countErrors` stored the newly wrapped error back as `lastErr`.
4. The next write repeated the cycle, adding another prefix each time.

Since `lastErr` is only cleared when a download completes with no error, the loop kept re-wrapping its own message.

The `kickWaiters()` failure is already logged on the line above, so returning it as this `Write`'s error is redundant as well as the source of the growth.

### Was the change discussed in an issue or in the forum before?

#4998, and the linked forum thread.

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#contributing-to-rclone).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added a note to `docs/content/changelog.md` if appropriate. (n/a — bugfix, changelog is generated from commit messages)
- [x] I have checked that all the tests pass.

### Testing

Added `TestDownloaders/WriteDoesNotFailOnStaleError`, which puts the downloaders into the state that triggers the bug (`errorCount` past `maxErrorCount`, a stale wrapped `lastErr`, and an undispatched waiter so `kickWaiters` reaches the error check) and asserts that a successful `Write` still returns no error. The test output confirms it exercises the real path:

```
ERROR : potato.txt: vfs cache: too many errors 11/10: last error: vfs reader: failed to write to cache file: no space left on device
ERROR : potato.txt: vfs cache: download write: failed to kick waiters: vfs reader: failed to write to cache file: no space left on device
--- PASS: TestDownloaders/WriteDoesNotFailOnStaleError (0.02s)
```

`go test ./vfs/...` passes in full, and `gofmt`/`go vet` are clean.
