### PR TITLE
bisync: create lock file atomically

### DIFF
--- a/cmd/bisync/lockfile.go
+++ b/cmd/bisync/lockfile.go
@@ -40,9 +40,26 @@ func (b *bisyncRun) setLockFile() (err error) {
 			}
 		}
 
-		pidStr := []byte(strconv.Itoa(os.Getpid()))
-		if err = os.WriteFile(b.lockFile, pidStr, bilib.PermSecure); err != nil {
-			return fmt.Errorf(Color(terminal.RedFg, "cannot create lock file: %s: %w"), b.lockFile, err)
+		for range 2 {
+			var df *os.File
+			df, err = os.OpenFile(b.lockFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, bilib.PermSecure)
+			if err == nil {
+				pidStr := strconv.Itoa(os.Getpid())
+				if _, err = df.WriteString(pidStr); err == nil {
+					err = df.Close()
+				}
+				if err == nil {
+					break
+				}
+				_ = df.Close()
+				_ = os.Remove(b.lockFile)
+			}
+			if !os.IsExist(err) || !b.lockFileIsExpired() {
+				return fmt.Errorf(Color(terminal.RedFg, "cannot create lock file: %s: %w"), b.lockFile, err)
+			}
+			if err = os.Remove(b.lockFile); err != nil {
+				return fmt.Errorf(Color(terminal.RedFg, "cannot remove expired lock file: %s: %w"), b.lockFile, err)
+			}
 		}
 		fs.Debugf(nil, "Lock file created: %s", b.lockFile)
 		b.renewLockFile()

--- a/cmd/bisync/lockfile_test.go
+++ b/cmd/bisync/lockfile_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -77,4 +79,81 @@ func TestLockfileIsExpired_ValidNotExpired(t *testing.T) {
 
 	b := newTestLockfileBisyncRun(t, string(content), fs.Duration(5*time.Minute))
 	assert.False(t, b.lockFileIsExpired(), "valid lockfile with future expiry should not be expired")
+}
+
+func TestSetLockFileRace(t *testing.T) {
+	const runners = 8
+	const rounds = 50
+	for round := range rounds {
+		dir := t.TempDir()
+		base := filepath.Join(dir, "session")
+		lockPath := base + ".lck"
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "listing1"), nil, 0600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "listing2"), nil, 0600))
+
+		start := make(chan struct{})
+		errs := make(chan error, runners)
+		var wg sync.WaitGroup
+		for range runners {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				b := &bisyncRun{
+					basePath: base,
+					opt:      &Options{},
+					listing1: filepath.Join(dir, "listing1"),
+					listing2: filepath.Join(dir, "listing2"),
+				}
+				errs <- b.setLockFile()
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(errs)
+
+		winners := 0
+		for err := range errs {
+			if err == nil {
+				winners++
+			}
+		}
+		require.Equal(t, 1, winners, "round %d: exactly one runner must acquire the lock", round)
+		require.NoError(t, os.Remove(lockPath))
+	}
+}
+
+func TestSetLockFileExpiredTakeover(t *testing.T) {
+	dir := t.TempDir()
+	base := filepath.Join(dir, "session")
+	lockPath := base + ".lck"
+	data := struct {
+		Session     string
+		PID         string
+		TimeRenewed time.Time
+		TimeExpires time.Time
+	}{
+		Session:     "old-session",
+		PID:         "99999",
+		TimeRenewed: time.Now().Add(-10 * time.Minute),
+		TimeExpires: time.Now().Add(-5 * time.Minute),
+	}
+	content, err := json.Marshal(data)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(lockPath, content, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "listing1"), nil, 0600))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "listing2"), nil, 0600))
+
+	b := &bisyncRun{
+		basePath: base,
+		opt:      &Options{MaxLock: fs.Duration(5 * time.Minute)},
+		listing1: filepath.Join(dir, "listing1"),
+		listing2: filepath.Join(dir, "listing2"),
+	}
+	require.NoError(t, b.setLockFile())
+	defer b.lockFileOpt.stopRenewal()
+
+	newContent, err := os.ReadFile(lockPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(newContent), strconv.Itoa(os.Getpid()))
 }


### PR DESCRIPTION
## What does this PR do?

`setLockFile()` checked `bilib.FileExists(b.lockFile)` and then wrote the lock with `os.WriteFile()` in a separate step. `os.WriteFile` creates-or-truncates unconditionally, so two bisync runs on the same session can both observe "no lock" and both create one — the exact race the lock file is supposed to prevent. Fixes #9793.

The check is kept for the friendly error message, but the creation itself now uses `os.OpenFile` with `O_CREATE|O_EXCL` so only one caller can win. If the file already exists, it is taken over only when `lockFileIsExpired()` says so (which also removes it first), with one retry so the expiry takeover doesn't lose to another process removing the file at the same time.

## How has this been tested?

New tests in `cmd/bisync/lockfile_test.go`:
- `TestSetLockFileRace`: 8 goroutines race on the same session lock for 50 rounds; exactly one winner per round. Fails reliably on the old check-then-write code.
- `TestSetLockFileExpiredTakeover`: an expired lock file is taken over and rewritten with the current PID.

Full `go test ./cmd/bisync/` passes (61s), `go vet` clean. Existing lockfile tests untouched and green.
