### PR TITLE
http: retry transient errors and add strict_listings option

### DIFF
--- a/backend/http/http.go
+++ b/backend/http/http.go
@@ -21,8 +21,10 @@ import (
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/config/configmap"
 	"github.com/rclone/rclone/fs/config/configstruct"
+	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fs/fshttp"
 	"github.com/rclone/rclone/fs/hash"
+	"github.com/rclone/rclone/lib/pacer"
 	"github.com/rclone/rclone/lib/rest"
 	"golang.org/x/net/html"
 )
@@ -98,6 +100,23 @@ sizes of any files, and some files that don't exist may be in the listing.`,
 			Name:    "no_escape",
 			Help:    "Do not escape URL metacharacters in path names.",
 			Default: false,
+		}, {
+			Name: "strict_listings",
+			Help: `Return an error on listing errors.
+
+If set then any error encountered while stat'ing an entry in a
+directory listing will be returned as an error from the listing
+rather than the entry being skipped.
+
+Without this flag rclone skips entries which fail to be stat'd as it
+may be scraping a web site with broken or transiently failing links.
+
+Setting this flag means that a transient error on a listing (e.g. a
+Cloudflare 524) will fail the whole sync instead, which will stop
+rclone from deleting files on the destination that appear to have
+disappeared from the source.`,
+			Default:  false,
+			Advanced: true,
 		}},
 	}
 	fs.Register(fsi)
@@ -139,11 +158,12 @@ var systemMetadataInfo = map[string]fs.MetadataHelp{
 
 // Options defines the configuration for this backend
 type Options struct {
-	Endpoint string          `config:"url"`
-	NoSlash  bool            `config:"no_slash"`
-	NoHead   bool            `config:"no_head"`
-	Headers  fs.CommaSepList `config:"headers"`
-	NoEscape bool            `config:"no_escape"`
+	Endpoint       string          `config:"url"`
+	NoSlash        bool            `config:"no_slash"`
+	NoHead         bool            `config:"no_head"`
+	Headers        fs.CommaSepList `config:"headers"`
+	NoEscape       bool            `config:"no_escape"`
+	StrictListings bool            `config:"strict_listings"`
 }
 
 // Fs stores the interface to the remote HTTP files
@@ -156,7 +176,8 @@ type Fs struct {
 	endpoint    *url.URL
 	endpointURL string // endpoint as a string
 	httpClient  *http.Client
-	fileName    string // set if we are pointing to a file
+	pacer       *fs.Pacer // pacer for API calls
+	fileName    string    // set if we are pointing to a file
 }
 
 // Object is a remote object that has been stat'd (so it exists, but is not necessarily open for reading)
@@ -185,6 +206,36 @@ func statusError(res *http.Response, err error) error {
 		return fmt.Errorf("HTTP Error: %s", res.Status)
 	}
 	return nil
+}
+
+// retryErrorCodes is a slice of error codes that we will retry
+//
+// This includes the Cloudflare specific errors 520-527 which are
+// returned transiently when the origin server is unreachable or
+// timing out.
+var retryErrorCodes = []int{
+	429, // Too Many Requests
+	500, // Internal Server Error
+	502, // Bad Gateway
+	503, // Service Unavailable
+	504, // Gateway Timeout
+	520, // Cloudflare: Unknown Error
+	521, // Cloudflare: Web Server Is Down
+	522, // Cloudflare: Connection Timed Out
+	523, // Cloudflare: Origin Is Unreachable
+	524, // Cloudflare: A Timeout Occurred
+	525, // Cloudflare: SSL Handshake Failed
+	526, // Cloudflare: Invalid SSL Certificate
+	527, // Cloudflare: Railgun Error
+}
+
+// shouldRetry returns a boolean as to whether this resp and err
+// deserve to be retried. It returns the err as a convenience
+func (f *Fs) shouldRetry(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	if fserrors.ContextError(ctx, &err) {
+		return false, err
+	}
+	return fserrors.ShouldRetry(err) || fserrors.ShouldRetryHTTP(resp, retryErrorCodes), err
 }
 
 // getFsEndpoint decides if url is to be considered a file or directory,
@@ -328,6 +379,8 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 		ReadMetadata:            true,
 		CanHaveEmptyDirectories: true,
 	}).Fill(ctx, f)
+
+	f.pacer = fs.NewPacer(ctx, pacer.NewDefault())
 
 	// Make the http connection
 	isFile, err := f.httpConnection(ctx, opt)
@@ -531,7 +584,11 @@ func (f *Fs) readDir(ctx context.Context, dir string) (names []string, err error
 		return nil, fmt.Errorf("readDir failed: %w", err)
 	}
 	f.addHeaders(req)
