### PR TITLE
box: fix truncated files being uploaded successfully when the source ends early

### DIFF
--- a/backend/box/box.go
+++ b/backend/box/box.go
@@ -45,6 +45,7 @@ import (
 	"github.com/rclone/rclone/lib/oauthutil"
 	"github.com/rclone/rclone/lib/pacer"
 	"github.com/rclone/rclone/lib/random"
+	"github.com/rclone/rclone/lib/readers"
 	"github.com/rclone/rclone/lib/rest"
 	"github.com/youmark/pkcs8"
 )
@@ -1691,7 +1692,7 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 // upload does a single non-multipart upload
 //
 // This is recommended for less than 50 MiB of content
-func (o *Object) upload(ctx context.Context, in io.Reader, leaf, directoryID string, modTime time.Time, options ...fs.OpenOption) (err error) {
+func (o *Object) upload(ctx context.Context, in io.Reader, leaf, directoryID string, size int64, modTime time.Time, options ...fs.OpenOption) (err error) {
 	upload := api.UploadFile{
 		Name:              o.fs.opt.Enc.FromStandardName(leaf),
 		ContentModifiedAt: api.Time(modTime),
@@ -1703,9 +1704,10 @@ func (o *Object) upload(ctx context.Context, in io.Reader, leaf, directoryID str
 
 	var resp *http.Response
 	var result api.FolderItems
+	counter := readers.NewCountingReader(in)
 	opts := rest.Opts{
 		Method:                "POST",
-		Body:                  in,
+		Body:                  counter,
 		MultipartMetadataName: "attributes",
 		MultipartContentName:  "contents",
 		MultipartFileName:     upload.Name,
@@ -1724,6 +1726,11 @@ func (o *Object) upload(ctx context.Context, in io.Reader, leaf, directoryID str
 	})
 	if err != nil {
 		return err
+	}
+	// Check the source supplied the number of bytes it declared
+	// otherwise a truncated file would be stored as a good upload.
+	if size >= 0 && int64(counter.BytesRead()) != size {
+		return fmt.Errorf("expected %d bytes in input, but got %d: %w", size, counter.BytesRead(), io.ErrUnexpectedEOF)
 	}
 	if result.TotalCount != 1 || len(result.Entries) != 1 {
 		return fmt.Errorf("failed to upload %v - not sure why", o)
@@ -1754,7 +1761,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 
 	// Upload with simple or multipart
 	if size <= int64(o.fs.opt.UploadCutoff) {
-		err = o.upload(ctx, in, leaf, directoryID, modTime, options...)
+		err = o.upload(ctx, in, leaf, directoryID, size, modTime, options...)
 	} else {
 		err = o.uploadMultipart(ctx, in, leaf, directoryID, size, modTime, options...)
 	}


### PR DESCRIPTION
Continues the "source ends early" sweep (5d05754 sia, a2baa97 pikpak, e1bf940 filelu,
7357fb8 internetarchive, 884b28c azurefiles, 18fa445 compress).

### Problem

`(*Object).upload` — the single-shot path taken when the size is at or below
`upload_cutoff` (50 MiB by default) — passes the source straight to Box as the multipart
body:

```go
opts := rest.Opts{
    Method:               "POST",
    Body:                 in,
    MultipartContentName: "contents",
    ...
}
```

No `ContentLength` is set, so the request is chunked and a source that stops short simply
produces a shorter body. Box accepts it, returns one entry, and the upload is reported as a
success with a truncated file stored.

`uploadMultipart` is not affected: it fills each chunk with `io.ReadFull`, which returns
`io.ErrUnexpectedEOF` when the source ends early.

### Fix

Wrap the body in `readers.NewCountingReader` and compare the bytes actually read against the
declared size, matching the sia fix. `size` is already computed in `Update` and passed to
`uploadMultipart`; it is now passed to `upload` as well.

### Verification

`go build ./...`, `go test ./backend/box/...` and `golangci-lint run ./backend/box/...`
(0 issues) all pass. `RCLONE_CONFIG=/notfound go test ./...` is unchanged from master:
`cmd/gitannex` and `cmd/serve/s3` fail identically before and after this commit on my
machine (no `git-annex` or `minio` binary locally). No Box remote here, so the backend
integration tests have not been run against a real remote.

### Possibly the same, not yet checked

While looking for this I noticed four more backends that stream the source with no
`ContentLength` and no byte-count check, so they may have the same problem — flagging rather
than claiming, as I have not confirmed any of them:

`yandex` (`yandex.go:1135`), `gofile` (`gofile.go:1450`), `filefabric`
(`filefabric.go:1276`), `googlephotos` (`googlephotos.go:1198`).

Happy to follow up on those if useful.
