### PR TITLE
onedrive: fall back to manual drive ID entry when drive listing fails

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -573,7 +573,7 @@ func chooseDrive(ctx context.Context, name string, m configmap.Mapper, srv *rest
 					drives.Drives = append(drives.Drives, meDrive)
 				}
 			} else if drivesErr != nil {
-				return fs.ConfigError("choose_type", fmt.Sprintf("Failed to query available drives: /me/drives: %v; /me/drive: %v", drivesErr, meDriveErr))
+				return fs.ConfigError("driveid", fmt.Sprintf("Failed to query available drives: /me/drives: %v; /me/drive: %v\nEnter the drive ID manually instead", drivesErr, meDriveErr))
 			}
 		} else if drivesErr != nil {
 			return fs.ConfigError("choose_type", fmt.Sprintf("Failed to query available drives: %v", drivesErr))


### PR DESCRIPTION
#### What does this change do?

When drive enumeration fails during OneDrive config for "OneDrive Personal or Business" — both `/me/drives` and `/me/drive` returning an account-level error such as `403 accessDenied / serviceReadOnly ("Database Is Read Only")` — the config flow currently dead-ends at `choose_type` with the raw error, even though the drive itself is fully usable and only the enumeration API is blocked.

This change routes that failure to the **existing** manual drive ID entry state (`driveid`, which already prompts for a Drive ID and defaults to any previously configured `drive_id`), so affected users can complete configuration by supplying their drive ID directly.

A note on the error format: the issue's debug log (rclone v1.67.0) shows the older single-error message. On current master the same account-level failure fails both calls and takes the combined-error branch this PR modifies. Reporter: it would be great if you could confirm the fallback engages for your account on a build of this branch.

#### Linked issue

Fixes #9794

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [ ] I have added tests for all changes in this PR if appropriate. *(No test added: the config state machine's drive-enumeration fallback isn't covered by the unit suite, and reproducing requires an account in the serviceReadOnly state. The affected package tests pass unchanged.)*
- [ ] I have added documentation for the changes if appropriate. *(No user-facing docs change: the fallback reuses the existing documented manual drive ID prompt.)*
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` — config-flow change only; no API surface or transfer-path change, so integration behaviour is unaffected.
- [x] This Pull Request is ready for review.
