### PR TITLE
dropbox: match shared-folder and received-file names case-insensitively

### DIFF
--- a/backend/dropbox/dropbox.go
+++ b/backend/dropbox/dropbox.go
@@ -954,7 +954,7 @@ func (f *Fs) listSharedFolders(ctx context.Context, callback func(fs.DirEntry) e
 func (f *Fs) findSharedFolder(ctx context.Context, name string) (id string, err error) {
 	errFoundFile := errors.New("found file")
 	err = f.listSharedFolders(ctx, func(entry fs.DirEntry) error {
-		if entry.(*fs.Dir).Remote() == name {
+		if strings.EqualFold(entry.(*fs.Dir).Remote(), name) {
 			id = entry.(*fs.Dir).ID()
 			return errFoundFile
 		}
@@ -1036,7 +1036,7 @@ func (f *Fs) listReceivedFiles(ctx context.Context, callback func(fs.DirEntry) e
 func (f *Fs) findSharedFile(ctx context.Context, name string) (o *Object, err error) {
 	errFoundFile := errors.New("found file")
 	err = f.listReceivedFiles(ctx, func(entry fs.DirEntry) error {
-		if entry.(*Object).remote == name {
+		if strings.EqualFold(entry.(*Object).remote, name) {
 			o = entry.(*Object)
 			return errFoundFile
 		}

--- a/backend/dropbox/dropbox_internal_test.go
+++ b/backend/dropbox/dropbox_internal_test.go
@@ -475,3 +475,48 @@ func TestFindSharedFileResolvesDecodedName(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, encodedName, o.remote)
 }
+
+// sharedFoldersHandler serves a single shared folder from list_folders.
+func sharedFoldersHandler(name, id string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "list_folders") {
+			http.NotFound(w, r)
+			return
+		}
+		resp := sharing.ListFoldersResult{
+			Entries: []*sharing.SharedFolderMetadata{{Name: name, SharedFolderId: id}},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}
+}
+
+// The Dropbox backend advertises CaseInsensitive: true, so a shared folder
+// lookup must match regardless of the case of the requested name.
+func TestInternalFindSharedFolderCaseInsensitive(t *testing.T) {
+	f := newSharingTestFs(t, sharedFoldersHandler("TestFolder", "folder-id"))
+
+	for _, name := range []string{"TestFolder", "testfolder", "TESTFOLDER"} {
+		id, err := f.findSharedFolder(context.Background(), name)
+		require.NoError(t, err, name)
+		assert.Equal(t, "folder-id", id, name)
+	}
+
+	_, err := f.findSharedFolder(context.Background(), "no-such-folder")
+	assert.ErrorIs(t, err, fs.ErrorDirNotFound)
+}
+
+// The Dropbox backend advertises CaseInsensitive: true, so a received file
+// lookup must match regardless of the case of the requested name.
+func TestInternalFindSharedFileCaseInsensitive(t *testing.T) {
+	f := newSharingTestFs(t, receivedFilesHandler(t, "TestFile.txt"))
+
+	for _, name := range []string{"TestFile.txt", "testfile.txt", "TESTFILE.TXT"} {
+		o, err := f.findSharedFile(context.Background(), name)
+		require.NoError(t, err, name)
+		assert.Equal(t, "TestFile.txt", o.remote, name)
+	}
+
+	_, err := f.findSharedFile(context.Background(), "no-such-file.txt")
+	assert.ErrorIs(t, err, fs.ErrorObjectNotFound)
+}


### PR DESCRIPTION
#### What does this change do?

The Dropbox backend advertises `CaseInsensitive: true`, but the special shared-folder and received-file lookup paths compared names with exact, case-sensitive Go string equality:

- `findSharedFolder` used `entry.(*fs.Dir).Remote() == name`
- `findSharedFile` used `entry.(*Object).remote == name`

These functions search API listings by hand rather than resolving the name through Dropbox's normal path lookup, so a shared item listed as `Project` was not found when requested as `project`, contrary to the backend's advertised behaviour.

This makes both comparisons case-insensitive with `strings.EqualFold`, consistent with what the backend advertises. Normal-path handling is unchanged, and this does not touch ChangeNotify (tracked separately in #9692).

Fixes #9706.

#### Tests

Added unit tests in `backend/dropbox/dropbox_internal_test.go` covering case-insensitive shared-folder and received-file lookup, plus the not-found paths. Both fail on unpatched code.

They are built on the `newSharingTestFs` mock-server helper added in #9796, rather than a hand-rolled fake `sharing.Client`, so they exercise the real client and do not break when the SDK's interface changes.

This is a Dropbox backend change, so a live `go run ./fstest/test_all -backends dropbox` run is worth doing before merge. I do not have a Dropbox account to run that against.