### PR TITLE
iclouddrive: avoid size verification for package downloads

### DIFF
--- a/backend/iclouddrive/api/drive.go
+++ b/backend/iclouddrive/api/drive.go
@@ -3,6 +3,7 @@ package api
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"mime"
 	"net/http"
@@ -208,7 +209,8 @@ func (d *DriveService) GetItemsInFolder(ctx context.Context, id string, limit in
 }
 
 // GetDownloadURLByDriveID retrieves the download URL for a file in the DriveService.
-func (d *DriveService) GetDownloadURLByDriveID(ctx context.Context, id string) (string, *http.Response, error) {
+// It also reports whether the URL contains a package rather than the file data.
+func (d *DriveService) GetDownloadURLByDriveID(ctx context.Context, id string) (string, bool, *http.Response, error) {
 	_, zone, docid := DeconstructDriveID(id)
 	values := url.Values{}
 	values.Set("document_id", docid)
@@ -229,17 +231,20 @@ func (d *DriveService) GetDownloadURLByDriveID(ctx context.Context, id string) (
 	resp, err := d.icloud.Request(ctx, opts, nil, &filer)
 
 	if err != nil {
-		return "", resp, err
+		return "", false, resp, err
 	}
 
-	var url string
+	if filer == nil {
+		return "", false, resp, errors.New("download response is empty")
+	}
 	if filer.DataToken != nil {
-		url = filer.DataToken.URL
-	} else {
-		url = filer.PackageToken.URL
+		return filer.DataToken.URL, false, resp, nil
+	}
+	if filer.PackageToken != nil {
+		return filer.PackageToken.URL, true, resp, nil
 	}
 
-	return url, resp, err
+	return "", false, resp, errors.New("download response contains no token")
 }
 
 // DownloadFile downloads a file from the given URL using the provided options.

--- a/backend/iclouddrive/api/drive_test.go
+++ b/backend/iclouddrive/api/drive_test.go
@@ -1,10 +1,57 @@
 package api
 
 import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
+	"github.com/rclone/rclone/lib/rest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestGetDownloadURLByDriveID(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		response    string
+		wantURL     string
+		wantPackage bool
+	}{
+		{
+			name:     "data token",
+			response: `{"data_token":{"url":"https://download.example/data"}}`,
+			wantURL:  "https://download.example/data",
+		},
+		{
+			name:        "package token",
+			response:    `{"package_token":{"url":"https://download.example/package"}}`,
+			wantURL:     "https://download.example/package",
+			wantPackage: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/ws/com.apple.CloudDocs/download/by_id", r.URL.Path)
+				assert.Equal(t, "document", r.URL.Query().Get("document_id"))
+				_, _ = io.WriteString(w, test.response)
+			}))
+			defer server.Close()
+
+			service := &DriveService{
+				icloud:       &Client{Session: NewSession()},
+				docsEndpoint: server.URL,
+			}
+			service.icloud.Session.srv = rest.NewClient(server.Client())
+
+			url, isPackage, _, err := service.GetDownloadURLByDriveID(context.Background(), "FILE::com.apple.CloudDocs::document")
+			require.NoError(t, err)
+			assert.Equal(t, test.wantURL, url)
+			assert.Equal(t, test.wantPackage, isPackage)
+		})
+	}
+}
 
 func TestZoneFromDriveID(t *testing.T) {
 	for _, test := range []struct {

--- a/backend/iclouddrive/iclouddrive.go
+++ b/backend/iclouddrive/iclouddrive.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/rclone/rclone/fs"
@@ -83,6 +84,7 @@ type Object struct {
 	itemID      string    // item ID of the object
 	etag        string
 	downloadURL string
+	isPackage   atomic.Bool
 }
 
 // find item by path. Will not return any children for the item
@@ -811,6 +813,7 @@ func (o *Object) setMetaData(item *api.DriveItem) (err error) {
 	if item.IsFolder() {
 		return fs.ErrorIsDir
 	}
+	o.isPackage.Store(false)
 	o.size = item.Size
 	o.modTime = item.DateModified
 	o.createdTime = item.DateCreated
@@ -844,18 +847,18 @@ func (o *Object) ModTime(context.Context) time.Time {
 
 // Open implements fs.Object.
 func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
-	fs.FixRangeOption(options, o.size)
-
 	// Drive does not support empty files, so we cheat
-	if o.size == 0 {
+	if o.Size() == 0 {
 		return io.NopCloser(bytes.NewBufferString("")), nil
 	}
 
 	var resp *http.Response
 	var err error
+	var optionsFixed bool
 
 	if err = o.fs.pacer.Call(func() (bool, error) {
 		var url string
+		var isPackage bool
 
 		//var doc *api.Document
 		//if o.docID == "" {
@@ -863,7 +866,17 @@ func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadClo
 		//}
 
 		// Can not get the download url on a item to work, so do it the hard way.
-		url, _, err = o.fs.service.GetDownloadURLByDriveID(ctx, o.driveID)
+		url, isPackage, resp, err = o.fs.service.GetDownloadURLByDriveID(ctx, o.driveID)
+		if err != nil {
+			return shouldRetry(ctx, resp, err)
+		}
+		if isPackage {
+			o.isPackage.Store(true)
+		}
+		if !optionsFixed {
+			fs.FixRangeOption(options, o.Size())
+			optionsFixed = true
+		}
 
 		resp, err = o.fs.service.DownloadFile(ctx, url, options)
 		return shouldRetry(ctx, resp, err)
@@ -904,6 +917,9 @@ func (o *Object) SetModTime(ctx context.Context, t time.Time) error {
 
 // Size implements fs.Object.
 func (o *Object) Size() int64 {
+	if o.isPackage.Load() {
+		return -1
+	}
 	return o.size
 }
 

--- a/backend/iclouddrive/iclouddrive_internal_test.go
+++ b/backend/iclouddrive/iclouddrive_internal_test.go
@@ -1,0 +1,97 @@
+//go:build !plan9 && !solaris
+
+package iclouddrive
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/rclone/rclone/backend/iclouddrive/api"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/lib/pacer"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestObjectOpenHandlesPackageTokenSize(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		token     string
+		wantSize  int64
+		wantRange string
+	}{
+		{
+			name:      "data token keeps reported size",
+			token:     "data",
+			wantSize:  10,
+			wantRange: "bytes=2-9",
+		},
+		{
+			name:      "package token makes size unknown",
+			token:     "package",
+			wantSize:  -1,
+			wantRange: "bytes=2-",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var (
+				mu       sync.Mutex
+				gotRange string
+				server   *httptest.Server
+			)
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/ws/com.apple.CloudDocs/download/by_id":
+					assert.Equal(t, "document", r.URL.Query().Get("document_id"))
+					response := map[string]any{
+						test.token + "_token": map[string]string{"url": server.URL + "/payload"},
+					}
+					_ = json.NewEncoder(w).Encode(response)
+				case "/payload":
+					mu.Lock()
+					gotRange = r.Header.Get("Range")
+					mu.Unlock()
+					_, _ = io.WriteString(w, "0123456789")
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			client, err := api.New("", "", "", "", nil, nil, "test", "")
+			require.NoError(t, err)
+			accountInfo := map[string]any{
+				"webservices": map[string]any{
+					api.WsDocs:  map[string]string{"url": server.URL},
+					api.WsDrive: map[string]string{"url": server.URL},
+				},
+			}
+			accountInfoJSON, err := json.Marshal(accountInfo)
+			require.NoError(t, err)
+			require.NoError(t, json.Unmarshal(accountInfoJSON, &client.Session.AccountInfo))
+			service, err := client.DriveService()
+			require.NoError(t, err)
+
+			o := &Object{
+				fs:      &Fs{service: service, pacer: fs.NewPacer(context.Background(), pacer.NewDefault())},
+				size:    10,
+				driveID: "FILE::com.apple.CloudDocs::document",
+			}
+			rc, err := o.Open(context.Background(), &fs.SeekOption{Offset: 2})
+			require.NoError(t, err)
+			body, err := io.ReadAll(rc)
+			require.NoError(t, err)
+			require.NoError(t, rc.Close())
+			assert.Equal(t, []byte("0123456789"), body)
+			mu.Lock()
+			assert.Equal(t, test.wantRange, gotRange)
+			mu.Unlock()
+			assert.Equal(t, test.wantSize, o.Size())
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Fixes a false corruption report when iCloud Drive returns a `package_token` for an iWork document.

The `/download/by_id` response can provide a zipped package whose byte size differs from the stored bundle size reported by enumeration. The backend now tracks the token kind, treats package downloads as unknown-sized after URL resolution so rclone uses the streaming copy path and skips the invalid size comparison, and keeps open-ended ranges intact for package payloads. Ordinary `data_token` downloads retain their reported-size range behavior.

The change adds simulated HTTP coverage for both token kinds and their resulting `Range` headers.

Fixes #9798

## Verification

- `go build ./...`
- `go test -count=1 ./backend/iclouddrive/...`
- `git diff --check`
- `go vet ./backend/iclouddrive/...` reaches an existing unrelated unreachable-code warning at `backend/iclouddrive/iclouddrive.go:290`.

I do not have an iCloud account in this environment, so live package-token validation is still required. The reporter/maintainers should test real `.key`, `.pages`, and `.numbers` files.