### PR TITLE
bisync: fix failed transfers of empty files being recorded as synced

### DIFF
--- a/cmd/bisync/listing.go
+++ b/cmd/bisync/listing.go
@@ -675,7 +675,7 @@ func (b *bisyncRun) modifyListing(ctx context.Context, src fs.Fs, dst fs.Fs, res
 			b.debugFn(tr.Name, func() {
 				prettyprint(tr, tr.Name, fs.LogLevelInfo)
 			})
-			if tr.Error == nil && tr.Bytes > 0 || tr.Size <= 0 {
+			if tr.Error == nil && (tr.Bytes > 0 || tr.Size <= 0) {
 				prettyprint(tr, "keeping: "+tr.Name, fs.LogLevelDebug)
 				toKeep = append(toKeep, tr.Name)
 			}


### PR DESCRIPTION
When bisync is interrupted with a graceful shutdown it keeps the files
which transferred successfully in its listings and rolls the rest back.
An operator precedence mistake in that check meant a transfer of an
empty file (or one of unknown size) was kept even when it had failed,
so bisync recorded it as synced when it had not been.
