### PR TITLE
s3: preserve system metadata when setting the modification time

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -3263,6 +3263,23 @@ func (f *Fs) Copy(ctx context.Context, src fs.Object, remote string) (fs.Object,
 		f.opt.ObjectLockLegalHoldStatus != ""
 	if needsReplace {
 		req.MetadataDirective = types.MetadataDirectiveReplace
+		// REPLACE discards whatever is not supplied, so when it was not
+		// --metadata that forced it, carry the source values over.
+		if !ci.Metadata {
+			err = srcObj.readMetaData(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read source metadata: %w", err)
+			}
+			req.CacheControl = srcObj.cacheControl
+			req.ContentDisposition = srcObj.contentDisposition
+			req.ContentEncoding = srcObj.contentEncoding
+			req.ContentLanguage = srcObj.contentLanguage
+			for k, v := range srcObj.meta {
+				if _, found := req.Metadata[k]; !found {
+					req.Metadata[k] = v
+				}
+			}
+		}
 	}
 
 	err = f.copy(ctx, &req, dstBucket, dstPath, srcBucket, srcPath, srcObj)

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -4314,11 +4314,24 @@ func (o *Object) SetModTime(ctx context.Context, modTime time.Time) error {
 	}
 
 	// Copy the object to itself to update the metadata
+	//
+	// This needs the REPLACE directive as the modification time lives in the
+	// user metadata, and REPLACE drops any system metadata not supplied here.
 	bucket, bucketPath := o.split()
 	req := s3.CopyObjectInput{
-		ContentType:       aws.String(fs.MimeType(ctx, o)), // Guess the content type
-		Metadata:          mapToS3Metadata(o.meta),
-		MetadataDirective: types.MetadataDirectiveReplace, // replace metadata with that passed in
+		ContentType:        aws.String(fs.MimeType(ctx, o)), // Guess the content type
+		Metadata:           mapToS3Metadata(o.meta),
+		MetadataDirective:  types.MetadataDirectiveReplace, // replace metadata with that passed in
+		CacheControl:       o.cacheControl,
+		ContentDisposition: o.contentDisposition,
+		ContentEncoding:    o.contentEncoding,
+		ContentLanguage:    o.contentLanguage,
+	}
+	// AWS omits x-amz-storage-class from HEAD responses for STANDARD
+	// objects, so an unknown class has to be sent as STANDARD to stop
+	// f.copy applying the configured storage class instead.
+	if o.storageClass != nil || o.fs.opt.StorageClass != "" {
+		req.StorageClass = types.StorageClass(o.GetTier())
 	}
 	if o.fs.opt.RequesterPays {
 		req.RequestPayer = types.RequestPayerRequester

--- a/backend/s3/s3_internal_test.go
+++ b/backend/s3/s3_internal_test.go
@@ -883,6 +883,57 @@ func (f *Fs) InternalTestObjectLock(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, "GOVERNANCE", gotMetadata["object-lock-mode"])
 	})
+
+	t.Run("CopyMetadata", func(t *testing.T) {
+		// Impossible Cloud silently drops cache-control,
+		// content-disposition, content-encoding and content-language
+		// system metadata on retrieval.
+		if f.opt.Provider == "ImpossibleCloud" {
+			t.Skip("Impossible Cloud does not preserve all S3 system metadata")
+		}
+		if f.features.Copy == nil {
+			t.Skip("provider can't copy server side")
+		}
+		contents := gz(t, random.String(100))
+		metadata := fs.Metadata{
+			"cache-control":       "no-cache",
+			"content-disposition": "inline",
+			"content-encoding":    "gzip",
+			"content-language":    "en-US",
+		}
+		// Cloudflare insists on decompressing `Content-Encoding: gzip`
+		// unless `Cache-Control: no-transform` is supplied, as in
+		// InternalTestMetadata above.
+		if f.opt.Provider == "Cloudflare" {
+			metadata["cache-control"] = "no-transform"
+		}
+		item := fstest.NewItem("test-object-lock-copy-src", contents, fstest.Time("2001-05-06T04:05:06.499999999Z"))
+		src := fstests.PutTestContentsMetadata(ctx, t, f, &item, true, contents, true, "text/plain", metadata)
+		defer func() {
+			removeLocked(t, src)
+		}()
+
+		// An Object Lock option makes Copy use the REPLACE metadata
+		// directive, which discards whatever is not supplied with the copy.
+		f.opt.ObjectLockMode = "GOVERNANCE"
+		f.opt.ObjectLockRetainUntilDate = retainUntilDate.Format(time.RFC3339)
+		defer func() {
+			f.opt.ObjectLockMode = ""
+			f.opt.ObjectLockRetainUntilDate = ""
+		}()
+
+		dst, err := f.Copy(ctx, src, "test-object-lock-copy-dst")
+		require.NoError(t, err)
+		defer func() {
+			removeLocked(t, dst)
+		}()
+
+		gotMetadata, err := dst.(*Object).Metadata(ctx)
+		require.NoError(t, err)
+		for _, k := range []string{"cache-control", "content-disposition", "content-encoding", "content-language"} {
+			assert.Equal(t, metadata[k], gotMetadata[k], "%s not preserved by copy", k)
+		}
+	})
 }
 
 func (f *Fs) InternalTest(t *testing.T) {

--- a/backend/s3/s3_internal_test.go
+++ b/backend/s3/s3_internal_test.go
@@ -130,6 +130,55 @@ func (f *Fs) InternalTestMetadata(t *testing.T) {
 	})
 }
 
