### PR TITLE
protondrive: fix Go 1.27 vet warning in retry test

### DIFF
--- a/backend/protondrive/protondrive_internal_test.go
+++ b/backend/protondrive/protondrive_internal_test.go
@@ -86,7 +86,7 @@ func TestShouldRetry(t *testing.T) {
 		{"rate limit Status=429 (handled by SDK, not retried here)", ctx, apiErr(429, 0), false},
 		{"client error Status=400", ctx, apiErr(400, 0), false},
 		{"client error Status=404", ctx, apiErr(404, 0), false},
-		{"wrapped API error retried via errors.As", ctx, fmt.Errorf("wrapped: %w", &proton.APIError{Status: 500}), true},
+		{"wrapped API error retried via errors.As", ctx, fmt.Errorf("wrapped: %w", apiErr(500, 0)), true},
 		{"non-API error falls back to fserrors.ShouldRetry", ctx, errors.New("plain error"), false},
 	} {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
#### What does this change do?

Pass the wrapped API error through the error-typed test helper so the %w operand satisfies Go 1.27's printf analyzer without changing test behavior.

Tested on Fedora Rawhide

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
