### PR TITLE
s3: support server-side move for SeaweedFS via RenameObject - fixes #9755

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1932,6 +1932,11 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	if opt.Provider == "Rabata" {
 		f.features.Copy = nil
 	}
+	if opt.Provider != "SeaweedFS" {
+		// RenameObject is a SeaweedFS extension to the S3 API - fall back
+		// to copy+delete for all other providers.
+		f.features.Move = nil
+	}
 	if opt.Provider == "TencentCOS" && strings.Contains(opt.Endpoint, "cos.accelerate.myqcloud.com") {
 		// Global Acceleration endpoint does not support bucket creation.
 		f.opt.NoCheckBucket = true
@@ -3285,6 +3290,80 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 	}
 
 	return dstObj, nil
+}
+
+// addRenameObjectParams returns a stack mutator that turns a PutObject
+// request into a SeaweedFS RenameObject request by adding the renameObject
+// query parameter and the x-amz-rename-source header before the request is
+// signed.
+//
+// See: https://github.com/seaweedfs/seaweedfs/pull/10659
+func addRenameObjectParams(source string) func(stack *middleware.Stack) error {
+	return func(stack *middleware.Stack) error {
+		return stack.Build.Add(middleware.BuildMiddlewareFunc("AddRenameObjectParams", func(ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler) (middleware.BuildOutput, middleware.Metadata, error) {
+			req, ok := in.Request.(*smithyhttp.Request)
+			if !ok {
+				return middleware.BuildOutput{}, middleware.Metadata{}, fmt.Errorf("unknown transport type %T", in.Request)
+			}
+			query := req.URL.Query()
+			query.Set("renameObject", "")
+			req.URL.RawQuery = query.Encode()
+			req.Header.Set("x-amz-rename-source", source)
+			return next.HandleBuild(ctx, in)
+		}), middleware.After)
+	}
+}
+
+// Move src to this remote using server-side move operations.
+//
+// This is stored with the remote path given.
+//
+// It returns the destination Object and a possible error.
+//
+// Will only be called if src.Fs().Name() == f.Name()
+//
+// If it isn't possible then return fs.ErrorCantMove
+func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object, error) {
+	if f.opt.VersionAt.IsSet() {
+		return nil, errNotWithVersionAt
+	}
+	srcObj, ok := src.(*Object)
+	if !ok {
+		fs.Debugf(src, "Can't move - not same remote type")
+		return nil, fs.ErrorCantMove
+	}
+	dstBucket, dstPath := f.split(remote)
+	srcBucket, srcPath := srcObj.split()
+	if srcBucket != dstBucket {
+		// RenameObject only moves within a single bucket
+		fs.Debugf(src, "Can't move - source and destination buckets differ: %q != %q", srcBucket, dstBucket)
+		return nil, fs.ErrorCantMove
+	}
+	err := f.mkdirParent(ctx, remote)
+	if err != nil {
+		return nil, err
+	}
+	source := pathEscape(bucket.Join(srcBucket, srcPath))
+
+	req := &s3.PutObjectInput{
+		Bucket: &dstBucket,
+		Key:    &dstPath,
+	}
+	err = f.pacer.Call(func() (bool, error) {
+		_, err := f.c.PutObject(ctx, req, s3.WithAPIOptions(addRenameObjectParams(source)))
+		if err != nil {
+			if getHTTPStatusCode(err) == http.StatusNotImplemented {
+				// SeaweedFS returns 501 for versioned buckets - fall back to copy+delete
+				return false, fs.ErrorCantMove
+			}
+			return f.shouldRetry(ctx, err)
+		}
+		return false, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return f.NewObject(ctx, remote)
 }
 
 // Hashes returns the supported hash sets.

--- a/backend/s3/s3_internal_test.go
+++ b/backend/s3/s3_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/md5"
 	"errors"
 	"fmt"
+	"net/http"
 	"path"
 	"strings"
 	"testing"
@@ -16,6 +17,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/smithy-go"
+	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/cache"
 	"github.com/rclone/rclone/fs/hash"
@@ -319,6 +322,42 @@ func TestRemoveAWSChunked(t *testing.T) {
 			check(got, got2)
 		})
 	}
