### PR TITLE
drive: resolve shortcut targets concurrently during listing - fixes #9683

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -48,6 +48,7 @@ import (
 	"github.com/rclone/rclone/lib/readers"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
+	"golang.org/x/sync/errgroup"
 	drive_v2 "google.golang.org/api/drive/v2"
 	drive "google.golang.org/api/drive/v3"
 	"google.golang.org/api/googleapi"
@@ -1017,8 +1018,15 @@ func (f *Fs) getRootID(ctx context.Context) (string, error) {
 //
 // If the user fn ever returns true then it early exits with found = true
 //
+// Set stopEarly if fn is expected to return true before the whole
+// directory has been listed (eg because it only wants to know if the
+// directory is non-empty) so that shortcuts are resolved one at a
+// time rather than concurrently for the whole page - this preserves
+// laziness so fn can stop the listing without paying for resolving
+// shortcuts it will never see.
+//
 // Search params: https://developers.google.com/drive/search-parameters
-func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directoriesOnly, filesOnly, trashedOnly, includeAll bool, fn listFn) (found bool, err error) {
+func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directoriesOnly, filesOnly, trashedOnly, includeAll, stopEarly bool, fn listFn) (found bool, err error) {
 	var query []string
 	if !includeAll {
 		q := "trashed=" + strconv.FormatBool(trashedOnly)
@@ -1152,44 +1160,108 @@ OUTER:
 		}
 		for _, item := range files.Files {
 			item.Name = f.opt.Enc.ToStandardName(item.Name)
-			if isShortcut(item) {
-				// ignore shortcuts if directed
-				if f.opt.SkipShortcuts {
-					continue
-				}
-				// skip file shortcuts if directory only
-				if directoriesOnly && item.ShortcutDetails.TargetMimeType != driveFolderType {
-					continue
-				}
-				// skip directory shortcuts if file only
-				if filesOnly && item.ShortcutDetails.TargetMimeType == driveFolderType {
-					continue
-				}
-				item, err = f.resolveShortcut(ctx, item)
-				if err != nil {
-					return false, fmt.Errorf("list: %w", err)
-				}
-				// leave the dangling shortcut out of the listings
-				// we've already logged about the dangling shortcut in resolveShortcut
-				if f.opt.SkipDanglingShortcuts && item.MimeType == shortcutMimeTypeDangling {
-					continue
-				}
+		}
+		// skipShortcut reports whether a shortcut item should be
+		// ignored without resolving its target.
+		skipShortcut := func(item *drive.File) bool {
+			switch {
+			case f.opt.SkipShortcuts:
+				return true
+			case directoriesOnly && item.ShortcutDetails.TargetMimeType != driveFolderType:
+				return true
+			case filesOnly && item.ShortcutDetails.TargetMimeType == driveFolderType:
+				return true
 			}
+			return false
+		}
+		// checkItem applies the title match (if any) and calls fn,
+		// returning true if fn signals to stop.
+		checkItem := func(item *drive.File) bool {
 			// Check the case of items is correct since
 			// the `=` operator is case insensitive.
 			if title != "" && title != item.Name {
 				found := slices.Contains(stems, item.Name)
 				if !found {
-					continue
+					return false
 				}
 				_, exportName, _, _ := f.findExportFormat(ctx, item)
 				if exportName == "" || exportName != title {
-					continue
+					return false
 				}
 			}
-			if fn(item) {
-				found = true
-				break OUTER
+			return fn(item)
+		}
+		if title != "" || stopEarly {
+			// Single item lookup (eg FindLeaf, NewObject), or a
+			// caller whose fn is expected to stop before the whole
+			// page is processed (eg purgeCheck checking for a
+			// non-empty directory) - resolve shortcuts one at a time
+			// so we can stop at the first match without resolving
+			// the rest of the page.
+			for _, item := range files.Files {
+				if isShortcut(item) {
+					if skipShortcut(item) {
+						continue
+					}
+					item, err = f.resolveShortcut(ctx, item)
+					if err != nil {
+						return false, fmt.Errorf("list: %w", err)
+					}
+					// leave the dangling shortcut out of the listings
+					// we've already logged about the dangling shortcut in resolveShortcut
+					if f.opt.SkipDanglingShortcuts && item.MimeType == shortcutMimeTypeDangling {
+						continue
+					}
+				}
+				if checkItem(item) {
+					found = true
+					break OUTER
+				}
+			}
+		} else {
+			// Bulk listing - resolve shortcut targets concurrently,
+			// bounded by --checkers, since each resolution is a
+			// separate API call.
+			//
+			// dangling[i] records whether files.Files[i] resolved to
+			// a dangling shortcut; this can't be recovered from the
+			// resolved item's MimeType alone once files.Files[i] is
+			// overwritten, since resolveShortcut mutates MimeType to
+			// shortcutMimeTypeDangling on a 404, which is a distinct
+			// value from shortcutMimeType that isShortcut checks for.
+			dangling := make([]bool, len(files.Files))
+			g, gCtx := errgroup.WithContext(ctx)
+			g.SetLimit(f.ci.Checkers)
+			for i, item := range files.Files {
+				if !isShortcut(item) || skipShortcut(item) {
+					continue
+				}
+				g.Go(func() error {
+					newItem, err := f.resolveShortcut(gCtx, item)
+					if err != nil {
+						return fmt.Errorf("list: %w", err)
+					}
+					dangling[i] = newItem.MimeType == shortcutMimeTypeDangling
+					files.Files[i] = newItem
+					return nil
+				})
+			}
+			if err = g.Wait(); err != nil {
+				return false, err
+			}
+			for i, item := range files.Files {
+				if isShortcut(item) && skipShortcut(item) {
+					continue
+				}
+				// leave the dangling shortcut out of the listings
+				// we've already logged about the dangling shortcut in resolveShortcut
+				if f.opt.SkipDanglingShortcuts && dangling[i] {
+					continue
+				}
+				if checkItem(item) {
+					found = true
+					break OUTER
+				}
 			}
 		}
 		if files.NextPageToken == "" {
@@ -1753,7 +1825,7 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (pathIDOut string, found bool, err error) {
 	// Find the leaf in pathID
 	pathID = actualID(pathID)
-	found, err = f.list(ctx, []string{pathID}, leaf, true, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+	found, err = f.list(ctx, []string{pathID}, leaf, true, false, f.opt.TrashedOnly, false, false, func(item *drive.File) bool {
 		if !f.opt.SkipGdocs {
 			_, exportName, _, isDocument := f.findExportFormat(ctx, item)
 			if exportName == leaf {
@@ -2030,7 +2102,7 @@ func (f *Fs) ListP(ctx context.Context, dir string, callback fs.ListRCallback) e
 	directoryID = actualID(directoryID)
 
 	var iErr error
-	_, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+	_, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, false, false, func(item *drive.File) bool {
 		entry, err := f.itemToDirEntry(ctx, path.Join(dir, item.Name), item)
 		if err != nil {
 			iErr = err
@@ -2120,7 +2192,7 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 		listRSlices{dirs, paths}.Sort()
 		var iErr error
 		foundItems := false
-		_, err := f.list(ctx, dirs, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+		_, err := f.list(ctx, dirs, "", false, false, f.opt.TrashedOnly, false, false, func(item *drive.File) bool {
 			// shared with me items have no parents when at the root
 			if f.opt.SharedWithMe && len(item.Parents) == 0 && len(paths) == 1 && paths[0] == "" {
 				item.Parents = dirs
@@ -2635,7 +2707,7 @@ func (f *Fs) MergeDirs(ctx context.Context, dirs []fs.Directory) error {
 	for _, srcDir := range dirs[1:] {
 		// list the objects
 		infos := []*drive.File{}
-		_, err := f.list(ctx, []string{srcDir.ID()}, "", false, false, f.opt.TrashedOnly, true, func(info *drive.File) bool {
+		_, err := f.list(ctx, []string{srcDir.ID()}, "", false, false, f.opt.TrashedOnly, true, false, func(info *drive.File) bool {
 			infos = append(infos, info)
 			return false
 		})
@@ -2771,7 +2843,7 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 		// to enumerate trashed children: let the server filter them out instead of
 		// paging through them. Hard deletes still need to see them (#1040).
 		includeAll := !f.opt.UseTrash || f.opt.TrashedOnly
-		found, err := f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, includeAll, func(item *drive.File) bool {
+		found, err := f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, includeAll, true, func(item *drive.File) bool {
 			if !item.Trashed {
 				fs.Debugf(dir, "Rmdir: contains file: %q", item.Name)
 				return true
@@ -2960,7 +3032,7 @@ func (r cleanupResult) Error() string {
 }
 
 func (f *Fs) cleanupTeamDrive(ctx context.Context, dir string, directoryID string) (r cleanupResult, err error) {
-	_, err = f.list(ctx, []string{directoryID}, "", false, false, true, false, func(item *drive.File) bool {
+	_, err = f.list(ctx, []string{directoryID}, "", false, false, true, false, false, func(item *drive.File) bool {
 		remote := path.Join(dir, item.Name)
 		if item.ExplicitlyTrashed { // description is wrong - can also be set for folders - no need to recurse them
 			err := f.delete(ctx, item.Id, false)
@@ -3559,7 +3631,7 @@ func (r unTrashResult) Error() string {
 func (f *Fs) unTrash(ctx context.Context, dir string, directoryID string, recurse bool) (r unTrashResult, err error) {
 	directoryID = actualID(directoryID)
 	fs.Debugf(dir, "finding trash to restore in directory %q", directoryID)
-	_, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, true, func(item *drive.File) bool {
+	_, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, true, false, func(item *drive.File) bool {
 		remote := path.Join(dir, item.Name)
 		if item.ExplicitlyTrashed {
 			fs.Infof(remote, "restoring %q", item.Id)
@@ -4230,7 +4302,7 @@ func (f *Fs) getRemoteInfoWithExport(ctx context.Context, remote string) (
 	}
 	directoryID = actualID(directoryID)
 
-	found, err := f.list(ctx, []string{directoryID}, leaf, false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+	found, err := f.list(ctx, []string{directoryID}, leaf, false, false, f.opt.TrashedOnly, false, false, func(item *drive.File) bool {
 		if !f.opt.SkipGdocs {
 			extension, exportName, exportMimeType, isDocument = f.findExportFormat(ctx, item)
 			if exportName == leaf {

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -1218,18 +1218,11 @@ OUTER:
 					break OUTER
 				}
 			}
-		} else {
-			// Bulk listing - resolve shortcut targets concurrently,
-			// bounded by --checkers, since each resolution is a
-			// separate API call.
-			//
-			// dangling[i] records whether files.Files[i] resolved to
-			// a dangling shortcut; this can't be recovered from the
-			// resolved item's MimeType alone once files.Files[i] is
-			// overwritten, since resolveShortcut mutates MimeType to
-			// shortcutMimeTypeDangling on a 404, which is a distinct
-			// value from shortcutMimeType that isShortcut checks for.
-			dangling := make([]bool, len(files.Files))
+		} else if hasShortcutToResolve(files.Files, skipShortcut) {
+			// Bulk listing with at least one shortcut to resolve -
+			// resolve shortcut targets concurrently, bounded by
+			// --checkers, since each resolution is a separate API
+			// call.
 			g, gCtx := errgroup.WithContext(ctx)
 			g.SetLimit(f.ci.Checkers)
 			for i, item := range files.Files {
@@ -1241,7 +1234,6 @@ OUTER:
 					if err != nil {
 						return fmt.Errorf("list: %w", err)
 					}
-					dangling[i] = newItem.MimeType == shortcutMimeTypeDangling
 					files.Files[i] = newItem
 					return nil
 				})
@@ -1249,13 +1241,28 @@ OUTER:
 			if err = g.Wait(); err != nil {
 				return false, err
 			}
-			for i, item := range files.Files {
+			for _, item := range files.Files {
 				if isShortcut(item) && skipShortcut(item) {
 					continue
 				}
 				// leave the dangling shortcut out of the listings
 				// we've already logged about the dangling shortcut in resolveShortcut
-				if f.opt.SkipDanglingShortcuts && dangling[i] {
+				if f.opt.SkipDanglingShortcuts && item.MimeType == shortcutMimeTypeDangling {
+					continue
+				}
+				if checkItem(item) {
+					found = true
+					break OUTER
+				}
+			}
+		} else {
+			// Bulk listing with no shortcuts to resolve on this page -
+			// skip the errgroup setup entirely. Shortcuts can still be
+			// present here if every one of them is skip-eligible (eg
+			// --drive-skip-shortcuts), so they still need filtering
+			// out rather than being passed to fn unresolved.
+			for _, item := range files.Files {
+				if isShortcut(item) && skipShortcut(item) {
 					continue
 				}
 				if checkItem(item) {
@@ -2470,6 +2477,17 @@ func shortcutID(compositeID string) (shortcutID string) {
 // isShortcut returns true of the item is a shortcut
 func isShortcut(item *drive.File) bool {
 	return item.MimeType == shortcutMimeType && item.ShortcutDetails != nil
+}
+
+// hasShortcutToResolve returns true if any item in items is a
+// shortcut that skip doesn't want ignored.
+func hasShortcutToResolve(items []*drive.File, skip func(*drive.File) bool) bool {
+	for _, item := range items {
+		if isShortcut(item) && !skip(item) {
+			return true
+		}
+	}
+	return false
 }
 
 // Dereference shortcut if required. It returns the newItem (which may

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -334,6 +334,69 @@ func TestInternalListStopEarlyStopsAtFirstMatch(t *testing.T) {
 	assert.Equal(t, int32(0), resolved.Load())
 }
 
+// TestInternalListBulkNoShortcuts checks that a bulk listing page
+// with no shortcuts on it lists correctly without ever hitting the
+// Files.Get endpoint (ie the errgroup path is bypassed entirely).
+func TestInternalListBulkNoShortcuts(t *testing.T) {
+	var getCalls atomic.Int32
+	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/files") {
+			_, err := fmt.Fprint(w, `{"files":[
+				{"id":"file-1","name":"file1","mimeType":"text/plain"},
+				{"id":"file-2","name":"file2","mimeType":"text/plain"}
+			]}`)
+			assert.NoError(t, err)
+			return
+		}
+		getCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+
+	var names []string
+	found, err := f.list(context.Background(), []string{"parent-id"}, "", false, false, false, false, false, func(item *drive.File) bool {
+		names = append(names, item.Name)
+		return false
+	})
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, []string{"file1", "file2"}, names)
+	assert.Equal(t, int32(0), getCalls.Load())
+}
+
+// TestInternalListBulkAllShortcutsSkipped checks that a bulk listing
+// page where every shortcut is skip-eligible (eg --drive-skip-shortcuts)
+// still filters those shortcuts out of what's passed to fn, even
+// though hasShortcutToResolve is false for the page (nothing needs
+// resolving) and the errgroup path is bypassed.
+func TestInternalListBulkAllShortcutsSkipped(t *testing.T) {
+	var getCalls atomic.Int32
+	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/files") {
+			_, err := fmt.Fprint(w, `{"files":[
+				{"id":"shortcut-1","name":"link1","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-1","targetMimeType":"text/plain"}},
+				{"id":"file-1","name":"file1","mimeType":"text/plain"}
+			]}`)
+			assert.NoError(t, err)
+			return
+		}
+		getCalls.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	f.opt.SkipShortcuts = true
+
+	var names []string
+	found, err := f.list(context.Background(), []string{"parent-id"}, "", false, false, false, false, false, func(item *drive.File) bool {
+		names = append(names, item.Name)
+		return false
+	})
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, []string{"file1"}, names)
+	assert.Equal(t, int32(0), getCalls.Load())
+}
+
 func TestDriveScopes(t *testing.T) {
 	for _, test := range []struct {
 		in       string

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -136,6 +136,204 @@ func TestInternalGetPermissionCacheHit(t *testing.T) {
 	assert.Equal(t, int32(1), requests.Load())
 }
 
+// newListTestFs makes a Fs suitable for exercising f.list() against a
+// fake Drive server, with the fields f.list() and its callees need
+// but without going through NewFs (which requires OAuth config).
+func newListTestFs(t *testing.T, handler http.Handler) *Fs {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	service, err := drive.NewService(
+		context.Background(),
+		option.WithHTTPClient(server.Client()),
+		option.WithEndpoint(server.URL+"/"),
+	)
+	require.NoError(t, err)
+	return &Fs{
+		svc:             service,
+		ci:              fs.GetConfig(context.Background()),
+		pacer:           fs.NewPacer(context.Background(), pacer.NewGoogleDrive()),
+		dirResourceKeys: new(stdsync.Map),
+	}
+}
+
+// TestInternalListResolvesShortcutsConcurrently checks that f.list()
+// resolves multiple shortcuts in a listing page concurrently rather
+// than one at a time, and that the resolved items are still reported
+// in their original listing order.
+func TestInternalListResolvesShortcutsConcurrently(t *testing.T) {
+	const shortcutCount = 3
+	arrived := make(chan string, shortcutCount)
+	release := make(chan struct{})
+	var releaseOnce stdsync.Once
+	releaseRequests := func() {
+		releaseOnce.Do(func() { close(release) })
+	}
+	defer releaseRequests()
+
+	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/files") {
+			_, err := fmt.Fprint(w, `{"files":[
+				{"id":"shortcut-1","name":"link1","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-1","targetMimeType":"text/plain"}},
+				{"id":"shortcut-2","name":"link2","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-2","targetMimeType":"text/plain"}},
+				{"id":"shortcut-3","name":"link3","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-3","targetMimeType":"text/plain"}}
+			]}`)
+			assert.NoError(t, err)
+			return
+		}
+		// Files.Get for a shortcut target
+		targetID := path.Base(r.URL.Path)
+		arrived <- targetID
+		<-release
+		_, err := fmt.Fprintf(w, `{"id":%q,"name":"resolved-%s","mimeType":"text/plain"}`, targetID, targetID)
+		assert.NoError(t, err)
+	}))
+
+	type listResult struct {
+		found bool
+		err   error
+		names []string
+	}
+	results := make(chan listResult, 1)
+	go func() {
+		var names []string
+		found, err := f.list(context.Background(), []string{"parent-id"}, "", false, false, false, false, false, func(item *drive.File) bool {
+			names = append(names, item.Name)
+			return false
+		})
+		results <- listResult{found: found, err: err, names: names}
+	}()
+
+	arrivedIDs := make(map[string]bool, shortcutCount)
+	timer := time.NewTimer(time.Second)
+	defer timer.Stop()
+	for len(arrivedIDs) < shortcutCount {
+		select {
+		case targetID := <-arrived:
+			arrivedIDs[targetID] = true
+		case <-timer.C:
+			releaseRequests()
+			t.Fatalf("timed out waiting for concurrent shortcut resolution: got %d of %d", len(arrivedIDs), shortcutCount)
+		}
+	}
+	releaseRequests()
+
+	assert.Equal(t, map[string]bool{"target-1": true, "target-2": true, "target-3": true}, arrivedIDs)
+	result := <-results
+	require.NoError(t, result.err)
+	assert.False(t, result.found)
+	// original listing order must be preserved even though resolution was concurrent
+	assert.Equal(t, []string{"link1", "link2", "link3"}, result.names)
+}
+
+// TestInternalListSkipDanglingShortcuts checks that a dangling
+// shortcut (whose target 404s) is left out of the listing when
+// SkipDanglingShortcuts is set, even though it is resolved
+// concurrently with the other items on the page.
+func TestInternalListSkipDanglingShortcuts(t *testing.T) {
+	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/files") {
+			_, err := fmt.Fprint(w, `{"files":[
+				{"id":"shortcut-ok","name":"link-ok","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-ok","targetMimeType":"text/plain"}},
+				{"id":"shortcut-dangling","name":"link-dangling","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-missing","targetMimeType":"text/plain"}}
+			]}`)
+			assert.NoError(t, err)
+			return
+		}
+		targetID := path.Base(r.URL.Path)
+		if targetID == "target-missing" {
+			w.WriteHeader(http.StatusNotFound)
+			_, err := fmt.Fprint(w, `{"error":{"code":404,"message":"File not found"}}`)
+			assert.NoError(t, err)
+			return
+		}
+		_, err := fmt.Fprintf(w, `{"id":%q,"name":"resolved-%s","mimeType":"text/plain"}`, targetID, targetID)
+		assert.NoError(t, err)
+	}))
+	f.opt.SkipDanglingShortcuts = true
+
+	var names []string
+	found, err := f.list(context.Background(), []string{"parent-id"}, "", false, false, false, false, false, func(item *drive.File) bool {
+		names = append(names, item.Name)
+		return false
+	})
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.Equal(t, []string{"link-ok"}, names)
+}
+
+// TestInternalListTitleLookupStopsAtFirstMatch checks that a single
+// item lookup (title != "", as used by FindLeaf and NewObject) stops
+// at the first match without resolving shortcuts that come after it
+// in the listing - ie shortcut resolution stays lazy for early-exit
+// lookups rather than resolving the whole page concurrently.
+func TestInternalListTitleLookupStopsAtFirstMatch(t *testing.T) {
+	var resolved atomic.Int32
+	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/files") {
+			_, err := fmt.Fprint(w, `{"files":[
+				{"id":"target-match","name":"wanted","mimeType":"text/plain"},
+				{"id":"shortcut-1","name":"link1","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-1","targetMimeType":"text/plain"}},
+				{"id":"shortcut-2","name":"link2","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-2","targetMimeType":"text/plain"}}
+			]}`)
+			assert.NoError(t, err)
+			return
+		}
+		targetID := path.Base(r.URL.Path)
+		resolved.Add(1)
+		_, err := fmt.Fprintf(w, `{"id":%q,"name":"resolved-%s","mimeType":"text/plain"}`, targetID, targetID)
+		assert.NoError(t, err)
+	}))
+
+	var names []string
+	found, err := f.list(context.Background(), []string{"parent-id"}, "wanted", false, false, false, false, false, func(item *drive.File) bool {
+		names = append(names, item.Name)
+		return true
+	})
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, []string{"wanted"}, names)
+	assert.Equal(t, int32(0), resolved.Load())
+}
+
+// TestInternalListStopEarlyStopsAtFirstMatch checks that a caller
+// with stopEarly set (as purgeCheck uses to detect a non-empty
+// directory, title == "") stops at the first match without resolving
+// shortcuts that come after it in the listing, the same way a
+// title != "" lookup does.
+func TestInternalListStopEarlyStopsAtFirstMatch(t *testing.T) {
+	var resolved atomic.Int32
+	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.HasSuffix(r.URL.Path, "/files") {
+			_, err := fmt.Fprint(w, `{"files":[
+				{"id":"file-1","name":"file1","mimeType":"text/plain"},
+				{"id":"shortcut-1","name":"link1","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-1","targetMimeType":"text/plain"}},
+				{"id":"shortcut-2","name":"link2","mimeType":"application/vnd.google-apps.shortcut","shortcutDetails":{"targetId":"target-2","targetMimeType":"text/plain"}}
+			]}`)
+			assert.NoError(t, err)
+			return
+		}
+		targetID := path.Base(r.URL.Path)
+		resolved.Add(1)
+		_, err := fmt.Fprintf(w, `{"id":%q,"name":"resolved-%s","mimeType":"text/plain"}`, targetID, targetID)
+		assert.NoError(t, err)
+	}))
+
+	var names []string
+	found, err := f.list(context.Background(), []string{"parent-id"}, "", false, false, false, false, true, func(item *drive.File) bool {
+		names = append(names, item.Name)
+		return true
+	})
+	require.NoError(t, err)
+	assert.True(t, found)
+	assert.Equal(t, []string{"file1"}, names)
+	assert.Equal(t, int32(0), resolved.Load())
+}
+
 func TestDriveScopes(t *testing.T) {
 	for _, test := range []struct {
 		in       string


### PR DESCRIPTION
#### What does this change do?

Google Drive shortcuts encountered while listing a directory are now resolved with
bounded concurrency (limited by `--checkers`) instead of one at a time. Previously,
`list()` called `Files.Get` synchronously for each shortcut in a page before moving to
the next item, so a directory with many shortcuts paid for N sequential round trips to
Google's API.

Two call patterns needed special handling so this stays a pure performance change:

- **Early-exit lookups** (`FindLeaf`, `NewObject`, and `purgeCheck`'s "is this directory
  empty" check) still resolve shortcuts one at a time and stop at the first match,
  exactly as before — they don't benefit from concurrency and shouldn't pay for
  resolving shortcuts they'll never look at. This is done via a `stopEarly` parameter on
  `list()` in addition to the existing `title != ""` check.
- **`--drive-skip-dangling-shortcuts`** required tracking which items were dangling
  *before* their `MimeType` gets overwritten during resolution (a dangling shortcut's
  `MimeType` becomes a different sentinel value than what marks it as a shortcut in the
  first place), since concurrent resolution no longer lets a later pass re-derive that
  from the item's mime type alone.

Added three unit tests exercising: concurrent resolution + result ordering,
`SkipDanglingShortcuts` filtering under concurrent resolution, and that early-exit
callers (both `title != ""` and `stopEarly`) still resolve zero shortcuts past their
match. All run offline against a fake `httptest` Drive server, no `TestDrive:` remote
needed.

#### Linked issue

Fixes #9683

#### For new or changed backends

- [ ] `go run ./fstest/test_all -backends drive` — **not run**. No `TestDrive:` test
      account available in my current environment. `go build ./...`,
      `go vet ./backend/drive/...`, `golangci-lint run ./backend/drive/...`, and
      `go test ./backend/drive/...` (unit tests) all pass. Also built and ran the binary
      in Docker to confirm it compiles and the `drive` backend registers correctly in a
      clean container — not a substitute for the real integration suite against live
      Drive.
- No test account to offer for the integration tester at this time.

#### Checklist

- [ ] This change is trivial **OR** it has been discussed and agreed in the linked
      issue. *(Partially: one maintainer comment on the issue endorsing the general
      approach — bounded errgroup, preserve early-exit for `purgeCheck` and title
      searches — but no explicit go-ahead on this exact implementation.)*
- [x] I have read the contribution guidelines.
- [x] (AI-assisted) I have tested and take ownership of this change.
- [x] I have added tests for all changes in this PR.
- [ ] I have added documentation for the changes if appropriate. *(Not needed — no new
      flag/option, no user-visible behavior change.)*
- [x] All commit messages are in house style.
- [ ] `test_all` passes for this backend. *(Not run — no `TestDrive:` account available,
      see above.)*
- [ ] This Pull Request is ready for review. *(Flagging as not fully ready until
      `test_all` runs against real Drive — happy for a maintainer/contributor with a
      test account to run it, or to run it myself if given credentials.)*
