### PR TITLE
webdav: adds support for digest authentication to the webdav backend

### DIFF
--- a/backend/webdav/webdav.go
+++ b/backend/webdav/webdav.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/Azure/go-ntlmssp"
+	"github.com/icholy/digest"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/rclone/rclone/backend/webdav/api"
@@ -235,6 +236,10 @@ type Fs struct {
 	canChunk           bool          // set if nextcloud and nextcloud_chunk_size is set
 	canRecalcHash      bool          // set if the server can recalculate checksums with PATCH (nextcloud)
 	authSingleflight   *singleflight.Group
+	digestMu           sync.Mutex        // protects the digest fields below
+	digestChal         *digest.Challenge // challenge to sign requests with, nil if the server hasn't asked for digest
+	digestHost         string            // host digestChal came from
+	digestCount        int               // number of times digestChal has been used
 }
 
 // Object describes a webdav object
@@ -299,7 +304,100 @@ func (f *Fs) shouldRetry(ctx context.Context, resp *http.Response, err error) (b
 		}
 		return true, err
 	}
+	// If the server asked for digest authentication then sign the retry with it
+	if resp != nil && resp.StatusCode == 401 && f.setDigestChallenge(resp) {
+		return true, err
+	}
 	return fserrors.ShouldRetry(err) || fserrors.ShouldRetryHTTP(resp, retryErrorCodes), err
+}
+
+// setDigestChallenge stores the digest authentication challenge from a 401
+// response so that later requests can be signed with it.
+//
+// It returns true if the request which produced resp should be retried, now
+// that it can be signed.
+func (f *Fs) setDigestChallenge(resp *http.Response) bool {
+	if f.opt.User == "" && f.opt.Pass == "" {
+		return false
+	}
+	chal, err := digest.FindChallenge(resp.Header)
+	if err != nil || resp.Request == nil {
+		return false
+	}
+	// A request which was signed and still came back 401 means the credentials
+	// are wrong, so signing it again would only repeat it. The exception is a
+	// stale nonce, which is the server asking for a fresh signature.
+	if digest.IsDigest(resp.Request.Header.Get("Authorization")) && !chal.Stale {
+		return false
+	}
+	host := resp.Request.URL.Host
+	f.digestMu.Lock()
+	defer f.digestMu.Unlock()
+	if f.digestChal == nil {
+		fs.Debugf(f, "Server requires digest authentication")
+	}
+	// Only restart the count for a nonce we haven't seen: two requests can be
+	// challenged with the same one at once and must not share a count
+	if f.digestChal == nil || f.digestChal.Nonce != chal.Nonce || f.digestHost != host {
+		f.digestChal = chal
+		f.digestHost = host
+		f.digestCount = 0
+	}
+	return true
+}
+
+// takeDigestChallenge returns the challenge to sign a request to host with
+// and the nonce count to sign it with, or nil if that host hasn't asked for
+// digest authentication.
+//
+// Every call takes the next count, so no two requests are signed with the
+// same one.
+func (f *Fs) takeDigestChallenge(host string) (*digest.Challenge, int) {
+	f.digestMu.Lock()
+	defer f.digestMu.Unlock()
+	// Credentials are only for the host which asked for them, so a redirect
+	// somewhere else is sent unsigned rather than leaking them
+	if f.digestChal == nil || f.digestHost != host {
+		return nil, 0
+	}
+	f.digestCount++
+	return f.digestChal, f.digestCount
+}
+
+// digestRoundTripper signs requests with digest authentication once the
+// server has asked for it.
+//
+// The signature covers the request method and URI, so each request sent needs
+// one of its own - in particular each hop of a redirect. It signs in a
+// RoundTripper rather than using digest.Transport because that reads the
+// whole body into memory to be able to send it twice, which would buffer
+// every uploaded file.
+type digestRoundTripper struct {
+	f  *Fs
+	rt http.RoundTripper
+}
+
+// RoundTrip implements http.RoundTripper
+func (d *digestRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	chal, count := d.f.takeDigestChallenge(req.URL.Host)
+	if chal == nil {
+		return d.rt.RoundTrip(req)
+	}
+	cred, err := digest.Digest(chal, digest.Options{
+		Method:   req.Method,
+		URI:      req.URL.RequestURI(),
+		GetBody:  req.GetBody,
+		Count:    count,
+		Username: d.f.opt.User,
+		Password: d.f.opt.Pass,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign request with digest authentication: %w", err)
+	}
+	// RoundTrip must not modify the request it was given
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", cred.String())
+	return d.rt.RoundTrip(req)
 }
 
 // safeRoundTripper is a wrapper for http.RoundTripper that serializes
@@ -515,6 +613,11 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 			fs: f,
 			rt: ntlmssp.Negotiator{RoundTripper: t},
 		}
