### PR TITLE
s3: document env_auth for Huawei OBS and its AWS-only IMDS limitation

### DIFF
--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -6172,8 +6172,10 @@ Note that the ECS/EC2/EKS IAM role and process credential methods listed
 under [Authentication](#authentication) are AWS-only and do not apply to
 Huawei OBS. If `env_auth = true` is set with no environment variables or
 shared credentials file present, rclone will try to reach the AWS EC2
-metadata service and fail with a connection error to `169.254.169.254`
-rather than a clear "no credentials found" message.
+metadata service at `169.254.169.254` and fail with a confusing
+low-level networking or HTTP error (for example a connection error, or
+an HTTP 404 "no EC2 IMDS role found") rather than a clear "no
+credentials found" message.
 
 Or you can also configure via the interactive command line:
 

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -6159,6 +6159,22 @@ endpoint = obs.af-south-1.myhuaweicloud.com
 acl = private
 ```
 
+Alternatively, instead of setting `access_key_id` and `secret_access_key` in the
+config file, you can set `env_auth = true` and export your OBS Access Key
+(AK) and Secret Key (SK) as the standard AWS environment variables:
+
+```console
+export AWS_ACCESS_KEY_ID=your-access-key-id
+export AWS_SECRET_ACCESS_KEY=your-secret-access-key
+```
+
+Note that the ECS/EC2/EKS IAM role and process credential methods listed
+under [Authentication](#authentication) are AWS-only and do not apply to
+Huawei OBS. If `env_auth = true` is set with no environment variables or
+shared credentials file present, rclone will try to reach the AWS EC2
+metadata service and fail with a connection error to `169.254.169.254`
+rather than a clear "no credentials found" message.
+
 Or you can also configure via the interactive command line:
 
 ```text


### PR DESCRIPTION
#### What does this change do?

Documents the `env_auth = true` option for the Huawei OBS provider, and
notes that the IAM-role-based credential methods (ECS/EC2/EKS metadata)
are AWS-only and do not apply to Huawei OBS.

The Huawei OBS docs section only ever showed the static
`access_key_id`/`secret_access_key` example. A user who instead set
`env_auth = true` with no environment variables (reasonably expecting
some Huawei-native runtime credential resolution, since the config
wizard's `env_auth` prompt talks generically about "environment
variables or EC2/ECS meta data") got the AWS SDK's default credential
chain falling through to the EC2 Instance Metadata Service, which
doesn't exist on Huawei Cloud, and failed with a confusing low-level
error instead of a clear "no credentials found" message.

This is a docs-only change - no backend code was modified. I verified
the root cause by reading `s3Connection` in `backend/s3/s3.go` and
reproduced the reporter's failure directly: built rclone from this
branch's base commit in Docker and ran `rclone ls` against a config
matching theirs (`provider = HuaweiOBS`, `env_auth = true`, no static
keys, no AWS env vars), which hit the same AWS-only IMDS credential
chain and failed for the same reason.

#### Linked issue

Fixes #9736

#### Checklist

- [x] This change is trivial (doc tweak) **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
