### PR TITLE
protondrive: fall back to decrypted-name search when the name-hash lookup misses

### DIFF
--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -663,6 +663,44 @@ func (f *Fs) NewObject(ctx context.Context, remote string) (fs.Object, error) {
 	return f.newObject(ctx, remote)
 }
 
+// searchByNameInFolderByID looks for a file or folder named leaf in the
+// folder with ID folderLinkID, returning nil if it can't be found.
+//
+// The API-side search matches children by their legacy name hash, but
+// links written by newer Proton clients carry a hash in a different
+// format which never matches. When the hash search finds nothing, fall
+// back to listing the folder and comparing the decrypted names.
+func (f *Fs) searchByNameInFolderByID(ctx context.Context, folderLinkID, leaf string, searchFile, searchFolder bool) (*proton.Link, error) {
+	var link *proton.Link
+	var err error
+	if err = f.pacer.Call(func() (bool, error) {
+		link, err = f.protonDrive.SearchByNameInActiveFolderByID(ctx, folderLinkID, leaf, searchFile, searchFolder, proton.LinkStateActive)
+		return shouldRetry(ctx, err)
+	}); err != nil {
+		return nil, err
+	}
+	if link != nil {
+		return link, nil
+	}
+
+	var foldersAndFiles []*protonDriveAPI.ProtonDirectoryData
+	if err = f.pacer.Call(func() (bool, error) {
+		foldersAndFiles, err = f.protonDrive.ListDirectory(ctx, folderLinkID)
+		return shouldRetry(ctx, err)
+	}); err != nil {
+		return nil, err
+	}
+	for _, entry := range foldersAndFiles {
+		if entry.Name != leaf {
+			continue
+		}
+		if (entry.IsFolder && searchFolder) || (!entry.IsFolder && searchFile) {
+			return entry.Link, nil
+		}
+	}
+	return nil, nil
+}
+
 func (f *Fs) getObjectLink(ctx context.Context, remote string) (*proton.Link, error) {
 	// attempt to locate the file
 	leaf, folderLinkID, err := f.dirCache.FindPath(ctx, f.sanitizePath(remote), false)
@@ -675,11 +713,8 @@ func (f *Fs) getObjectLink(ctx context.Context, remote string) (*proton.Link, er
 		return nil, err
 	}
 
-	var link *proton.Link
-	if err = f.pacer.Call(func() (bool, error) {
-		link, err = f.protonDrive.SearchByNameInActiveFolderByID(ctx, folderLinkID, leaf, true, false, proton.LinkStateActive)
-		return shouldRetry(ctx, err)
-	}); err != nil {
+	link, err := f.searchByNameInFolderByID(ctx, folderLinkID, leaf, true, false)
+	if err != nil {
 		return nil, err
 	}
 	if link == nil { // both link and err are nil, file not found
@@ -796,12 +831,8 @@ func (f *Fs) List(ctx context.Context, dir string) (fs.DirEntries, error) {
 func (f *Fs) FindLeaf(ctx context.Context, pathID, leaf string) (string, bool, error) {
 	/* f.opt.Enc.FromStandardName(leaf) not required since the DirCache only process sanitized path */
 
-	var link *proton.Link
-	var err error
-	if err = f.pacer.Call(func() (bool, error) {
-		link, err = f.protonDrive.SearchByNameInActiveFolderByID(ctx, pathID, leaf, false, true, proton.LinkStateActive)
-		return shouldRetry(ctx, err)
-	}); err != nil {
+	link, err := f.searchByNameInFolderByID(ctx, pathID, leaf, false, true)
+	if err != nil {
 		return "", false, err
 	}
 	if link == nil {


### PR DESCRIPTION
#### What does this change do?

Files and folders created by newer Proton Drive clients (3.x) could not be found by rclone: the API-side `SearchByNameInActiveFolderByID` matches children by their legacy name hash, and links written by new clients carry a hash in a different format which never matches, so lookups returned not-found for entries that clearly exist.

This adds a fallback: when the hash search misses, list the folder and compare the decrypted names directly. `getObjectLink` and `FindLeaf` both go through the new helper, so object lookup and directory traversal are covered. Entries created by old clients resolve exactly as before (the fallback only runs when the hash search returns nothing).

**Deliberately not addressed here — input wanted:** #9622 also reports that *uploading a new revision* to files created by new clients fails, because their content session key decrypts but can't be used for encryption ("bad key length" from gopenpgp). I considered trashing the old link on that error and recreating the file with a fresh key, but that silently destroys the file's revision history, and detecting the condition means string-matching the error — both felt like decisions the maintainers should make. Options I can see: (a) trash-and-recreate (loses revisions, transparent to the user), (b) surface a clearer actionable error telling the user to re-upload, (c) fix key handling upstream in the Proton API library. Happy to implement whichever direction you prefer in a follow-up.

#### Linked issue

Fixes #9622

#### For new or changed backends

I could not run `test_all` for protondrive — I don't have a Proton test account. `go build` / `go vet` / the package tests pass locally. Happy to work through integration issues if the daily tester flags anything.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [ ] I have added tests for all changes in this PR if appropriate. *(The fallback needs a live Proton remote to exercise; no protondrive unit-test harness exists in-tree.)*
- [ ] I have added documentation for the changes if appropriate. *(Behavior fix, no user-facing option changes.)*
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend — see note above.
- [x] This Pull Request is ready for review.
