### PR TITLE
gofile, googlephotos: fix truncated files being uploaded successfully when the source ends early

### DIFF
--- a/backend/gofile/gofile.go
+++ b/backend/gofile/gofile.go
@@ -27,6 +27,7 @@ import (
 	"github.com/rclone/rclone/lib/dircache"
 	"github.com/rclone/rclone/lib/encoder"
 	"github.com/rclone/rclone/lib/pacer"
+	"github.com/rclone/rclone/lib/readers"
 	"github.com/rclone/rclone/lib/rest"
 )
 
@@ -1445,9 +1446,10 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	// Do the upload
 	var resp *http.Response
 	var result api.UploadResponse
+	counter := readers.NewCountingReader(in)
 	opts := rest.Opts{
 		Method: "POST",
-		Body:   in,
+		Body:   counter,
 		MultipartParams: url.Values{
 			"folderId": {directoryID},
 			"modTime":  {strconv.FormatInt(modTime.Unix(), 10)},
@@ -1463,6 +1465,12 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	})
 	if err = result.Err(err); err != nil {
 		return fmt.Errorf("failed to upload file: %w", err)
+	}
+
+	// Check the source supplied the number of bytes it declared
+	// otherwise a truncated file would be stored as a good upload.
+	if size := src.Size(); size >= 0 && int64(counter.BytesRead()) != size {
+		return fmt.Errorf("expected %d bytes in input, but got %d: %w", size, counter.BytesRead(), io.ErrUnexpectedEOF)
 	}
 	return o.setMetaData(&result.Data)
 }

--- a/backend/googlephotos/googlephotos.go
+++ b/backend/googlephotos/googlephotos.go
@@ -32,6 +32,7 @@ import (
 	"github.com/rclone/rclone/lib/encoder"
 	"github.com/rclone/rclone/lib/oauthutil"
 	"github.com/rclone/rclone/lib/pacer"
+	"github.com/rclone/rclone/lib/readers"
 	"github.com/rclone/rclone/lib/rest"
 	"golang.org/x/oauth2/google"
 )
@@ -1187,6 +1188,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	}
 
 	// Upload the media item in exchange for an UploadToken
+	counter := readers.NewCountingReader(in)
 	opts := rest.Opts{
 		Method:  "POST",
 		Path:    "/uploads",
@@ -1195,7 +1197,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 			"X-Goog-Upload-File-Name": fileName,
 			"X-Goog-Upload-Protocol":  "raw",
 		},
-		Body: in,
+		Body: counter,
 	}
 	var token []byte
 	var resp *http.Response
@@ -1209,6 +1211,12 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 	})
 	if err != nil {
 		return fmt.Errorf("couldn't upload file: %w", err)
+	}
+
+	// Check the source supplied the number of bytes it declared
+	// otherwise a truncated file would be stored as a good upload.
+	if size := src.Size(); size >= 0 && int64(counter.BytesRead()) != size {
+		return fmt.Errorf("expected %d bytes in input, but got %d: %w", size, counter.BytesRead(), io.ErrUnexpectedEOF)
 	}
 	uploadToken := strings.TrimSpace(string(token))
 	if uploadToken == "" {


### PR DESCRIPTION
Continues the "source ends early" sweep (5d05754 sia, a2baa97 pikpak, e1bf940 filelu,
7357fb8 internetarchive, 884b28c azurefiles, 18fa445 compress), for the two remaining
backends I could find that stream the source with no `Content-Length` and never check how
much of it arrived.

### gofile

`Update` posts the source as a multipart body with no `Content-Length` and nothing in the
function looks at the size, so a source that stops short is accepted by the server and
`setMetaData` runs on the result as a success.

### googlephotos

`Update` sends the source to `/uploads` with `X-Goog-Upload-Protocol: raw` and no
`Content-Length`. A short source still returns an upload token, and the media item is then
created from truncated data.

Both now count the bytes read and fail if they do not match the declared size, matching the
sia fix.

### Not included

`filefabric` looked like the same shape but is already covered: it sets
`opts.ContentLength` when the size is known and rejects a mismatch afterwards with
`uploader.FileSize != size`. Left alone.

`box` (#9785) and `yandex` (#9786) are the same class and are sent separately since they are
independent of these two.

### Verification

`go build ./...`, `go test` on both backends and `golangci-lint run` on both (0 issues) all
pass. `RCLONE_CONFIG=/notfound go test ./...` is unchanged from master: `cmd/gitannex` and
`cmd/serve/s3` fail identically before and after on my machine (no `git-annex` or `minio`
binary locally). I have no gofile or Google Photos remote, so the backend integration tests
have not been run against a real remote.
