### PR TITLE
dropbox: decode received shared-file names - fixes #9707

### DIFF
--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -1010,7 +1010,7 @@ func (f *Fs) listReceivedFiles(ctx context.Context, callback func(fs.DirEntry) e
 			}
 		}
 		for _, entry := range res.Entries {
-			entryPath := entry.Name
+			entryPath := f.opt.Enc.ToStandardName(entry.Name)
 			o := &Object{
 				fs:      f,
 				url:     entry.PreviewUrl,

--- a/backend/dropbox/dropbox_internal_test.go
+++ b/backend/dropbox/dropbox_internal_test.go
@@ -2,7 +2,9 @@ package dropbox
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -12,9 +14,11 @@ import (
 
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox"
 	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/sharing"
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fstest/fstests"
 	"github.com/rclone/rclone/lib/batcher"
+	"github.com/rclone/rclone/lib/encoder"
 	"github.com/rclone/rclone/lib/pacer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -318,3 +322,91 @@ func (f *Fs) InternalTest(t *testing.T) {
 }
 
 var _ fstests.InternalTester = (*Fs)(nil)
+
+// newSharingTestFs builds a minimal *Fs whose sharing client talks to a
+// local mock server instead of the real Dropbox API.
+func newSharingTestFs(t *testing.T, handler http.HandlerFunc) *Fs {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	cfg := dropbox.Config{
+		Client: &http.Client{Transport: http.DefaultTransport},
+		URLGenerator: func(hostType, namespace, route string) string {
+			return fmt.Sprintf("%s/2/%s/%s", ts.URL, namespace, route)
+		},
+	}
+
+	return &Fs{
+		opt: Options{
+			Enc: encoder.Base |
+				encoder.EncodeBackSlash |
+				encoder.EncodeDel |
+				encoder.EncodeRightSpace |
+				encoder.EncodeInvalidUtf8,
+		},
+		sharing: sharing.NewContext(cfg),
+		pacer:   fs.NewPacer(context.Background(), pacer.NewDefault(pacer.MinSleep(time.Millisecond))),
+	}
+}
+
+func mustParseDBXTime(t *testing.T, s string) *dropbox.DBXTime {
+	t.Helper()
+	tm, err := time.Parse(time.RFC3339, s)
+	require.NoError(t, err)
+	return (*dropbox.DBXTime)(&tm)
+}
+
+func receivedFilesHandler(t *testing.T, rawName string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "list_received_files") {
+			http.NotFound(w, r)
+			return
+		}
+		resp := sharing.ListFilesResult{
+			Entries: []*sharing.SharedFileMetadata{{
+				Id:          "id:123",
+				Name:        rawName,
+				PreviewUrl:  "https://dropbox.com/preview/123",
+				Policy:      &sharing.FolderPolicy{},
+				TimeInvited: mustParseDBXTime(t, "2024-01-01T00:00:00Z"),
+			}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// TestListReceivedFilesDecodesName confirms received-file names are decoded
+// via Enc.ToStandardName before being returned, matching listSharedFolders'
+// handling of shared-folder names.
+func TestListReceivedFilesDecodesName(t *testing.T) {
+	const rawName = "report.txt␠"
+	f := newSharingTestFs(t, receivedFilesHandler(t, rawName))
+
+	wantName := f.opt.Enc.ToStandardName(rawName)
+	require.NotEqual(t, rawName, wantName)
+
+	var gotNames []string
+	err := f.listReceivedFiles(context.Background(), func(entry fs.DirEntry) error {
+		gotNames = append(gotNames, entry.Remote())
+		return nil
+	})
+	require.NoError(t, err)
+	require.Len(t, gotNames, 1)
+	assert.Equal(t, wantName, gotNames[0])
+}
+
+// TestFindSharedFileResolvesDecodedName confirms findSharedFile can look up
+// a received file by its standard, decoded rclone-visible name.
+func TestFindSharedFileResolvesDecodedName(t *testing.T) {
+	const rawName = "report.txt␠"
+	f := newSharingTestFs(t, receivedFilesHandler(t, rawName))
+
+	encodedName := f.opt.Enc.ToStandardName(rawName)
+	require.NotEqual(t, rawName, encodedName)
+
+	o, err := f.findSharedFile(context.Background(), encodedName)
+	require.NoError(t, err)
+	assert.Equal(t, encodedName, o.remote)
+}


### PR DESCRIPTION
#### What does this change do?

`listSharedFolders` decodes shared-folder names with `f.opt.Enc.ToStandardName`
before returning them, but `listReceivedFiles` (which lists files individually
shared with the user, not folders) stored the raw name from the Dropbox API
unchanged. A file whose real name needs backend-specific encoding - e.g. a
trailing space, which Dropbox itself rejects, so rclone's `EncodeRightSpace`
option stores it as `name␠` - was shown under that raw encoded form instead
of being decoded back to the standard name, and `findSharedFile` could not
resolve such a file when a caller looked it up by its standard name, since it
compares against the raw stored name.

This applies the same `ToStandardName` conversion `listSharedFolders` already
uses, so received-file names go through the same decoding as every other
listing path in this backend.

#### Was the change discussed in an issue or in the forum before?

Fixes #9707, opened by the reporter, who traced the inconsistency to these
exact two functions and the missing conversion. Not yet acknowledged by a
maintainer, so please treat the approach as up for discussion - it is a
one-line change that mirrors the already-correct sibling function
(`listSharedFolders`), so I don't expect it to be controversial, but flagging
per the contribution guidelines.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue. *(one-line fix mirroring the existing `listSharedFolders` pattern; issue not yet maintainer-acknowledged)*
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself. 
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate. *(not applicable - internal bug fix, no user-facing option/flag change)*
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester. *(I do not have a Dropbox account to run the live integration suite. `go build ./...`, `go vet ./...`, `gofmt`, and `go test ./backend/dropbox/...` are all clean. Added two unit tests that exercise the real `listReceivedFiles`/`findSharedFile` code against a mock Dropbox API server standing in for the live API; confirmed both fail without this fix and pass with it. Happy to provide a test account later if a maintainer can help verify against the live API in the meantime.)*
- [x] This Pull Request is ready for review.
