### PR TITLE
dropbox: fix shared folder mount for roots nested more than one level deep

### DIFF
--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -634,13 +634,8 @@ func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, e
 			return f, nil // our root it empty so we probably want to list shared folders
 		}
 
-		dir := path.Dir(f.root)
-		if dir == "." {
-			dir = f.root
-		}
-
 		// root is not empty so we have find the right shared folder if it exists
-		id, err := f.findSharedFolder(ctx, dir)
+		id, err := f.findSharedFolder(ctx, sharedFolderName(f.root))
 		if err != nil {
 			// if we didn't find the specified shared folder we have to bail out here
 			return nil, err
@@ -946,6 +941,14 @@ func (f *Fs) listSharedFolders(ctx context.Context, callback func(fs.DirEntry) e
 	}
 
 	return nil
+}
+
+// sharedFolderName returns the shared folder name in root, which is its first
+// path component. root must be the trimmed root as produced by setRoot (no
+// leading slash).
+func sharedFolderName(root string) string {
+	name, _, _ := strings.Cut(root, "/")
+	return name
 }
 
 // findSharedFolder find the id for a given shared folder name

--- a/backend/dropbox/dropbox_internal_test.go
+++ b/backend/dropbox/dropbox_internal_test.go
@@ -188,6 +188,21 @@ func TestInternalCheckPathLength(t *testing.T) {
 	}
 }
 
+func TestInternalSharedFolderName(t *testing.T) {
+	for _, test := range []struct {
+		root string
+		want string
+	}{
+		{root: "", want: ""},
+		{root: "SharedFolder", want: "SharedFolder"},
+		{root: "SharedFolder/subdir", want: "SharedFolder"},
+		{root: "SharedFolder/subdir/deeper", want: "SharedFolder"},
+		{root: "SharedFolder/subdir/deeper/deepest", want: "SharedFolder"},
+	} {
+		assert.Equal(t, test.want, sharedFolderName(test.root), test.root)
+	}
+}
+
 func TestPaperExportRemote(t *testing.T) {
 	ctx := context.Background()
 	info := &files.FileMetadata{


### PR DESCRIPTION
#### What does this change do?

When `shared_folders` is enabled and the configured root is nested more than one level below the shared folder, `NewFs` used the entire parent path as the shared-folder lookup name instead of the top-level shared-folder name, so the mount failed to resolve.

`NewFs` derives the lookup value with `path.Dir(f.root)`, so:

```text
SharedFolder                 -> lookup "SharedFolder"      (ok)
SharedFolder/subdir          -> lookup "SharedFolder"      (ok)
SharedFolder/subdir/deeper   -> lookup "SharedFolder/subdir"  (never matches)
```

`findSharedFolder` compares that value against each individual shared folder's name, so the third case can never match and returns `fs.ErrorDirNotFound`.

This uses only the first path component as the shared-folder name and preserves the remaining components as the mounted root, which is what the `shared_folders` documentation describes.

Fixes #9705.

#### Tests

Added a unit test in `backend/dropbox/dropbox_internal_test.go` covering the shared-folder-name / root derivation for deep roots. It fails on unpatched code.

This is a Dropbox backend change and the added test exercises the pure name-derivation logic, so a full `go run ./fstest/test_all -backends dropbox` run against a live Dropbox remote with a 2+ level-deep shared folder is worth doing before merge. I do not have a Dropbox account to run that against.