### PR TITLE
yandex: fix truncated files being uploaded successfully when the source ends early

### DIFF
--- a/backend/yandex/yandex.go
+++ b/backend/yandex/yandex.go
@@ -1189,6 +1189,12 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		return err
 	}
 
+	// Check the source supplied the number of bytes it declared
+	// otherwise a truncated file would be stored as a good upload.
+	if size := src.Size(); size >= 0 && int64(in1.BytesRead()) != size {
+		return fmt.Errorf("expected %d bytes in input, but got %d: %w", size, in1.BytesRead(), io.ErrUnexpectedEOF)
+	}
+
 	// Set the modTime of the uploaded file and re-read the metadata
 	// so the object has the md5sum the server computed for the upload.
 	//


### PR DESCRIPTION
Continues the "source ends early" sweep (5d05754 sia, a2baa97 pikpak, e1bf940 filelu,
7357fb8 internetarchive, 884b28c azurefiles, 18fa445 compress).

### Problem

`(*Object).Update` already wraps the source in a counting reader:

```go
in1 := readers.NewCountingReader(in)
...
err = o.upload(ctx, in1, true, fs.MimeType(ctx, src), options...)
```

but `BytesRead()` is never called anywhere in the package, so the count is discarded.

The upload itself is a `PUT` with `Body: in1` and no `ContentLength`, so it is chunked: a
source that stops short just sends a shorter body, the server accepts it, and `Update`
carries on to set the modtime and returns success with a truncated file stored.

### Fix

Compare the bytes actually read against the declared size after the upload, using the
counter that is already there. No new imports.

### Verification

`go build ./...`, `go test ./backend/yandex/...` and `golangci-lint run ./backend/yandex/...`
(0 issues) all pass. `RCLONE_CONFIG=/notfound go test ./...` is unchanged from master:
`cmd/gitannex` and `cmd/serve/s3` fail identically before and after this commit on my
machine (no `git-annex` or `minio` binary locally). No Yandex remote here, so the backend
integration tests have not been run against a real remote.

Companion to #9785 (box), same class.
