### PR TITLE
bisync: don't abort on stale errors from a shared stats group

### DIFF
--- a/cmd/bisync/operations.go
+++ b/cmd/bisync/operations.go
@@ -308,25 +308,11 @@ func (b *bisyncRun) runLocked(octx context.Context) (err error) {
 	}
 
 	fs.Infof(nil, "Building Path1 and Path2 listings")
-	startErrors := accounting.Stats(fctx).GetErrors()
 	b.march.ls1, b.march.ls2, err = b.makeMarchListing(fctx)
-	// Only count errors recorded while building this run's listings.
-	// The stats group can be long-lived and shared between separate rc
-	// calls (the "_group" parameter under rclone rcd), so a stale error
-	// from an earlier, unrelated operation must not make this run abort
-	// as critical. For a one-shot run the group is fresh, so the delta
-	// equals the absolute count and behaviour is unchanged.
-	if err != nil || accounting.Stats(fctx).GetErrors() > startErrors {
+	if err != nil {
 		fs.Error(nil, Color(terminal.RedFg, "There were errors while building listings. Aborting as it is too dangerous to continue."))
 		b.critical = true
 		b.retryable = true
-		if err == nil {
-			if lastErr := accounting.Stats(fctx).GetLastError(); lastErr != nil {
-				err = fmt.Errorf("errors while building listings: %w", lastErr)
-			} else {
-				err = errors.New("errors while building listings")
-			}
-		}
 		return err
 	}
 

--- a/cmd/bisync/operations.go
+++ b/cmd/bisync/operations.go
@@ -308,11 +308,25 @@ func (b *bisyncRun) runLocked(octx context.Context) (err error) {
 	}
 
 	fs.Infof(nil, "Building Path1 and Path2 listings")
+	startErrors := accounting.Stats(fctx).GetErrors()
 	b.march.ls1, b.march.ls2, err = b.makeMarchListing(fctx)
-	if err != nil || accounting.Stats(fctx).Errored() {
+	// Only count errors recorded while building this run's listings.
+	// The stats group can be long-lived and shared between separate rc
+	// calls (the "_group" parameter under rclone rcd), so a stale error
+	// from an earlier, unrelated operation must not make this run abort
+	// as critical. For a one-shot run the group is fresh, so the delta
+	// equals the absolute count and behaviour is unchanged.
+	if err != nil || accounting.Stats(fctx).GetErrors() > startErrors {
 		fs.Error(nil, Color(terminal.RedFg, "There were errors while building listings. Aborting as it is too dangerous to continue."))
 		b.critical = true
 		b.retryable = true
+		if err == nil {
+			if lastErr := accounting.Stats(fctx).GetLastError(); lastErr != nil {
+				err = fmt.Errorf("errors while building listings: %w", lastErr)
+			} else {
+				err = errors.New("errors while building listings")
+			}
+		}
 		return err
 	}
 

--- a/cmd/bisync/operations_test.go
+++ b/cmd/bisync/operations_test.go
@@ -1,0 +1,48 @@
+package bisync
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	_ "github.com/rclone/rclone/backend/local"
+	"github.com/rclone/rclone/fs/accounting"
+	"github.com/rclone/rclone/fs/cache"
+	"github.com/rclone/rclone/lib/random"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBisyncStaleGroupError checks that an error recorded against a
+// long-lived stats group by an earlier, unrelated operation (as happens
+// under rclone rcd with a reused "_group") does not make a clean bisync
+// run abort as critical, while a listing error during the run itself
+// still does.
+func TestBisyncStaleGroupError(t *testing.T) {
+	ctx := context.Background()
+	ctx = accounting.WithStatsGroup(ctx, "bisync-test-"+random.String(8))
+
+	dir1 := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir1, "file1.txt"), []byte("hello"), 0644))
+	fs1, err := cache.Get(ctx, dir1)
+	require.NoError(t, err)
+	fs2, err := cache.Get(ctx, t.TempDir())
+	require.NoError(t, err)
+
+	opt := &Options{Workdir: t.TempDir(), Resync: true}
+	require.NoError(t, Bisync(ctx, fs1, fs2, opt))
+
+	// Simulate an earlier, unrelated operation having recorded an error
+	// against the same group before this run starts.
+	accounting.Stats(ctx).Error(errors.New("earlier unrelated error"))
+	require.True(t, accounting.Stats(ctx).Errored())
+
+	opt.Resync = false
+	require.NoError(t, Bisync(ctx, fs1, fs2, opt))
+
+	// A listing error during the run itself must still abort.
+	require.NoError(t, os.RemoveAll(dir1))
+	err = Bisync(ctx, fs1, fs2, opt)
+	require.ErrorIs(t, err, ErrBisyncAborted)
+}

--- a/cmd/bisync/operations_test.go
+++ b/cmd/bisync/operations_test.go
@@ -35,7 +35,7 @@ func TestBisyncStaleGroupError(t *testing.T) {
 
 	// Simulate an earlier, unrelated operation having recorded an error
 	// against the same group before this run starts.
-	accounting.Stats(ctx).Error(errors.New("earlier unrelated error"))
+	_ = accounting.Stats(ctx).Error(errors.New("earlier unrelated error"))
 	require.True(t, accounting.Stats(ctx).Errored())
 
 	opt.Resync = false


### PR DESCRIPTION
Fixes #9824

Under `rclone rcd` with a reused `_group`, the stats group is long-lived and shared across rc calls. Bisync's critical-abort gate after building listings checked `accounting.Stats(fctx).Errored()`, which is group-global — so one stale error from an earlier unrelated operation made every later bisync run in that group abort as critical and demand `--resync`.

This scopes the check to this run: capture the group's error count before `makeMarchListing` and gate on the delta. For a one-shot CLI run the group is fresh, so the delta equals the absolute count and behaviour is unchanged there — CLI and rc now share the same semantics.

It also fixes the `Bisync critical error: <nil>` log — when the gate tripped via the stats check with `err == nil`, nil was returned as the critical error; now the last recorded stats error is returned (wrapped), with a generic error as fallback.

Same class of bug as #9634, but in bisync's abort path.

Tested:

```
$ go vet ./cmd/bisync
$ go test ./cmd/bisync -run 'TestBisyncRemoteRemote/basic|TestBisyncStaleGroupError' -v
--- PASS: TestBisyncStaleGroupError (0.01s)
--- PASS: TestBisyncRemoteRemote (0.03s)
    --- PASS: TestBisyncRemoteRemote/basic (0.02s)
ok  	github.com/rclone/rclone/cmd/bisync	0.879s
```

The new regression test seeds a stale error into a named stats group, checks a clean bisync run still succeeds, and checks a genuine listing failure during the run still aborts with `ErrBisyncAborted`.