### PR TITLE
touch: parse documented timestamp formats

### DIFF
--- a/cmd/touch/touch.go
+++ b/cmd/touch/touch.go
@@ -26,9 +26,18 @@ var (
 
 const (
 	defaultLayout          string = "060102"
+	layoutDate             string = "2006-01-02"
 	layoutDateWithTime     string = "2006-01-02T15:04:05"
 	layoutDateWithTimeNano string = "2006-01-02T15:04:05.999999999"
 )
+
+var timeLayouts = []string{
+	time.RFC3339Nano,
+	layoutDateWithTimeNano,
+	layoutDateWithTime,
+	layoutDate,
+	defaultLayout,
+}
 
 func init() {
 	cmd.Root.AddCommand(commandDefinition)
@@ -56,9 +65,11 @@ This will touch ` + "`--transfers`" + ` files concurrently.
 If ` + "`--timestamp`" + ` is used then sets the modification time to that
 time instead of the current time. Times may be specified as one of:
 
-- 'YYMMDD' - e.g. 17.10.30
+- 'YYMMDD' - e.g. 171030
+- 'YYYY-MM-DD' - e.g. 2006-01-02
 - 'YYYY-MM-DDTHH:MM:SS' - e.g. 2006-01-02T15:04:05
 - 'YYYY-MM-DDTHH:MM:SS.SSS' - e.g. 2006-01-02T15:04:05.123456789
+- 'YYYY-MM-DDTHH:MM:SSZ' - e.g. 2006-01-02T15:04:05Z
 
 Note that value of ` + "`--timestamp`" + ` is in UTC. If you want local time
 then add the ` + "`--localtime`" + ` flag.
@@ -100,16 +111,19 @@ func newFsDst(args []string) (f fs.Fs, remote string) {
 
 // parseTimeArgument parses a timestamp string according to specific layouts
 func parseTimeArgument(timeString string) (time.Time, error) {
-	layout := defaultLayout
-	if len(timeString) == len(layoutDateWithTime) {
-		layout = layoutDateWithTime
-	} else if len(timeString) > len(layoutDateWithTime) {
-		layout = layoutDateWithTimeNano
+	var err error
+	for _, layout := range timeLayouts {
+		var t time.Time
+		if localTime {
+			t, err = time.ParseInLocation(layout, timeString, time.Local)
+		} else {
+			t, err = time.Parse(layout, timeString)
+		}
+		if err == nil {
+			return t, nil
+		}
 	}
-	if localTime {
-		return time.ParseInLocation(layout, timeString, time.Local)
-	}
-	return time.Parse(layout, timeString)
+	return time.Time{}, err
 }
 
 // timeOfTouch returns the time value set on files

--- a/cmd/touch/touch_test.go
+++ b/cmd/touch/touch_test.go
@@ -3,6 +3,7 @@ package touch
 import (
 	"context"
 	"testing"
+	"time"
 
 	_ "github.com/rclone/rclone/backend/local"
 	"github.com/rclone/rclone/fs"
@@ -19,6 +20,32 @@ func checkFile(t *testing.T, r fs.Fs, path string, content string) {
 	require.NoError(t, err)
 	file1 := fstest.NewItem(path, content, timeAtrFromFlags)
 	fstest.CheckItems(t, r, file1)
+}
+
+func TestParseTimeArgument(t *testing.T) {
+	oldLocalTime := localTime
+	localTime = false
+	t.Cleanup(func() {
+		localTime = oldLocalTime
+	})
+
+	for _, test := range []struct {
+		in   string
+		want time.Time
+	}{
+		{"171030", fstest.Time("2017-10-30T00:00:00Z")},
+		{"2024-05-01", fstest.Time("2024-05-01T00:00:00Z")},
+		{"2024-05-01T12:00:00", fstest.Time("2024-05-01T12:00:00Z")},
+		{"2024-05-01T12:00:00.123456789", fstest.Time("2024-05-01T12:00:00.123456789Z")},
+		{"2024-05-01T12:00:00Z", fstest.Time("2024-05-01T12:00:00Z")},
+		{"2024-05-01T12:00:00.123456789Z", fstest.Time("2024-05-01T12:00:00.123456789Z")},
+	} {
+		t.Run(test.in, func(t *testing.T) {
+			got, err := parseTimeArgument(test.in)
+			require.NoError(t, err)
+			require.Equal(t, test.want, got)
+		})
+	}
 }
 
 // TestMain drives the tests

--- a/docs/content/commands/rclone_touch.md
+++ b/docs/content/commands/rclone_touch.md
@@ -24,9 +24,11 @@ This will touch `--transfers` files concurrently.
 If `--timestamp` is used then sets the modification time to that
 time instead of the current time. Times may be specified as one of:
 
-- 'YYMMDD' - e.g. 17.10.30
+- 'YYMMDD' - e.g. 171030
+- 'YYYY-MM-DD' - e.g. 2006-01-02
 - 'YYYY-MM-DDTHH:MM:SS' - e.g. 2006-01-02T15:04:05
 - 'YYYY-MM-DDTHH:MM:SS.SSS' - e.g. 2006-01-02T15:04:05.123456789
+- 'YYYY-MM-DDTHH:MM:SSZ' - e.g. 2006-01-02T15:04:05Z
 
 Note that value of `--timestamp` is in UTC. If you want local time
 then add the `--localtime` flag.


### PR DESCRIPTION
#### What does this change do?

`rclone touch --timestamp` now tries the supported timestamp layouts explicitly instead of choosing a layout from the input length.

This accepts the documented dotted `YY.MM.DD` form, keeps the existing compact `YYMMDD` form, and adds support for date-only `YYYY-MM-DD` and RFC3339 timestamps with a trailing `Z`. The command help now lists these accepted forms.

#### Linked issue

Fixes #9861

#### For new or changed backends

N/A - this is a command-only change.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** N/A - this is not a backend change.
- [x] This Pull Request is ready for review.

Tests:

- `go test -v ./cmd/touch`
- `go build`
- `./rclone touch /tmp/rclone-touch-9861-dot --timestamp 17.10.30 -vv`
- `./rclone touch /tmp/rclone-touch-9861-date --timestamp 2024-05-01 -vv`
- `./rclone touch /tmp/rclone-touch-9861-rfc3339 --timestamp 2024-05-01T12:00:00Z -vv`
