### PR TITLE
local: checksummed copies now write as few blocks as --ignore-checksum

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -1650,12 +1650,13 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		out = nopWriterCloser{&symlinkData}
 	}
 
-	// Calculate the hash of the object we are reading as we go along
+	// Calculate the hash of the object as we write it
+	var w io.Writer = out
 	if hasher != nil {
-		in = io.TeeReader(in, hasher)
+		w = io.MultiWriter(w, hasher)
 	}
 
-	_, err = io.Copy(out, in)
+	_, err = io.Copy(w, in)
 	closeErr := out.Close()
 	if err == nil {
 		err = closeErr

--- a/backend/local/local_internal_test.go
+++ b/backend/local/local_internal_test.go
@@ -499,6 +499,32 @@ func TestHashOnUpdate(t *testing.T) {
 	assert.Equal(t, "45685e95985e20822fb2538a522a5ccf", md5)
 }
 
+// Test the hash cached by Update matches a HashesOption hint passed by the caller
+func TestHashOnUpdateWithHashOption(t *testing.T) {
+	ctx := context.Background()
+	r := fstest.NewRun(t)
+	const filePath = "file.txt"
+	when := time.Now()
+	r.WriteFile(filePath, "x", when)
+	f := r.Flocal.(*Fs)
+
+	o, err := f.NewObject(ctx, filePath)
+	require.NoError(t, err)
+
+	b := bytes.NewBufferString("content")
+	src := object.NewStaticObjectInfo(filePath, when, int64(b.Len()), true, nil, f)
+	options := []fs.OpenOption{&fs.HashesOption{Hashes: hash.NewHashSet(hash.MD5)}}
+	require.NoError(t, o.Update(ctx, b, src, options...))
+
+	gotContent, err := os.ReadFile(filepath.Join(f.root, filePath))
+	require.NoError(t, err)
+	assert.Equal(t, "content", string(gotContent))
+
+	md5, err := o.Hash(ctx, hash.MD5)
+	require.NoError(t, err)
+	assert.Equal(t, "9a0364b9e99bb480dd25e1f0284c8555", md5)
+}
+
 // Test hashes on deleting an object
 func TestHashOnDelete(t *testing.T) {
 	ctx := context.Background()


### PR DESCRIPTION
#### What does this change do?

This optimizes the default local write path to behave the same with checksumming enabled as without. Before one had to choose between either being able to checksum "inline" while writing the data in 32 KiB chunks when using the single threaded operation, or having to re-read the destination with the multi-threaded operation which gives configurable buffer sizes.

With the change local writes use the same optimizations with checksumming, most files (assuming they are at least 1 MiB) are written in 1 MiB chunks. This is a significant performance improvement especially on FUSE filesystems like LucidLink where both small writes as well as re-reading data to perform checksumming after the transfer is expensive. Skipping the checksumming is an acceptable tradeoff, but wasn't really an option when copying from S3 to local (FUSE) drives where the source hash comes from S3 rather than from rclone itself.

Copying a 100 MiB file to a LucidLink FUSE mount with checksums on did 3203 x 32 KiB writes taking 3.6s; it now does 108 x ~1 MiB writes taking 0.47s. Passing `--ignore-checksum` before this change already gave the larger writes, which is what pointed at the hashing wrapper as the cause.

`Update()` hashed the object on the read side via `io.TeeReader` while copying. `TeeReader` has no `WriteTo`, which knocks `io.Copy` off any fast path the source reader offers and forces it through the generic 32 KiB `copyBuffer` loop for every checksummed transfer.

The destination `*os.File` does implement `io.ReaderFrom`, so `io.Copy` calls `out.ReadFrom(in)`, but that could not use `copy_file_range` either, since the source is never a raw file or pipe fd once it's wrapped for hashing. It fell back to Go's own `genericReadFrom`, which hides `*os.File`'s `ReaderFrom` behind an unexported wrapper and lands on the same 32 KiB `io.Copy`.

Hash via `io.MultiWriter` on the write side instead, leaving the source reader unwrapped so its fast path (where it has one) survives. Hashing after the write rather than before doesn't change what gets hashed: `io.Writer` implementations must not modify the slice passed to `Write`, so `MultiWriter` hands the hasher byte for byte what went to the file.

#### For new or changed backends

```
go run ./fstest/test_all -backends local
PASS: All tests finished OK in 42.323137626s
```

`make racequicktest` and `make quicktest` pass as well locally.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
