### PR TITLE
protondrive: flush the destination directory cache on Move and DirMove

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -1235,6 +1235,7 @@ func (f *Fs) Move(ctx context.Context, src fs.Object, remote string) (fs.Object,
 	}
 
 	f.dirCache.FlushDir(f.sanitizePath(src.Remote()))
+	f.dirCache.FlushDir(f.sanitizePath(remote))
 
 	return f.NewObject(ctx, remote)
 }
@@ -1267,6 +1268,7 @@ func (f *Fs) DirMove(ctx context.Context, src fs.Fs, srcRemote, dstRemote string
 	}
 
 	srcFs.dirCache.FlushDir(f.sanitizePath(srcRemote))
+	f.dirCache.FlushDir(f.sanitizePath(dstRemote))
 
 	return nil
 }


### PR DESCRIPTION
### What

`Move` and `DirMove` in the protondrive backend flush the **source** directory's cache entry
but not the **destination's**. After a move the object is therefore gone from its old
directory and not yet visible in its new one, until the destination's entry expires on its own.

With a long `--dir-cache-time` that window is long: at `720h`, a moved file can be missing from
a listing of its new parent for up to 30 days. A scripted rollover that moves entries between
directories on a schedule hits it on every run.

Both call sites already flush the source, so this is the matching flush for the destination —
two lines, no behaviour change on any other path.

### How it was found

A daily job that moves entries into dated directories: the entries were reliably gone from the
source and reliably absent from the destination, while `rclone lsl` with the cache bypassed
showed them in the right place all along.

### Notes for review

- I have **not** been able to run `go build` or the test suite: no Go toolchain on the machine
  this was prepared on. The change is two calls to a method already used on the line above
  each, with arguments (`remote`, `dstRemote`) already in scope and already passed through
  `f.sanitizePath` elsewhere in the same functions — but it has not been compiled, and I would
  rather say so than let CI be the first to find out.
- Happy to add an integration test if you would like one, though I could not see an existing
  pattern for asserting cache invalidation in the backend tests.
