### PR TITLE
vfs: give stable inode numbers from the backend ID

### DIFF
--- a/vfs/dir.go
+++ b/vfs/dir.go
@@ -64,7 +64,7 @@ func newDir(vfs *VFS, f fs.Fs, parent *Dir, fsDir fs.Directory) *Dir {
 		entry:   fsDir,
 		path:    fsDir.Remote(),
 		modTime: fsDir.ModTime(vfs.ctx),
-		inode:   newInode(),
+		inode:   deriveInode(fsDir),
 		items:   make(map[string]Node),
 	}
 	// Set timer up like this to avoid race of d.cacheCleanup being called

--- a/vfs/file.go
+++ b/vfs/file.go
@@ -70,7 +70,7 @@ func newFile(d *Dir, dPath string, o fs.Object, leaf string) *File {
 		dPath: dPath,
 		o:     o,
 		leaf:  leaf,
-		inode: newInode(),
+		inode: deriveInode(o),
 		ctx:   d.vfs.ctx,
 	}
 	if o != nil {

--- a/vfs/vfs.go
+++ b/vfs/vfs.go
@@ -22,7 +22,9 @@ package vfs
 
 import (
 	"context"
+	"crypto/md5"
 	_ "embed"
+	"encoding/binary"
 	"fmt"
 	"io"
 	"os"
@@ -486,6 +488,24 @@ var inodeCount atomic.Uint64
 // newInode creates a new unique inode number
 func newInode() (inode uint64) {
 	return inodeCount.Add(1)
+}
+
+// deriveInode attempts to create a stable inode number from a backend ID.
+// If the backend does not support IDs, it falls back to a volatile atomic counter.
+func deriveInode(entry fs.DirEntry) uint64 {
+	if entry != nil {
+		if ider, ok := entry.(fs.IDer); ok {
+			if id := ider.ID(); id != "" {
+				sum := md5.Sum([]byte(id))
+				// the range of possible values is restricted to the upper half of
+				// the uint64 range to avoid collisions with the atomic counter
+				return binary.BigEndian.Uint64(sum[:8]) | 0x8000000000000000
+			}
+		}
+	}
+	// the range of possible values is restricted to the lower half of
+	// the uint64 range to avoid collisions with the backend ID hash
+	return newInode() & 0x7FFFFFFFFFFFFFFF
 }
 
 // Stat finds the Node by path starting from the root

--- a/vfs/vfs.md
+++ b/vfs/vfs.md
@@ -449,6 +449,29 @@ and compute the total used space itself.
 result is accurate. However, this is very inefficient and may cost lots of API
 calls resulting in extra charges. Use it as a last resort and only with caching.
 
+### VFS inode Numbers
+
+Files and directories in the VFS are given inode numbers. Where the
+backend can supply a persistent ID for an object (for example Drive,
+Onedrive, Box, Dropbox, B2 and Mega can), the inode number is derived
+from that ID, which means it stays the same for as long as the object
+exists.
+
+This matters when the mount is re-exported by another file server, most
+notably NFS, which validates its file handles against the inode number.
+Without a stable inode the same file can be given a new inode number
+when the directory cache expires and the entry is read from the backend
+again, and clients then see stale file handle errors.
+
+Backends which can't supply an ID have inode numbers allocated in
+sequence instead. These are unique within the lifetime of the rclone
+process, but the same file is not guaranteed the same inode number
+after the directory cache has expired, or if rclone is restarted.
+
+Because the inode number follows the object's ID rather than its path,
+renaming a file keeps its inode number on backends where the ID is
+itself stable across renames.
+
 ### VFS Metadata
 
 If you use the `--vfs-metadata-extension` flag you can get the VFS to

--- a/vfs/vfs_test.go
+++ b/vfs/vfs_test.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fstest"
+	"github.com/rclone/rclone/fstest/mockfs"
+	"github.com/rclone/rclone/fstest/mockobject"
 	"github.com/rclone/rclone/vfs/vfscommon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -499,4 +501,165 @@ func TestVFSIsMetadataFile(t *testing.T) {
 	rawName, found = vfs.isMetadataFile("leaf.metadata")
 	assert.Equal(t, "leaf", rawName)
 	assert.Equal(t, true, found)
+}
+
+// idObject wraps a mock object with a backend ID so it satisfies fs.IDer.
+//
+// An empty id means ID() reports no ID is available, as backends do for
+// objects whose ID they don't know.
+type idObject struct {
+	fs.Object
+	id string
+}
+
+// ID returns the backend ID of the object
+func (o idObject) ID() string { return o.id }
+
+// newIDObject makes an object of the given size with the given backend ID
+func newIDObject(remote, id string, contents []byte) idObject {
+	return idObject{
+		Object: mockobject.New(remote).WithContent(contents, mockobject.SeekModeNone),
+		id:     id,
+	}
+}
+
+// The high bit marks an inode as being derived from a backend ID rather
+// than from the counter.
+const inodeIDBit = uint64(0x8000000000000000)
+
+func TestDeriveInode(t *testing.T) {
+	contents := []byte("mock file content")
+
+	t.Run("SameIDSameInode", func(t *testing.T) {
+		// Two distinct objects sharing a backend ID - as happens when the
+		// VFS drops a node and later recreates it from a fresh listing.
+		a := newIDObject("file.txt", "backend-id-1", contents)
+		b := newIDObject("file.txt", "backend-id-1", contents)
+		assert.Equal(t, deriveInode(a), deriveInode(b))
+	})
+
+	t.Run("DifferentIDDifferentInode", func(t *testing.T) {
+		a := newIDObject("a.txt", "backend-id-1", contents)
+		b := newIDObject("b.txt", "backend-id-2", contents)
+		assert.NotEqual(t, deriveInode(a), deriveInode(b))
+	})
+
+	t.Run("IDSetsHighBit", func(t *testing.T) {
+		inode := deriveInode(newIDObject("file.txt", "backend-id-1", contents))
+		assert.Equal(t, inodeIDBit, inode&inodeIDBit)
+	})
+
+	t.Run("EmptyIDUsesCounter", func(t *testing.T) {
+		// fs.Directory requires ID() but backends which have no ID for a
+		// directory return "", so that must fall back to the counter.
+		a := deriveInode(newIDObject("file.txt", "", contents))
+		b := deriveInode(newIDObject("file.txt", "", contents))
+		assert.NotEqual(t, a, b)
+		assert.Zero(t, a&inodeIDBit)
+		assert.Zero(t, b&inodeIDBit)
+	})
+
+	t.Run("NoIDerUsesCounter", func(t *testing.T) {
+		// A backend which doesn't implement fs.IDer at all
+		a := deriveInode(mockobject.New("file.txt"))
+		b := deriveInode(mockobject.New("file.txt"))
+		assert.NotEqual(t, a, b)
+		assert.Zero(t, a&inodeIDBit)
+		assert.Zero(t, b&inodeIDBit)
+	})
+
+	t.Run("NilEntryUsesCounter", func(t *testing.T) {
+		// newFile is called with a nil object for files being created
+		a := deriveInode(nil)
+		b := deriveInode(nil)
+		assert.NotEqual(t, a, b)
+		assert.Zero(t, a&inodeIDBit)
+		assert.Zero(t, b&inodeIDBit)
+	})
+}
+
+// inodeAfterForget returns the inode of remote, then forgets the whole
+// directory cache and returns the inode of remote as freshly listed.
+func inodeAfterForget(t *testing.T, vfs *VFS, remote string) (before, after uint64) {
+	node, err := vfs.Stat(remote)
+	require.NoError(t, err)
+	before = node.Inode()
+
+	root, err := vfs.Root()
+	require.NoError(t, err)
+	root.ForgetAll()
+
+	node, err = vfs.Stat(remote)
+	require.NoError(t, err)
+	return before, node.Inode()
+}
+
+// newMockVFS makes a VFS on a mockfs holding the entries given
+func newMockVFS(t *testing.T, entries ...fs.DirEntry) *VFS {
+	fMock, err := mockfs.NewFs(context.Background(), "test", "root", nil)
+	require.NoError(t, err)
+	f := fMock.(*mockfs.Fs)
+	for _, entry := range entries {
+		switch x := entry.(type) {
+		case fs.Object:
+			f.AddObject(x)
+		default:
+			t.Fatalf("can't add %T to mockfs", entry)
+		}
+	}
+	vfs := New(context.Background(), f, nil)
+	t.Cleanup(func() {
+		cleanupVFS(t, vfs)
+	})
+	return vfs
+}
+
+func TestFileInodeAfterForget(t *testing.T) {
+	contents := []byte("mock file content")
+
+	t.Run("WithID", func(t *testing.T) {
+		vfs := newMockVFS(t, newIDObject("file.txt", "backend-id-1", contents))
+		before, after := inodeAfterForget(t, vfs, "file.txt")
+		assert.Equal(t, before, after, "inode should survive the file being forgotten")
+		assert.Equal(t, inodeIDBit, before&inodeIDBit)
+	})
+
+	// Without a backend ID there is nothing stable to derive the inode
+	// from, so it changes - this is what the ID is needed to avoid.
+	t.Run("WithoutID", func(t *testing.T) {
+		vfs := newMockVFS(t, mockobject.New("file.txt").WithContent(contents, mockobject.SeekModeNone))
+		before, after := inodeAfterForget(t, vfs, "file.txt")
+		assert.NotEqual(t, before, after)
+	})
+}
+
+// Unlike TestFileInodeAfterForget this calls newDir directly rather than
+// forgetting and re-listing the directory: mockfs lists only the objects
+// added to its flat root, so it never returns a directory entry to
+// rediscover. Calling newDir twice covers the same thing - that the same
+// directory ID gives the same inode each time a *Dir is made for it.
+func TestDirInodeAfterForget(t *testing.T) {
+	const dir = "dir"
+	const remote = dir + "/file.txt"
+
+	t.Run("WithID", func(t *testing.T) {
+		vfs := newMockVFS(t, newIDObject(remote, "file-id", []byte("x")))
+		root, err := vfs.Root()
+		require.NoError(t, err)
+		d := newDir(vfs, vfs.f, root, fs.NewDir(dir, t1).SetID("dir-id"))
+		before := d.Inode()
+		again := newDir(vfs, vfs.f, root, fs.NewDir(dir, t1).SetID("dir-id"))
+		assert.Equal(t, before, again.Inode(), "inode should be the same for the same directory ID")
+		assert.Equal(t, inodeIDBit, before&inodeIDBit)
+	})
+
+	t.Run("WithoutID", func(t *testing.T) {
+		vfs := newMockVFS(t, newIDObject(remote, "file-id", []byte("x")))
+		root, err := vfs.Root()
+		require.NoError(t, err)
+		d := newDir(vfs, vfs.f, root, fs.NewDir(dir, t1))
+		again := newDir(vfs, vfs.f, root, fs.NewDir(dir, t1))
+		assert.NotEqual(t, d.Inode(), again.Inode())
+		assert.Zero(t, d.Inode()&inodeIDBit)
+	})
 }


### PR DESCRIPTION
`newInode` allocates inode numbers from a process-wide atomic counter, and `newFile`/`newDir` call it every time they construct a node. When the directory cache expires, `ForgetAll` empties `d.items`, so the next listing rebuilds those nodes and the same file comes back with a different inode number.

This derives the inode number from the backend's own object ID when the entry implements `fs.IDer` and has one, so it stays the same for as long as the object does, however many times the node is dropped and rebuilt.

Many backends can supply an object ID - Drive, Onedrive, Box, Dropbox, B2 and Mega among them - plus the wrapping backends (crypt, union, chunker, compress, hasher, cache, combine) which forward it. Anything without an ID keeps the counter exactly as before: that includes `local`, which has no IDs at all, and most directories, since far fewer backends give a directory an ID than give one to an object. The two are kept in separate halves of the uint64 range so they cannot collide.

This complements #9548, which made `cmd/mount2` report the VFS inode to the kernel at all: that made the number visible, this makes it stable.

I have opened this as a draft because the following are open to your preference:

- **Hashing.** I used md5 of the ID truncated to 8 bytes, to match the existing `md5.Sum([]byte(...))` idiom in `cmd/serve/nfs/cache.go`, `fs/newfs.go` and `fs/filter/filter.go`. Happy to change it.
- **The high-bit split** between ID-derived and counter-derived inodes. It makes collisions between the two impossible, but halves each space.
- **Whether this should be opt-in behind a flag.** I did not add one because inode stability was never guaranteed and #9548 shipped without one, but I can add one if you would rather not change existing behaviour by default.

#### Linked issue

Fixes #9830

#### For new or changed backends

Not a backend change.

#### Testing

`vfs/vfs_test.go` adds `TestDeriveInode` (same ID gives the same inode number, different IDs give different inode numbers, missing or empty ID falls back to the counter), plus `TestFileInodeAfterForget` and `TestDirInodeAfterForget`, which check a file/dir keeps its inode across a `ForgetAll` and that it does not without an ID. I verified the tests fail without the change and pass with it.

The ESTALE path itself needs a kernel NFS server, so as with #9548 it is not covered by the local harness. `make quicktest` passes apart from `cmd/mountlib` and `cmd/serve/s3`, which fail on my machine for environmental reasons (macFUSE too old, and `flock` not present on macOS); both fail identically on a clean master.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [ ] This Pull Request is ready for review.