### PR TITLE
smb: make operation contexts cancel in-flight SMB I/O - fixes #9708

### DIFF
--- a/backend/smb/connpool.go
+++ b/backend/smb/connpool.go
@@ -103,6 +103,36 @@ func (c *conn) closed() bool {
 	return c.smbSession.Echo() != nil
 }
 
+// withContext returns the session and share bound to ctx so that a
+// single operation's I/O can be cancelled without affecting the
+// pooled connection, which keeps its own long-lived context.
+func (c *conn) withContext(ctx context.Context) (session *smb2.Session, share *smb2.Share) {
+	session = c.smbSession.WithContext(ctx)
+	if c.smbShare != nil {
+		share = c.smbShare.WithContext(ctx)
+	}
+	return session, share
+}
+
+// cleanupGracePeriod bounds how long a withCleanupContext-bound share
+// remains usable after the caller's ctx has been cancelled, so cleanup
+// requests (closing or removing a file) have a chance to reach the server.
+const cleanupGracePeriod = 30 * time.Second
+
+// withCleanupContext returns a share which stays usable for
+// cleanupGracePeriod after ctx is cancelled, so that a file opened on it
+// can still be closed or removed even if the operation that opened it was
+// cancelled. It does not itself watch ctx for cancellation - callers that
+// need the operation to be interruptible must check ctx themselves, e.g.
+// by wrapping the reader or writer with readers.NewContextReader.
+func (c *conn) withCleanupContext(ctx context.Context) (share *smb2.Share, cancel func()) {
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), cleanupGracePeriod)
+	if c.smbShare == nil {
+		return nil, cancel
+	}
+	return c.smbShare.WithContext(cleanupCtx), cancel
+}
+
 // Show that we are using a SMB session
 //
 // Call removeSession() when done

--- a/backend/smb/filepool.go
+++ b/backend/smb/filepool.go
@@ -56,7 +56,8 @@ func (p *filePool) get() (*file, error) {
 		return nil, err
 	}
 
