### PR TITLE
accounting: guard token bucket burst size against overflow

### DIFF
--- a/fs/accounting/token_bucket.go
+++ b/fs/accounting/token_bucket.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -64,8 +65,17 @@ const defaultMaxBurstSize = 4 * 1024 * 1024 // must be bigger than the biggest r
 func newEmptyTokenBucket(bandwidth fs.SizeSuffix) *rate.Limiter {
 	// Relate maxBurstSize to bandwidth limit
 	// 4M gives 2.5 Gb/s on Windows
-	// Use defaultMaxBurstSize up to 2GBit/s (256MiB/s) then scale
-	maxBurstSize := max((bandwidth*defaultMaxBurstSize)/(256*1024*1024), defaultMaxBurstSize)
+	// Use defaultMaxBurstSize up to 2GBit/s (256MiB/s) then scale.
+	// The scale factor defaultMaxBurstSize/(256*1024*1024) equals 1/64,
+	// so compute bandwidth/64 directly to avoid int64 overflow for
+	// bandwidths >= 2TiB/s (the product (bandwidth*4M) wraps negative).
+	// Clamp to math.MaxInt32 so the int() conversion cannot truncate to a
+	// negative burst on 32-bit builds, which would silently disable the
+	// limiter.
+	maxBurstSize := max(bandwidth/64, defaultMaxBurstSize)
+	if maxBurstSize > math.MaxInt32 {
+		maxBurstSize = math.MaxInt32
+	}
 	// fs.Debugf(nil, "bandwidth=%v maxBurstSize=%v", bandwidth, maxBurstSize)
 	tb := rate.NewLimiter(rate.Limit(bandwidth), int(maxBurstSize))
 	if tb != nil {

--- a/fs/accounting/token_bucket_test.go
+++ b/fs/accounting/token_bucket_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/rc"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -89,4 +90,21 @@ func TestRcBwLimit(t *testing.T) {
 		"rate":             "off",
 	}, out)
 
+}
+
+func TestNewEmptyTokenBucketHugeBandwidth(t *testing.T) {
+	// Large bandwidths used to overflow int64 in the burst scaling
+	// product (bandwidth*defaultMaxBurstSize) and, on 32-bit builds,
+	// wrap negative in the int() conversion, which silently disabled
+	// the limiter. The burst must stay positive and the limiter usable.
+	for _, bw := range []fs.SizeSuffix{
+		200 * fs.Gibi, // 32-bit int() truncation used to go negative
+		2 * fs.Tebi,   // int64 overflow boundary
+		4 * fs.Tebi,
+		10 * fs.Tebi,
+	} {
+		tb := newEmptyTokenBucket(bw)
+		require.NotNil(t, tb)
+		assert.Greater(t, tb.Burst(), 0, "burst must be positive for %v", bw)
+	}
 }


### PR DESCRIPTION
Fixes #9820

### Problem

`newEmptyTokenBucket` scales the token-burst size with the configured bandwidth:

```go
maxBurstSize := max((bandwidth*defaultMaxBurstSize)/(256*1024*1024), defaultMaxBurstSize)
tb := rate.NewLimiter(rate.Limit(bandwidth), int(maxBurstSize))
```

Two failure modes silently disable `--bwlimit` for large values:

1. **int64 overflow** (all builds): `bandwidth*defaultMaxBurstSize` overflows int64 once `bandwidth >= 2 TiB/s`, producing a wildly wrong burst.
2. **32-bit truncation**: `int(maxBurstSize)` wraps negative for `--bwlimit` ~200G and above on 32-bit builds (e.g. `3355443200` truncates to `-939524096`), so every `WaitN` fails immediately with `rate: Wait(n=...) exceeds limiter's burst`, and `LimitBandwidth` proceeds without throttling.

### Fix

- The scale factor `defaultMaxBurstSize/(256*1024*1024)` mathematically equals `1/64`, so compute `bandwidth/64` directly — identical results without the overflow (verified byte-for-byte for all non-overflow inputs).
- Clamp the burst to `math.MaxInt32` so the `int()` conversion is safe on 32-bit builds.

Verified with a standalone Go program against `golang.org/x/time/rate`: 200G, 2T, 4T, 10T all produce a positive burst and successful `WaitN` calls (previously negative/0 burst on 32-bit semantics).

---
Assisted-by: Hermes/deepseek-v4-flash
