### PR TITLE
dropbox: fix ChangeNotify dropping changes when root casing differs from display casing

### DIFF
--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -392,8 +392,8 @@ type Fs struct {
 	sharing        sharing.ContextClient // as above, but for generating sharing links
 	users          users.ContextClient   // as above, but for accessing user information
 	team           team.ContextClient    // for the Teams API
-	slashRoot      string                // root with "/" prefix, lowercase
-	slashRootSlash string                // root with "/" prefix and postfix, lowercase
+	slashRoot      string                // root with "/" prefix
+	slashRootSlash string                // root with "/" prefix and postfix
 	pacer          *fs.Pacer             // To pace the API calls
 	ns             string                // The namespace we are using or "" for none
 	batcher        *batcher.Batcher[*files.UploadSessionFinishArg, *files.FileMetadata]
@@ -1672,6 +1672,19 @@ func (f *Fs) changeNotifyCursor(ctx context.Context) (cursor string, err error) 
 	return startCursor.Cursor, nil
 }
 
+// trimRootDisplay trims the configured root prefix from a Dropbox display
+// path. PathDisplay comes back with server-side display casing while
+// slashRootSlash keeps the casing the user typed in the config, so a
+// case-sensitive comparison would silently fail for case-mismatched roots.
+// The match is therefore case-insensitive, mirroring the CaseInsensitive
+// feature of this backend.
+func (f *Fs) trimRootDisplay(p string) string {
+	if len(p) >= len(f.slashRootSlash) && strings.EqualFold(p[:len(f.slashRootSlash)], f.slashRootSlash) {
+		return p[len(f.slashRootSlash):]
+	}
+	return p
+}
+
 func (f *Fs) changeNotifyRunner(ctx context.Context, notifyFunc func(string, fs.EntryType), startCursor string) (newCursor string, err error) {
 	cursor := startCursor
 	var res *files.ListFolderLongpollResult
@@ -1731,13 +1744,13 @@ func (f *Fs) changeNotifyRunner(ctx context.Context, notifyFunc func(string, fs.
 			switch info := entry.(type) {
 			case *files.FolderMetadata:
 				entryType = fs.EntryDirectory
-				entryPath = strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)
+				entryPath = f.trimRootDisplay(info.PathDisplay)
 			case *files.FileMetadata:
 				entryType = fs.EntryObject
-				entryPath = strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)
+				entryPath = f.trimRootDisplay(info.PathDisplay)
 			case *files.DeletedMetadata:
 				entryType = fs.EntryObject
-				entryPath = strings.TrimPrefix(info.PathDisplay, f.slashRootSlash)
+				entryPath = f.trimRootDisplay(info.PathDisplay)
 			default:
 				fs.Errorf(entry, "dropbox ChangeNotify: ignoring unknown EntryType %T", entry)
 				continue

--- a/backend/dropbox/dropbox_changenotify_test.go
+++ b/backend/dropbox/dropbox_changenotify_test.go
@@ -1,0 +1,138 @@
+package dropbox
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/dropbox/dropbox-sdk-go-unofficial/v6/dropbox/files"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/lib/encoder"
+	"github.com/rclone/rclone/lib/pacer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// longpollClient satisfies the longpoll call without network access.
+type longpollClient struct {
+	files.ContextClient
+}
+
+func (c *longpollClient) ListFolderLongpollContext(ctx context.Context, arg *files.ListFolderLongpollArg) (*files.ListFolderLongpollResult, error) {
+	return &files.ListFolderLongpollResult{Changes: true}, nil
+}
+
+// continueClient serves canned list_folder/continue responses.
+type continueClient struct {
+	files.ContextClient
+	responses []string // raw JSON bodies returned in order
+}
+
+func (c *continueClient) ListFolderContinueContext(ctx context.Context, arg *files.ListFolderContinueArg) (*files.ListFolderResult, error) {
+	if len(c.responses) == 0 {
+		return &files.ListFolderResult{Cursor: arg.Cursor, HasMore: false}, nil
+	}
+	raw := c.responses[0]
+	c.responses = c.responses[1:]
+	var res files.ListFolderResult
+	err := json.Unmarshal([]byte(raw), &res)
+	return &res, err
+}
+
+// TestChangeNotifyRunnerTrimsRootCaseInsensitive checks that ChangeNotify
+// entries are trimmed of the configured root even when the server-side
+// display casing of PathDisplay differs from the casing typed in the config
+// (https://github.com/rclone/rclone/issues/9692).
+func TestChangeNotifyRunnerTrimsRootCaseInsensitive(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		root          string // config root (user-typed casing)
+		displayPath   string // PathDisplay as reported by Dropbox
+		wantEntryPath string
+	}{
+		{
+			name:          "matching case",
+			root:          "Docs",
+			displayPath:   "/Docs/file.txt",
+			wantEntryPath: "file.txt",
+		},
+		{
+			name:          "root casing differs from display",
+			root:          "docs", // user typed lowercase
+			displayPath:   "/Docs/file.txt",
+			wantEntryPath: "file.txt",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx := context.Background()
+			f := &Fs{
+				ci:             fs.GetConfig(ctx),
+				opt:            Options{Enc: encoder.Standard},
+				slashRoot:      "/" + test.root,
+				slashRootSlash: "/" + test.root + "/",
+				pacer:          fs.NewPacer(ctx, pacer.NewDefault(pacer.MinSleep(0), pacer.MaxSleep(time.Millisecond))),
+			}
+			f.svc = &longpollClient{}
+			f.srv = &continueClient{
+				responses: []string{`{
+					"entries": [
+						{".tag": "file", "name": "file.txt", "path_display": "` + test.displayPath + `"},
+						{".tag": "folder", "name": "dir", "path_display": "/` + test.root + `Sub/dir"}
+					],
+					"cursor": "c1",
+					"has_more": false
+				}`},
+			}
+
+			type notification struct {
+				path  string
+				entry fs.EntryType
+			}
+			got := []notification{}
+			cursor, err := f.changeNotifyRunner(ctx, func(path string, entryType fs.EntryType) {
+				got = append(got, notification{path, entryType})
+			}, "start")
+			require.NoError(t, err)
+			assert.Equal(t, "c1", cursor)
+
+			require.Len(t, got, 2)
+			// The file entry must be trimmed despite the root/display casing
+			// mismatch.
+			assert.Equal(t, test.wantEntryPath, got[0].path)
+			assert.Equal(t, fs.EntryObject, got[0].entry)
+			assert.Equal(t, "/"+test.root+"Sub/dir", got[1].path)
+			assert.Equal(t, fs.EntryDirectory, got[1].entry)
+		})
+	}
+}
+
+// TestChangeNotifyRunnerKeepsUnmatchedPaths checks that paths outside the
+// configured root still reach the notify function untrimmed.
+func TestChangeNotifyRunnerKeepsUnmatchedPaths(t *testing.T) {
+	ctx := context.Background()
+	f := &Fs{
+		ci:             fs.GetConfig(ctx),
+		opt:            Options{Enc: encoder.Standard},
+		slashRoot:      "",
+		slashRootSlash: "/",
+		pacer:          fs.NewPacer(ctx, pacer.NewDefault(pacer.MinSleep(0), pacer.MaxSleep(time.Millisecond))),
+	}
+	f.svc = &longpollClient{}
+	f.srv = &continueClient{
+		responses: []string{`{
+			"entries": [
+				{".tag": "file", "name": "file.txt", "path_display": "/some/path/file.txt"}
+			],
+			"cursor": "c2",
+			"has_more": false
+		}`},
+	}
+
+	paths := []string{}
+	_, err := f.changeNotifyRunner(ctx, func(path string, _ fs.EntryType) {
+		paths = append(paths, path)
+	}, "start")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"some/path/file.txt"}, paths)
+}