+}
+
+// TestAddRenameObjectParams checks the renameObject query parameter and
+// x-amz-rename-source header are added to the request before it would be
+// signed, mimicking the SeaweedFS RenameObject wire contract.
+func TestAddRenameObjectParams(t *testing.T) {
+	httpReq, err := http.NewRequest("PUT", "https://example.com/bucket/dst/path", nil)
+	require.NoError(t, err)
+	req := &smithyhttp.Request{Request: httpReq}
+
+	stack := middleware.NewStack("RenameObject", smithyhttp.NewStackRequest)
+	err = addRenameObjectParams("bucket/src/path")(stack)
+	require.NoError(t, err)
+
+	terminal := middleware.HandlerFunc(func(ctx context.Context, in interface{}) (interface{}, middleware.Metadata, error) {
+		return in, middleware.Metadata{}, nil
+	})
+	out, _, err := stack.Build.HandleMiddleware(context.Background(), req, terminal)
+	require.NoError(t, err)
+
+	got, ok := out.(*smithyhttp.Request)
+	require.True(t, ok)
+	assert.True(t, got.URL.Query().Has("renameObject"))
+	assert.Equal(t, "bucket/src/path", got.Header.Get("x-amz-rename-source"))
+}
+
+// TestMoveCrossBucket checks Move refuses a rename across buckets, since
+// SeaweedFS's RenameObject only moves within a single bucket, instead of
+// sending a request the server can't satisfy.
+func TestMoveCrossBucket(t *testing.T) {
+	srcFs := &Fs{root: "bucketA"}
+	dstFs := &Fs{root: "bucketB"}
+	srcObj := &Object{fs: srcFs, remote: "path/file.txt"}
+
+	_, err := dstFs.Move(context.Background(), srcObj, "path/file.txt")
+	assert.ErrorIs(t, err, fs.ErrorCantMove)
 }
 
 func (f *Fs) InternalTestVersions(t *testing.T) {


### PR DESCRIPTION
#### What does this change do?

SeaweedFS added a `RenameObject` S3-API extension (proprietary, not part of
standard S3) enabling atomic server-side rename. Previously rclone's S3
backend had no `Move`/rename support for any provider, so `move`/`moveto`
always fell back to copy-then-delete-source.

This adds `Fs.Move` to the S3 backend, gated strictly to
`provider = SeaweedFS` (via `Features().Move`, nil for every other
provider) so behaviour for AWS/MinIO/Backblaze/etc. is unchanged. It issues
a normal `PutObject` request carrying the `renameObject` query parameter
and `x-amz-rename-source` header per SeaweedFS's documented wire contract.

A destination in a different bucket falls back to `fs.ErrorCantMove`
(RenameObject is intra-bucket only), as does a destination on a versioned
bucket (SeaweedFS returns 501 there) — both cases transparently fall back
to rclone's existing copy+delete path.

Verified end-to-end against a real SeaweedFS server (Docker
`chrislusf/seaweedfs`): basic move, overwrite-destination move, recursive
directory move, cross-bucket fallback, and versioned-bucket fallback all
behave correctly.

#### Linked issue

Fixes #9755

#### For new or changed backends

Not a new backend - existing `backend/s3` package, gated to one provider
profile. Ran `go build ./...`, `go vet ./backend/s3/...`,
`golangci-lint run ./backend/s3/...`, and
`RCLONE_CONFIG="/notfound" go test ./backend/s3/...` - all clean.

`go run ./fstest/test_all -backends s3` was not run since it requires a
configured `TestS3:` remote; manual end-to-end verification was done
against a live SeaweedFS container instead (see above).

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the contribution guidelines.
- [x] (If I used AI tools...) I have read and understood the AI-assisted contributions guidance, and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in house style.
- [ ] (Backend changes only) `test_all` passes for this backend...
- [ ] This Pull Request is ready for review.
