### PR TITLE
asyncreader: run the skip-bytes test under the race detector again

### DIFF
--- a/fs/asyncreader/asyncreader_test.go
+++ b/fs/asyncreader/asyncreader_test.go
@@ -13,7 +13,6 @@ import (
 	"testing/iotest"
 	"time"
 
-	"github.com/rclone/rclone/lib/israce"
 	"github.com/rclone/rclone/lib/readers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -316,9 +315,6 @@ func TestAsyncReaderSkipBytes(t *testing.T) {
 		8000, len(data), BufferSize, 2 * BufferSize}
 
 	for buffers := 1; buffers <= 5; buffers++ {
-		if israce.Enabled && buffers > 1 {
-			t.Skip("FIXME Skipping further tests with race detector until https://github.com/golang/go/issues/27070 is fixed.")
-		}
 		t.Run(fmt.Sprintf("%d", buffers), func(t *testing.T) {
 			for _, initialRead := range initialReads {
 				t.Run(fmt.Sprintf("%d", initialRead), func(t *testing.T) {


### PR DESCRIPTION
#### What does this change do?

`TestAsyncReaderSkipBytes` skips every buffer count above 1 when run under the race detector, pointing at golang/go#27070. That issue was **closed on 2018-09-18**, so the workaround has been outliving its cause by seven years — and it costs most of the race coverage of this file: under `-race` the test runs **137 subtests today, against 681 without it**. Since `asyncreader` is concurrency code with a background filler goroutine, that is the coverage one would most want kept.

Removing the guard restores full parity: `go test -race ./fs/asyncreader/` now runs the same **681** subtests as a non-race run, and passes.

Verified in a clean container (`golang:1.26`, no network):

- `go test -race ./fs/asyncreader/ -count=10` — pass (10 consecutive runs)
- `go test ./fs/asyncreader/ -count=10` — pass
- `gofmt -l` clean, `go vet ./fs/asyncreader/` clean

The `lib/israce` import goes away with the guard; the package is still used elsewhere.

#### Linked issue

None — this is a test-only change that deletes an obsolete skip, with the evidence above.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate — no new tests are needed here; the change re-enables existing ones.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] This Pull Request is ready for review.
