### PR TITLE
docs: fix broken --check-filename self-link in bisync docs

### DIFF
--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -323,7 +323,7 @@ Time stamps and file contents for `RCLONE_TEST` files are not important, just
 the names and locations. If you have symbolic links in your sync tree it is
 recommended to place `RCLONE_TEST` files in the linked-to directory tree to
 protect against bisync assuming a bunch of deleted files if the linked-to tree
-should not be accessible. See also the [--check-filename](--check-filename) flag.
+should not be accessible. See also the [--check-filename](#--check-filename) flag.
 
 ### --check-filename
 

--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -323,7 +323,7 @@ Time stamps and file contents for `RCLONE_TEST` files are not important, just
 the names and locations. If you have symbolic links in your sync tree it is
 recommended to place `RCLONE_TEST` files in the linked-to directory tree to
 protect against bisync assuming a bunch of deleted files if the linked-to tree
-should not be accessible. See also the [--check-filename](#--check-filename) flag.
+should not be accessible. See also the [--check-filename](#check-filename) flag.
 
 ### --check-filename
 


### PR DESCRIPTION
### What

The bisync docs link to the `--check-filename` flag with a bare relative target:

```
See also the [--check-filename](--check-filename) flag.
```

That resolves to a relative path rather than the in-page `### --check-filename` heading a few lines below it, so the link 404s on the rendered docs site.

### Fix

Point it at the heading anchor `#--check-filename`, matching the existing convention for flag headings elsewhere in the docs (e.g. `#--rc-no-auth` in `rc.md`, `#--sftp-path-override` in `sftp.md`).

Docs-only, single-character change.