### PR TITLE
docker: make container user UID and GID configurable via build ARGs (#9839)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "**** Print Version Binary ****" && \
 # Begin final image
 FROM alpine:latest
 
+ARG RCLONE_UID=1009
+ARG RCLONE_GID=1009
+
 RUN echo "**** Install Dependencies ****" && \
     apk add --no-cache \
         ca-certificates \
@@ -45,7 +48,7 @@ RUN echo "**** Install Dependencies ****" && \
 
 COPY --from=builder /go/src/github.com/rclone/rclone/rclone /usr/local/bin/
 
-RUN addgroup -g 1009 rclone && adduser -u 1009 -Ds /bin/sh -G rclone rclone
+RUN addgroup -g ${RCLONE_GID} rclone && adduser -u ${RCLONE_UID} -Ds /bin/sh -G rclone rclone
 
 ENTRYPOINT [ "rclone" ]
 


### PR DESCRIPTION
#### What is the purpose of this change?
Fixes #9839

The official \clone/rclone\ Docker image creates and runs as a non-root \clone\ user with a hardcoded UID/GID of \1009:1009\. When deploying the image in Kubernetes environments subject to static security scanning rules (e.g. Checkov \CKV_K8S_40\ / Pod Security Standards requiring high UIDs >= 10000 to prevent host UID collisions), downstream users previously had to manually re-layer or recreate the user.

#### What does this PR change?
- Introduced \ARG RCLONE_UID=1009\ and \ARG RCLONE_GID=1009\ in \Dockerfile\ before the user creation step.
- Uses \\\ and \\\ in \ddgroup\ and \dduser\.
- Preserves the default \1009:1009\ for full backward compatibility while allowing custom UIDs/GIDs at build time (e.g. \--build-arg RCLONE_UID=10001 --build-arg RCLONE_GID=10001\).

#### Was the change discussed in an issue or on the forum before?
Yes, fixes #9839.

#### Checklist
- [x] I have read the contribution guidelines.
- [x] The title of the PR matches the conventions.