### PR TITLE
drive: unlink shared files on delete permission errors

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -2728,8 +2728,23 @@ func (f *Fs) DirSetModTime(ctx context.Context, dir string, modTime time.Time) e
 	return o.SetModTime(ctx, modTime)
 }
 
-// delete a file or directory unconditionally by ID
+// delete a file or directory unconditionally by ID.
+//
+// Shared files that the user can see but not delete return 403
+// insufficientFilePermissions. In that case fall back to removing the
+// file from its parent folder (unlinking) instead of deleting the
+// underlying owned object. See https://github.com/rclone/rclone/issues/3998
 func (f *Fs) delete(ctx context.Context, id string, useTrash bool) error {
+	err := f.deleteOwned(ctx, id, useTrash)
+	if err == nil || !isInsufficientFilePermissions(err) {
+		return err
+	}
+	fs.Debugf(f, "delete of %s forbidden (%v); unlinking from parent instead", id, err)
+	return f.unlinkFromParents(ctx, id)
+}
+
+// deleteOwned trashes or permanently deletes a Drive file by ID.
+func (f *Fs) deleteOwned(ctx context.Context, id string, useTrash bool) error {
 	return f.pacer.Call(func() (bool, error) {
 		var err error
 		if useTrash {
@@ -2748,6 +2763,67 @@ func (f *Fs) delete(ctx context.Context, id string, useTrash bool) error {
 		}
 		return f.shouldRetry(ctx, err)
 	})
+}
+
+// unlinkFromParents removes id from its Drive parent folders.
+//
+// This is used when the user cannot delete the owned file (shared with
+// them) but can remove it from a folder they can write to.
+func (f *Fs) unlinkFromParents(ctx context.Context, id string) error {
+	info, err := f.getFile(ctx, id, "id,parents")
+	if err != nil {
+		return fmt.Errorf("can't unlink shared file %s: %w", id, err)
+	}
+	parentID, err := chooseUnlinkParent(id, info.Parents)
+	if err != nil {
+		return err
+	}
+	return f.unlinkFromParent(ctx, id, parentID)
+}
+
+// chooseUnlinkParent picks the single parent folder to remove id from.
+func chooseUnlinkParent(id string, parents []string) (string, error) {
+	if len(parents) == 0 {
+		return "", fmt.Errorf("can't delete shared file %s: no parent folder to unlink from", id)
+	}
+	if len(parents) > 1 {
+		return "", errors.New("can't delete safely - has multiple parents")
+	}
+	return parents[0], nil
+}
+
+// unlinkFromParent removes id from a single parent folder.
+func (f *Fs) unlinkFromParent(ctx context.Context, id, parentID string) error {
+	return f.pacer.Call(func() (bool, error) {
+		_, err := f.svc.Files.Update(id, nil).
+			RemoveParents(parentID).
+			Fields("").
+			SupportsAllDrives(true).
+			Context(ctx).Do()
+		return f.shouldRetry(ctx, err)
+	})
+}
+
+// isInsufficientFilePermissions reports whether err is a Drive 403
+// insufficientFilePermissions error (typical for shared files the user
+// can see but not delete).
+func isInsufficientFilePermissions(err error) bool {
+	var gerr *googleapi.Error
+	if !errors.As(err, &gerr) {
+		return false
+	}
+	if gerr.Code != http.StatusForbidden {
+		return false
+	}
+	for _, item := range gerr.Errors {
+		if item.Reason == "insufficientFilePermissions" {
+			return true
+		}
+	}
+	// Some responses only set the top-level message.
+	msg := strings.ToLower(gerr.Message)
+	return strings.Contains(msg, "insufficientfilepermissions") ||
+		strings.Contains(msg, "does not have sufficient permissions")
 }
 
 // purgeCheck removes the dir directory, if check is set then it

--- a/backend/drive/drive_shared_delete_test.go
+++ b/backend/drive/drive_shared_delete_test.go
@@ -1,0 +1,141 @@
+package drive
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/api/googleapi"
+)
+
+func TestIsInsufficientFilePermissions(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "plain error",
+			err:  errors.New("boom"),
+			want: false,
+		},
+		{
+			name: "403 with insufficientFilePermissions reason",
+			err: &googleapi.Error{
+				Code: http.StatusForbidden,
+				Errors: []googleapi.ErrorItem{{
+					Reason:  "insufficientFilePermissions",
+					Message: "The user does not have sufficient permissions for this file.",
+				}},
+			},
+			want: true,
+		},
+		{
+			name: "403 with message only",
+			err: &googleapi.Error{
+				Code:    http.StatusForbidden,
+				Message: "The user does not have sufficient permissions for this file.",
+			},
+			want: true,
+		},
+		{
+			name: "403 wrapped",
+			err: fmt.Errorf("delete failed: %w", &googleapi.Error{
+				Code: http.StatusForbidden,
+				Errors: []googleapi.ErrorItem{{
+					Reason: "insufficientFilePermissions",
+				}},
+			}),
+			want: true,
+		},
+		{
+			name: "403 other reason",
+			err: &googleapi.Error{
+				Code: http.StatusForbidden,
+				Errors: []googleapi.ErrorItem{{
+					Reason:  "userRateLimitExceeded",
+					Message: "User rate limit exceeded.",
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "404 not found",
+			err: &googleapi.Error{
+				Code: http.StatusNotFound,
+				Errors: []googleapi.ErrorItem{{
+					Reason: "notFound",
+				}},
+			},
+			want: false,
+		},
+		{
+			name: "500 server error",
+			err: &googleapi.Error{
+				Code:    http.StatusInternalServerError,
+				Message: "backend error",
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, isInsufficientFilePermissions(tt.err))
+		})
+	}
+}
+
+func TestUnlinkFromParentsDecision(t *testing.T) {
+	// Document the parent-count rules used by unlinkFromParents without a live Drive API.
+	tests := []struct {
+		name        string
+		parents     []string
+		wantErr     string
+		wantParent  string
+		wantProceed bool
+	}{
+		{
+			name:    "no parents",
+			parents: nil,
+			wantErr: "no parent folder to unlink from",
+		},
+		{
+			name:    "empty parents",
+			parents: []string{},
+			wantErr: "no parent folder to unlink from",
+		},
+		{
+			name:        "single parent",
+			parents:     []string{"parent-1"},
+			wantParent:  "parent-1",
+			wantProceed: true,
+		},
+		{
+			name:    "multiple parents",
+			parents: []string{"parent-1", "parent-2"},
+			wantErr: "can't delete safely - has multiple parents",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parent, err := chooseUnlinkParent("file-1", tt.parents)
+			if tt.wantProceed {
+				require.NoError(t, err)
+				assert.Equal(t, tt.wantParent, parent)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -449,6 +449,14 @@ files.  If deleting them permanently is required then use the
 `--drive-use-trash=false` flag, or set the equivalent environment
 variable.
 
+When deleting a file that was shared with you, Google Drive often
+rejects a normal delete with `insufficientFilePermissions` because you
+do not own the file. In that case rclone unlinks the file from the
+folder you can see it in (via `removeParents`) instead of deleting the
+owner's original. If the shared item has no parent folder (typical for
+some Shared-with-me root entries) or has multiple parents, the delete
+still fails and rclone reports why.
+
 ### Shortcuts
 
 In March 2020 Google introduced a new feature in Google Drive called


### PR DESCRIPTION
Fixes #3998

## Problem
Deleting a Google Drive file that was shared with you fails with:

`403: The user does not have sufficient permissions for this file. (insufficientFilePermissions)`

Drive rejects deleting the owner's object; recipients should unlink it from the folder they can see instead.

## Fix
Follows maintainer option 2 from the issue thread:

1. Attempt normal trash/delete
2. On `insufficientFilePermissions`, fetch parents and `removeParents` for the single parent
3. Keep failing safely when there is no parent or multiple parents

## Docs / tests
- Document the behaviour under `--drive-shared-with-me`
- Unit tests for permission detection and parent selection

## Testing
```
go test ./backend/drive/ -run 'TestIsInsufficientFilePermissions|TestUnlinkFromParentsDecision' -count=1
```