### PR TITLE
operations: don't merge DirMove over an existing directory - fixes #8253

### DIFF
--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -2447,7 +2447,9 @@ func DirMove(ctx context.Context, f fs.Fs, srcRemote, dstRemote string) (err err
 		if err == nil {
 			accounting.Stats(ctx).Renames(1)
 		}
-		if err != fs.ErrorCantDirMove && err != fs.ErrorDirExists {
+		// Only ErrorCantDirMove falls back (combine across upstreams);
+		// ErrorDirExists must fail like POSIX rename-over-dir.
+		if err != fs.ErrorCantDirMove {
 			return err
 		}
 		fs.Infof(f, "Can't DirMove - falling back to file moves: %v", err)

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -1432,6 +1432,7 @@ func TestDirMove(t *testing.T) {
 
 	// Disable DirMove
 	features := r.Fremote.Features()
+	origDirMove := features.DirMove
 	features.DirMove = nil
 
 	require.NoError(t, operations.DirMove(ctx, r.Fremote, "A2", "A3"))
@@ -1479,6 +1480,28 @@ func TestDirMove(t *testing.T) {
 			"A4/B1/C1",
 			"A4/B1/C2",
 			"A4/B1/C3",
+		},
+		fs.GetModifyWindow(ctx, r.Fremote),
+	)
+
+	// Dest directory already exists: must return ErrorDirExists, not merge.
+	features.DirMove = origDirMove
+	destFile := r.WriteObject(ctx, "B_exists/keep", "keep", t1)
+	err := operations.DirMove(ctx, r.Fremote, "A4", "B_exists")
+	require.Equal(t, fs.ErrorDirExists, err)
+
+	fstest.CheckListingWithPrecision(
+		t,
+		r.Fremote,
+		append(files, destFile),
+		[]string{
+			"A4",
+			"A4/B1",
+			"A4/B2",
+			"A4/B1/C1",
+			"A4/B1/C2",
+			"A4/B1/C3",
+			"B_exists",
 		},
 		fs.GetModifyWindow(ctx, r.Fremote),
 	)


### PR DESCRIPTION
#### What does this change do?

Don't fall through to a file-move merge when DirMove hits an existing destination directory. POSIX rename-over-dir must fail; the merge was succeeding and breaking borg exclusive locks on rclone mount. Only `ErrorCantDirMove` still falls back (combine, #7661).

#### Linked issue

Fixes #8253

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.

AI-assisted; FAIL then PASS verified locally (`go test ./fs/operations -run TestDirMove`, combine `TestLocal|TestMemory|TestMixed`). I take ownership of the change. Docs n/a.