### PR TITLE
docs: fix duplicated words in vfs and backend documentation

### DIFF
--- a/docs/content/azureblob.md
+++ b/docs/content/azureblob.md
@@ -354,13 +354,13 @@ be explicitly specified using exactly one of the `msi_object_id`,
 `msi_client_id`, or `msi_mi_res_id` parameters.
 
 If none of `msi_object_id`, `msi_client_id`, or `msi_mi_res_id` is
-set, this is is equivalent to using `env_auth`.
+set, this is equivalent to using `env_auth`.
 
 #### Federated Identity Credentials
 
 If these variables are set, rclone will authenticate with federated identity.
 
-- `tenant`: tenant ID of of the storage
+- `tenant`: tenant ID of the storage
 - `client_id`: client ID of the application the user will authenticate to storage
 - `msi_client_id`: managed identity client ID of the application the user will
   authenticate to

--- a/docs/content/azurefiles.md
+++ b/docs/content/azurefiles.md
@@ -325,13 +325,13 @@ be explicitly specified using exactly one of the `msi_object_id`,
 `msi_client_id`, or `msi_mi_res_id` parameters.
 
 If none of `msi_object_id`, `msi_client_id`, or `msi_mi_res_id` is
-set, this is is equivalent to using `env_auth`.
+set, this is equivalent to using `env_auth`.
 
 #### Federated Identity Credentials
 
 If these variables are set, rclone will authenticate with federated identity.
 
-- `tenant`: tenant ID of of the storage
+- `tenant`: tenant ID of the storage
 - `client_id`: client ID of the application the user will authenticate to storage
 - `msi_client_id`: managed identity client ID of the application the user will
   authenticate to

--- a/docs/content/bisync.md
+++ b/docs/content/bisync.md
@@ -1974,7 +1974,7 @@ for performance improvements and less
 options as in `sync`)
 - Equality checks before a sync conflict rename now fall back to `cryptcheck`
 (when possible) or `--download`,
-instead of of `--size-only`, when `check` is not available.
+instead of `--size-only`, when `check` is not available.
 - Bisync no longer fails to find the correct listing file when configs are
 overridden with backend-specific flags.
 - Bisync now fully supports comparing based on any combination of size, modtime,

--- a/docs/content/docs.md
+++ b/docs/content/docs.md
@@ -1702,7 +1702,7 @@ like symlinks under Windows). Ignored files won't be copied, moved or
 deleted in a sync.
 
 If you supply this flag then rclone will copy symbolic links from any
-supported backend backend, and store them as text files, with a
+supported backend, and store them as text files, with a
 `.rclonelink` suffix in the destination.
 
 The text file will contain the target of the symbolic link.
@@ -2234,7 +2234,7 @@ rclone will use multiple threads to transfer the file (default 256M).
 Capable backends are marked in the
 [overview](/overview/#optional-features) as `MultithreadUpload`. (They
 need to implement either the `OpenWriterAt` or `OpenChunkWriter`
-internal interfaces). These include include, `local`, `s3`,
+internal interfaces). These include `local`, `s3`,
 `azureblob`, `b2`, `oracleobjectstorage` and `smb` at the time of
 writing.
 

--- a/docs/content/swift.md
+++ b/docs/content/swift.md
@@ -151,7 +151,7 @@ rclone sync --interactive /home/local/directory remote:container
 
 ### Configuration from an OpenStack credentials file
 
-An OpenStack credentials file typically looks something something
+An OpenStack credentials file typically looks something
 like this (without the comments)
 
 ```sh

--- a/vfs/vfs.md
+++ b/vfs/vfs.md
@@ -271,7 +271,7 @@ Rclone reads `--vfs-read-chunk-streams` chunks of size
 `--vfs-read-chunk-size` concurrently. The size for each read will stay
 constant.
 
-This improves performance performance massively on high latency links
+This improves performance massively on high latency links
 or very high bandwidth links to high performance object stores.
 
 Some experimentation will be needed to find the optimum values of


### PR DESCRIPTION
Nine duplicated words across six hand-written documentation files. Found with a duplicate-word scan, then read individually rather than applied in bulk, because that kind of scan is mostly false positives here (contributor lists, `ls -l` output samples, and `markdownlint-disable-line line-length`).

## Why `vfs/vfs.md` is the one that matters

It is not only website copy. It is `//go:embed`ed into `vfs.go` and appended by `vfs.Help()` to the help text of the nine commands that call it, so rclone itself was printing the duplicate.

Built the binary before and after and diffed the real output:

```
$ diff <(rclone_master serve http --help) <(rclone_branch serve http --help)
437c437
< This improves performance performance massively on high latency links
---
> This improves performance massively on high latency links
```

One line differs, and nothing else.

## The rest

| File | Was |
|---|---|
| `docs/content/azureblob.md` | "this **is is** equivalent to using `env_auth`" |
| `docs/content/azureblob.md` | "`tenant`: tenant ID **of of** the storage" |
| `docs/content/azurefiles.md` | same two, in the shared federated-identity section |
| `docs/content/bisync.md` | "instead **of of** `--size-only`" |
| `docs/content/docs.md` | "These **include include**, `local`, `s3`" |
| `docs/content/docs.md` | "from any supported **backend backend**, and store them" |
| `docs/content/swift.md` | "typically looks **something something** like this" |

The `docs.md` one also drops the stray comma that the duplicate left behind, so the sentence reads "These include `local`, `s3`, ...".

## Checks

- **None of these is in a generated block.** All nine sit above the `autogenerated options start - DO NOT EDIT` markers in their files (azureblob line 391, azurefiles 353, swift 261), so none of them wants fixing in `fs.RegInfo` instead.
- **Nothing refers to the edited strings.** No Go source or test matches any of them, so no help-text assertion breaks.
- `MANUAL.txt` and `MANUAL.md` are generated by the Makefile from `docs/content/*.md`, so they are left alone and will pick these up on the next `make doc`.
- `go build ./...` passes, and `RCLONE_CONFIG=/notfound go test ./...` passes over the tree excluding `cmd/serve` (skipped only because its tests bind listeners and trip the Windows firewall prompt on this machine).

## Deliberately not included

`vfs/vfscache/item.go` has "if **the the** cached range metadata" in a code comment. I left it out to keep this to text a user actually sees. Happy to add it if you would rather have the comment fixed in the same pass.
