### PR TITLE
test: skip the symlink tests when the platform won't allow symlinks

### DIFF
--- a/backend/local/local_internal_test.go
+++ b/backend/local/local_internal_test.go
@@ -96,7 +96,19 @@ func TestVerifyCopy(t *testing.T) {
 	assert.Error(t, err)
 }
 
+// skipIfNoSymlinks skips the test if this process can't create symlinks.
+//
+// Windows grants the privilege only to an elevated process or one running with
+// Developer Mode enabled, so an ordinary user gets ERROR_PRIVILEGE_NOT_HELD.
+func skipIfNoSymlinks(t *testing.T) {
+	t.Helper()
+	if err := os.Symlink("target", filepath.Join(t.TempDir(), "link")); err != nil {
+		t.Skipf("Skipping as symlinks are unavailable: %v", err)
+	}
+}
+
 func TestSymlink(t *testing.T) {
+	skipIfNoSymlinks(t)
 	ctx := context.Background()
 	r := fstest.NewRun(t)
 	f := r.Flocal.(*Fs)
@@ -238,6 +250,7 @@ func linksMode(f *Fs) {
 // faithful backup of the source) but must refuse to write through it, so
 // nothing lands outside the destination (CWE-59).
 func TestSymlinkEscapeWriteThroughBlocked(t *testing.T) {
+	skipIfNoSymlinks(t)
 	ctx := context.Background()
 
 	// A directory outside the destination the attacker wants to write into
@@ -273,6 +286,7 @@ func TestSymlinkEscapeWriteThroughBlocked(t *testing.T) {
 // re-validated against the root, so the write-through is refused and nothing
 // escapes.
 func TestSymlinkEscapeNestedBlocked(t *testing.T) {
+	skipIfNoSymlinks(t)
 	ctx := context.Background()
 
 	evil := t.TempDir()
@@ -324,6 +338,7 @@ func TestSymlinkEscapeConcurrent(t *testing.T) {
 // use: an in-tree symlink to a sibling directory can still be created and
 // written through, since that write stays inside the destination.
 func TestSymlinkInTreeWriteThroughWorks(t *testing.T) {
+	skipIfNoSymlinks(t)
 	ctx := context.Background()
 
 	r := fstest.NewRun(t)
@@ -555,6 +570,7 @@ func TestHashOnDelete(t *testing.T) {
 }
 
 func TestMetadata(t *testing.T) {
+	skipIfNoSymlinks(t)
 	ctx := context.Background()
 	r := fstest.NewRun(t)
 	const filePath = "metafile.txt"
@@ -831,6 +847,7 @@ func TestFilter(t *testing.T) {
 }
 
 func testFilterSymlink(t *testing.T, copyLinks bool) {
+	skipIfNoSymlinks(t)
 	ctx := context.Background()
 	r := fstest.NewRun(t)
 	defer r.Finalise()
@@ -935,6 +952,7 @@ func TestFilterSymlinkLinks(t *testing.T) {
 }
 
 func TestCopySymlink(t *testing.T) {
+	skipIfNoSymlinks(t)
 	ctx := context.Background()
 	r := fstest.NewRun(t)
 	defer r.Finalise()

--- a/cmdtest/environment_test.go
+++ b/cmdtest/environment_test.go
@@ -141,13 +141,12 @@ func TestEnvironmentVariables(t *testing.T) {
 	// Reference: https://rclone.org/docs/#precedence
 	// Create a symlink in test data
 	err = os.Symlink(testdataPath+"/folderA", testdataPath+"/symlinkA")
-	if runtime.GOOS == "windows" {
-		errNote := "The policy settings on Windows often prohibit the creation of symlinks due to security issues.\n"
-		errNote += "You can safely ignore this test, if your change didn't affect environment variables."
-		require.NoError(t, err, errNote)
-	} else {
-		require.NoError(t, err)
+	if err != nil && runtime.GOOS == "windows" {
+		// Windows grants the privilege only to an elevated process or one
+		// running with Developer Mode enabled.
+		t.Skipf("Skipping as symlinks are unavailable: %v", err)
 	}
+	require.NoError(t, err)
 
 	// Create a local remote with explicit skip_links=false
 	out, err = rclone("config", "create", "myLocal", "local", "skip_links", "false")


### PR DESCRIPTION
## What this does

Skips the tests that need to create a symlink when the platform will not let the process create one, instead of failing.

## Why

Nine tests fail on an ordinary Windows machine, eight in `backend/local` and one in `cmdtest`:

```
--- FAIL: TestSymlink
--- FAIL: TestSymlinkEscapeWriteThroughBlocked
--- FAIL: TestSymlinkEscapeNestedBlocked
--- FAIL: TestSymlinkInTreeWriteThroughWorks
--- FAIL: TestMetadata
--- FAIL: TestFilterSymlinkCopyLinks
--- FAIL: TestFilterSymlinkLinks
--- FAIL: TestCopySymlink
--- FAIL: TestEnvironmentVariables
```

All nine fail the same way:

```
symlink file.txt \\?\C:\Users\...\symlink.txt: A required privilege is not held by the client.
```

Windows grants `SeCreateSymbolicLinkPrivilege` only to an elevated process, or to one running while Developer Mode is on. A default install gives an ordinary user neither, so `os.Symlink` returns `ERROR_PRIVILEGE_NOT_HELD`. CI does not see this because the `windows-latest` runner is elevated, so the failures only appear on a contributor's own machine.

`cmdtest` already knows about this. `TestEnvironmentVariables` special-cases the platform and attaches a note to the failure:

```go
if runtime.GOOS == "windows" {
    errNote := "The policy settings on Windows often prohibit the creation of symlinks due to security issues.\n"
    errNote += "You can safely ignore this test, if your change didn't affect environment variables."
    require.NoError(t, err, errNote)
}
```

If the failure is safe to ignore then the test knows it cannot run, which is what a skip is for. Telling the reader to ignore a red test asks them to hold that exception in their head every run, and it stops `make quicktest` being usable as a yes or no answer.

That matters because AGENTS.md asks for `make quicktest` to pass before a pull request goes up. On Windows it cannot, and someone looking at nine red tests on a clean checkout has no easy way to tell whether they broke something.

## The change

In `backend/local/local_internal_test.go`, a helper that tries a symlink in `t.TempDir()` and skips if it cannot make one, called from the six tests that need the privilege.

In `cmdtest/environment_test.go`, the Windows branch becomes a skip carrying the underlying error, so the note is no longer needed.

Where a platform can create symlinks the probe succeeds and nothing is skipped, so Linux, macOS, and an elevated or Developer Mode Windows box are unchanged.

`TestMetadata` is skipped whole rather than in part, because it creates its symlink before anything else and the object built from it is used throughout.

`TestSymlinkEscapeConcurrent` is left alone deliberately. It goes through `putLink` and ignores the error, so it does not need the privilege and passes either way.

This follows the pattern already used for the permission-gated symlink test in `cmd/serve/nfs/cache_test.go`, which skips with an explanation rather than failing.

## Verification

On Windows 11, Go 1.26.5, ordinary user, Developer Mode off:

- `go test ./backend/local/` fails 8 tests before and passes after, with those 8 skipped.
- `go test ./cmdtest/` fails before and passes after, with `TestEnvironmentVariables` skipped.
- `RCLONE_CONFIG="/notfound" go test ./...` reports 164 packages passing and nothing failing, against two failing packages before. That run excluded `cmd/serve/...`, whose tests bind listeners and so prompt the Windows firewall; they are untouched by this change and passed in an earlier full run.
- `gofmt -l` and `go vet` are clean on both files.

I have not run this on Linux or macOS. The probe succeeds wherever symlinks can be created, so the skip never fires and those platforms behave exactly as before.
