### PR TITLE
azureblob: fix VFS cache object size corruption on ranged reads

### DIFF
--- a/backend/azureblob/azureblob.go
+++ b/backend/azureblob/azureblob.go
@@ -2367,21 +2367,20 @@ func (o *Object) decodeMetaDataFromDownloadResponse(info *blob.DownloadStreamRes
 	} else {
 		o.mimeType = *info.ContentType
 	}
-	o.size = size
-	if info.LastModified == nil {
-		o.modTime = time.Now()
-	} else {
-		o.modTime = *info.LastModified
-	}
-	// FIXME response doesn't appear to have AccessTier in?
-	// if info.AccessTier == nil {
-	// 	o.accessTier = blob.AccessTier("")
-	// } else {
-	// 	o.accessTier = blob.AccessTier(*info.AccessTier)
-	// }
-	o.setMetadata(metadata)
-
-	// If it was a Range request, the size is wrong, so correct it
+	// The download response's size depends on the kind of request:
+	//
+	//   - For a ranged request the ContentLength is the length of the
+	//     response body (i.e. the chunk size), not the size of the
+	//     object. The true object size is given in the Content-Range
+	//     header, so parse that when present.
+	//   - For a full download ContentLength is the object size.
+	//
+	// Never overwrite a known object size with the (smaller) response
+	// body length of a ranged request: the VFS cache compares the
+	// remote object size against the size of its local cache file, and
+	// with the object size incorrectly reported as one chunk long it
+	// would treat every read past the first chunk as a corrupt cache
+	// file and enter an unbounded recovery loop (see #9782).
 	if info.ContentRange != nil {
 		contentRange := *info.ContentRange
 		slash := strings.IndexRune(contentRange, '/')
@@ -2395,7 +2394,23 @@ func (o *Object) decodeMetaDataFromDownloadResponse(info *blob.DownloadStreamRes
 		} else {
 			fs.Debugf(o, "Failed to find length in %q", contentRange)
 		}
+	} else if o.size == 0 || size > o.size {
+		// Full download response, or object size not known yet:
+		// ContentLength is the object size. Never shrink a known size.
+		o.size = size
 	}
+	if info.LastModified == nil {
+		o.modTime = time.Now()
+	} else {
+		o.modTime = *info.LastModified
+	}
+	// FIXME response doesn't appear to have AccessTier in?
+	// if info.AccessTier == nil {
+	// 	o.accessTier = blob.AccessTier("")
+	// } else {
+	// 	o.accessTier = blob.AccessTier(*info.AccessTier)
+	// }
+	o.setMetadata(metadata)
 	o.contentEncoding = info.ContentEncoding
 
 	// If decompressing then size and md5sum are unknown

--- a/backend/azureblob/azureblob_internal_test.go
+++ b/backend/azureblob/azureblob_internal_test.go
@@ -632,3 +632,75 @@ func (f *Fs) testMetadataPaths(t *testing.T) {
 		assert.Contains(t, err.Error(), "invalid tag")
 	})
 }
+
+func TestDecodeMetaDataFromDownloadResponseRangeNoContentRange(t *testing.T) {
+	// Regression test for #9782:
+	// A ranged download response without a Content-Range header must not
+	// overwrite a known object size with the (smaller) Content-Length
+	// (the length of the range body).
+
+	originalSize := int64(169 * 1024 * 1024 * 1024) // 169 GiB — known from listing
+	chunkSize := int64(64 * 1024 * 1024)            // 64 MiB — a typical --vfs-read-chunk-size
+
+	o := &Object{
+		size:   originalSize,
+		remote: "test-blob.dat",
+		fs:     &Fs{},
+	}
+
+	// Simulate a ranged response for a 64 MiB chunk, no Content-Range header
+	info := &blob.DownloadStreamResponse{}
+	info.ContentLength = &chunkSize
+	info.Metadata = map[string]*string{}
+
+	err := o.decodeMetaDataFromDownloadResponse(info)
+	require.NoError(t, err)
+	assert.Equal(t, originalSize, o.size,
+		"object size should not be shrunk by a ranged response without Content-Range")
+}
+
+func TestDecodeMetaDataFromDownloadResponseRangeWithContentRange(t *testing.T) {
+	// A ranged download response WITH a Content-Range header should set the
+	// object size from the total-size part of the header.
+
+	originalSize := int64(169 * 1024 * 1024 * 1024) // 169 GiB
+	chunkSize := int64(64 * 1024 * 1024)            // 64 MiB
+	contentRange := "bytes 0-67108863/181289406464" // chunk/total = 169 GiB
+
+	o := &Object{
+		size:   originalSize,
+		remote: "test-blob.dat",
+		fs:     &Fs{},
+	}
+
+	info := &blob.DownloadStreamResponse{}
+	info.ContentLength = &chunkSize
+	info.ContentRange = &contentRange
+	info.Metadata = map[string]*string{}
+
+	err := o.decodeMetaDataFromDownloadResponse(info)
+	require.NoError(t, err)
+	assert.Equal(t, int64(181289406464), o.size,
+		"object size should be set from Content-Range header total")
+}
+
+func TestDecodeMetaDataFromDownloadResponseFullDownload(t *testing.T) {
+	// A full download response (no Content-Range, ContentLength matches the
+	// object size) should set the size normally.
+
+	originalSize := int64(1024 * 1024) // 1 MiB
+
+	o := &Object{
+		remote: "test-blob.dat",
+		fs:     &Fs{},
+	}
+
+	info := &blob.DownloadStreamResponse{}
+	info.ContentLength = &originalSize
+	info.Metadata = map[string]*string{}
+
+	err := o.decodeMetaDataFromDownloadResponse(info)
+	require.NoError(t, err)
+	assert.Equal(t, originalSize, o.size,
+		"object size should be set from ContentLength on full download")
+}


### PR DESCRIPTION
**Root cause**

`decodeMetaDataFromDownloadResponse` unconditionally overwrites `o.size` with the `Content-Length` of the download response. For a ranged request the `Content-Length` is the length of the response body (the chunk size, e.g. 64 MiB), **not** the size of the object. The `Content-Range` header, when present, carries the true object size and is parsed to correct `o.size` — but not all backends or SDK versions reliably return this header, leaving the object's size permanently corrupted to the chunk size.

With `--vfs-cache-mode full` and `--vfs-read-chunk-size` this causes every subsequent range check in the VFS cache to compare the growing local cache file against the truncated "remote object" size (the chunk size). The cache then enters an unbounded recovery loop spamming:

```
vfs cache: cached file (...) is unexpectedly larger than the remote object (67108864)
```

**Fix**

Only update `o.size` from the download response's `Content-Length` when:
1. The `Content-Range` header is present (parse the total size from it), **or**
2. The `Content-Length` is larger than the already-known size (new object, or a full download of a grown object)

Never shrink a known object size with a download response's `Content-Length` — a ranged response can legitimately have a smaller `Content-Length` (the chunk size) without a `Content-Range` header, and overwriting `o.size` with it would corrupt the object metadata.

**Reproduction**

```bash
rclone mount remote:container /mnt/rclone/mount --vfs-cache-mode full --vfs-read-chunk-size 64M
```

Reading a large blob (>100 GB, e.g. MXF video files) — after the first few GB the error appears and repeats indefinitely.

**Workaround** (existing): `--vfs-read-chunk-size 0` disables chunked reading.

Fixes #9782.

Signed-off-by: waterWang <waterwang@example.com>