### PR TITLE
huaweidrive: fix truncated files being uploaded successfully when the source ends early

### DIFF
--- a/backend/huaweidrive/huaweidrive.go
+++ b/backend/huaweidrive/huaweidrive.go
@@ -33,6 +33,7 @@ import (
 	"github.com/rclone/rclone/lib/encoder"
 	"github.com/rclone/rclone/lib/oauthutil"
 	"github.com/rclone/rclone/lib/pacer"
+	"github.com/rclone/rclone/lib/readers"
 	"github.com/rclone/rclone/lib/rest"
 	"golang.org/x/oauth2"
 )
@@ -1771,9 +1772,16 @@ func (o *Object) uploadMultipart(ctx context.Context, in io.Reader, leaf, direct
 	}
 
 	// Read and write file content
-	_, err = io.Copy(fileWriter, in)
+	counter := readers.NewCountingReader(in)
+	_, err = io.Copy(fileWriter, counter)
 	if err != nil {
 		return fmt.Errorf("failed to copy file content: %w", err)
+	}
+
+	// Check the source supplied the number of bytes it declared
+	// otherwise a truncated file would be stored as a good upload.
+	if int64(counter.BytesRead()) != size {
+		return fmt.Errorf("expected %d bytes in input, but got %d: %w", size, counter.BytesRead(), io.ErrUnexpectedEOF)
 	}
 
 	err = writer.Close()


### PR DESCRIPTION
Continues the "source ends early" sweep (#9785, #9786, #9787 and the commits it started from).

`uploadSimple` copied the source into the multipart request buffer with `io.Copy` and discarded the byte count, so a source supplying fewer bytes than its declared size was accepted by the server and reported as a success with a truncated file stored. Same shape as gofile: buffered body, no length check, silent truncation.

Count the bytes actually read with `readers.NewCountingReader` and fail with `io.ErrUnexpectedEOF` if they do not match the declared size — the same idiom as the merged box/gofile/googlephotos fixes.

`uploadResume` was checked and left alone: its final chunk is sent with an explicit `Content-Range` against the declared total, so a short source surfaces as an API error rather than a silent truncation.

Verified with `go build ./...`, `go vet` on the package, and the full unit suite matching the pre-change baseline (only the two recorded environmental failures, `cmd/gitannex` / `cmd/serve/s3`, which need git-annex and minio binaries).