### PR TITLE
lib/transform: validate --name-transform values when the flag is parsed

### DIFF
--- a/lib/transform/options.go
+++ b/lib/transform/options.go
@@ -3,6 +3,8 @@ package transform
 import (
 	"context"
 	"errors"
+	"fmt"
+	"regexp"
 	"slices"
 	"strings"
 	"sync"
@@ -11,9 +13,10 @@ import (
 )
 
 type transform struct {
-	key   Algo   // for example, "prefix"
-	value string // for example, "some_prefix_"
-	tag   tag    // file, dir, or all
+	key   Algo           // for example, "prefix"
+	value string         // for example, "some_prefix_"
+	tag   tag            // file, dir, or all
+	re    *regexp.Regexp // compiled pattern, for regex only
 }
 
 // tag controls which part of the file path is affected (file, dir, all)
@@ -135,6 +138,35 @@ func (t *transform) parseKeyVal(s string) (err error) {
 		return err
 	}
 	t.value = split[1]
+	if err := t.parseValue(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// parseValue validates the value of those algorithms that pack more than one
+// operand into it, and precompiles the regex so that it is compiled once
+// instead of once per path segment.
+//
+// Doing this while the flag is parsed means an invalid value is reported
+// before any transfer starts, rather than failing on every file.
+func (t *transform) parseValue() error {
+	switch t.key {
+	case ConvFindReplace:
+		if len(strings.Split(t.value, ":")) != 2 {
+			return fmt.Errorf("wrong number of values: %v", t.value)
+		}
+	case ConvRegex:
+		split := strings.Split(t.value, "/")
+		if len(split) != 2 {
+			return fmt.Errorf("regex syntax error: %v", t.value)
+		}
+		re, err := regexp.Compile(split[0])
+		if err != nil {
+			return fmt.Errorf("regex syntax error: %v: %w", t.value, err)
+		}
+		t.re = re
+	}
 	return nil
 }
 

--- a/lib/transform/transform.go
+++ b/lib/transform/transform.go
@@ -14,7 +14,6 @@ import (
 	"net/url"
 	"os/exec"
 	"path"
-	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -63,7 +62,11 @@ func Path(ctx context.Context, s string, isDir bool) string {
 		}
 		if err != nil {
 			err = fs.CountError(ctx, fserrors.NoRetryError(err))
-			fs.Errorf(s, "Failed to transform: %v", err)
+			fs.Errorf(old, "Failed to transform: %v", err)
+			// keep the original name: a failed transform can leave s empty or
+			// half converted, and copying to that name is worse than not
+			// transforming at all (same as the segment count check below)
+			return old
 		}
 	}
 	if old != s {
@@ -226,11 +229,10 @@ func transformPathSegment(s string, t transform) (string, error) {
 		return s + AppyTimeGlobs(t.value, time.Now()), nil
 	case ConvRegex:
 		split := strings.Split(t.value, "/")
-		if len(split) != 2 {
+		if len(split) != 2 || t.re == nil {
 			return s, fmt.Errorf("regex syntax error: %v", t.value)
 		}
-		re := regexp.MustCompile(split[0])
-		return re.ReplaceAllString(s, split[1]), nil
+		return t.re.ReplaceAllString(s, split[1]), nil
 	case ConvCommand:
 		return mapper(s, t.value)
 	default:

--- a/lib/transform/transform_test.go
+++ b/lib/transform/transform_test.go
@@ -146,3 +146,43 @@ func TestVarious(t *testing.T) {
 		assert.Equal(t, test.want, got)
 	}
 }
+
+// an invalid value must be rejected when the flag is parsed, so that the
+// command fails before transferring anything instead of failing per file
+func TestInvalidValueRejectedWhenParsed(t *testing.T) {
+	for _, test := range []struct {
+		flag string
+		want string
+	}{
+		{"all,replace=10:30:10-30", "wrong number of values: 10:30:10-30"},
+		{"all,replace=onlyone", "wrong number of values: onlyone"},
+		{"all,regex=a/b/c", "regex syntax error: a/b/c"},
+		{"all,regex=[/x", "regex syntax error: [/x: error parsing regexp: missing closing ]: `[`"},
+	} {
+		_, err := newOptions(test.flag)
+		require.Error(t, err, test.flag)
+		assert.Equal(t, test.want, err.Error())
+	}
+}
+
+// a valid regex is compiled once when parsed, not once per path segment
+func TestRegexCompiledOnce(t *testing.T) {
+	tr, err := parse("all,regex=[0-9]/#")
+	require.NoError(t, err)
+	require.NotNil(t, tr.re)
+	assert.Equal(t, "[0-9]", tr.re.String())
+}
+
+// a failing transform must leave the name alone rather than return an empty
+// one, which would then be used as the destination name
+//
+// The existing "number of path segments must match" check only catches this
+// for a path containing a separator: a bare file name has as many segments as
+// the empty string, so it used to pass straight through.
+func TestFailedTransformKeepsOriginalName(t *testing.T) {
+	for _, path := range []string{"file.txt", "dir/file.txt"} {
+		ctx, err := newOptions("all,truncate=notanumber")
+		require.NoError(t, err) // truncate takes any value at parse time
+		assert.Equal(t, path, Path(ctx, path, false))
+	}
+}


### PR DESCRIPTION
#### What does this change do?

An invalid `--name-transform` value is only noticed while a name is being transformed, and the failure mode is worse than a rejected flag. This makes the parser reject it, and stops a failed transform from blanking the name.

Three things happen today, all reproducible on master (`f0b210a`):

1. **A failed transform empties the name.** `transformPathSegment` returns the error (`transform.go:150-154`), `transformPath` turns that into `""` (`:106`), and `Path` logs it but carries on with the empty string (`:63-67`). The guard that would catch it — `strings.Count(old, "/") != strings.Count(s, "/")` (`:75`) — does not fire for a bare file name, because `10:30 meeting.txt` and `""` both have zero separators. The empty name then reaches the copy, which is where the reporter's three `.partial` errors come from. A path with a directory in it hits the guard and survives, which is why this looks intermittent.

2. **An invalid regex panics.** `regexp.MustCompile` runs on unvalidated user input, once per path segment (`:232`):

```
$ rclone copy src dst --name-transform 'all,regex=[/x'
panic: regexp: Compile(`[`): error parsing regexp: missing closing ]: `[`
  .../lib/transform.transformPathSegment(...) lib/transform/transform.go:232
  .../fs/march.(*March).matchListings(...) fs/march/march.go:333
```

3. **The regex is recompiled for every path segment**, which this change also removes by compiling once at parse time.

After the change both cases fail immediately and cleanly, before anything is transferred:

```
$ rclone copy src dst --name-transform "all,replace=10:30:10-30"
NOTICE: Failed to copy: wrong number of values: 10:30:10-30
$ rclone copy src dst --name-transform 'all,regex=[/x'
NOTICE: Failed to copy: regex syntax error: [/x: error parsing regexp: missing closing ]: `[`
```

Verified in a clean container (`golang:1.26`, no network): the two new tests fail on master (`An error is expected but got nil`, `expected "file.txt"`) and pass here; `go test -race ./lib/transform/ ./fs/sync/ ./fs/operations/` green; `gofmt`/`go vet` clean.

Note on scope: this does not add a way to put a colon *inside* `replace=`, which is what #9773 asks for — that needs a syntax decision (escape character or an alternative separator), so it is left out. In the meantime `regex=` splits on `/` rather than `:`, so `--name-transform "all,regex=10:30/10-30"` already does what the reporter wants.

#### Linked issue

#9773 — the diagnosis above is posted there. Not marked as "Fixes" because the colon syntax the issue asks for is deliberately not part of this change.

#### Checklist

- [ ] This change is trivial **OR** it has been discussed and agreed in the linked issue. — the analysis is in #9773 but nobody has commented yet, so I cannot honestly tick this; happy to close this and wait if you would rather settle the approach in the issue first.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] This Pull Request is ready for review.
