### PR TITLE
azureblob: fix object size wrongly set to chunk size on ranged reads

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -2367,7 +2367,6 @@ func (o *Object) decodeMetaDataFromDownloadResponse(info *blob.DownloadStreamRes
 	} else {
 		o.mimeType = *info.ContentType
 	}
-	o.size = size
 	if info.LastModified == nil {
 		o.modTime = time.Now()
 	} else {
@@ -2381,7 +2380,9 @@ func (o *Object) decodeMetaDataFromDownloadResponse(info *blob.DownloadStreamRes
 	// }
 	o.setMetadata(metadata)
 
-	// If it was a Range request, the size is wrong, so correct it
+	// If ContentRange is present, the response was a ranged request
+	// where Content-Length is the chunk size, not the full object size.
+	// In that case use the total size from the Content-Range header.
 	if info.ContentRange != nil {
 		contentRange := *info.ContentRange
 		slash := strings.IndexRune(contentRange, '/')
@@ -2390,11 +2391,13 @@ func (o *Object) decodeMetaDataFromDownloadResponse(info *blob.DownloadStreamRes
 			if err == nil {
 				o.size = i
 			} else {
-				fs.Debugf(o, "Failed to find parse integer from in %q: %v", contentRange, err)
+				fs.Debugf(o, "Failed to parse integer from Content-Range %q: %v", contentRange, err)
 			}
 		} else {
-			fs.Debugf(o, "Failed to find length in %q", contentRange)
+			fs.Debugf(o, "Failed to find length in Content-Range %q", contentRange)
 		}
+	} else {
+		o.size = size
 	}
 	o.contentEncoding = info.ContentEncoding
 


### PR DESCRIPTION
When `Object.Open()` was called with a `RangeOption` (e.g. by the VFS cache reading with `--vfs-read-chunk-size`), `decodeMetaDataFromDownloadResponse` unconditionally set `o.size` from the response `Content-Length`. For a ranged response this is the **chunk size**, not the full blob size.

While the existing code tried to correct this by parsing the `Content-Range` header, the `o.size` was first set to the chunk size, and only then corrected to the total size. This meant:

1. **Race condition**: in parallel read scenarios (multiple downloaders), another goroutine could read the corrupted `o.size` between the `Content-Length` write and the `Content-Range` correction
2. **No correction when `Content-Range` is absent**: if the header is missing or parsing fails, `o.size` stays at the chunk size

**Fix**: Only set `o.size` from `Content-Length` when `Content-Range` is absent (i.e. the response is a full object download, not a ranged response). When `Content-Range` is present, use the total size from the `Content-Range` header directly.

Fixes #9782