### PR TITLE
accounting: fix bwlimit burst overflow - fixes #9820

### DIFF
--- a/fs/accounting/token_bucket.go
+++ b/fs/accounting/token_bucket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -59,18 +60,25 @@ func (bs *buckets) _setOff() {
 }
 
 const defaultMaxBurstSize = 4 * 1024 * 1024 // must be bigger than the biggest request
+const tokenBucketBurstScale = (256 * 1024 * 1024) / defaultMaxBurstSize
 
-// make a new empty token bucket with the bandwidth given
-func newEmptyTokenBucket(bandwidth fs.SizeSuffix) *rate.Limiter {
+func tokenBucketBurst(bandwidth fs.SizeSuffix) int {
 	// Relate maxBurstSize to bandwidth limit
 	// 4M gives 2.5 Gb/s on Windows
 	// Use defaultMaxBurstSize up to 2GBit/s (256MiB/s) then scale
-	maxBurstSize := max((bandwidth*defaultMaxBurstSize)/(256*1024*1024), defaultMaxBurstSize)
+	maxBurstSize := max(bandwidth/tokenBucketBurstScale, defaultMaxBurstSize)
+	maxBurstSize = min(maxBurstSize, fs.SizeSuffix(math.MaxInt))
+	return int(maxBurstSize)
+}
+
+// make a new empty token bucket with the bandwidth given
+func newEmptyTokenBucket(bandwidth fs.SizeSuffix) *rate.Limiter {
+	maxBurstSize := tokenBucketBurst(bandwidth)
 	// fs.Debugf(nil, "bandwidth=%v maxBurstSize=%v", bandwidth, maxBurstSize)
-	tb := rate.NewLimiter(rate.Limit(bandwidth), int(maxBurstSize))
+	tb := rate.NewLimiter(rate.Limit(bandwidth), maxBurstSize)
 	if tb != nil {
 		// empty the bucket
-		err := tb.WaitN(context.Background(), int(maxBurstSize))
+		err := tb.WaitN(context.Background(), maxBurstSize)
 		if err != nil {
 			fs.Errorf(nil, "Failed to empty token bucket: %v", err)
 		}

--- a/fs/accounting/token_bucket_test.go
+++ b/fs/accounting/token_bucket_test.go
@@ -2,13 +2,33 @@ package accounting
 
 import (
 	"context"
+	"math"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/rc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 )
+
+func TestTokenBucketBurstScalesLargeBandwidthWithoutOverflow(t *testing.T) {
+	bandwidth := 4 * fs.Tebi
+
+	tb := newEmptyTokenBucket(bandwidth)
+	require.NotNil(t, tb)
+	assert.Equal(t, rate.Limit(bandwidth), tb.Limit())
+	assert.Equal(t, int(bandwidth/tokenBucketBurstScale), tb.Burst())
+}
+
+func TestTokenBucketBurstCapsAtMaxInt(t *testing.T) {
+	want := fs.SizeSuffix(fs.SizeSuffixMaxValue / 64)
+	if want > fs.SizeSuffix(math.MaxInt) {
+		want = fs.SizeSuffix(math.MaxInt)
+	}
+
+	assert.Equal(t, int(want), tokenBucketBurst(fs.SizeSuffixMaxValue))
+}
 
 func TestRcBwLimit(t *testing.T) {
 	call := rc.Calls.Get("core/bwlimit")

--- a/fs/accounting/token_bucket_test.go
+++ b/fs/accounting/token_bucket_test.go
@@ -14,15 +14,19 @@ import (
 
 func TestTokenBucketBurstScalesLargeBandwidthWithoutOverflow(t *testing.T) {
 	bandwidth := 4 * fs.Tebi
+	want := bandwidth / tokenBucketBurstScale
+	if want > fs.SizeSuffix(math.MaxInt) {
+		want = fs.SizeSuffix(math.MaxInt)
+	}
 
 	tb := newEmptyTokenBucket(bandwidth)
 	require.NotNil(t, tb)
 	assert.Equal(t, rate.Limit(bandwidth), tb.Limit())
-	assert.Equal(t, int(bandwidth/tokenBucketBurstScale), tb.Burst())
+	assert.Equal(t, int(want), tb.Burst())
 }
 
 func TestTokenBucketBurstCapsAtMaxInt(t *testing.T) {
-	want := fs.SizeSuffix(fs.SizeSuffixMaxValue / 64)
+	want := fs.SizeSuffix(fs.SizeSuffixMaxValue / tokenBucketBurstScale)
 	if want > fs.SizeSuffix(math.MaxInt) {
 		want = fs.SizeSuffix(math.MaxInt)
 	}


### PR DESCRIPTION
#### What does this change do?

Avoids overflow while scaling the accounting token-bucket burst for very large `--bwlimit` values. The burst calculation now divides before scaling can overflow and caps the burst at the platform `int` maximum before passing it to `rate.NewLimiter` / `WaitN`.

Regression coverage checks that a 4 TiB/s limit keeps the scaled burst instead of falling back to the default burst, and that the burst is capped safely for the largest `SizeSuffix` value.

#### Linked issue

Fixes #9820

#### For new or changed backends

Not a backend change.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.

Verification run locally:

- `go test ./fs/accounting -run TokenBucket -count=1`
- `go test ./fs/accounting -count=1`
- `go build`
- `git diff --check`

I also attempted `make quicktest`; it did not complete successfully in this container because unrelated environment-sensitive tests failed (for example `cmd/gitannex` could not find `rclone` in `PATH`, `cmd/nfsmount` could not mount NFS/FUSE, and `cmd/selfupdate` failed while testing installation). The focused accounting tests and build above pass.