-	res, err := f.httpClient.Do(req)
+	var res *http.Response
+	err = f.pacer.Call(func() (bool, error) {
+		res, err = f.httpClient.Do(req)
+		return f.shouldRetry(ctx, res, err)
+	})
 	if err == nil {
 		defer fs.CheckClose(res.Body, &err)
 		if res.StatusCode == http.StatusNotFound {
@@ -584,11 +641,15 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 	if err != nil {
 		return nil, fmt.Errorf("error listing %q: %w", dir, err)
 	}
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
 	var (
 		entriesMu sync.Mutex // to protect entries
+		errMu     sync.Mutex // to protect firstErr
 		wg        sync.WaitGroup
 		checkers  = f.ci.Checkers
 		in        = make(chan string, checkers)
+		firstErr  error
 	)
 	add := func(entry fs.DirEntry) {
 		entriesMu.Lock()
@@ -598,6 +659,9 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 	for range checkers {
 		wg.Go(func() {
 			for remote := range in {
+				if ctx.Err() != nil {
+					return
+				}
 				file := &Object{
 					fs:     f,
 					remote: remote,
@@ -609,6 +673,15 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 					// ...found a directory not a file
 					add(fs.NewDir(remote, time.Time{}))
 				default:
+					if f.opt.StrictListings {
+						errMu.Lock()
+						if firstErr == nil {
+							firstErr = fmt.Errorf("failed to stat %q: %w", remote, err)
+							cancel()
+						}
+						errMu.Unlock()
+						return
+					}
 					fs.Debugf(remote, "skipping because of error: %v", err)
 				}
 			}
@@ -621,11 +694,17 @@ func (f *Fs) List(ctx context.Context, dir string) (entries fs.DirEntries, err e
 		if isDir {
 			add(fs.NewDir(remote, time.Time{}))
 		} else {
-			in <- remote
+			select {
+			case in <- remote:
+			case <-ctx.Done():
+			}
 		}
 	}
 	close(in)
 	wg.Wait()
+	if firstErr != nil {
+		return nil, firstErr
+	}
 	return entries, nil
 }
 
@@ -698,7 +777,11 @@ func (o *Object) head(ctx context.Context) error {
 		return fmt.Errorf("stat failed: %w", err)
 	}
 	o.fs.addHeaders(req)
-	res, err := o.fs.httpClient.Do(req)
+	var res *http.Response
+	err = o.fs.pacer.Call(func() (bool, error) {
+		res, err = o.fs.httpClient.Do(req)
+		return o.fs.shouldRetry(ctx, res, err)
+	})
 	if err == nil && res.StatusCode == http.StatusNotFound {
 		return fs.ErrorObjectNotFound
 	}
@@ -782,7 +865,11 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.Read
 	o.fs.addHeaders(req)
 
 	// Do the request
-	res, err := o.fs.httpClient.Do(req)
+	var res *http.Response
+	err = o.fs.pacer.Call(func() (bool, error) {
+		res, err = o.fs.httpClient.Do(req)
+		return o.fs.shouldRetry(ctx, res, err)
+	})
 	err = statusError(res, err)
 	if err != nil {
 		return nil, fmt.Errorf("Open failed: %w", err)

--- a/backend/http/http_internal_test.go
+++ b/backend/http/http_internal_test.go
@@ -13,6 +13,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -580,4 +581,150 @@ func TestFsNoSlashRoots(t *testing.T) {
 			assert.Equal(t, ts.URL+endpoint, f.String(), what)
 		}
 	}
+}
+
+// TestRetryTransientErrors checks that transient errors (e.g. a
+// Cloudflare 524) on directory and head requests are retried by the
+// pacer rather than failing or being skipped.
+func TestRetryTransientErrors(t *testing.T) {
+	ci := fs.GetConfig(context.Background())
+	saved := ci.LowLevelRetries
+	ci.LowLevelRetries = 3
+	defer func() { ci.LowLevelRetries = saved }()
+
+	var (
+		mu       sync.Mutex
+		dirGets  int
+		headGets int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		transient := false
+		switch r.Method {
+		case http.MethodGet:
+			dirGets++
+			transient = dirGets <= 2
+		case http.MethodHead:
+			headGets++
+			transient = headGets <= 2
+		}
+		mu.Unlock()
+		if transient {
+			http.Error(w, "Gateway Timeout", 524)
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html><body><a href="one.txt">one.txt</a></body></html>`))
+			return
+		}
+		w.Header().Set("Content-Length", "5")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	m := configmap.Simple{"url": server.URL + "/"}
+	f, err := NewFs(context.Background(), remoteName, "", m)
+	require.NoError(t, err)
+
+	entries, err := f.List(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(entries))
+	assert.Equal(t, "one.txt", entries[0].Remote())
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 3, dirGets, "directory GET should have been retried twice")
+	assert.Equal(t, 3, headGets, "head request should have been retried twice")
+}
+
+// TestRetryOpen checks that transient errors on the GET request used
+// to download an object are retried by the pacer.
+func TestRetryOpen(t *testing.T) {
+	ci := fs.GetConfig(context.Background())
+	saved := ci.LowLevelRetries
+	ci.LowLevelRetries = 3
+	defer func() { ci.LowLevelRetries = saved }()
+
+	var (
+		mu       sync.Mutex
+		requests int
+		getGets  int
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		requests++
+		if r.Method == http.MethodGet {
+			getGets++
+		}
+		mu.Unlock()
+		if r.Method == http.MethodGet && requests <= 3 {
+			http.Error(w, "Gateway Timeout", 524)
+			return
+		}
+		w.Header().Set("Content-Length", "5")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("hello"))
+	}))
+	defer server.Close()
+
+	m := configmap.Simple{"url": server.URL + "/"}
+	f, err := NewFs(context.Background(), remoteName, "", m)
+	require.NoError(t, err)
+
+	o, err := f.NewObject(context.Background(), "one.txt")
+	require.NoError(t, err)
+	in, err := o.Open(context.Background())
+	require.NoError(t, err)
+	body, err := io.ReadAll(in)
+	require.NoError(t, err)
+	require.NoError(t, in.Close())
+	assert.Equal(t, "hello", string(body))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, 3, getGets, "GET request should have been retried twice")
+}
+
+// TestListStrictListings checks that when an entry fails to be
+// stat'd, the default behaviour is to skip it, but with the
+// strict_listings option set the listing returns an error instead so
+// that the sync delete phase won't run.
+func TestListStrictListings(t *testing.T) {
+	ci := fs.GetConfig(context.Background())
+	saved := ci.LowLevelRetries
+	ci.LowLevelRetries = 2
+	defer func() { ci.LowLevelRetries = saved }()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/bad.txt" {
+			http.Error(w, "Gateway Timeout", 524)
+			return
+		}
+		if r.Method == http.MethodGet {
+			w.Header().Set("Content-Type", "text/html")
+			_, _ = w.Write([]byte(`<html><body><a href="one.txt">one.txt</a><a href="bad.txt">bad.txt</a></body></html>`))
+			return
+		}
+		w.Header().Set("Content-Length", "5")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	// Default (lax): the entry which errors is silently skipped
+	m := configmap.Simple{"url": server.URL + "/"}
+	f, err := NewFs(context.Background(), remoteName, "", m)
+	require.NoError(t, err)
+	entries, err := f.List(context.Background(), "")
+	require.NoError(t, err)
+	require.Equal(t, 1, len(entries))
+	assert.Equal(t, "one.txt", entries[0].Remote())
+
+	// strict_listings: the listing returns an error
+	m = configmap.Simple{"url": server.URL + "/", "strict_listings": "true"}
+	f, err = NewFs(context.Background(), remoteName, "", m)
+	require.NoError(t, err)
+	_, err = f.List(context.Background(), "")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "bad.txt")
 }


### PR DESCRIPTION
## What does this PR do?

The http backend never retried anything - there is no pacer in it - and `List` dropped any entry which failed to stat with only a debug line. That combination means one Cloudflare 524 during a listing makes files vanish from the source view, and the sync delete phase then removes them from the destination. This is the root cause behind #5390 and #6582.

Two changes:

- Directory GETs, `Stat` HEADs and object opens now go through a pacer. It retries 429/500/502/503/504 plus the Cloudflare 52x codes, bounded by the existing `--low-level-retries`.
- A new advanced backend option `strict_listings` (default off) makes listing stat errors fail the whole listing instead of skipping the entry, so a sync stops rather than deleting. The default behaviour is unchanged for the web scraping use case ncw described back in the day.

## How has this been tested?

New unit tests in `backend/http/http_internal_test.go`: a local httptest server that answers 524 twice before succeeding verifies the retry counts on directory GET, HEAD and Open; another server with a permanently broken entry checks both the skip-by-default and strict_listings paths. All pass locally (`go test ./backend/http/`, go vet and golangci-lint clean).

I could not test against a real Cloudflare-fronted origin, only the synthetic 524s above.

Fixes #5390
Related: #6582