### PR DESCRIPTION
## Fix description

The `DescribeFields` description for `file.content.skip-files-above-size` claims the default is **1MB**:

https://github.com/anchore/syft/blob/bf82010f3c38508e30dd01ed8053f158513c0c9d/cmd/syft/internal/options/file.go#L74

but the actual default has been **250KB** since PR #1383 (Jan 2024) replaced the core SBOM-creation API and moved the default into `defaultFileConfig()` / `filecontent.DefaultConfig()`:

- `cmd/syft/internal/options/file.go`: `SkipFilesAboveSize: 250 * intFile.KB` (= 256000 bytes)
- `syft/file/cataloger/filecontent/cataloger.go`: `DefaultConfig()` returns `250 * intFile.KB`

The stale string surfaces in two user-visible places today:
1. `syft config` output (`syft config | grep -A1 SKIP_FILES_ABOVE`)
2. The auto-generated [configuration reference](https://oss.anchore.com/docs/reference/syft/configuration/) on oss.anchore.com, which renders `# ... (default = 1MB; unit = bytes)` directly above the actual value `skip-files-above-size: 256000` — an internal contradiction on the same page.

This PR updates the description to match reality. It is a one-line comment-string change with no behavior impact.

## How I verified

- `go build ./cmd/...` — exit 0
- `go vet ./cmd/syft/internal/options/` — clean
- `go test ./cmd/syft/internal/options/ -run 'TestFileConfig|Test_fileConfig|Describe' -count=1` — PASS
- Full package suite on Windows shows only `Test_defaultDir/no-xdg` and `Test_newSBOMMultiWriter` failing, both pre-existing on unmodified `main` (verified via stash baseline) and environment-related, not touched by this change.
- No test fixtures or snapshots reference the old `default = 1MB` string (grepped `*.go`, `*.snap`, `*.golden`).

## Note for maintainers

After this merges, regenerating the oss-docs config reference cache will clear the contradiction on the docs site as well.

Signed-off-by: Shurong Cao <CAOShurong@users.noreply.github.com>