+	} else if opt.User != "" || opt.Pass != "" {
+		// Signs requests if the server turns out to want digest
+		// authentication. NTLM is excluded as its negotiation takes the
+		// credentials from the basic authentication header itself.
+		client.Transport = &digestRoundTripper{f: f, rt: client.Transport}
 	}
 	// Refuse redirects that downgrade HTTPS to plaintext HTTP.
 	client.CheckRedirect = rest.RefuseHTTPSDowngradeRedirectFn

--- a/backend/webdav/webdav_internal_test.go
+++ b/backend/webdav/webdav_internal_test.go
@@ -6,10 +6,14 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
+	auth "github.com/abbot/go-http-auth"
 	"github.com/rclone/rclone/backend/local"
 	"github.com/rclone/rclone/backend/webdav"
 	"github.com/rclone/rclone/fs"
@@ -19,6 +23,7 @@ import (
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	netwebdav "golang.org/x/net/webdav"
 )
 
 var (
@@ -283,4 +288,175 @@ func TestCopyFallsBackWhenRangeIgnored(t *testing.T) {
 	assert.Positive(t, rangeRequests.Load())
 	assert.LessOrEqual(t, rangeRequests.Load(), int32(3))
 	assert.Equal(t, int32(1), fullRequests.Load())
+}
+
+const (
+	digestUser  = "user"
+	digestPass  = "pass"
+	digestRealm = "rclone"
+)
+
+// digestServer runs a WebDAV server on dir which only accepts digest
+// authentication
+func digestServer(t *testing.T, dir string) *httptest.Server {
+	authenticator := auth.NewDigestAuthenticator(digestRealm, func(user, realm string) string {
+		if user == digestUser {
+			return digestPass
+		}
+		return ""
+	})
+	authenticator.PlainTextSecrets = true
+	handler := &netwebdav.Handler{
+		FileSystem: netwebdav.Dir(dir),
+		LockSystem: netwebdav.NewMemLS(),
+	}
+	ts := httptest.NewServer(authenticator.Wrap(func(w http.ResponseWriter, r *auth.AuthenticatedRequest) {
+		handler.ServeHTTP(w, &r.Request)
+	}))
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// newDigestFs makes an Fs pointing at ts authenticating with pass
+func newDigestFs(t *testing.T, ts *httptest.Server, pass string) (fs.Fs, error) {
+	configfile.Install()
+	return webdav.NewFs(context.Background(), remoteName, "", configmap.Simple{
+		"type": "webdav",
+		"url":  ts.URL,
+		"user": digestUser,
+		"pass": obscure.MustObscure(pass),
+	})
+}
+
+// TestDigestAuth checks that a server which only accepts digest
+// authentication can be listed
+func TestDigestAuth(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte("hello"), 0600))
+
+	f, err := newDigestFs(t, digestServer(t, dir), digestPass)
+	require.NoError(t, err)
+
+	entries, err := f.List(context.Background(), "")
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "file.txt", entries[0].Remote())
+	assert.Equal(t, int64(5), entries[0].Size())
+}
+
+// TestDigestAuthUpload checks that a file can be uploaded to a server which
+// only accepts digest authentication.
+//
+// The signature covers the request URI but not the body, so the body is
+// streamed rather than held in memory to be sent a second time.
+func TestDigestAuthUpload(t *testing.T) {
+	dir := t.TempDir()
+	f, err := newDigestFs(t, digestServer(t, dir), digestPass)
+	require.NoError(t, err)
+
+	contents := "hello digest"
+	_, err = operations.Rcat(context.Background(), f, "uploaded.txt", io.NopCloser(strings.NewReader(contents)), time.Now(), nil)
+	require.NoError(t, err)
+
+	written, err := os.ReadFile(filepath.Join(dir, "uploaded.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, contents, string(written))
+}
+
+// TestDigestAuthWrongPassword checks that bad credentials fail rather than
+// being retried against the server for ever
+func TestDigestAuthWrongPassword(t *testing.T) {
+	f, err := newDigestFs(t, digestServer(t, t.TempDir()), "wrong")
+	require.NoError(t, err)
+
+	_, err = f.List(context.Background(), "")
+	require.Error(t, err)
+}
+
+// TestDigestAuthStaleNonce checks that a request signed with an expired nonce
+// is signed again with the replacement the server sends
+func TestDigestAuthStaleNonce(t *testing.T) {
+	var requests atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		authorization := r.Header.Get("Authorization")
+		switch n := requests.Add(1); {
+		case n == 1:
+			// Rclone sends basic authentication until it knows better
+			assert.False(t, strings.HasPrefix(authorization, "Digest"), "the first request can't be signed yet")
+			w.Header().Set("WWW-Authenticate", `Digest realm="rclone", nonce="nonce-1", algorithm=MD5, qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+		case n == 2:
+			assert.Contains(t, authorization, `nonce="nonce-1"`)
+			// The nonce has expired, so ask for a signature made with a new one
+			w.Header().Set("WWW-Authenticate", `Digest realm="rclone", nonce="nonce-2", algorithm=MD5, qop="auth", stale=true`)
+			w.WriteHeader(http.StatusUnauthorized)
+		default:
+			assert.Contains(t, authorization, `nonce="nonce-2"`, "the stale nonce should have been replaced")
+			_, err := fmt.Fprint(w, `<d:multistatus xmlns:d="DAV:"></d:multistatus>`)
+			require.NoError(t, err)
+		}
+	}))
+	defer ts.Close()
+
+	f, err := newDigestFs(t, ts, digestPass)
+	require.NoError(t, err)
+
+	_, err = f.List(context.Background(), "")
+	require.NoError(t, err)
+	assert.Equal(t, int32(3), requests.Load())
+}
+
+// TestBasicAuthNotRetried checks that a 401 from a server which doesn't offer
+// digest authentication is reported straight away
+func TestBasicAuthNotRetried(t *testing.T) {
+	var requests atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		w.Header().Set("WWW-Authenticate", `Basic realm="rclone"`)
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer ts.Close()
+
+	f, err := newDigestFs(t, ts, digestPass)
+	require.NoError(t, err)
+
+	_, err = f.List(context.Background(), "")
+	require.Error(t, err)
+	assert.Equal(t, int32(1), requests.Load(), "a 401 without a digest challenge shouldn't be retried")
+}
+
+// TestDigestAuthRedirectToOtherHost checks that a redirect somewhere else is
+// sent unsigned, so the credentials only reach the host which asked for them
+func TestDigestAuthRedirectToOtherHost(t *testing.T) {
+	var otherAuth atomic.Value
+	otherAuth.Store("")
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		otherAuth.Store(r.Header.Get("Authorization"))
+		_, err := fmt.Fprint(w, `<d:multistatus xmlns:d="DAV:"></d:multistatus>`)
+		require.NoError(t, err)
+	}))
+	defer other.Close()
+
+	var originAuth atomic.Value
+	originAuth.Store("")
+	var requests atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if requests.Add(1) == 1 {
+			w.Header().Set("WWW-Authenticate", `Digest realm="rclone", nonce="nonce-1", algorithm=MD5, qop="auth"`)
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		originAuth.Store(r.Header.Get("Authorization"))
+		http.Redirect(w, r, other.URL+"/", http.StatusFound)
+	}))
+	defer ts.Close()
+
+	f, err := newDigestFs(t, ts, digestPass)
+	require.NoError(t, err)
+
+	_, err = f.List(context.Background(), "")
+	require.NoError(t, err)
+
+	assert.Contains(t, originAuth.Load(), "Digest ", "the challenging host should be signed")
+	assert.NotContains(t, otherAuth.Load(), "Digest ", "another host shouldn't be sent the credentials")
 }

--- a/docs/content/webdav.md
+++ b/docs/content/webdav.md
@@ -110,6 +110,25 @@ To copy a local directory to an WebDAV directory called backup
 rclone copy /home/source remote:backup
 ```
 
+### Authentication
+
+When configured with a user name and password rclone uses basic
+authentication. If the server rejects that and asks for digest
+authentication instead, rclone signs the request again using the
+challenge the server sent and uses digest authentication for the rest of
+the session. This needs no configuration.
+
+Note that the first request of a session is still sent using basic
+authentication, so use an `https` URL if you don't want your password to
+be readable on the wire. If that first request is an upload then the
+server rejects it before rclone has the challenge, and rclone sends the
+file again once it can sign it.
+
+Rclone can sign with the `MD5`, `SHA-256`, `SHA-512` and `SHA-512-256`
+algorithms. A server which asks for anything else, `MD5-sess` for
+example, is not supported. Neither is a server offering only
+`qop=auth-int`, which hashes the body of the request into the signature.
+
 ### Modification times and hashes
 
 Plain WebDAV does not support modified times.  However when used with

--- a/go.mod
+++ b/go.mod
@@ -281,6 +281,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/golang-jwt/jwt/v4 v4.5.2
+	github.com/icholy/digest v1.2.0
 	github.com/pkg/xattr v0.4.12
 	github.com/pquerna/otp v1.5.0
 	golang.org/x/mobile v0.0.0-20260709172247-6129f5bee9d5

--- a/go.sum
+++ b/go.sum
@@ -324,6 +324,8 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
+github.com/icholy/digest v1.2.0 h1:oTbG4IsNOmidJ+421ehG7Ty93yt1yotq13kFMG569yw=
+github.com/icholy/digest v1.2.0/go.mod h1:1P1+LzUv48ybX7bu8tVpZ2QWdd+xRuePNuGawHjwRUE=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/internxt/rclone-adapter v0.0.0-20260708165336-dd6561bacfa2 h1:ZeebPK9Bnpy40uTuneEeVMYaMMerol3qsmIvzD0EIAk=
@@ -781,6 +783,8 @@ gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gotest.tools/v3 v3.5.1 h1:EENdUnS3pdur5nybKYIh2Vfgc8IUNBjxDPSjtiJcOzU=
+gotest.tools/v3 v3.5.1/go.mod h1:isy3WKz7GK6uNw/sbHzfKBLvlvXwUyV06n6brMxxopU=
 moul.io/http2curl/v2 v2.3.0 h1:9r3JfDzWPcbIklMOs2TnIFzDYvfAZvjeavG6EzP7jYs=
 moul.io/http2curl/v2 v2.3.0/go.mod h1:RW4hyBjTWSYDOxapodpNEtX0g5Eb16sxklBqmd2RHcE=
 sigs.k8s.io/yaml v1.6.0 h1:G8fkbMSAFqgEFgh4b1wmtzDnioxFCUgTZhlbj5P9QYs=


### PR DESCRIPTION
#### What does this change do?

Adds digest authentication to the webdav backend.

If a request comes back 401 with a digest challenge, rclone keeps the challenge, retries the request signed, and signs
the rest of the session: 

- Signing happens in a RoundTripper wrapping rclone's transport, not with
  `icholy/digest`'s own `Transport`. That one reads the whole request body into
  memory so it can send it twice for the handshake, which would buffer every
  uploaded file.
- The first request of a session still goes out with basic auth, so https is
  advisable. That and the supported algorithms are documented in `webdav.md`.

This supersedes #8273 and does the two things @ncw asked for in review there -
detecting digest from the 401 instead of probing at startup, and keeping
rclone's transport instead of building a new client.

#### Linked issue

Fixes #2110

Related: #8273

#### For new or changed backends

Tested against Apache 2.4.68 with `mod_dav_fs`, two vhosts on the same config -
one digest, one basic.

#### Checklist

- [ ] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [ ] This Pull Request is ready for review.
