### PR TITLE
docs: drive: document Branding step needed to publish own client_id

### DIFF
--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -2029,6 +2029,15 @@ Scroll down and click "+ Add users". Add yourself as a test user and press save.
 9. Go to "Audience" and then click "PUBLISH APP" button and confirm.
    Add yourself as a test user if you haven't already.
 
+    (If the "PUBLISH APP" button is greyed out, Google now requires a
+    homepage URL and a privacy policy URL before publishing, even for a
+    personal single-user app. Go to "Branding" in the left panel, fill in
+    "Application home page" and "Application privacy policy link" - a free
+    GitHub Pages site is fine for these if you don't have a domain of your
+    own - then "Authorized domains" with the domain you used, and click
+    Save. Return to "Audience" and the "PUBLISH APP" button should now be
+    available.)
+
 10. Provide the noted client ID and client secret to rclone.
 
 11. Run the web-based authorization flow from within `rclone config`, by answering


### PR DESCRIPTION
#### What does this change do?

Google now requires an app homepage URL and privacy policy URL to be set on
the OAuth consent screen's "Branding" page before the "PUBLISH APP" button
becomes clickable — even for a personal single-user app. The existing
"Making your own client_id" instructions jumped straight to publishing in
step 9 without mentioning this, so the button appears greyed out with no
explanation of why.

This adds a note under step 9 pointing users to the "Branding" page to fill
in the homepage/privacy policy URLs and authorized domains (suggesting a
free GitHub Pages site as an option if they don't have their own domain),
then return to publish.

Confirmed against the root cause described in the linked forum thread:
https://forum.rclone.org/t/cant-configure-google-drive-client-id/54191/5

#### Linked issue

Fixes #9854

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [ ] I have added tests for all changes in this PR if appropriate. — N/A, docs-only change
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend... — N/A, not a backend change
- [x] This Pull Request is ready for review.
