### PR TITLE
drive: fix ListR not disabling on incomplete multi-directory search results

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -690,11 +690,14 @@ resource key is not needed.
 
 Normally rclone will work around a bug in Google Drive when using
 --fast-list (ListR) where the search "(A in parents) or (B in
-parents)" returns nothing sometimes. See #3114, #4289 and
+parents)" returns nothing, or only some of the results, sometimes.
+See #3114, #4289, #9810 and
 https://issuetracker.google.com/issues/149522397
 
 Rclone detects this by finding no items in more than one directory
-when listing and retries them as lists of individual directories.
+when listing, or by the Drive API reporting the search as incomplete
+even though it returned some results, and retries the affected
+directories individually.
 
 This means that if you have a lot of empty directories rclone will end
 up listing them all individually and this can take many more API
@@ -1017,8 +1020,11 @@ func (f *Fs) getRootID(ctx context.Context) (string, error) {
 //
 // If the user fn ever returns true then it early exits with found = true
 //
+// incomplete is set if the Google API reports any page of the search as
+// incompleteSearch, which means the results may be missing entries.
+//
 // Search params: https://developers.google.com/drive/search-parameters
-func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directoriesOnly, filesOnly, trashedOnly, includeAll bool, fn listFn) (found bool, err error) {
+func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directoriesOnly, filesOnly, trashedOnly, includeAll bool, fn listFn) (found, incomplete bool, err error) {
 	var query []string
 	if !includeAll {
 		q := "trashed=" + strconv.FormatBool(trashedOnly)
@@ -1145,9 +1151,10 @@ OUTER:
 			return f.shouldRetry(ctx, err)
 		})
 		if err != nil {
-			return false, fmt.Errorf("couldn't list directory: %w", err)
+			return false, false, fmt.Errorf("couldn't list directory: %w", err)
 		}
 		if files.IncompleteSearch {
+			incomplete = true
 			fs.Errorf(f, "search result INCOMPLETE")
 		}
 		for _, item := range files.Files {
@@ -1167,7 +1174,7 @@ OUTER:
 				}
 				item, err = f.resolveShortcut(ctx, item)
 				if err != nil {
-					return false, fmt.Errorf("list: %w", err)
+					return false, false, fmt.Errorf("list: %w", err)
 				}
 				// leave the dangling shortcut out of the listings
 				// we've already logged about the dangling shortcut in resolveShortcut
