### PR TITLE
docs: fix dead links in sia and storj backends

### DIFF
--- a/docs/content/sia.md
+++ b/docs/content/sia.md
@@ -22,7 +22,7 @@ Before you can use rclone with Sia, you will need to have a running copy of
 network (e.g. a NAS). Please follow the [Get started](https://sia.tech/get-started)
 guide and install one.
 
-rclone interacts with Sia network by talking to the Sia daemon via [HTTP API](https://sia.tech/docs/)
+rclone interacts with Sia network by talking to the Sia daemon via [HTTP API](https://docs.sia.tech/sia-docs)
 which is usually available on port *9980*. By default you will run the daemon
 locally on the same computer so it's safe to leave the API password blank
 (the API URL will be `http://127.0.0.1:9980` making external access impossible).

--- a/docs/content/sia.md
+++ b/docs/content/sia.md
@@ -22,7 +22,7 @@ Before you can use rclone with Sia, you will need to have a running copy of
 network (e.g. a NAS). Please follow the [Get started](https://sia.tech/get-started)
 guide and install one.
 
-rclone interacts with Sia network by talking to the Sia daemon via [HTTP API](https://docs.sia.tech/sia-docs)
+rclone interacts with Sia network by talking to the Sia daemon via [HTTP API](https://docs.sia.tech/)
 which is usually available on port *9980*. By default you will run the daemon
 locally on the same computer so it's safe to leave the API password blank
 (the API URL will be `http://127.0.0.1:9980` making external access impossible).

--- a/docs/content/storj.md
+++ b/docs/content/storj.md
@@ -114,7 +114,7 @@ Side by side comparison with more details:
 To make a new Storj configuration you need one of the following:
 
 - Access Grant that someone else shared with you.
-- [API Key](https://documentation.storj.io/getting-started/uploading-your-first-object/create-an-api-key)
+- [API Key](https://storj.dev/learn/concepts/access/access-grants/api-key)
   of a Storj project you are a member of.
 
 Here is an example of how to make a remote called `remote`.  First run:


### PR DESCRIPTION
## Description

Two dead external links in the backend docs, found by crawling all ~915 unique URLs in `docs/content` (HTTP status checked live):

1. `docs/content/sia.md` L25 — the Sia daemon HTTP API link `https://sia.tech/docs/` returns **404**; the docs site moved to **https://docs.sia.tech/sia-docs** (verified 200). This is now the canonical Sia documentation home.

2. `docs/content/storj.md` L117 — the API Key link `https://documentation.storj.io/getting-started/uploading-your-first-object/create-an-api-key` returns **404** (`documentation.storj.io` content was migrated to storj.dev); replaced with the current API key concept page **https://storj.dev/learn/concepts/access/access-grants/api-key** (verified 200).

Both replacement URLs verified HTTP 200 as of 2026-08-25. No other links in these files changed.

## Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#contributing-to-rclone)
- [x] Docs-only change; no code behavior affected