+// InternalTestSetModTimeMetadata checks SetModTime preserves the system metadata
+func (f *Fs) InternalTestSetModTimeMetadata(t *testing.T) {
+	// SetModTime is a server side copy, so providers without Copy
+	// cannot set the modification time at all.
+	if f.features.Copy == nil {
+		t.Skip("provider can't set mod time without server side copy")
+	}
+	// Impossible Cloud silently drops cache-control,
+	// content-disposition, content-encoding and content-language
+	// system metadata on retrieval.
+	if f.opt.Provider == "ImpossibleCloud" {
+		t.Skip("Impossible Cloud does not preserve all S3 system metadata")
+	}
+	ctx := context.Background()
+	contents := gz(t, random.String(1000))
+
+	item := fstest.NewItem("test-setmodtime-metadata", contents, fstest.Time("2001-05-06T04:05:06.499999999Z"))
+	metadata := fs.Metadata{
+		"cache-control":       "no-cache",
+		"content-disposition": "inline",
+		"content-encoding":    "gzip",
+		"content-language":    "en-US",
+		"content-type":        "text/plain",
+	}
+	// Cloudflare insists on decompressing `Content-Encoding: gzip` unless
+	// `Cache-Control: no-transform` is supplied - see InternalTestMetadata.
+	if f.opt.Provider == "Cloudflare" {
+		metadata["cache-control"] = "no-transform"
+	}
+	obj := fstests.PutTestContentsMetadata(ctx, t, f, &item, true, contents, true, "text/plain", metadata)
+	defer func() {
+		assert.NoError(t, obj.Remove(ctx))
+	}()
+
+	newModTime := fstest.Time("2009-05-06T04:05:06.499999999Z")
+	require.NoError(t, obj.SetModTime(ctx, newModTime))
+
+	// Read back from the remote rather than trusting the cached object
+	checkObj, err := f.NewObject(ctx, item.Path)
+	require.NoError(t, err)
+	assert.True(t, newModTime.Equal(checkObj.ModTime(ctx)), fmt.Sprintf("want %v got %v", newModTime, checkObj.ModTime(ctx)))
+
+	gotMetadata, err := fs.GetMetadata(ctx, checkObj)
+	require.NoError(t, err)
+	for k, v := range metadata {
+		assert.Equal(t, v, gotMetadata[k], k)
+	}
+}
+
 func (f *Fs) InternalTestNoHead(t *testing.T) {
 	ctx := context.Background()
 	// Set NoHead for this test
@@ -838,6 +887,7 @@ func (f *Fs) InternalTestObjectLock(t *testing.T) {
 
 func (f *Fs) InternalTest(t *testing.T) {
 	t.Run("Metadata", f.InternalTestMetadata)
+	t.Run("SetModTimeMetadata", f.InternalTestSetModTimeMetadata)
 	t.Run("NoHead", f.InternalTestNoHead)
 	t.Run("NoHeadObjectCopy", f.InternalTestNoHeadObjectCopy)
 	t.Run("HasChildren", f.InternalTestHasChildren)


### PR DESCRIPTION
#### What does this change do?

`SetModTime` stores the modification time in the object's user metadata, so its
copy-to-self has to use the `REPLACE` metadata directive. `REPLACE` drops any system
metadata header not supplied with the copy, and the request only carried the content type.

So updating a modification time silently dropped `Cache-Control`,
`Content-Disposition`, `Content-Encoding` and `Content-Language`, and replaced the object's
storage class with `--s3-storage-class` or the account default rather than keeping the
class the object already had.

No extra request is needed to fix it, per the optimization @ncw noted on the issue:
`SetModTime` already calls `readMetaData`, which populates these fields, so they were in
hand and simply were not being passed to the copy. This passes them through.

New test `InternalTestSetModTimeMetadata` fails on master on all four headers.

#### Linked issue

Fixes #5243

#### For new or changed backends

`go run ./fstest/test_all -backends s3` against Minio:

```
SUMMARY
PASS: All tests finished OK in 16m40.021824416s
```

(s3 backend, fs/operations and fs/sync each with and without `-fast-list`, vfs,
cmd/gitannex, cmd/bisync.) Also `golangci-lint run ./backend/s3/...`, 0 issues.

#### Not changed here

The storage class is included because a modification time update resetting the tier is the
same wipe, but happy to drop those three lines if you would rather keep this to the headers
named in the issue. The `// Guess the content type` comment is now misleading, since
`fs.MimeType` prefers the object's own value, but it predates this change so I left it.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
