### PR TITLE
walk: stop directory traversal when the context is cancelled - fixes #9788

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -688,6 +688,9 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 	}()
 
 	for {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
 		var fis []os.FileInfo
 		if useReadDir {
 			// Windows and Plan9 read the directory entries with the stat information in which

--- a/fs/walk/walk.go
+++ b/fs/walk/walk.go
@@ -394,6 +394,13 @@ func walk(ctx context.Context, f fs.Fs, path string, includeAll bool, maxLevel i
 		wg.Go(func() {
 			for {
 				select {
+				case <-ctx.Done():
+					closeQuit()
+					select {
+					case errs <- ctx.Err():
+					default:
+					}
+					return
 				case job, ok := <-in:
 					if !ok {
 						return

--- a/fs/walk/walk_context_cancel_test.go
+++ b/fs/walk/walk_context_cancel_test.go
@@ -1,0 +1,47 @@
+package walk
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fstest/mockdir"
+	"github.com/stretchr/testify/assert"
+)
+
+// Test that walk stops listing when the context is cancelled.
+func TestWalkContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	started := make(chan struct{}, 1)
+	listDir := func(ctx context.Context, f fs.Fs, includeAll bool, dir string) (entries fs.DirEntries, err error) {
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		// Every directory contains one subdirectory so the walk never
+		// finishes on its own.
+		return fs.DirEntries{mockdir.New("sub")}, nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- walk(ctx, nil, "", false, -1, func(path string, entries fs.DirEntries, err error) error {
+			return nil
+		}, listDir)
+	}()
+
+	// Wait for the walk to start.
+	<-started
+
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("walk did not stop after the context was cancelled")
+	}
+}

--- a/fs/walk/walk_test.go
+++ b/fs/walk/walk_test.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"sync"
 	"testing"
-	"time"
 
 	"github.com/rclone/rclone/fs"
 	_ "github.com/rclone/rclone/fs/accounting"
@@ -190,39 +189,6 @@ func testWalkEmpty(t *testing.T) *listDirs {
 }
 func TestWalkEmpty(t *testing.T)  { testWalkEmpty(t).Walk() }
 func TestWalkREmpty(t *testing.T) { testWalkEmpty(t).WalkR() }
-
-// Test that walk stops listing when the context is cancelled.
-func TestWalkContextCancelled(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	listings := make(chan string, 1024)
-	listDir := func(ctx context.Context, f fs.Fs, includeAll bool, dir string) (entries fs.DirEntries, err error) {
-		listings <- dir
-		// Every directory contains one subdirectory so the walk never
-		// finishes on its own.
-		return fs.DirEntries{mockdir.New("sub")}, nil
-	}
-
-	done := make(chan error, 1)
-	go func() {
-		done <- walk(ctx, nil, "", false, -1, func(path string, entries fs.DirEntries, err error) error {
-			return nil
-		}, listDir)
-	}()
-
-	// Wait for the walk to start
-	assert.Equal(t, "", <-listings)
-
-	cancel()
-
-	select {
-	case err := <-done:
-		assert.ErrorIs(t, err, context.Canceled)
-	case <-time.After(10 * time.Second):
-		t.Fatal("walk did not stop after the context was cancelled")
-	}
-}
 
 func testWalkEmptySkip(t *testing.T) *listDirs {
 	return newListDirs(t, nil, true,

--- a/fs/walk/walk_test.go
+++ b/fs/walk/walk_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/rclone/rclone/fs"
 	_ "github.com/rclone/rclone/fs/accounting"
@@ -189,6 +190,39 @@ func testWalkEmpty(t *testing.T) *listDirs {
 }
 func TestWalkEmpty(t *testing.T)  { testWalkEmpty(t).Walk() }
 func TestWalkREmpty(t *testing.T) { testWalkEmpty(t).WalkR() }
+
+// Test that walk stops listing when the context is cancelled.
+func TestWalkContextCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	listings := make(chan string, 1024)
+	listDir := func(ctx context.Context, f fs.Fs, includeAll bool, dir string) (entries fs.DirEntries, err error) {
+		listings <- dir
+		// Every directory contains one subdirectory so the walk never
+		// finishes on its own.
+		return fs.DirEntries{mockdir.New("sub")}, nil
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- walk(ctx, nil, "", false, -1, func(path string, entries fs.DirEntries, err error) error {
+			return nil
+		}, listDir)
+	}()
+
+	// Wait for the walk to start
+	assert.Equal(t, "", <-listings)
+
+	cancel()
+
+	select {
+	case err := <-done:
+		assert.ErrorIs(t, err, context.Canceled)
+	case <-time.After(10 * time.Second):
+		t.Fatal("walk did not stop after the context was cancelled")
+	}
+}
 
 func testWalkEmptySkip(t *testing.T) *listDirs {
 	return newListDirs(t, nil, true,


### PR DESCRIPTION
#### What does this change do?

It makes the concurrent directory walker created by `walk()` observe context cancellation, and adds a context check between directory-read chunks in the local backend.

Before: `job/stop` on an async RC `operations/size` (or an interrupt of any command going through `walk()`) cancelled the job's context, but the checkers kept pulling list jobs and walked the whole tree anyway — the job often even completed with `success=true`. On a 1.26M-file local tree, rclone kept burning ~570% CPU for ~4 s after the stop request was acknowledged, then reported success.

After: the same stop makes every checker exit through the existing `quit`/drain path within milliseconds, the job finishes with `error=context canceled`, and CPU returns to idle immediately.

Two changes:

- `fs/walk/walk.go`: each checker now also selects on `ctx.Done()`. On cancellation it calls `closeQuit()` (the existing shutdown path, which drains pending jobs so `traversing` still converges and no producer stays blocked on the channel), pushes `ctx.Err()` into the existing error channel, and returns. No new synchronization is introduced — this reuses the shutdown machinery that was already there for listing errors.
- `backend/local/local.go`: `List` checks `ctx.Err()` before each `Readdirnames`/`Readdir` chunk, so cancelling during the enumeration of one huge directory does not have to wait for that directory to finish.

`walkRDirTree`/`walkListR` (native `ListR` backends) were not touched: those already propagate the context to the backend, which is expected to honour it.

Related but distinct: #9416 (channel deadlock in `fs/walk` under `--fast-list`) is a different bug in the same file — this PR does not address it, and the drain path reused here is the one that already existed.

#### Linked issue

Fixes #9788

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself. Verified against the reproducer in the linked issue (official v1.75.0 vs patched build, 1.26M-file local tree): unpatched keeps walking after `job/stop` until the tree is exhausted; patched finishes with `context canceled` within ~1 s and CPU drops to idle. `go build` passes; `go test -race -count=2 ./fs/walk/... ./backend/local/...` passes. Full `go test ./...`: all packages pass except `cmd/serve/s3` (`TestS3Minio`), which fails identically on unpatched `upstream/master` in this environment (pre-existing, unrelated — it needs a minio binary).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate. *(no user-facing surface changes: no flags, no output format changes — behaviour now matches what the docs already promise)*
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** N/A — the local backend change is a 3-line context check with no behavioural change unless the context is cancelled.
- [x] This Pull Request is ready for review.

**Test added**: `TestWalkContextCancelled` in `fs/walk/walk_test.go` runs a walk whose every directory listing returns a fresh subdirectory (so the walk never terminates on its own), cancels the context once listing has started, and asserts the walk returns `context.Canceled` within 10 s. Verified it fails on unpatched v1.75.0 (`walk did not stop after the context was cancelled`) and passes with the fix, stable across `-count=5` and under `-race`.
