### PR TITLE
sync: fix empty source directories not deleted after an unrelated error in the same stats group

### DIFF
--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -671,7 +671,12 @@ func (s *syncCopyMove) deleteEmptyDirectories(ctx context.Context, f fs.Fs, entr
 	if len(entriesMap) == 0 {
 		return nil
 	}
-	if accounting.Stats(ctx).Errored() && !s.ci.IgnoreErrors {
+	// Only this sync's own errors should stop directories being deleted.
+	// The stats group can outlive a single operation - it is shared by
+	// every rc call passing the same _group - so consulting it here would
+	// let an unrelated earlier error disable this for the rest of the
+	// group's lifetime.
+	if s.currentError() != nil && !s.ci.IgnoreErrors {
 		fs.Errorf(f, "%v", fs.ErrorNotDeletingDirs)
 		return fs.ErrorNotDeletingDirs
 	}

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1839,7 +1839,7 @@ func TestMoveWithDeleteEmptySrcDirsPreexistingGroupError(t *testing.T) {
 
 	ctx = accounting.WithStatsGroup(ctx, "TestMoveWithDeleteEmptySrcDirsPreexistingGroupError")
 	// Record an error against the group from an unrelated operation
-	accounting.Stats(ctx).Error(errors.New("unrelated earlier error"))
+	_ = accounting.Stats(ctx).Error(errors.New("unrelated earlier error"))
 	require.True(t, accounting.Stats(ctx).Errored())
 
 	err := MoveDir(ctx, r.Fremote, r.Flocal, true, false)

--- a/fs/sync/sync_test.go
+++ b/fs/sync/sync_test.go
@@ -1827,6 +1827,33 @@ func TestMoveWithDeleteEmptySrcDirs(t *testing.T) {
 	r.CheckRemoteItems(t, file1, file2)
 }
 
+// A stats group outlives a single operation - every rc call passing the
+// same _group shares it. An error recorded in the group by some earlier,
+// unrelated operation must not stop this move deleting its empty source
+// directories, as this move has no errors of its own.
+func TestMoveWithDeleteEmptySrcDirsPreexistingGroupError(t *testing.T) {
+	ctx := context.Background()
+	r := fstest.NewRun(t)
+	file1 := r.WriteFile("sub dir/hello world", "hello world", t1)
+	r.Mkdir(ctx, r.Fremote)
+
+	ctx = accounting.WithStatsGroup(ctx, "TestMoveWithDeleteEmptySrcDirsPreexistingGroupError")
+	// Record an error against the group from an unrelated operation
+	accounting.Stats(ctx).Error(errors.New("unrelated earlier error"))
+	require.True(t, accounting.Stats(ctx).Errored())
+
+	err := MoveDir(ctx, r.Fremote, r.Flocal, true, false)
+	require.NoError(t, err)
+
+	// The empty source directory must still have been removed
+	r.CheckLocalListing(
+		t,
+		nil,
+		[]string{},
+	)
+	r.CheckRemoteItems(t, file1)
+}
+
 func TestMoveWithoutDeleteEmptySrcDirs(t *testing.T) {
 	ctx := context.Background()
 	r := fstest.NewRun(t)


### PR DESCRIPTION
### What is the purpose of this change?

Fixes #9634 — on a long-lived `rclone rcd`, a single error anywhere in a stats group's lifetime permanently disabled `--delete-empty-src-dirs` for every later `sync/move` sharing that `_group`, even when those later operations had no errors of their own. The only recovery was `core/stats-reset`.

### Root cause

`deleteEmptyDirectories` gated on `accounting.Stats(ctx).Errored()`. That is the *stats group's* error count, and a stats group is shared by every rc call passing the same `_group` and outlives any single operation, so it stays "errored" indefinitely.

The destination path already gated on `s.currentError()` (this sync's own errors) before calling `deleteEmptyDirectories`, so the group-wide check was both inconsistent with it and the source of the bug. The source-directory path (`DoMove && deleteEmptySrcDirs`) reaches `deleteEmptyDirectories` directly, so the stale group state was the only thing consulted there.

Using `s.currentError()` makes both paths agree and scopes the check to the operation actually being run. Behaviour for a plain CLI invocation is unchanged: there each sync gets its own stats, so its own errors and the group's are the same thing.

### Was the change discussed in an issue or in the forum before?

#9634, which includes a full rc reproduction.

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#contributing-to-rclone).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added a note to `docs/content/changelog.md` if appropriate. (n/a — bugfix, changelog is generated from commit messages)
- [x] I have checked that all the tests pass.

### Testing

Added `TestMoveWithDeleteEmptySrcDirsPreexistingGroupError`, which records an unrelated error against a stats group, then runs a clean `MoveDir` with `deleteEmptySrcDirs` in that same group and asserts the empty source directory is removed.

Confirmed it reproduces the reported bug before the fix:

```
ERROR : Local file system at ...: not deleting directories as there were IO errors
--- FAIL: TestMoveWithDeleteEmptySrcDirsPreexistingGroupError
    Error: Received unexpected error: not deleting directories as there were IO errors
```

and passes with it. The rest of `./fs/sync/` passes, with one pre-existing unrelated failure (`TestNothingToTransferWithoutEmptyDirs`, a directory-modtime precision mismatch on Windows local) that reproduces identically on an unmodified master. `gofmt` and `go vet` are clean.
