### PR TITLE
sync: scope empty-dir deletion error gate to this run's errors (fixes #9634)

### DIFF
--- a/fs/sync/sync.go
+++ b/fs/sync/sync.go
@@ -671,7 +671,9 @@ func (s *syncCopyMove) deleteEmptyDirectories(ctx context.Context, f fs.Fs, entr
 	if len(entriesMap) == 0 {
 		return nil
 	}
-	if accounting.Stats(ctx).Errored() && !s.ci.IgnoreErrors {
+	// A stats group can be shared by independent RC jobs, so use this run's
+	// error state rather than errors carried by the group.
+	if s.currentError() != nil && !s.ci.IgnoreErrors {
 		fs.Errorf(f, "%v", fs.ErrorNotDeletingDirs)
 		return fs.ErrorNotDeletingDirs
 	}

--- a/fs/sync/sync_issue9634_test.go
+++ b/fs/sync/sync_issue9634_test.go
@@ -1,0 +1,63 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs/accounting"
+	"github.com/rclone/rclone/fstest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// A reused stats group must not disable empty-directory cleanup for a clean
+// move after an unrelated operation has failed.
+func TestMoveDeleteEmptySrcDirsAfterUnrelatedGroupError(t *testing.T) {
+	r := fstest.NewRun(t)
+	defer r.Finalise()
+	ctx := context.Background()
+	t1 := time.Now()
+
+	r.Mkdir(context.Background(), r.Flocal)
+	r.WriteFile("seed/file.txt", "seed", t1)
+	seedObj, err := r.Flocal.NewObject(ctx, "seed/file.txt")
+	require.NoError(t, err)
+
+	// Record an error on the shared group's StatsInfo, as an earlier failed
+	// operation would do.
+	badCtx := accounting.WithStatsGroup(ctx, "g")
+	tr := accounting.Stats(badCtx).NewTransfer(seedObj, r.Fremote)
+	tr.Done(badCtx, errors.New("file does not exist"))
+	assert.True(t, accounting.Stats(badCtx).Errored())
+
+	// The clean move uses the same group but has no errors of its own.
+	goodCtx := accounting.WithStatsGroup(ctx, "g")
+	file1 := r.WriteFile("nested/dir/file.txt", "content", t1)
+	r.Mkdir(context.Background(), r.Fremote)
+	fstest.CheckItems(t, r.Flocal, file1, fstest.NewItem("seed/file.txt", "seed", t1))
+
+	require.NoError(t, moveDir(goodCtx, r.Fremote, r.Flocal, true, false))
+	fstest.CheckItems(t, r.Fremote, file1, fstest.NewItem("seed/file.txt", "seed", t1))
+	// The emptied directory is removed even though the shared group retains
+	// the earlier error.
+	assert.NoDirExists(t, r.Flocal.Root()+"/nested/dir")
+}
+
+// Control: the same move on a FRESH group deletes the emptied dir.
+func TestMoveDeleteEmptySrcDirsCleanGroup(t *testing.T) {
+	r := fstest.NewRun(t)
+	defer r.Finalise()
+	ctx := context.Background()
+	t1 := time.Now()
+
+	r.Mkdir(context.Background(), r.Flocal)
+	file1 := r.WriteFile("nested/dir/file.txt", "content", t1)
+	r.Mkdir(context.Background(), r.Fremote)
+	fstest.CheckItems(t, r.Flocal, file1)
+
+	require.NoError(t, moveDir(ctx, r.Fremote, r.Flocal, true, false))
+	fstest.CheckItems(t, r.Fremote, file1)
+	assert.NoDirExists(t, r.Flocal.Root()+"/nested/dir")
+}


### PR DESCRIPTION
Fixes #9634.

### Root cause (from the RCA comment on the issue)

`deleteEmptyDirectories()` gated empty-dir deletion on
`accounting.Stats(ctx).Errored()`. `Stats(ctx)` resolves the **stats
group** from the context, and a group's error count is only cleared by an
explicit `core/stats-reset`. So when rc jobs share a `_group` (or any
other setup reusing one), a single counted error from an *earlier,
unrelated* job permanently poisons every later run in that group:

- `rc jobs/1`: `operations/copyfile` of a missing source → 1 counted error in group `g`
- `rc jobs/2`: clean `sync/move` with `--delete-empty-src-dirs`, same group →
  fails with `not deleting directories as there were IO errors`
  (`fs.ErrorNotDeletingDirs` at `sync.go:674`), forever.

The issue's log shows exactly this shape: the failing move itself had no errors; only the shared group did.

### Fix

Gate on **this run's own error state** instead of the group-wide stats:
`s.currentError() != nil` replaces `accounting.Stats(ctx).Errored()` in
`deleteEmptyDirectories`. Every error this sync encounters flows through
`processError` into `s.err`/`s.noRetryErr`/`s.fatalErr`, so behavior for
a genuinely failing move is unchanged — it still skips empty-dir deletion.
Only pollution inherited from earlier jobs is dropped. The file-deletion
gate in `deleteFiles()` is intentionally left untouched: it fires within
the same job that produced the errors, so group stats are accurate there.

### Tests

New `TestMoveDeleteEmptySrcDirsAfterUnrelatedGroupError` seeds a stats
group with an unrelated error via `Transfer.Done()`, then asserts a
subsequent clean move **in the same group** removes the emptied source
directory (fails on master with `not deleting directories as there were
IO errors`). `TestMoveDeleteEmptySrcDirsCleanGroup` is the fresh-group
control.

Local validation:

- `go test ./fs/sync/ -count=1` — full package suite PASS (11.5s)
- red/green verified: regression test FAILs without the fix, PASSes with it
- `go build ./...`, `go vet ./fs/sync/` clean; gofmt clean

### Notes

This implements fix direction 1 ("scope the check to per-run error
state") proposed in my RCA comment on #9634. Direction 2 (expiring group
stats per rc job) would be a wider accounting change touching other
gates; direction 3 (documenting) alone leaves the trap in place.
Happy to adjust if maintainers prefer a different scope.