@@ -1753,7 +1760,7 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (pathIDOut string, found bool, err error) {
 	// Find the leaf in pathID
 	pathID = actualID(pathID)
-	found, err = f.list(ctx, []string{pathID}, leaf, true, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+	found, _, err = f.list(ctx, []string{pathID}, leaf, true, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 		if !f.opt.SkipGdocs {
 			_, exportName, _, isDocument := f.findExportFormat(ctx, item)
 			if exportName == leaf {
@@ -2030,7 +2037,7 @@ func (f *Fs) ListP(ctx context.Context, dir string, callback fs.ListRCallback) e
 	directoryID = actualID(directoryID)
 
 	var iErr error
-	_, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+	_, _, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 		entry, err := f.itemToDirEntry(ctx, path.Join(dir, item.Name), item)
 		if err != nil {
 			iErr = err
@@ -2120,7 +2127,7 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 		listRSlices{dirs, paths}.Sort()
 		var iErr error
 		foundItems := false
-		_, err := f.list(ctx, dirs, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+		_, incomplete, err := f.list(ctx, dirs, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 			// shared with me items have no parents when at the root
 			if f.opt.SharedWithMe && len(item.Parents) == 0 && len(paths) == 1 && paths[0] == "" {
 				item.Parents = dirs
@@ -2168,14 +2175,19 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 			}
 			return false
 		})
-		// Found no items in more than one directory. Retry these as
-		// individual directories This is to work around a bug in google
-		// drive where (A in parents) or (B in parents) returns nothing
-		// sometimes. See #3114, #4289 and
+		// Found no items in more than one directory, or the API reported the
+		// search as incomplete. Retry these as individual directories. This
+		// is to work around a bug in google drive where (A in parents) or (B
+		// in parents) returns nothing, or only partial results, sometimes.
+		// See #3114, #4289, #9810 and
 		// https://issuetracker.google.com/issues/149522397
-		if f.opt.FastListBugFix && len(dirs) > 1 && !foundItems {
+		if f.opt.FastListBugFix && len(dirs) > 1 && (!foundItems || incomplete) {
 			if atomic.SwapInt32(&f.grouping, 1) != 1 {
-				fs.Debugf(f, "Disabling ListR to work around bug in drive as multi listing (%d) returned no entries", len(dirs))
+				if incomplete {
+					fs.Debugf(f, "Disabling ListR to work around bug in drive as multi listing (%d) returned an incomplete search", len(dirs))
+				} else {
+					fs.Debugf(f, "Disabling ListR to work around bug in drive as multi listing (%d) returned no entries", len(dirs))
+				}
 			}
 			f.listRmu.Lock()
 			for i := range dirs {
@@ -2191,7 +2203,7 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 		}
 		// If using a grouping of 1 and dir was empty then check to see if it
 		// is part of the group that caused grouping to be disabled.
-		if grouping == 1 && len(dirs) == 1 && !foundItems {
+		if grouping == 1 && len(dirs) == 1 && !foundItems && !incomplete {
 			f.listRmu.Lock()
 			if _, found := f.listRempties[dirs[0]]; found {
 				// Remove the ID
@@ -2635,7 +2647,7 @@ func (f *Fs) MergeDirs(ctx context.Context, dirs []fs.Directory) error {
 	for _, srcDir := range dirs[1:] {
 		// list the objects
 		infos := []*drive.File{}
-		_, err := f.list(ctx, []string{srcDir.ID()}, "", false, false, f.opt.TrashedOnly, true, func(info *drive.File) bool {
+		_, _, err := f.list(ctx, []string{srcDir.ID()}, "", false, false, f.opt.TrashedOnly, true, func(info *drive.File) bool {
 			infos = append(infos, info)
 			return false
 		})
@@ -2771,7 +2783,7 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 		// to enumerate trashed children: let the server filter them out instead of
 		// paging through them. Hard deletes still need to see them (#1040).
 		includeAll := !f.opt.UseTrash || f.opt.TrashedOnly
-		found, err := f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, includeAll, func(item *drive.File) bool {
+		found, _, err := f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, includeAll, func(item *drive.File) bool {
 			if !item.Trashed {
 				fs.Debugf(dir, "Rmdir: contains file: %q", item.Name)
 				return true
@@ -2960,7 +2972,7 @@ func (r cleanupResult) Error() string {
 }
 
 func (f *Fs) cleanupTeamDrive(ctx context.Context, dir string, directoryID string) (r cleanupResult, err error) {
-	_, err = f.list(ctx, []string{directoryID}, "", false, false, true, false, func(item *drive.File) bool {
+	_, _, err = f.list(ctx, []string{directoryID}, "", false, false, true, false, func(item *drive.File) bool {
 		remote := path.Join(dir, item.Name)
 		if item.ExplicitlyTrashed { // description is wrong - can also be set for folders - no need to recurse them
 			err := f.delete(ctx, item.Id, false)
@@ -3559,7 +3571,7 @@ func (r unTrashResult) Error() string {
 func (f *Fs) unTrash(ctx context.Context, dir string, directoryID string, recurse bool) (r unTrashResult, err error) {
 	directoryID = actualID(directoryID)
 	fs.Debugf(dir, "finding trash to restore in directory %q", directoryID)
-	_, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, true, func(item *drive.File) bool {
+	_, _, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, true, func(item *drive.File) bool {
 		remote := path.Join(dir, item.Name)
 		if item.ExplicitlyTrashed {
 			fs.Infof(remote, "restoring %q", item.Id)
@@ -4230,7 +4242,7 @@ func (f *Fs) getRemoteInfoWithExport(ctx context.Context, remote string) (
 	}
 	directoryID = actualID(directoryID)
 
-	found, err := f.list(ctx, []string{directoryID}, leaf, false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+	found, _, err := f.list(ctx, []string{directoryID}, leaf, false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 		if !f.opt.SkipGdocs {
 			extension, exportName, exportMimeType, isDocument = f.findExportFormat(ctx, item)
 			if exportName == leaf {

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -695,11 +695,12 @@ search sometimes. See #3114, #4289, #9810 and
 https://issuetracker.google.com/issues/149522397
 
 Rclone detects this by finding directories with no items in a listing
-of more than one directory and retries them individually.
+of more than one directory and retries just those directories together
+as a single extra listing.
 
-This means that if you have a lot of empty directories rclone will end
-up listing them all individually and this can take many more API
-calls.
+This means that if you have a lot of directories affected by this bug
+in a single listing rclone will end up doing an extra API call to
+re-list them.
 
 This flag allows the work-around to be disabled. This is **not**
 recommended in normal use - only if you have a particular case you are
@@ -871,8 +872,6 @@ type Fs struct {
 	isTeamDrive      bool               // true if this is a team drive
 	m                configmap.Mapper
 	grouping         int32                        // number of IDs to search at once in ListR - read with atomic
-	listRmu          *sync.Mutex                  // protects listRempties
-	listRempties     map[string]struct{}          // IDs of supposedly empty directories which triggered grouping disable
 	dirResourceKeys  *sync.Map                    // map directory ID to resource key
 	permissionsMu    *sync.Mutex                  // protect the below
 	permissions      map[string]*drive.Permission // map permission IDs to Permissions
@@ -1405,8 +1404,6 @@ func newFs(ctx context.Context, name, path string, m configmap.Mapper) (*Fs, err
 		pacer:           fs.NewPacer(ctx, pacer.NewGoogleDrive(pacer.MinSleep(opt.PacerMinSleep), pacer.Burst(opt.PacerBurst))),
 		m:               m,
 		grouping:        listRGrouping,
-		listRmu:         new(sync.Mutex),
-		listRempties:    make(map[string]struct{}),
 		dirResourceKeys: new(sync.Map),
 		permissionsMu:   new(sync.Mutex),
 		permissions:     make(map[string]*drive.Permission),
@@ -2092,12 +2089,59 @@ func (s listRSlices) Less(i, j int) bool {
 	return s.dirs[i] < s.dirs[j]
 }
 
+// listRItem finds which of the sorted dirs (with matching paths) item
+// belongs to, converts it to a DirEntry and calls cb with it for each
+// matching parent. dirs must be sorted. found[i] is set to true for each
+// dirs[i] that item belongs to.
+//
+// It returns true (to stop the listing early) if cb or the DirEntry
+// conversion returns an error, which is then returned in iErr.
+func (f *Fs) listRItem(ctx context.Context, item *drive.File, dirs, paths []string, found []bool, cb func(fs.DirEntry) error) (stop bool, iErr error) {
+	for _, parent := range item.Parents {
+		var i int
+		earlyExit := false
+		// If only one item in paths then no need to search for the ID
+		// assuming google drive is doing its job properly.
+		//
+		// Note that we at the root when len(paths) == 1 && paths[0] == ""
+		if len(paths) == 1 {
+			// don't check parents at root because
+			// - shared with me items have no parents at the root
+			// - if using a root alias, e.g. "root" or "appDataFolder" the ID won't match
+			i = 0
+			// items at root can have more than one parent so we need to put
+			// the item in just once.
+			earlyExit = true
+		} else {
+			// only handle parents that are in the requested dirs list if not at root
+			i = sort.SearchStrings(dirs, parent)
+			if i == len(dirs) || dirs[i] != parent {
+				continue
+			}
+		}
+		found[i] = true
+		remote := path.Join(paths[i], item.Name)
+		entry, err := f.itemToDirEntry(ctx, remote, item)
+		if err != nil {
+			return true, err
+		}
+		if err := cb(entry); err != nil {
+			return true, err
+		}
+		// If didn't check parents then insert only once
+		if earlyExit {
+			break
+		}
+	}
+	return false, nil
+}
+
 // listRRunner will read dirIDs from the in channel, perform the file listing and call cb with each DirEntry.
 //
 // In each cycle it will read up to grouping entries from the in channel without blocking.
 // If an error occurs it will be send to the out channel and then return. Once the in channel is closed,
 // nil is send to the out channel and the function returns.
-func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listREntry, out chan<- error, cb func(fs.DirEntry) error, sendJob func(listREntry)) {
+func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listREntry, out chan<- error, cb func(fs.DirEntry) error) {
 	var dirs []string
 	var paths []string
 	var grouping int32
@@ -2120,104 +2164,50 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 		}
 		listRSlices{dirs, paths}.Sort()
 		var iErr error
-		foundItems := false
 		foundInDir := make([]bool, len(dirs))
 		_, err := f.list(ctx, dirs, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 			// shared with me items have no parents when at the root
 			if f.opt.SharedWithMe && len(item.Parents) == 0 && len(paths) == 1 && paths[0] == "" {
 				item.Parents = dirs
 			}
-			for _, parent := range item.Parents {
-				var i int
-				foundItems = true
-				earlyExit := false
-				// If only one item in paths then no need to search for the ID
-				// assuming google drive is doing its job properly.
-				//
-				// Note that we at the root when len(paths) == 1 && paths[0] == ""
-				if len(paths) == 1 {
-					// don't check parents at root because
-					// - shared with me items have no parents at the root
-					// - if using a root alias, e.g. "root" or "appDataFolder" the ID won't match
-					i = 0
-					// items at root can have more than one parent so we need to put
-					// the item in just once.
-					earlyExit = true
-				} else {
-					// only handle parents that are in the requested dirs list if not at root
-					i = sort.SearchStrings(dirs, parent)
-					if i == len(dirs) || dirs[i] != parent {
-						continue
-					}
-				}
-				foundInDir[i] = true
-				remote := path.Join(paths[i], item.Name)
-				entry, err := f.itemToDirEntry(ctx, remote, item)
-				if err != nil {
-					iErr = err
-					return true
-				}
-
-				err = cb(entry)
-				if err != nil {
-					iErr = err
-					return true
-				}
-
-				// If didn't check parents then insert only once
-				if earlyExit {
-					break
-				}
+			stop, err := f.listRItem(ctx, item, dirs, paths, foundInDir, cb)
+			if err != nil {
+				iErr = err
 			}
-			return false
+			return stop
 		})
-		// Found no items at all in more than one directory, or found items in
-		// some but not all of the directories in the batch. Retry the
-		// directories with no items as individual directories. This is to
-		// work around a bug in google drive where (A in parents) or (B in
-		// parents) returns nothing for some of A or B sometimes. See #3114,
-		// #4289, #9810 and https://issuetracker.google.com/issues/149522397
-		if f.opt.FastListBugFix && len(dirs) > 1 {
-			var empty []int
+		// Found items in some but not all of the directories in the batch.
+		// Retry the directories with no items together as a single fresh
+		// batch (without disabling grouping). This is to work around a bug
+		// in google drive where (A in parents) or (B in parents) returns
+		// nothing for some of A or B sometimes. See #3114, #4289, #9810 and
+		// https://issuetracker.google.com/issues/149522397
+		//
+		// A batch of genuinely empty directories costs one extra query for
+		// the whole batch rather than one query per directory, and if that
+		// retry also comes back with no items at all, they are simply empty.
+		if f.opt.FastListBugFix && len(dirs) > 1 && iErr == nil {
+			var emptyDirs, emptyPaths []string
 			for i, found := range foundInDir {
 				if !found {
-					empty = append(empty, i)
+					emptyDirs = append(emptyDirs, dirs[i])
+					emptyPaths = append(emptyPaths, paths[i])
 				}
 			}
-			if len(empty) > 0 {
-				if atomic.SwapInt32(&f.grouping, 1) != 1 {
-					fs.Debugf(f, "Disabling ListR to work around bug in drive as multi listing (%d) returned no entries for %d of the directories", len(dirs), len(empty))
-				}
-				f.listRmu.Lock()
-				for _, i := range empty {
-					// Requeue the jobs that got no items
-					job := listREntry{id: dirs[i], path: paths[i]}
-					sendJob(job)
-					// Make a note of these dirs - if they all turn
-					// out to be empty then we can re-enable grouping
-					f.listRempties[dirs[i]] = struct{}{}
-				}
-				f.listRmu.Unlock()
-				fs.Debugf(f, "Recycled %d entries", len(empty))
-			}
-		}
-		// If using a grouping of 1 and dir was empty then check to see if it
-		// is part of the group that caused grouping to be disabled.
-		if grouping == 1 && len(dirs) == 1 && !foundItems {
-			f.listRmu.Lock()
-			if _, found := f.listRempties[dirs[0]]; found {
-				// Remove the ID
-				delete(f.listRempties, dirs[0])
-				// If no empties left => all the directories that
-				// triggered the grouping being set to 1 were actually
-				// empty so must have made a mistake
-				if len(f.listRempties) == 0 {
-					if atomic.SwapInt32(&f.grouping, listRGrouping) != listRGrouping {
-						fs.Debugf(f, "Re-enabling ListR as previous detection was in error")
+			if len(emptyDirs) > 0 {
+				fs.Debugf(f, "Retrying %d directories with no entries from multi listing (%d) to work around bug in drive", len(emptyDirs), len(dirs))
+				emptyFound := make([]bool, len(emptyDirs))
+				_, retryErr := f.list(ctx, emptyDirs, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+					stop, err := f.listRItem(ctx, item, emptyDirs, emptyPaths, emptyFound, cb)
+					if err != nil {
+						iErr = err
 					}
+					return stop
+				})
+				if retryErr != nil && iErr == nil {
+					iErr = retryErr
 				}
 			}
-			f.listRmu.Unlock()
 		}
 
 		for range dirs {
@@ -2303,7 +2293,7 @@ func (f *Fs) ListR(ctx context.Context, dir string, callback fs.ListRCallback) (
 	in <- listREntry{directoryID, dir}
 
 	for range f.ci.Checkers {
-		go f.listRRunner(ctx, &wg, in, out, cb, sendJob)
+		go f.listRRunner(ctx, &wg, in, out, cb)
 	}
 	go func() {
 		// wait until the all directories are processed

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -690,14 +690,12 @@ resource key is not needed.
 
 Normally rclone will work around a bug in Google Drive when using
 --fast-list (ListR) where the search "(A in parents) or (B in
-parents)" returns nothing, or only some of the results, sometimes.
-See #3114, #4289, #9810 and
+parents)" returns nothing for one or more of the directories in the
+search sometimes. See #3114, #4289, #9810 and
 https://issuetracker.google.com/issues/149522397
 
-Rclone detects this by finding no items in more than one directory
-when listing, or by the Drive API reporting the search as incomplete
-even though it returned some results, and retries the affected
-directories individually.
+Rclone detects this by finding directories with no items in a listing
+of more than one directory and retries them individually.
 
 This means that if you have a lot of empty directories rclone will end
 up listing them all individually and this can take many more API
@@ -1020,11 +1018,8 @@ func (f *Fs) getRootID(ctx context.Context) (string, error) {
 //
 // If the user fn ever returns true then it early exits with found = true
 //
-// incomplete is set if the Google API reports any page of the search as
-// incompleteSearch, which means the results may be missing entries.
-//
 // Search params: https://developers.google.com/drive/search-parameters
-func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directoriesOnly, filesOnly, trashedOnly, includeAll bool, fn listFn) (found, incomplete bool, err error) {
+func (f *Fs) list(ctx context.Context, dirIDs []string, title string, directoriesOnly, filesOnly, trashedOnly, includeAll bool, fn listFn) (found bool, err error) {
 	var query []string
 	if !includeAll {
 		q := "trashed=" + strconv.FormatBool(trashedOnly)
@@ -1151,10 +1146,9 @@ OUTER:
 			return f.shouldRetry(ctx, err)
 		})
 		if err != nil {
-			return false, false, fmt.Errorf("couldn't list directory: %w", err)
+			return false, fmt.Errorf("couldn't list directory: %w", err)
 		}
 		if files.IncompleteSearch {
-			incomplete = true
 			fs.Errorf(f, "search result INCOMPLETE")
 		}
 		for _, item := range files.Files {
@@ -1174,7 +1168,7 @@ OUTER:
 				}
 				item, err = f.resolveShortcut(ctx, item)
 				if err != nil {
-					return false, false, fmt.Errorf("list: %w", err)
+					return false, fmt.Errorf("list: %w", err)
 				}
 				// leave the dangling shortcut out of the listings
 				// we've already logged about the dangling shortcut in resolveShortcut
@@ -1760,7 +1754,7 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (pathIDOut string, found bool, err error) {
 	// Find the leaf in pathID
 	pathID = actualID(pathID)
-	found, _, err = f.list(ctx, []string{pathID}, leaf, true, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+	found, err = f.list(ctx, []string{pathID}, leaf, true, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 		if !f.opt.SkipGdocs {
 			_, exportName, _, isDocument := f.findExportFormat(ctx, item)
 			if exportName == leaf {
@@ -2037,7 +2031,7 @@ func (f *Fs) ListP(ctx context.Context, dir string, callback fs.ListRCallback) e
 	directoryID = actualID(directoryID)
 
 	var iErr error
-	_, _, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+	_, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 		entry, err := f.itemToDirEntry(ctx, path.Join(dir, item.Name), item)
 		if err != nil {
 			iErr = err
@@ -2127,7 +2121,8 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 		listRSlices{dirs, paths}.Sort()
 		var iErr error
 		foundItems := false
-		_, incomplete, err := f.list(ctx, dirs, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+		foundInDir := make([]bool, len(dirs))
+		_, err := f.list(ctx, dirs, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 			// shared with me items have no parents when at the root
 			if f.opt.SharedWithMe && len(item.Parents) == 0 && len(paths) == 1 && paths[0] == "" {
 				item.Parents = dirs
@@ -2155,6 +2150,7 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 						continue
 					}
 				}
+				foundInDir[i] = true
 				remote := path.Join(paths[i], item.Name)
 				entry, err := f.itemToDirEntry(ctx, remote, item)
 				if err != nil {
@@ -2175,35 +2171,39 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 			}
 			return false
 		})
-		// Found no items in more than one directory, or the API reported the
-		// search as incomplete. Retry these as individual directories. This
-		// is to work around a bug in google drive where (A in parents) or (B
-		// in parents) returns nothing, or only partial results, sometimes.
-		// See #3114, #4289, #9810 and
-		// https://issuetracker.google.com/issues/149522397
-		if f.opt.FastListBugFix && len(dirs) > 1 && (!foundItems || incomplete) {
-			if atomic.SwapInt32(&f.grouping, 1) != 1 {
-				if incomplete {
-					fs.Debugf(f, "Disabling ListR to work around bug in drive as multi listing (%d) returned an incomplete search", len(dirs))
-				} else {
-					fs.Debugf(f, "Disabling ListR to work around bug in drive as multi listing (%d) returned no entries", len(dirs))
+		// Found no items at all in more than one directory, or found items in
+		// some but not all of the directories in the batch. Retry the
+		// directories with no items as individual directories. This is to
+		// work around a bug in google drive where (A in parents) or (B in
+		// parents) returns nothing for some of A or B sometimes. See #3114,
+		// #4289, #9810 and https://issuetracker.google.com/issues/149522397
+		if f.opt.FastListBugFix && len(dirs) > 1 {
+			var empty []int
+			for i, found := range foundInDir {
+				if !found {
+					empty = append(empty, i)
 				}
 			}
-			f.listRmu.Lock()
-			for i := range dirs {
-				// Requeue the jobs
-				job := listREntry{id: dirs[i], path: paths[i]}
-				sendJob(job)
-				// Make a note of these dirs - if they all turn
-				// out to be empty then we can re-enable grouping
-				f.listRempties[dirs[i]] = struct{}{}
+			if len(empty) > 0 {
+				if atomic.SwapInt32(&f.grouping, 1) != 1 {
+					fs.Debugf(f, "Disabling ListR to work around bug in drive as multi listing (%d) returned no entries for %d of the directories", len(dirs), len(empty))
+				}
+				f.listRmu.Lock()
+				for _, i := range empty {
+					// Requeue the jobs that got no items
+					job := listREntry{id: dirs[i], path: paths[i]}
+					sendJob(job)
+					// Make a note of these dirs - if they all turn
+					// out to be empty then we can re-enable grouping
+					f.listRempties[dirs[i]] = struct{}{}
+				}
+				f.listRmu.Unlock()
+				fs.Debugf(f, "Recycled %d entries", len(empty))
 			}
-			f.listRmu.Unlock()
-			fs.Debugf(f, "Recycled %d entries", len(dirs))
 		}
 		// If using a grouping of 1 and dir was empty then check to see if it
 		// is part of the group that caused grouping to be disabled.
-		if grouping == 1 && len(dirs) == 1 && !foundItems && !incomplete {
+		if grouping == 1 && len(dirs) == 1 && !foundItems {
 			f.listRmu.Lock()
 			if _, found := f.listRempties[dirs[0]]; found {
 				// Remove the ID
@@ -2647,7 +2647,7 @@ func (f *Fs) MergeDirs(ctx context.Context, dirs []fs.Directory) error {
 	for _, srcDir := range dirs[1:] {
 		// list the objects
 		infos := []*drive.File{}
-		_, _, err := f.list(ctx, []string{srcDir.ID()}, "", false, false, f.opt.TrashedOnly, true, func(info *drive.File) bool {
+		_, err := f.list(ctx, []string{srcDir.ID()}, "", false, false, f.opt.TrashedOnly, true, func(info *drive.File) bool {
 			infos = append(infos, info)
 			return false
 		})
@@ -2783,7 +2783,7 @@ func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
 		// to enumerate trashed children: let the server filter them out instead of
 		// paging through them. Hard deletes still need to see them (#1040).
 		includeAll := !f.opt.UseTrash || f.opt.TrashedOnly
-		found, _, err := f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, includeAll, func(item *drive.File) bool {
+		found, err := f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, includeAll, func(item *drive.File) bool {
 			if !item.Trashed {
 				fs.Debugf(dir, "Rmdir: contains file: %q", item.Name)
 				return true
@@ -2972,7 +2972,7 @@ func (r cleanupResult) Error() string {
 }
 
 func (f *Fs) cleanupTeamDrive(ctx context.Context, dir string, directoryID string) (r cleanupResult, err error) {
-	_, _, err = f.list(ctx, []string{directoryID}, "", false, false, true, false, func(item *drive.File) bool {
+	_, err = f.list(ctx, []string{directoryID}, "", false, false, true, false, func(item *drive.File) bool {
 		remote := path.Join(dir, item.Name)
 		if item.ExplicitlyTrashed { // description is wrong - can also be set for folders - no need to recurse them
 			err := f.delete(ctx, item.Id, false)
@@ -3571,7 +3571,7 @@ func (r unTrashResult) Error() string {
 func (f *Fs) unTrash(ctx context.Context, dir string, directoryID string, recurse bool) (r unTrashResult, err error) {
 	directoryID = actualID(directoryID)
 	fs.Debugf(dir, "finding trash to restore in directory %q", directoryID)
-	_, _, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, true, func(item *drive.File) bool {
+	_, err = f.list(ctx, []string{directoryID}, "", false, false, f.opt.TrashedOnly, true, func(item *drive.File) bool {
 		remote := path.Join(dir, item.Name)
 		if item.ExplicitlyTrashed {
 			fs.Infof(remote, "restoring %q", item.Id)
@@ -4242,7 +4242,7 @@ func (f *Fs) getRemoteInfoWithExport(ctx context.Context, remote string) (
 	}
 	directoryID = actualID(directoryID)
 
-	found, _, err := f.list(ctx, []string{directoryID}, leaf, false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+	found, err := f.list(ctx, []string{directoryID}, leaf, false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
 		if !f.opt.SkipGdocs {
 			extension, exportName, exportMimeType, isDocument = f.findExportFormat(ctx, item)
 			if exportName == leaf {

--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -696,10 +696,12 @@ https://issuetracker.google.com/issues/149522397
 
 Rclone detects this by finding directories with no items in a listing
 of more than one directory and retries just those directories together
-as a single extra listing.
+as a single extra listing. Any directory still showing no items after
+that is queried on its own, since the bug is triggered by combining
+multiple directories into one search.
 
 This means that if you have a lot of directories affected by this bug
-in a single listing rclone will end up doing an extra API call to
+in a single listing rclone will end up doing extra API calls to
 re-list them.
 
 This flag allows the work-around to be disabled. This is **not**
@@ -2184,8 +2186,12 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 		// https://issuetracker.google.com/issues/149522397
 		//
 		// A batch of genuinely empty directories costs one extra query for
-		// the whole batch rather than one query per directory, and if that
-		// retry also comes back with no items at all, they are simply empty.
+		// the whole batch rather than one query per directory. However the
+		// bug can affect the same directories again when they are retried
+		// together, since it is the multi-parent query itself that
+		// triggers it - so any directory still empty after the batch retry
+		// is queried once more on its own, which has no "or" clause to
+		// trigger the bug.
 		if f.opt.FastListBugFix && len(dirs) > 1 && iErr == nil {
 			var emptyDirs, emptyPaths []string
 			for i, found := range foundInDir {
@@ -2206,6 +2212,25 @@ func (f *Fs) listRRunner(ctx context.Context, wg *sync.WaitGroup, in chan listRE
 				})
 				if retryErr != nil && iErr == nil {
 					iErr = retryErr
+				}
+				if iErr == nil {
+					for i, found := range emptyFound {
+						if found {
+							continue
+						}
+						fs.Debugf(f, "Retrying directory %q individually as it still had no entries after the batch retry", emptyPaths[i])
+						_, dirErr := f.list(ctx, []string{emptyDirs[i]}, "", false, false, f.opt.TrashedOnly, false, func(item *drive.File) bool {
+							stop, err := f.listRItem(ctx, item, []string{emptyDirs[i]}, []string{emptyPaths[i]}, []bool{false}, cb)
+							if err != nil {
+								iErr = err
+							}
+							return stop
+						})
+						if dirErr != nil {
+							iErr = dirErr
+							break
+						}
+					}
 				}
 			}
 		}

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -136,6 +136,56 @@ func TestInternalGetPermissionCacheHit(t *testing.T) {
 	assert.Equal(t, int32(1), requests.Load())
 }
 
+func newListTestFs(t *testing.T, handler http.Handler) *Fs {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+	service, err := drive.NewService(
+		context.Background(),
+		option.WithHTTPClient(server.Client()),
+		option.WithEndpoint(server.URL+"/"),
+	)
+	require.NoError(t, err)
+	return &Fs{
+		svc:             service,
+		pacer:           fs.NewPacer(context.Background(), pacer.NewGoogleDrive()),
+		dirResourceKeys: new(stdsync.Map),
+	}
+}
+
+func TestInternalListIncompleteSearch(t *testing.T) {
+	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{"files":[{"id":"file-1","name":"file-1"}],"incompleteSearch":true}`)
+		assert.NoError(t, err)
+	}))
+
+	var seen []string
+	found, incomplete, err := f.list(context.Background(), []string{"dir-id"}, "", false, false, false, false, func(item *drive.File) bool {
+		seen = append(seen, item.Id)
+		return false
+	})
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.True(t, incomplete, "incomplete should reflect incompleteSearch in the API response even though items were returned")
+	assert.Equal(t, []string{"file-1"}, seen)
+}
+
+func TestInternalListCompleteSearch(t *testing.T) {
+	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := io.WriteString(w, `{"files":[],"incompleteSearch":false}`)
+		assert.NoError(t, err)
+	}))
+
+	found, incomplete, err := f.list(context.Background(), []string{"dir-id"}, "", false, false, false, false, func(item *drive.File) bool {
+		return false
+	})
+	require.NoError(t, err)
+	assert.False(t, found)
+	assert.False(t, incomplete)
+}
+
 func TestDriveScopes(t *testing.T) {
 	for _, test := range []struct {
 		in       string

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -153,37 +153,60 @@ func newListTestFs(t *testing.T, handler http.Handler) *Fs {
 	}
 }
 
-func TestInternalListIncompleteSearch(t *testing.T) {
+// TestInternalListRRunnerPartialBatch reproduces the scenario in #9810: a
+// batched multi-directory listing where the Drive API silently returns no
+// items for some of the requested directories while returning items
+// normally for others. It checks that only the directories which got no
+// items are retried individually (not the whole batch, which would
+// duplicate the entries already emitted for the healthy directories) and
+// that ListR grouping is disabled as a result.
+func TestInternalListRRunnerPartialBatch(t *testing.T) {
 	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		_, err := io.WriteString(w, `{"files":[{"id":"file-1","name":"file-1"}],"incompleteSearch":true}`)
+		// dir-a has a file, dir-b and dir-c are silently dropped by the
+		// simulated Drive bug even though they are not actually empty
+		_, err := io.WriteString(w, `{"files":[{"id":"file-a","name":"file-a.txt","mimeType":"text/plain","md5Checksum":"d41d8cd98f00b204e9800998ecf8427e","parents":["dir-a"]}]}`)
 		assert.NoError(t, err)
 	}))
+	f.opt.FastListBugFix = true
+	f.grouping = listRGrouping
+	f.listRmu = new(stdsync.Mutex)
+	f.listRempties = make(map[string]struct{})
 
-	var seen []string
-	found, incomplete, err := f.list(context.Background(), []string{"dir-id"}, "", false, false, false, false, func(item *drive.File) bool {
-		seen = append(seen, item.Id)
-		return false
-	})
-	require.NoError(t, err)
-	assert.False(t, found)
-	assert.True(t, incomplete, "incomplete should reflect incompleteSearch in the API response even though items were returned")
-	assert.Equal(t, []string{"file-1"}, seen)
-}
+	in := make(chan listREntry, 10)
+	out := make(chan error, 1)
+	var wg stdsync.WaitGroup
+	var mu stdsync.Mutex
+	var emitted []string
+	var requeued []listREntry
+	cb := func(entry fs.DirEntry) error {
+		mu.Lock()
+		defer mu.Unlock()
+		emitted = append(emitted, entry.Remote())
+		return nil
+	}
+	sendJob := func(job listREntry) {
+		mu.Lock()
+		defer mu.Unlock()
+		requeued = append(requeued, job)
+	}
 
-func TestInternalListCompleteSearch(t *testing.T) {
-	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_, err := io.WriteString(w, `{"files":[],"incompleteSearch":false}`)
-		assert.NoError(t, err)
-	}))
+	wg.Add(3)
+	in <- listREntry{id: "dir-a", path: "a"}
+	in <- listREntry{id: "dir-b", path: "b"}
+	in <- listREntry{id: "dir-c", path: "c"}
+	close(in)
 
-	found, incomplete, err := f.list(context.Background(), []string{"dir-id"}, "", false, false, false, false, func(item *drive.File) bool {
-		return false
-	})
-	require.NoError(t, err)
-	assert.False(t, found)
-	assert.False(t, incomplete)
+	f.listRRunner(context.Background(), &wg, in, out, cb, sendJob)
+	require.NoError(t, <-out)
+
+	assert.Equal(t, []string{"a/file-a.txt"}, emitted, "the healthy directory's item should be emitted exactly once")
+	requeuedIDs := make([]string, len(requeued))
+	for i, job := range requeued {
+		requeuedIDs[i] = job.id
+	}
+	assert.ElementsMatch(t, []string{"dir-b", "dir-c"}, requeuedIDs, "only the directories that returned no items should be retried, not dir-a")
+	assert.Equal(t, int32(1), f.grouping, "grouping should be disabled after a partial batch")
 }
 
 func TestDriveScopes(t *testing.T) {

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -210,6 +210,63 @@ func TestInternalListRRunnerPartialBatch(t *testing.T) {
 	assert.Len(t, requests, 2, "expected one batch request and one retry request for the empty directories")
 }
 
+// TestInternalListRRunnerBatchRetryStillEmpty covers the case where the
+// drive bug affects a directory consistently across multi-parent queries:
+// dir-b has no items on the initial batch (dir-a, dir-b, dir-c) or the
+// batch retry (dir-b, dir-c), only when queried entirely on its own. It
+// checks that listRRunner falls back to querying dir-b individually and
+// still finds its item, since a single-directory query has no "or" clause
+// for the bug to affect.
+func TestInternalListRRunnerBatchRetryStillEmpty(t *testing.T) {
+	var requests []string
+	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		requests = append(requests, q)
+		w.Header().Set("Content-Type", "application/json")
+		var err error
+		switch {
+		case strings.Contains(q, "dir-a") && strings.Contains(q, "dir-b") && strings.Contains(q, "dir-c"):
+			// initial batch of 3: only dir-a has an item
+			_, err = io.WriteString(w, `{"files":[{"id":"file-a","name":"file-a.txt","mimeType":"text/plain","md5Checksum":"d41d8cd98f00b204e9800998ecf8427e","parents":["dir-a"]}]}`)
+		case strings.Contains(q, "dir-b") && strings.Contains(q, "dir-c"):
+			// batch retry of the two empty dirs: only dir-c has an item, dir-b is still empty
+			_, err = io.WriteString(w, `{"files":[{"id":"file-c","name":"file-c.txt","mimeType":"text/plain","md5Checksum":"d41d8cd98f00b204e9800998ecf8427e","parents":["dir-c"]}]}`)
+		case strings.Contains(q, "dir-b"):
+			// dir-b queried entirely on its own finally finds its item
+			_, err = io.WriteString(w, `{"files":[{"id":"file-b","name":"file-b.txt","mimeType":"text/plain","md5Checksum":"d41d8cd98f00b204e9800998ecf8427e","parents":["dir-b"]}]}`)
+		default:
+			t.Fatalf("unexpected query: %s", q)
+		}
+		assert.NoError(t, err)
+	}))
+	f.opt.FastListBugFix = true
+	f.grouping = listRGrouping
+
+	in := make(chan listREntry, 10)
+	out := make(chan error, 1)
+	var wg stdsync.WaitGroup
+	var mu stdsync.Mutex
+	var emitted []string
+	cb := func(entry fs.DirEntry) error {
+		mu.Lock()
+		defer mu.Unlock()
+		emitted = append(emitted, entry.Remote())
+		return nil
+	}
+
+	wg.Add(3)
+	in <- listREntry{id: "dir-a", path: "a"}
+	in <- listREntry{id: "dir-b", path: "b"}
+	in <- listREntry{id: "dir-c", path: "c"}
+	close(in)
+
+	f.listRRunner(context.Background(), &wg, in, out, cb)
+	require.NoError(t, <-out)
+
+	assert.ElementsMatch(t, []string{"a/file-a.txt", "b/file-b.txt", "c/file-c.txt"}, emitted, "dir-b's item should still be found via the individual fallback")
+	assert.Len(t, requests, 3, "expected the initial batch, the batch retry (dir-b still empty), and one individual query for dir-b")
+}
+
 func TestDriveScopes(t *testing.T) {
 	for _, test := range []struct {
 		in       string

--- a/backend/drive/drive_internal_test.go
+++ b/backend/drive/drive_internal_test.go
@@ -156,39 +156,44 @@ func newListTestFs(t *testing.T, handler http.Handler) *Fs {
 // TestInternalListRRunnerPartialBatch reproduces the scenario in #9810: a
 // batched multi-directory listing where the Drive API silently returns no
 // items for some of the requested directories while returning items
-// normally for others. It checks that only the directories which got no
-// items are retried individually (not the whole batch, which would
-// duplicate the entries already emitted for the healthy directories) and
-// that ListR grouping is disabled as a result.
+// normally for others. It checks that the directories with no items are
+// retried together as a single fresh batch, without duplicating the
+// entries already emitted for the healthy directory, and that ListR
+// grouping is left untouched.
 func TestInternalListRRunnerPartialBatch(t *testing.T) {
+	var requests [][]string
 	f := newListTestFs(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		requests = append(requests, []string{q})
 		w.Header().Set("Content-Type", "application/json")
-		// dir-a has a file, dir-b and dir-c are silently dropped by the
-		// simulated Drive bug even though they are not actually empty
-		_, err := io.WriteString(w, `{"files":[{"id":"file-a","name":"file-a.txt","mimeType":"text/plain","md5Checksum":"d41d8cd98f00b204e9800998ecf8427e","parents":["dir-a"]}]}`)
+		var err error
+		switch {
+		case strings.Contains(q, "dir-a") && strings.Contains(q, "dir-b") && strings.Contains(q, "dir-c"):
+			// first request: only dir-a has an item, dir-b and dir-c are
+			// silently dropped by the simulated Drive bug even though
+			// they are not actually empty
+			_, err = io.WriteString(w, `{"files":[{"id":"file-a","name":"file-a.txt","mimeType":"text/plain","md5Checksum":"d41d8cd98f00b204e9800998ecf8427e","parents":["dir-a"]}]}`)
+		case strings.Contains(q, "dir-b") && strings.Contains(q, "dir-c"):
+			// retry of just the empty directories: both turn out to have items
+			_, err = io.WriteString(w, `{"files":[{"id":"file-b","name":"file-b.txt","mimeType":"text/plain","md5Checksum":"d41d8cd98f00b204e9800998ecf8427e","parents":["dir-b"]},{"id":"file-c","name":"file-c.txt","mimeType":"text/plain","md5Checksum":"d41d8cd98f00b204e9800998ecf8427e","parents":["dir-c"]}]}`)
+		default:
+			t.Fatalf("unexpected query: %s", q)
+		}
 		assert.NoError(t, err)
 	}))
 	f.opt.FastListBugFix = true
 	f.grouping = listRGrouping
-	f.listRmu = new(stdsync.Mutex)
-	f.listRempties = make(map[string]struct{})
 
 	in := make(chan listREntry, 10)
 	out := make(chan error, 1)
 	var wg stdsync.WaitGroup
 	var mu stdsync.Mutex
 	var emitted []string
-	var requeued []listREntry
 	cb := func(entry fs.DirEntry) error {
 		mu.Lock()
 		defer mu.Unlock()
 		emitted = append(emitted, entry.Remote())
 		return nil
-	}
-	sendJob := func(job listREntry) {
-		mu.Lock()
-		defer mu.Unlock()
-		requeued = append(requeued, job)
 	}
 
 	wg.Add(3)
@@ -197,16 +202,12 @@ func TestInternalListRRunnerPartialBatch(t *testing.T) {
 	in <- listREntry{id: "dir-c", path: "c"}
 	close(in)
 
-	f.listRRunner(context.Background(), &wg, in, out, cb, sendJob)
+	f.listRRunner(context.Background(), &wg, in, out, cb)
 	require.NoError(t, <-out)
 
-	assert.Equal(t, []string{"a/file-a.txt"}, emitted, "the healthy directory's item should be emitted exactly once")
-	requeuedIDs := make([]string, len(requeued))
-	for i, job := range requeued {
-		requeuedIDs[i] = job.id
-	}
-	assert.ElementsMatch(t, []string{"dir-b", "dir-c"}, requeuedIDs, "only the directories that returned no items should be retried, not dir-a")
-	assert.Equal(t, int32(1), f.grouping, "grouping should be disabled after a partial batch")
+	assert.ElementsMatch(t, []string{"a/file-a.txt", "b/file-b.txt", "c/file-c.txt"}, emitted, "all three directories' items should be emitted exactly once")
+	assert.Equal(t, int32(listRGrouping), f.grouping, "grouping should be left untouched by the retry")
+	assert.Len(t, requests, 2, "expected one batch request and one retry request for the empty directories")
 }
 
 func TestDriveScopes(t *testing.T) {


### PR DESCRIPTION
## Summary

`listRRunner` batches multiple directories into a single Drive API query
(`"(A in parents) or (B in parents) or ..."`) when using `--fast-list`
(ListR). There's a known Drive server bug where such a query can silently
return items for only *some* of the requested parents (#3114, #4289).
rclone already had a workaround: if a batch's callback found **no items at
all**, it disabled batching and retried the directories individually.

That workaround was tracked at the wrong granularity. It used a single
`foundItems` flag for the whole batch, so a batch where most directories
were silently dropped but *one* directory still had items looked fully
successful — the zero-items check never fired, and the empty directories'
contents were lost for the rest of the run. This is exactly #9810: two
accounts listing the same shared folder got different counts (639 vs 352
objects) because one account's batch happened to come back fully empty
(tripping the existing check) while the other's came back partial. The
reporter confirmed `--disable ListR` makes both accounts agree, which
points at the batching path specifically.

An earlier revision of this PR tried to detect this via the API's
`incompleteSearch` field. As @ncw and @CAOShurong pointed out, that field
is `false` throughout both accounts' logs in #9810, so that detection
never actually fires for the reported scenario. This revision drops
`incompleteSearch` entirely and instead tracks coverage **per directory**
within a batch, per @CAOShurong's suggestion.

## Changes

- `listRRunner` now tracks `foundInDir[i]`, one bool per directory in the
  batch, set from the existing per-directory index (`sort.SearchStrings`)
  already used to route each returned item to its parent.
- After a batch completes, only the directories with **no** matched items
  are disabled-and-retried individually — not the whole batch. A
  directory that already had items delivered to the callback is never
  requeued, so it can't be listed twice.
- The re-enable-grouping heuristic is unchanged from `master`; it no
  longer needs a special case since detection isn't tied to
  `incompleteSearch` anymore.
- `f.list()` is back to its original two-value return; the `incomplete`
  plumbing from the previous revision is fully removed.
- Replaced the two `f.list()`-level unit tests with
  `TestInternalListRRunnerPartialBatch`, which drives `listRRunner`
  directly against a batch where one directory has items and two don't,
  and asserts the healthy directory's item is emitted exactly once and
  only the two empty directories are requeued.

## Test plan

- [x] `TestInternalListRRunnerPartialBatch` — confirmed it fails against
      unpatched `master` (the empty directories are never requeued and
      grouping stays enabled) and passes against this fix
- [x] `go build ./...`
- [x] `go vet ./backend/drive/...`
- [x] `golangci-lint run ./backend/drive/...` (0 issues)
- [x] `gofmt -l` (clean)
- [x] `RCLONE_CONFIG="/notfound" go test ./backend/drive/...`

Fixes #9810
