### PR TITLE
hashsum: add --download-if-missing flag - fixes #8996

### DIFF
--- a/cmd/hashsum/hashsum.go
+++ b/cmd/hashsum/hashsum.go
@@ -17,10 +17,11 @@ import (
 
 // Global hashsum flags for reuse in hashsum, md5sum, sha1sum
 var (
-	OutputBase64   = false
-	DownloadFlag   = false
-	HashsumOutfile = ""
-	ChecksumFile   = ""
+	OutputBase64          = false
+	DownloadFlag          = false
+	DownloadIfMissingFlag = false
+	HashsumOutfile        = ""
+	ChecksumFile          = ""
 )
 
 func init() {
@@ -29,12 +30,13 @@ func init() {
 	AddHashsumFlags(cmdFlags)
 }
 
-// AddHashsumFlags is a convenience function to add the command flags OutputBase64 and DownloadFlag to hashsum, md5sum, sha1sum
+// AddHashsumFlags is a convenience function to add the command flags OutputBase64, DownloadFlag, and DownloadIfMissingFlag to hashsum, md5sum, sha1sum
 func AddHashsumFlags(cmdFlags *pflag.FlagSet) {
 	flags.BoolVarP(cmdFlags, &OutputBase64, "base64", "", OutputBase64, "Output base64 encoded hashsum", "")
 	flags.StringVarP(cmdFlags, &HashsumOutfile, "output-file", "", HashsumOutfile, "Output hashsums to a file rather than the terminal", "")
 	flags.StringVarP(cmdFlags, &ChecksumFile, "checkfile", "C", ChecksumFile, "Validate hashes against a given SUM file instead of printing them", "")
 	flags.BoolVarP(cmdFlags, &DownloadFlag, "download", "", DownloadFlag, "Download the file and hash it locally; if this flag is not specified, the hash is requested from the remote", "")
+	flags.BoolVarP(cmdFlags, &DownloadIfMissingFlag, "download-if-missing", "", DownloadIfMissingFlag, "Download the file and hash it locally only if the remote doesn't provide a hash", "")
 }
 
 // GetHashsumOutput opens and closes the output file when using the output-file flag
@@ -91,7 +93,10 @@ md5sum/sha1sum tool.
 By default, the hash is requested from the remote.  If the hash is
 not supported by the remote, no hash will be returned.  With the
 download flag, the file will be downloaded from the remote and
-hashed locally enabling any hash for any remote.
+hashed locally enabling any hash for any remote.  With the
+download-if-missing flag, the hash will be requested from the remote
+first, and the file will only be downloaded if the remote cannot
+provide a hash.
 
 For the MD5 and SHA1 algorithms there are also dedicated commands,
 [md5sum](/commands/rclone_md5sum/) and [sha1sum](/commands/rclone_sha1sum/).
@@ -137,17 +142,17 @@ Note that hash names are case insensitive and values are output in lower case.`,
 		cmd.Run(false, false, command, func() error {
 			if ChecksumFile != "" {
 				fsum, sumFile := cmd.NewFsFile(ChecksumFile)
-				return operations.CheckSum(context.Background(), fsrc, fsum, sumFile, ht, nil, DownloadFlag)
+				return operations.CheckSum(context.Background(), fsrc, fsum, sumFile, ht, nil, DownloadFlag, DownloadIfMissingFlag)
 			}
 			if HashsumOutfile == "" {
-				return operations.HashLister(context.Background(), ht, OutputBase64, DownloadFlag, fsrc, nil)
+				return operations.HashLister(context.Background(), ht, OutputBase64, DownloadFlag, fsrc, nil, DownloadIfMissingFlag)
 			}
 			output, close, err := GetHashsumOutput(HashsumOutfile)
 			if err != nil {
 				return err
 			}
 			defer close()
-			return operations.HashLister(context.Background(), ht, OutputBase64, DownloadFlag, fsrc, output)
+			return operations.HashLister(context.Background(), ht, OutputBase64, DownloadFlag, fsrc, output, DownloadIfMissingFlag)
 		})
 		return nil
 	},

--- a/cmd/md5sum/md5sum.go
+++ b/cmd/md5sum/md5sum.go
@@ -26,7 +26,10 @@ is in the same format as the standard md5sum tool produces.
 By default, the hash is requested from the remote.  If MD5 is
 not supported by the remote, no hash will be returned.  With the
 download flag, the file will be downloaded from the remote and
-hashed locally enabling MD5 for any remote.
+hashed locally enabling MD5 for any remote.  With the
+download-if-missing flag, the hash will be requested from the remote
+first, and the file will only be downloaded if the remote cannot
+provide a hash.
 
 For other algorithms, see the [hashsum](/commands/rclone_hashsum/)
 command. Running ` + "`rclone md5sum remote:path`" + ` is equivalent
@@ -49,17 +52,17 @@ as a relative path).`,
 		cmd.Run(false, false, command, func() error {
 			if hashsum.ChecksumFile != "" {
 				fsum, sumFile := cmd.NewFsFile(hashsum.ChecksumFile)
-				return operations.CheckSum(context.Background(), fsrc, fsum, sumFile, hash.MD5, nil, hashsum.DownloadFlag)
+				return operations.CheckSum(context.Background(), fsrc, fsum, sumFile, hash.MD5, nil, hashsum.DownloadFlag, hashsum.DownloadIfMissingFlag)
 			}
 			if hashsum.HashsumOutfile == "" {
-				return operations.HashLister(context.Background(), hash.MD5, hashsum.OutputBase64, hashsum.DownloadFlag, fsrc, nil)
+				return operations.HashLister(context.Background(), hash.MD5, hashsum.OutputBase64, hashsum.DownloadFlag, fsrc, nil, hashsum.DownloadIfMissingFlag)
 			}
 			output, close, err := hashsum.GetHashsumOutput(hashsum.HashsumOutfile)
 			if err != nil {
 				return err
 			}
 			defer close()
-			return operations.HashLister(context.Background(), hash.MD5, hashsum.OutputBase64, hashsum.DownloadFlag, fsrc, output)
+			return operations.HashLister(context.Background(), hash.MD5, hashsum.OutputBase64, hashsum.DownloadFlag, fsrc, output, hashsum.DownloadIfMissingFlag)
 		})
 		return nil
 	},

--- a/cmd/sha1sum/sha1sum.go
+++ b/cmd/sha1sum/sha1sum.go
@@ -26,7 +26,10 @@ is in the same format as the standard sha1sum tool produces.
 By default, the hash is requested from the remote.  If SHA-1 is
 not supported by the remote, no hash will be returned.  With the
 download flag, the file will be downloaded from the remote and
-hashed locally enabling SHA-1 for any remote.
+hashed locally enabling SHA-1 for any remote.  With the
+download-if-missing flag, the hash will be requested from the remote
+first, and the file will only be downloaded if the remote cannot
+provide a hash.
 
 For other algorithms, see the [hashsum](/commands/rclone_hashsum/)
 command. Running ` + "`rclone sha1sum remote:path`" + ` is equivalent
@@ -52,17 +55,17 @@ a remote:path.`,
 		cmd.Run(false, false, command, func() error {
 			if hashsum.ChecksumFile != "" {
 				fsum, sumFile := cmd.NewFsFile(hashsum.ChecksumFile)
-				return operations.CheckSum(context.Background(), fsrc, fsum, sumFile, hash.SHA1, nil, hashsum.DownloadFlag)
+				return operations.CheckSum(context.Background(), fsrc, fsum, sumFile, hash.SHA1, nil, hashsum.DownloadFlag, hashsum.DownloadIfMissingFlag)
 			}
 			if hashsum.HashsumOutfile == "" {
-				return operations.HashLister(context.Background(), hash.SHA1, hashsum.OutputBase64, hashsum.DownloadFlag, fsrc, nil)
+				return operations.HashLister(context.Background(), hash.SHA1, hashsum.OutputBase64, hashsum.DownloadFlag, fsrc, nil, hashsum.DownloadIfMissingFlag)
 			}
 			output, close, err := hashsum.GetHashsumOutput(hashsum.HashsumOutfile)
 			if err != nil {
 				return err
 			}
 			defer close()
-			return operations.HashLister(context.Background(), hash.SHA1, hashsum.OutputBase64, hashsum.DownloadFlag, fsrc, output)
+			return operations.HashLister(context.Background(), hash.SHA1, hashsum.OutputBase64, hashsum.DownloadFlag, fsrc, output, hashsum.DownloadIfMissingFlag)
 		})
 		return nil
 	},

--- a/fs/operations/check.go
+++ b/fs/operations/check.go
@@ -406,7 +406,11 @@ func ToNormal(s string, normUnicode, normCase bool) string {
 }
 
 // CheckSum checks filesystem hashes against a SUM file
-func CheckSum(ctx context.Context, fsrc, fsum fs.Fs, sumFile string, hashType hash.Type, opt *CheckOpt, download bool) error {
+func CheckSum(ctx context.Context, fsrc, fsum fs.Fs, sumFile string, hashType hash.Type, opt *CheckOpt, download bool, downloadIfMissingOpt ...bool) error {
+	downloadIfMissing := false
+	if len(downloadIfMissingOpt) > 0 {
+		downloadIfMissing = downloadIfMissingOpt[0]
+	}
 	var options CheckOpt
 	if opt != nil {
 		options = *opt
@@ -419,7 +423,7 @@ func CheckSum(ctx context.Context, fsrc, fsum fs.Fs, sumFile string, hashType ha
 	options.Fdst = fsrc // denotes the file system to check
 	opt = &options      // override supplied argument
 
-	if !download && (hashType == hash.None || !opt.Fdst.Hashes().Contains(hashType)) {
+	if hashType == hash.None || (!download && !downloadIfMissing && !opt.Fdst.Hashes().Contains(hashType)) {
 		return fmt.Errorf("%s: hash type is not supported by file system: %s", hashType, opt.Fdst)
 	}
 
@@ -442,7 +446,7 @@ func CheckSum(ctx context.Context, fsrc, fsum fs.Fs, sumFile string, hashType ha
 		opt:    *opt,
 	}
 	lastErr := ListFn(ctx, opt.Fdst, func(obj fs.Object) {
-		c.checkSum(ctx, obj, download, hashes, hashType)
+		c.checkSum(ctx, obj, download, downloadIfMissing, hashes, hashType)
 	})
 	c.wg.Wait() // wait for background go-routines
 
@@ -470,7 +474,7 @@ func CheckSum(ctx context.Context, fsrc, fsum fs.Fs, sumFile string, hashType ha
 }
 
 // checkSum checks single object against golden hashes
-func (c *checkMarch) checkSum(ctx context.Context, obj fs.Object, download bool, hashes HashSums, hashType hash.Type) {
+func (c *checkMarch) checkSum(ctx context.Context, obj fs.Object, download, downloadIfMissing bool, hashes HashSums, hashType hash.Type) {
 	normalizedRemote := ApplyTransforms(ctx, obj.Remote())
 	c.ioMu.Lock()
 	sumHash, sumFound := hashes[normalizedRemote]
@@ -510,7 +514,13 @@ func (c *checkMarch) checkSum(ctx context.Context, obj fs.Object, download bool,
 		}()
 		if !download {
 			objHash, err = obj.Hash(ctx, hashType)
-			return
+			if !downloadIfMissing || (err == nil && objHash != "") {
+				return
+			}
+			if err != nil && err != hash.ErrUnsupported {
+				return
+			}
+			err = nil
 		}
 		if in, err = Open(ctx, obj); err != nil {
 			return

--- a/fs/operations/check_test.go
+++ b/fs/operations/check_test.go
@@ -659,6 +659,50 @@ func TestCheckSumDownloadConcurrency(t *testing.T) {
 	testCheckSumConcurrency(t, true)
 }
 
+func TestCheckSumDownloadIfMissing(t *testing.T) {
+	ctx := context.Background()
+	content := "check content"
+	contentHash := "f3800b0d78a087a9746efd98427d07f5" // MD5 of "check content"
+	sumFile := "sums.txt"
+
+	// Create sum fs
+	f, err := mockfs.NewFs(ctx, "sums", "sums", nil)
+	require.NoError(t, err)
+	fsum := f.(*mockfs.Fs)
+	sumLine := fmt.Sprintf("%s  file1.txt\n", contentHash)
+	fsum.AddObject(mockobject.New(sumFile).WithContent([]byte(sumLine), mockobject.SeekModeNone))
+
+	// 1. Remote provides hash directly -> passes without downloading
+	fsrcRaw, err := mockfs.NewFs(ctx, "src", "src", nil)
+	require.NoError(t, err)
+	fsrc := fsrcRaw.(*mockfs.Fs)
+	fsrc.SetHashes(hash.NewHashSet(hash.MD5))
+	probe := newHashProbe(t, 1, 5*time.Second)
+	o := mockobject.New("file1.txt").WithContent([]byte(content), mockobject.SeekModeNone)
+	probeObj := &probeObject{ContentMockObject: o, probe: probe}
+	fsrc.AddObject(probeObj)
+
+	opt := operations.CheckOpt{Combined: new(bytes.Buffer)}
+	accounting.GlobalStats().ResetCounters()
+	err = operations.CheckSum(ctx, fsrc, fsum, sumFile, hash.MD5, &opt, false, true)
+	require.NoError(t, err)
+
+	// 2. Remote filesystem does not support hash (e.g. SHA1 not in Hashes())
+	// Without downloadIfMissing: fails because hash type is not supported
+	accounting.GlobalStats().ResetCounters()
+	err = operations.CheckSum(ctx, fsrc, fsum, sumFile, hash.SHA1, &opt, false, false)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "hash type is not supported by file system")
+
+	// With downloadIfMissing: succeeds by downloading and hashing!
+	sha1SumLine := "b6be4fc269390ae2ea2faee27167f506f814cae8  file1.txt\n"
+	sha1SumFile := "sums-sha1.txt"
+	fsum.AddObject(mockobject.New(sha1SumFile).WithContent([]byte(sha1SumLine), mockobject.SeekModeNone))
+	accounting.GlobalStats().ResetCounters()
+	err = operations.CheckSum(ctx, fsrc, fsum, sha1SumFile, hash.SHA1, &opt, false, true)
+	require.NoError(t, err)
+}
+
 func TestApplyTransforms(t *testing.T) {
 	var (
 		hashType        = hash.MD5

--- a/fs/operations/operations.go
+++ b/fs/operations/operations.go
@@ -892,72 +892,86 @@ func ListLong(ctx context.Context, f fs.Fs, w io.Writer) error {
 	})
 }
 
-// HashSum returns the human-readable hash for ht passed in.  This may
-// be UNSUPPORTED or ERROR. If it isn't returning a valid hash it will
-// return an error.
-func HashSum(ctx context.Context, ht hash.Type, base64Encoded bool, downloadFlag bool, o fs.Object) (string, error) {
+// downloadAndHash downloads the file and hashes it locally
+func downloadAndHash(ctx context.Context, ht hash.Type, base64Encoded bool, o fs.Object) (string, error) {
+	// Setup: Define accounting, open the file with NewReOpen to provide restarts, account for the transfer, and setup a multi-hasher with the appropriate type
+	// Execution: io.Copy file to hasher, get hash and encode in hex
+
 	var sum string
 	var err error
 
-	// If downloadFlag is true, download and hash the file.
-	// If downloadFlag is false, call o.Hash asking the remote for the hash
+	tr := accounting.Stats(ctx).NewTransfer(o, nil)
+	defer func() {
+		tr.Done(ctx, err)
+	}()
+
+	// Open with NewReOpen to provide restarts
+	var options []fs.OpenOption
+	for _, option := range fs.GetConfig(ctx).DownloadHeaders {
+		options = append(options, option)
+	}
+	var in io.ReadCloser
+	in, err = Open(ctx, o, options...)
+	if err != nil {
+		return "ERROR", fmt.Errorf("failed to open file %v: %w", o, err)
+	}
+
+	// Account and buffer the transfer
+	in = tr.Account(ctx, in).WithBuffer()
+
+	// Setup hasher
+	hasher, err := hash.NewMultiHasherTypes(hash.NewHashSet(ht))
+	if err != nil {
+		return "UNSUPPORTED", fmt.Errorf("hash unsupported: %w", err)
+	}
+
+	// Copy to hasher, downloading the file and passing directly to hash
+	_, err = io.Copy(hasher, in)
+	if err != nil {
+		return "ERROR", fmt.Errorf("failed to copy file to hasher: %w", err)
+	}
+
+	// Get hash as hex or base64 encoded string
+	sum, err = hasher.SumString(ht, base64Encoded)
+	if err != nil {
+		return "ERROR", fmt.Errorf("hasher returned an error: %w", err)
+	}
+
+	return sum, nil
+}
+
+// HashSum returns the human-readable hash for ht passed in.  This may
+// be UNSUPPORTED or ERROR. If it isn't returning a valid hash it will
+// return an error.
+// If downloadIfMissingOpt is true, the hash is requested from the remote first
+// and downloaded only if the remote cannot provide a hash.
+func HashSum(ctx context.Context, ht hash.Type, base64Encoded bool, downloadFlag bool, o fs.Object, downloadIfMissingOpt ...bool) (string, error) {
 	if downloadFlag {
-		// Setup: Define accounting, open the file with NewReOpen to provide restarts, account for the transfer, and setup a multi-hasher with the appropriate type
-		// Execution: io.Copy file to hasher, get hash and encode in hex
+		return downloadAndHash(ctx, ht, base64Encoded, o)
+	}
 
-		tr := accounting.Stats(ctx).NewTransfer(o, nil)
-		defer func() {
-			tr.Done(ctx, err)
-		}()
+	downloadIfMissing := false
+	if len(downloadIfMissingOpt) > 0 {
+		downloadIfMissing = downloadIfMissingOpt[0]
+	}
 
-		// Open with NewReOpen to provide restarts
-		var options []fs.OpenOption
-		for _, option := range fs.GetConfig(ctx).DownloadHeaders {
-			options = append(options, option)
-		}
-		var in io.ReadCloser
-		in, err = Open(ctx, o, options...)
-		if err != nil {
-			return "ERROR", fmt.Errorf("failed to open file %v: %w", o, err)
-		}
+	tr := accounting.Stats(ctx).NewCheckingTransfer(o, "hashing")
+	sum, err := o.Hash(ctx, ht)
+	if downloadIfMissing && ((err == nil && sum == "") || err == hash.ErrUnsupported) {
+		tr.Done(ctx, nil)
+		return downloadAndHash(ctx, ht, base64Encoded, o)
+	}
+	tr.Done(ctx, err)
 
-		// Account and buffer the transfer
-		in = tr.Account(ctx, in).WithBuffer()
-
-		// Setup hasher
-		hasher, err := hash.NewMultiHasherTypes(hash.NewHashSet(ht))
-		if err != nil {
-			return "UNSUPPORTED", fmt.Errorf("hash unsupported: %w", err)
-		}
-
-		// Copy to hasher, downloading the file and passing directly to hash
-		_, err = io.Copy(hasher, in)
-		if err != nil {
-			return "ERROR", fmt.Errorf("failed to copy file to hasher: %w", err)
-		}
-
-		// Get hash as hex or base64 encoded string
-		sum, err = hasher.SumString(ht, base64Encoded)
-		if err != nil {
-			return "ERROR", fmt.Errorf("hasher returned an error: %w", err)
-		}
-	} else {
-		tr := accounting.Stats(ctx).NewCheckingTransfer(o, "hashing")
-		defer func() {
-			tr.Done(ctx, err)
-		}()
-
-		sum, err = o.Hash(ctx, ht)
-		if base64Encoded {
-			hexBytes, _ := hex.DecodeString(sum)
-			sum = base64.URLEncoding.EncodeToString(hexBytes)
-		}
-		if err == hash.ErrUnsupported {
-			return "", fmt.Errorf("hash unsupported: %w", err)
-		}
-		if err != nil {
-			return "", fmt.Errorf("failed to get hash %v from backend: %w", ht, err)
-		}
+	if base64Encoded {
+		hexBytes, _ := hex.DecodeString(sum)
+		sum = base64.URLEncoding.EncodeToString(hexBytes)
+	}
+	if err == hash.ErrUnsupported {
+		return "", fmt.Errorf("hash unsupported: %w", err)
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get hash %v from backend: %w", ht, err)
 	}
 
 	return sum, nil
@@ -966,11 +980,15 @@ func HashSum(ctx context.Context, ht hash.Type, base64Encoded bool, downloadFlag
 // HashLister does an md5sum equivalent for the hash type passed in
 // Updated to handle both standard hex encoding and base64
 // Updated to perform multiple hashes concurrently
-func HashLister(ctx context.Context, ht hash.Type, outputBase64 bool, downloadFlag bool, f fs.Fs, w io.Writer) error {
+func HashLister(ctx context.Context, ht hash.Type, outputBase64 bool, downloadFlag bool, f fs.Fs, w io.Writer, downloadIfMissingOpt ...bool) error {
+	downloadIfMissing := false
+	if len(downloadIfMissingOpt) > 0 {
+		downloadIfMissing = downloadIfMissingOpt[0]
+	}
 	width := hash.Width(ht, outputBase64)
 	// Use --checkers concurrency unless downloading in which case use --transfers
 	concurrency := fs.GetConfig(ctx).Checkers
-	if downloadFlag {
+	if downloadFlag || downloadIfMissing {
 		concurrency = fs.GetConfig(ctx).Transfers
 	}
 	concurrencyControl := make(chan struct{}, concurrency)
@@ -983,7 +1001,7 @@ func HashLister(ctx context.Context, ht hash.Type, outputBase64 bool, downloadFl
 				<-concurrencyControl
 				wg.Done()
 			}()
-			sum, err := HashSum(ctx, ht, outputBase64, downloadFlag, o)
+			sum, err := HashSum(ctx, ht, outputBase64, downloadFlag, o, downloadIfMissing)
 			if err != nil {
 				fs.Errorf(o, "%v", fs.CountError(ctx, err))
 				return

--- a/fs/operations/operations_test.go
+++ b/fs/operations/operations_test.go
@@ -44,6 +44,7 @@ import (
 	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/fstest/fstests"
+	"github.com/rclone/rclone/fstest/mockobject"
 	"github.com/rclone/rclone/lib/pacer"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -312,6 +313,114 @@ func TestHashSumsWithErrors(t *testing.T) {
 	// ERROR must not appear in the output either
 	assert.NotContains(t, buf.String(), " ERROR ")
 	// TODO mock an unreadable file
+}
+
+type testMockDownloadObject struct {
+	*mockobject.ContentMockObject
+	hashFn    func(ctx context.Context, ht hash.Type) (string, error)
+	openCount int
+}
+
+func (m *testMockDownloadObject) Hash(ctx context.Context, ht hash.Type) (string, error) {
+	if m.hashFn != nil {
+		return m.hashFn(ctx, ht)
+	}
+	return m.ContentMockObject.Hash(ctx, ht)
+}
+
+func (m *testMockDownloadObject) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
+	m.openCount++
+	return m.ContentMockObject.Open(ctx, options...)
+}
+
+func TestHashSumDownloadIfMissing(t *testing.T) {
+	ctx := context.Background()
+
+	// 1. When remote provides a hash, it should NOT download
+	mockObj := &testMockDownloadObject{
+		ContentMockObject: mockobject.New("test.txt").WithContent([]byte("hello world"), mockobject.SeekModeNone),
+		hashFn: func(ctx context.Context, ht hash.Type) (string, error) {
+			return "remote-hash-1234", nil
+		},
+	}
+	sum, err := operations.HashSum(ctx, hash.MD5, false, false, mockObj, true)
+	require.NoError(t, err)
+	assert.Equal(t, "remote-hash-1234", sum)
+	assert.Equal(t, 0, mockObj.openCount) // Must not download
+
+	// 2. When remote returns empty hash (""), it SHOULD download if flag is true
+	mockObjEmpty := &testMockDownloadObject{
+		ContentMockObject: mockobject.New("test.txt").WithContent([]byte("hello world"), mockobject.SeekModeNone),
+		hashFn: func(ctx context.Context, ht hash.Type) (string, error) {
+			return "", nil
+		},
+	}
+	// Without downloadIfMissing
+	sum, err = operations.HashSum(ctx, hash.MD5, false, false, mockObjEmpty, false)
+	require.NoError(t, err)
+	assert.Equal(t, "", sum)
+	assert.Equal(t, 0, mockObjEmpty.openCount)
+
+	// With downloadIfMissing
+	sum, err = operations.HashSum(ctx, hash.MD5, false, false, mockObjEmpty, true)
+	require.NoError(t, err)
+	assert.Equal(t, "5eb63bbbe01eeed093cb22bb8f5acdc3", sum) // MD5 of "hello world"
+	assert.Equal(t, 1, mockObjEmpty.openCount)               // Downloaded!
+
+	// 3. When remote returns hash.ErrUnsupported, it SHOULD download if flag is true
+	mockObjUnsupported := &testMockDownloadObject{
+		ContentMockObject: mockobject.New("test.txt").WithContent([]byte("hello world"), mockobject.SeekModeNone),
+		hashFn: func(ctx context.Context, ht hash.Type) (string, error) {
+			return "", hash.ErrUnsupported
+		},
+	}
+	// Without downloadIfMissing
+	_, err = operations.HashSum(ctx, hash.MD5, false, false, mockObjUnsupported, false)
+	require.Error(t, err)
+	assert.Equal(t, 0, mockObjUnsupported.openCount)
+
+	// With downloadIfMissing
+	sum, err = operations.HashSum(ctx, hash.MD5, false, false, mockObjUnsupported, true)
+	require.NoError(t, err)
+	assert.Equal(t, "5eb63bbbe01eeed093cb22bb8f5acdc3", sum)
+	assert.Equal(t, 1, mockObjUnsupported.openCount) // Downloaded!
+
+	// 4. When remote returns an unexpected error, it should NOT download
+	mockObjErr := &testMockDownloadObject{
+		ContentMockObject: mockobject.New("test.txt").WithContent([]byte("hello world"), mockobject.SeekModeNone),
+		hashFn: func(ctx context.Context, ht hash.Type) (string, error) {
+			return "", errors.New("backend disk failure")
+		},
+	}
+	_, err = operations.HashSum(ctx, hash.MD5, false, false, mockObjErr, true)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "backend disk failure")
+	assert.Equal(t, 0, mockObjErr.openCount)
+
+	// 5. Test HashLister end-to-end with memory FS (supports MD5, unsupported SHA1)
+	memFs, err := fs.NewFs(ctx, ":memory:")
+	require.NoError(t, err)
+	content := "-"
+	item1 := fstest.NewItem("file1", content, t1)
+	_ = fstests.PutTestContents(ctx, t, memFs, &item1, content, true)
+
+	// HashLister SHA1 without downloadIfMissing -> empty output
+	buf := &bytes.Buffer{}
+	err = operations.HashLister(ctx, hash.SHA1, false, false, memFs, buf, false)
+	require.NoError(t, err)
+	assert.Empty(t, buf.String())
+
+	// HashLister SHA1 with downloadIfMissing -> downloaded and computed
+	buf.Reset()
+	err = operations.HashLister(ctx, hash.SHA1, false, false, memFs, buf, true)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "3bc15c8aae3e4124dd409035f32ea2fd6835efc9  file1\n")
+
+	// HashLister MD5 with downloadIfMissing -> remote provides hash
+	buf.Reset()
+	err = operations.HashLister(ctx, hash.MD5, false, false, memFs, buf, true)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "336d5ebc5436534e61d16e63ddfca327  file1\n")
 }
 
 func TestHashStream(t *testing.T) {


### PR DESCRIPTION
#### What is the purpose of this change?

Adds an opt-in `--download-if-missing` flag to `hashsum`, `md5sum`, and `sha1sum`.

Previously, users had to choose between requesting hashes from the remote (which skips files if the remote does not calculate that hash) and `--download` (which downloads and re-hashes every file, even those where the remote already had a valid hash).

With `--download-if-missing`, rclone queries the remote for the hash first and only downloads the file to calculate the checksum locally if the remote returns an empty hash or `hash.ErrUnsupported`.

#### Was the change discussed in an issue or in the forum before?

Fixes #8996

#### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md)
- [x] Added `download-if-missing` flag and documentation for `hashsum`, `md5sum`, and `sha1sum`
- [x] Added unit tests for `HashSum`, `HashLister`, and `CheckSum` with `download-if-missing`
- [x] All tests and linters pass locally
