### PR TITLE
s3: disable signing Accept-Encoding for Ceph and Linode

### DIFF
--- a/backend/s3/provider/Ceph.yaml
+++ b/backend/s3/provider/Ceph.yaml
@@ -19,3 +19,7 @@ quirks:
   force_path_style: true
   list_url_encode: false
   use_already_exists: false
+  # Ceph RGW (and reverse proxies such as Cloudflare in front of it) can
+  # mutate Accept-Encoding and break SigV4 when that header is signed.
+  # See: https://github.com/rclone/rclone/issues/8206
+  sign_accept_encoding: false

--- a/backend/s3/provider/Linode.yaml
+++ b/backend/s3/provider/Linode.yaml
@@ -24,3 +24,8 @@ endpoint:
   us-iad-10.linodeobjects.com: Washington, DC, US (us-iad-10)
 acl: {}
 bucket_acl: true
+quirks:
+  # Linode Object Storage is Ceph-backed; signing Accept-Encoding causes
+  # SignatureDoesNotMatch with rclone 1.68+. Match the Ceph quirk.
+  # See: https://github.com/rclone/rclone/issues/8206
+  sign_accept_encoding: false

--- a/docs/content/s3.md
+++ b/docs/content/s3.md
@@ -5159,6 +5159,12 @@ parameter `--s3-upload-cutoff 0` or put this in the config file as
 `upload_cutoff 0` to work around a bug which causes uploading of small
 files to fail.
 
+Rclone defaults `sign_accept_encoding` to false for the Ceph provider.
+That avoids `SignatureDoesNotMatch` errors when a reverse proxy (for
+example Cloudflare) rewrites the `Accept-Encoding` request header. You
+can override this with `--s3-sign-accept-encoding` / `sign_accept_encoding`
+if needed.
+
 Note also that Ceph sometimes puts `/` in the passwords it gives
 users.  If you read the secret access key using the command line tools
 you will get a JSON blob with the `/` escaped as `\/`.  Make sure you
@@ -7476,6 +7482,10 @@ access_key_id = ACCESS_KEY
 secret_access_key = SECRET_ACCESS_KEY
 endpoint = eu-central-1.linodeobjects.com
 ```
+
+Linode Object Storage is Ceph-backed. Rclone defaults
+`sign_accept_encoding` to false for this provider so SigV4 requests do
+not fail with `SignatureDoesNotMatch` (see the [Ceph](#ceph) section).
 
 ### Magalu {#magalu}
 


### PR DESCRIPTION
Fixes #8206

## Problem
From rclone 1.68+, SigV4 requests to Ceph RGW (and Linode Object Storage, which is Ceph-backed) can fail with `SignatureDoesNotMatch` when `Accept-Encoding` is included in the signature. This is especially common when a reverse proxy such as Cloudflare rewrites that header.

The confirmed workaround was `sign_accept_encoding = false`. @ncw suggested making that part of the Ceph provider quirks.

## Change
- Set `sign_accept_encoding: false` for the **Ceph** and **Linode** provider quirks (same approach as GCS)
- Document the default in the Ceph and Linode sections of `docs/content/s3.md`