-	fl, err := c.smbShare.OpenFile(p.path, os.O_WRONLY, 0o644)
+	_, cShare := c.withContext(p.ctx)
+	fl, err := cShare.OpenFile(p.path, os.O_WRONLY, 0o644)
 	if err != nil {
 		p.fs.putConnection(&c, err)
 		return nil, fmt.Errorf("failed to open: %w", err)

--- a/backend/smb/smb.go
+++ b/backend/smb/smb.go
@@ -230,7 +230,8 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 	if err != nil {
 		return nil, err
 	}
-	stat, err := cn.smbShare.Stat(f.toSambaPath(dir))
+	_, cnShare := cn.withContext(ctx)
+	stat, err := cnShare.Stat(f.toSambaPath(dir))
 	f.putConnection(&cn, err)
 	if err != nil {
 		// ignore stat error here
@@ -291,7 +292,8 @@ func (f *Fs) findObjectSeparate(ctx context.Context, share, path string) (fs.Obj
 	if err != nil {
 		return nil, err
 	}
-	stat, err := cn.smbShare.Stat(f.toSambaPath(path))
+	_, cnShare := cn.withContext(ctx)
+	stat, err := cnShare.Stat(f.toSambaPath(path))
 	f.putConnection(&cn, err)
 	if err != nil {
 		return nil, translateError(err, false)
@@ -313,7 +315,8 @@ func (f *Fs) Mkdir(ctx context.Context, dir string) (err error) {
 	if err != nil {
 		return err
 	}
-	err = cn.smbShare.MkdirAll(f.toSambaPath(path), 0o755)
+	_, cnShare := cn.withContext(ctx)
+	err = cnShare.MkdirAll(f.toSambaPath(path), 0o755)
 	f.putConnection(&cn, err)
 	return err
 }
@@ -328,7 +331,8 @@ func (f *Fs) Rmdir(ctx context.Context, dir string) error {
 	if err != nil {
 		return err
 	}
-	err = cn.smbShare.Remove(f.toSambaPath(path))
+	_, cnShare := cn.withContext(ctx)
+	err = cnShare.Remove(f.toSambaPath(path))
 	f.putConnection(&cn, err)
 	return err
 }
@@ -398,7 +402,8 @@ func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (_ fs.Objec
 	if err != nil {
 		return nil, err
 	}
-	err = cn.smbShare.Rename(f.toSambaPath(srcPath), f.toSambaPath(dstPath))
+	_, cnShare := cn.withContext(ctx)
+	err = cnShare.Rename(f.toSambaPath(srcPath), f.toSambaPath(dstPath))
 	f.putConnection(&cn, err)
 	if err != nil {
 		return nil, translateError(err, false)
@@ -437,14 +442,15 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 		return err
 	}
 	defer f.putConnection(&cn, err)
+	_, cnShare := cn.withContext(ctx)
 
-	_, err = cn.smbShare.Stat(f.toSambaPath(dstPath))
+	_, err = cnShare.Stat(f.toSambaPath(dstPath))
 	if err == nil {
 		return fs.ErrorDirExists
 	} else if !os.IsNotExist(err) {
 		return fmt.Errorf("failed to check destination directory: %w", err)
 	}
-	err = cn.smbShare.Rename(f.toSambaPath(srcPath), f.toSambaPath(dstPath))
+	err = cnShare.Rename(f.toSambaPath(srcPath), f.toSambaPath(dstPath))
 	return translateError(err, true)
 }
 
@@ -457,9 +463,10 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 		return nil, err
 	}
 	defer f.putConnection(&cn, err)
+	cnSession, cnShare := cn.withContext(ctx)
 
 	if share == "" {
-		shares, err := cn.smbSession.ListSharenames()
+		shares, err := cnSession.ListSharenames()
 		for _, shh := range shares {
 			shh = f.toNativePath(shh)
 			if strings.HasSuffix(shh, "$") && f.opt.HideSpecial {
@@ -470,7 +477,7 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 		return entries, err
 	}
 
-	dirents, err := cn.smbShare.ReadDir(f.toSambaPath(_path))
+	dirents, err := cnShare.ReadDir(f.toSambaPath(_path))
 	if err != nil {
 		return entries, translateError(err, true)
 	}
@@ -499,7 +506,8 @@ func (f *Fs) About(ctx context.Context) (_ *fs.Usage, err error) {
 	if err != nil {
 		return nil, err
 	}
-	stat, err := cn.smbShare.Statfs(dir)
+	_, cnShare := cn.withContext(ctx)
+	stat, err := cnShare.Statfs(dir)
 	f.putConnection(&cn, err)
 	if err != nil {
 		return nil, err
@@ -602,7 +610,8 @@ func (f *Fs) OpenWriterAt(ctx context.Context, remote string, size int64) (fs.Wr
 	if err != nil {
 		return nil, err
 	}
-	file, err := cn.smbShare.OpenFile(smbPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	_, cnShare := cn.withContext(ctx)
+	file, err := cnShare.OpenFile(smbPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
 		o.fs.putConnection(&cn, err)
 		return nil, err
@@ -656,7 +665,8 @@ func (f *Fs) ensureDirectory(ctx context.Context, share, _path string) error {
 	if err != nil {
 		return err
 	}
-	err = cn.smbShare.MkdirAll(f.toSambaPath(dir), 0o755)
+	_, cnShare := cn.withContext(ctx)
+	err = cnShare.MkdirAll(f.toSambaPath(dir), 0o755)
 	f.putConnection(&cn, err)
 	return err
 }
@@ -706,13 +716,14 @@ func (o *Object) SetModTime(ctx context.Context, t time.Time) (err error) {
 		return err
 	}
 	defer o.fs.putConnection(&cn, err)
+	_, cnShare := cn.withContext(ctx)
 
-	err = cn.smbShare.Chtimes(reqDir, t, t)
+	err = cnShare.Chtimes(reqDir, t, t)
 	if err != nil {
 		return err
 	}
 
-	fi, err := cn.smbShare.Stat(reqDir)
+	fi, err := cnShare.Stat(reqDir)
 	if err != nil {
 		return fmt.Errorf("SetModTime: stat: %w", err)
 	}
@@ -749,7 +760,8 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	if err != nil {
 		return nil, err
 	}
-	fl, err := cn.smbShare.OpenFile(filename, os.O_RDONLY, 0)
+	_, cnShare := cn.withContext(ctx)
+	fl, err := cnShare.OpenFile(filename, os.O_RDONLY, 0)
 	if err != nil {
 		o.fs.putConnection(&cn, err)
 		return nil, fmt.Errorf("failed to open: %w", err)
@@ -802,7 +814,14 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		o.fs.putConnection(&cn, err)
 	}()
 
-	fl, err := cn.smbShare.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+	// The file is opened on a share that outlives cancellation of ctx (for
+	// cleanupGracePeriod) so that Close and Remove below can still reach
+	// the server if the upload is cancelled; the upload itself stays
+	// cancellable because in is wrapped with a context-checking reader.
+	cnShare, cancelCleanup := cn.withCleanupContext(ctx)
+	defer cancelCleanup()
+
+	fl, err := cnShare.OpenFile(filename, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
 	if err != nil {
 		return fmt.Errorf("failed to open: %w", err)
 	}
@@ -816,7 +835,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 			// try to remove the file anyway; the file may be already closed
 		}
 
-		removeErr = cn.smbShare.Remove(filename)
+		removeErr = cnShare.Remove(filename)
 		if removeErr != nil {
 			fs.Debugf(src, "failed to remove: %v", removeErr)
 		} else {
@@ -824,7 +843,7 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		}
 	}
 
-	_, err = fl.ReadFrom(in)
+	_, err = fl.ReadFrom(readers.NewContextReader(ctx, in))
 	if err != nil {
 		remove()
 		return fmt.Errorf("Update ReadFrom failed: %w", err)
@@ -862,8 +881,9 @@ func (o *Object) Remove(ctx context.Context) (err error) {
 	if err != nil {
 		return err
 	}
+	_, cnShare := cn.withContext(ctx)
 
-	err = cn.smbShare.Remove(filename)
+	err = cnShare.Remove(filename)
 	o.fs.putConnection(&cn, err)
 
 	return err

--- a/backend/smb/smb_internal_test.go
+++ b/backend/smb/smb_internal_test.go
@@ -11,12 +11,41 @@ import (
 	"testing"
 	"time"
 
+	smb2 "github.com/cloudsoda/go-smb2"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/object"
 	"github.com/rclone/rclone/fstest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestConnWithContext checks that withContext returns session and share
+// wrappers bound to the given ctx without modifying the pooled conn, so
+// cancelling one operation's ctx can't affect a connection still in the pool.
+func TestConnWithContext(t *testing.T) {
+	origSession := &smb2.Session{}
+	origShare := &smb2.Share{}
+	c := &conn{smbSession: origSession, smbShare: origShare}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	session, share := c.withContext(ctx)
+	assert.NotSame(t, origSession, session, "should return a new session wrapper, not mutate the pooled one")
+	assert.NotSame(t, origShare, share, "should return a new share wrapper, not mutate the pooled one")
+	assert.Same(t, origSession, c.smbSession, "pooled conn's session must be unchanged")
+	assert.Same(t, origShare, c.smbShare, "pooled conn's share must be unchanged")
+}
+
+// TestConnWithContextNilShare checks withContext tolerates a conn with no
+// mounted share, which happens before mountShare has been called.
+func TestConnWithContextNilShare(t *testing.T) {
+	c := &conn{smbSession: &smb2.Session{}}
+
+	session, share := c.withContext(context.Background())
+	assert.NotNil(t, session)
+	assert.Nil(t, share)
+}
 
 func TestDialClosesConnectionOnSetupError(t *testing.T) {
 	listener, err := net.Listen("tcp", "127.0.0.1:0")
@@ -91,6 +120,67 @@ func TestUploadConnectionReuse(t *testing.T) {
 	pooled := len(f.pool)
 	f.poolMu.Unlock()
 	assert.Equal(t, 1, pooled, "upload should leave exactly one connection in the pool")
+}
+
+// cancelAfterReader cancels ctx after n bytes have been read from r, to
+// simulate a caller cancelling an in-progress upload.
+type cancelAfterReader struct {
+	r      io.Reader
+	n      int
+	cancel context.CancelFunc
+}
+
+func (c *cancelAfterReader) Read(p []byte) (int, error) {
+	if c.n <= 0 {
+		c.cancel()
+		<-time.After(10 * time.Millisecond) // give ctx cancellation time to propagate
+		return 0, context.Canceled
+	}
+	if len(p) > c.n {
+		p = p[:c.n]
+	}
+	n, err := c.r.Read(p)
+	c.n -= n
+	return n, err
+}
+
+// TestUploadCleansUpOnCancel checks that cancelling an upload's context
+// still results in the partial file being removed from the server, ie the
+// cleanup in Object.Update doesn't itself get cancelled.
+//
+// This needs a real SMB server so it is skipped if one isn't configured.
+func TestUploadCleansUpOnCancel(t *testing.T) {
+	ctx := context.Background()
+	fstest.Initialise()
+	remoteName := *fstest.RemoteName
+	if remoteName == "" {
+		remoteName = "TestSMB:rclone"
+	}
+	remote, err := fs.NewFs(ctx, remoteName)
+	if errors.Is(err, fs.ErrorNotFoundInConfigFile) {
+		t.Skipf("skipping as %q is not configured", remoteName)
+	}
+	require.NoError(t, err)
+	f, ok := remote.(*Fs)
+	if !ok {
+		t.Skipf("skipping as %q is not an SMB remote", remoteName)
+	}
+	defer func() { require.NoError(t, f.Shutdown(ctx)) }()
+
+	contents := strings.Repeat("cancel upload test ", 1024)
+	remotePath := fmt.Sprintf("rclone-test-cancel-upload-%d.txt", time.Now().UnixNano())
+	src := object.NewStaticObjectInfo(remotePath, time.Now(), int64(len(contents)), true, nil, nil)
+
+	uploadCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	in := &cancelAfterReader{r: strings.NewReader(contents), n: len(contents) / 2, cancel: cancel}
+
+	o := &Object{fs: f, remote: remotePath}
+	err = o.Update(uploadCtx, in, src)
+	require.Error(t, err, "upload should fail once cancelled")
+
+	_, err = f.NewObject(ctx, remotePath)
+	assert.ErrorIs(t, err, fs.ErrorObjectNotFound, "partial file should have been cleaned up despite the cancelled context")
 }
 
 // TestIsPathDir tests the isPathDir function logic


### PR DESCRIPTION
#### What does this change do?

Pooled SMB connections only used the caller's `context.Context` while dialling and establishing the session/share. Once a connection was checked out of the pool, every operation on it - `Stat`, `MkdirAll`, `Remove`, `Rename`, `ReadDir`, `ListSharenames`, `Statfs`, `OpenFile`, `Chtimes`, and file reads/writes - ran against the connection's own long-lived context, not the caller's. Cancelling an rclone operation (Ctrl-C, `--timeout`, a sync being aborted) had no way to interrupt SMB I/O already in flight on a reused connection; it would sit there until a transport or OS-level timeout gave up on it.

`conn.withContext(ctx)` (`backend/smb/connpool.go`) returns the pooled connection's session and share rebound to the caller's `ctx` via the `go-smb2` library's own `Session.WithContext`/`Share.WithContext`, without mutating the pooled connection itself - the pool keeps its own long-lived session/share so a cancelled operation can't poison a connection still sat in the pool. Every read-only and write call site in `smb.go` and `filepool.go` now goes through this bound copy instead of the pool's raw session/share, so cancellation now actually reaches the server.

Uploads needed one more piece. `Object.Update` deletes the partial file if an upload fails, and if the upload failed *because* `ctx` was cancelled, that cleanup call was itself running on the same cancelled context - so it silently failed too (`go-smb2` skips sending anything once `ctx.Done()` is closed), leaving a truncated file behind on the server. Confirmed against a real Samba server: the cleanup's `Remove()` was rejected with "A file cannot be opened because the share access flags are incompatible", because the original file handle was still open server-side (its `Close()` never reached the wire either) and a second open for delete collides with it.

`Update` now opens the upload file on `conn.withCleanupContext(ctx)`, a share bound to `context.WithoutCancel(ctx)` plus a 30s grace period, so `Close`/`Remove` in the cleanup path can still reach the server after `ctx` is cancelled. The upload itself stays cancellable: the reader passed to `ReadFrom` is wrapped with the existing `readers.NewContextReader`, which checks `ctx.Err()` before every read and aborts the write loop promptly without waiting on the share's own (now grace-period) context. A direct `Object.Remove` call is unaffected and still uses the plain cancellable `withContext`, since there's no cleanup-after-failure concern there.

#### Linked issue

Fixes #9708

#### For new or changed backends

Ran the full SMB backend suite against a real Samba server (`dperson/samba` in Docker, same image/arguments as `fstest/testserver/init.d/TestSMB`), not just `go build`/`go vet`. The first version of the upload-cleanup fix looked correct statically but failed against the live server with a real SMB protocol error; the version in this PR was verified to pass against that server, including confirming via the container that no orphaned partial file was left behind after a cancelled upload.

`go run ./fstest/test_all -backends smb` was not run (no persistent test account for the integration tester); the manual live-server run above covers the connection-pool and cancellation behaviour this PR changes.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the contribution guidelines.
- [x] **(If I used AI tools to help write this code)** I have read and understood the AI-assisted contributions guidance, and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in house style.
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester.
- [ ] This Pull Request is ready for review.
