### PR TITLE
config: disable HTTP/2 by default

### DIFF
--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1359,6 +1359,11 @@ This stops rclone from trying to use HTTP/2 if available. This can
 sometimes speed up transfers due to a
 [problem in the Go standard library](https://github.com/golang/go/issues/37373).
 
+HTTP/2 is disabled by default for this reason - it multiplexes all
+concurrent transfers onto a single TCP connection, which performs
+badly on lossy or high latency networks. Use `--disable-http2=false`
+to turn HTTP/2 back on.
+
 ### --dscp string
 
 Specify a DSCP value or name to use in connections. This could help QoS

--- a/fs/config.go
+++ b/fs/config.go
@@ -496,7 +496,7 @@ var ConfigOptionsInfo = Options{{
 	Groups:  "Config",
 }, {
 	Name:    "disable_http2",
-	Default: false,
+	Default: true,
 	Help:    "Disable HTTP/2 in the global transport",
 	Groups:  "Networking",
 }, {

--- a/fs/config_test.go
+++ b/fs/config_test.go
@@ -47,3 +47,15 @@ func TestRCRequestContext(t *testing.T) {
 	// An unmarked context stays unmarked
 	assert.False(t, IsRCRequest(CopyConfig(context.Background(), ctx)))
 }
+
+// HTTP/2 multiplexes all concurrent transfers over a single TCP
+// connection, which performs badly on lossy networks - see #8379.
+// The disable_http2 default must stay on so that multi-threaded
+// downloads get multiple connections.
+func TestDisableHTTP2Default(t *testing.T) {
+	opt := ConfigOptionsInfo.Get("disable_http2")
+	assert.NotNil(t, opt)
+	if opt != nil {
+		assert.Equal(t, true, opt.Default)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

HTTP/2 multiplexes all concurrent transfers onto a single TCP connection, which performs badly on lossy or high latency links - transfers slow to a crawl instead of running in parallel. See #8379 for reports.

Flip the `disable_http2` default from `false` to `true` so multi-threaded downloads get multiple connections out of the box, and document the reasoning in the docs for `--disable-http2`. Users who want HTTP/2 can set `--disable-http2=false`.

## How has this been tested?

`go test ./fs/config/` passes, `go vet` clean. New `TestDisableHTTP2Default` guards the default so it doesn't silently flip back. Behavioural testing against real remotes not done - this matches what many users already set manually.