### PR TITLE
fs/fshttp: fix TestCertificates leaking client cert/key onto global config

### DIFF
--- a/fs/fshttp/http_test.go
+++ b/fs/fshttp/http_test.go
@@ -172,14 +172,8 @@ func TestCertificates(t *testing.T) {
 	// Set --client-cert and --client-key in config to
 	// a pair of temp files
 	// create a test cert/key pair and write it to the files
-	ctx := context.TODO()
-	ci := fs.GetConfig(ctx)
-	// Restore the global config for later tests as the temp files
-	// are removed when this test finishes
-	oldCert, oldKey := ci.ClientCert, ci.ClientKey
-	t.Cleanup(func() {
-		ci.ClientCert, ci.ClientKey = oldCert, oldKey
-	})
+	// Use a private config so the cert paths don't leak into other tests
+	ctx, ci := fs.AddConfig(context.TODO())
 	// Create a test certificate and write it to a temp file
 	ci.ClientCert = t.TempDir() + "client.cert"
 	ci.ClientKey = t.TempDir() + "client.key"


### PR DESCRIPTION
Split out from the discussion in #9841, per @ncw's request there.

`TestCertificates` sets `ci.ClientCert`/`ci.ClientKey` on the process-global `ConfigInfo` (the test's `ctx` carries no override) to a path under `t.TempDir()`, and never resets them. Go removes `t.TempDir()` on test cleanup, so any *later* test in `fs/fshttp` that builds a client via `NewTransportCustom` fails trying to load a cert file that no longer exists.

Harmless on its own -- it only surfaces once something else in the same test binary calls `NewClient`/`NewTransportCustom` after `TestCertificates` runs, since `go test` executes tests within a package in source order by default. I hit it while adding a new test to this package for #9841.

One-line fix: reset both fields in a `defer`, same pattern used elsewhere in this file.