### PR TITLE
filelu: fix duplicate root path during multipart folder creation

### DIFF
--- a/backend/filelu/filelu_file_uploader.go
+++ b/backend/filelu/filelu_file_uploader.go
@@ -25,7 +25,9 @@ func (f *Fs) multipartUpload(ctx context.Context, in io.Reader, remote string) e
 	}
 
 	if dir != "" {
-		_ = f.Mkdir(ctx, dir)
+		if _, err := f.createFolder(ctx, dir); err != nil {
+			return fmt.Errorf("failed to create multipart folder: %w", err)
+		}
 	}
 
 	folder := strings.Trim(dir, "/")


### PR DESCRIPTION
<!--
Thank you for contributing to rclone!

Please discuss anything more than a trivial fix in an issue FIRST - see the
"Linked issue" section below. Then fill in the questions to help us review.
-->

#### What does this change do?

Fixes multipart uploads to nested directories when the FileLu remote has a configured root. The root was added twice during folder creation, causing multipart initialization to fail with Folder not found.

#### Linked issue

None


#### For new or changed backends
`go run ./fstest/test_all -backends filelu` passed successfully. PASS: All tests finished OK in 17m0.89877854s

Also manually verified a 1 GiB multipart upload to a nested directory with a configured remote root.

<!--
Backend pull requests are often sent without the integration tests having been run.
We cannot merge a backend change until it passes the integration tests.

To be merged, a backend change REQUIRES:
  1. A clean run of `go run ./fstest/test_all -backends <remote>` (summarise the
     result below or paste a screenshot of the test_all output in the web browser).
  2. A test account so the maintainers can run the integration tests daily against
     the backend on the integration test server.

If the tests aren't quite passing yet and you need help getting them
to pass, then submit the PR and we can help getting you over the line.

See https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#writing-a-new-backend
and https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests
-->

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
