### PR TITLE
onedrive: fix 403 Forbidden for configuration personal onedrive

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -549,31 +549,34 @@ func chooseDrive(ctx context.Context, name string, m configmap.Mapper, srv *rest
 	// We don't have the final ID yet?
 	// query Microsoft Graph
 	if opt.finalDriveID == "" {
-		_, err := srv.CallJSON(ctx, &opt.opts, nil, &drives)
-		if err != nil {
-			return fs.ConfigError("choose_type", fmt.Sprintf("Failed to query available drives: %v", err))
+		_, drivesErr := srv.CallJSON(ctx, &opt.opts, nil, &drives)
+		if drivesErr != nil {
+			fs.Debugf(nil, "Failed to query /me/drives: %v - trying /me/drive", drivesErr)
 		}
-
 		// Also call /me/drive as sometimes /me/drives doesn't return it #4068
 		if opt.opts.Path == "/me/drives" {
-			opt.opts.Path = "/me/drive"
+			meDriveOpts := opt.opts
+			meDriveOpts.Path = "/me/drive"
 			meDrive := api.DriveResource{}
-			_, err := srv.CallJSON(ctx, &opt.opts, nil, &meDrive)
-			if err != nil {
-				return fs.ConfigError("choose_type", fmt.Sprintf("Failed to query available drives: %v", err))
-			}
-			found := false
-			for _, drive := range drives.Drives {
-				if drive.DriveID == meDrive.DriveID {
-					found = true
-					break
+			_, meDriveErr := srv.CallJSON(ctx, &meDriveOpts, nil, &meDrive)
+			if meDriveErr == nil {
+				found := false
+				for _, drive := range drives.Drives {
+					if drive.DriveID == meDrive.DriveID {
+						found = true
+						break
+					}
 				}
+				// add the me drive if not found already
+				if !found {
+					fs.Debugf(nil, "Adding %v to drives list from /me/drive", meDrive)
+					drives.Drives = append(drives.Drives, meDrive)
+				}
+			} else if drivesErr != nil {
+				return fs.ConfigError("choose_type", fmt.Sprintf("Failed to query available drives: /me/drives: %v; /me/drive: %v", drivesErr, meDriveErr))
 			}
-			// add the me drive if not found already
-			if !found {
-				fs.Debugf(nil, "Adding %v to drives list from /me/drive", meDrive)
-				drives.Drives = append(drives.Drives, meDrive)
-			}
+		} else if drivesErr != nil {
+			return fs.ConfigError("choose_type", fmt.Sprintf("Failed to query available drives: %v", drivesErr))
 		}
 	} else {
 		drives.Drives = append(drives.Drives, api.DriveResource{


### PR DESCRIPTION
<!--
Thank you for contributing to rclone!

Please discuss anything more than a trivial fix in an issue FIRST - see the
"Linked issue" section below. Then fill in the questions to help us review.
-->

#### What does this change do?

Onedrive personal account will give the following error when requesting `/me/drives`, which causes rclone to unconditionally throw without trying `/me/drive` endpoint
```
{State:"choose_type" Error:"Failed to query available drives: HTTP error 403 (403 Forbidden) returned body: \"{\\\"error\\\":{\\\"code\\\":\\\"accessDenied\\\",\\\"message\\\":\\\"Access denied\\\",\\\"innerError\\\":{\\\"date\\\":\\\"2026-08-20T03:36:58\\\",\\\"request-id\\\":\\\"148da341-cdcf-411c-bb53-cc786b0b4bc3\\\",\\\"client-request-id\\\":\\\"148da341-cdcf-411c-bb53-cc786b0b4bc3\\\"}}}\"" Result:""}, err=<nil>
Failed to query available drives: HTTP error 403 (403 Forbidden) returned body: "{\"error\":{\"code\":\"accessDenied\",\"message\":\"Access denied\",\"innerError\":{\"date\":\"2026-08-20T03:36:58\",\"request-id\":\"148da341-cdcf-411c-bb53-cc786b0b4bc3\",\"client-request-id\":\"148da341-cdcf-411c-bb53-cc786b0b4bc3\"}}}"
```

#### Linked issue

https://forum.rclone.org/t/onedrive-config-403-forbidden/54161

#### For new or changed backends

OneDrive: don't throw until both endpoints are tested

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
