### PR TITLE
serve docker: fix volume path being lost when the plugin restarts

### DIFF
--- a/cmd/serve/docker/volume.go
+++ b/cmd/serve/docker/volume.go
@@ -140,6 +140,9 @@ func (vol *Volume) restoreState(ctx context.Context, drv *Driver) error {
 	volOpt := vol.Options
 	volOpt["fs"] = vol.Fs
 	volOpt["type"] = vol.Type
+	// applyOptions consumes "path" into vol.Path rather than leaving it in
+	// vol.Options, so it must be fed back explicitly like fs and type.
+	volOpt["path"] = vol.Path
 	if err := vol.applyOptions(volOpt); err != nil {
 		return err
 	}

--- a/cmd/serve/docker/volume_test.go
+++ b/cmd/serve/docker/volume_test.go
@@ -1,0 +1,99 @@
+package docker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/rclone/rclone/backend/local"
+)
+
+// persistedCopy returns vol as it comes back from the plugin state file:
+// only the exported fields survive being marshalled and reloaded.
+func persistedCopy(t *testing.T, vol *Volume) *Volume {
+	t.Helper()
+	vol.prepareState()
+	data, err := json.Marshal(vol)
+	require.NoError(t, err)
+	restored := &Volume{}
+	require.NoError(t, json.Unmarshal(data, restored))
+	return restored
+}
+
+// TestRestoreStatePath checks that the on-remote path of a volume survives
+// being reloaded from the plugin state file, for each of the option
+// combinations that can carry one.
+func TestRestoreStatePath(t *testing.T) {
+	ctx := context.Background()
+	for _, test := range []struct {
+		name     string
+		volOpt   VolOpts
+		fsString string
+	}{{
+		name:     "type and path",
+		volOpt:   VolOpts{"type": "local", "path": "/tmp/path"},
+		fsString: ":local:/tmp/path",
+	}, {
+		name:     "remote only",
+		volOpt:   VolOpts{"remote": "/tmp/remote"},
+		fsString: ":local:/tmp/remote",
+	}, {
+		// an explicit path overrides the path of the connection string,
+		// and must keep doing so after a restart
+		name:     "remote and path",
+		volOpt:   VolOpts{"remote": "/tmp/remote", "path": "/tmp/path"},
+		fsString: ":local:/tmp/path",
+	}, {
+		name:     "type only",
+		volOpt:   VolOpts{"type": "local"},
+		fsString: ":local:",
+	}} {
+		t.Run(test.name, func(t *testing.T) {
+			drv := &Driver{
+				root:    t.TempDir(),
+				volumes: map[string]*Volume{},
+				dummy:   true,
+			}
+			vol, err := newVolume(ctx, "vol1", test.volOpt, drv)
+			require.NoError(t, err)
+			require.Equal(t, test.fsString, vol.fsString)
+
+			restored := persistedCopy(t, vol)
+			require.NoError(t, restored.restoreState(ctx, drv))
+			assert.Equal(t, test.fsString, restored.fsString)
+			assert.Equal(t, vol.Path, restored.Path)
+		})
+	}
+}
+
+// TestDriverRestoreStatePath checks the same through the real state file: a
+// volume persisted by a previous plugin instance is reloaded with its path.
+func TestDriverRestoreStatePath(t *testing.T) {
+	ctx := context.Background()
+	testDir := t.TempDir()
+
+	state := fmt.Sprintf(`[{"name":"vol1","mountpoint":%q,"created":%q,"fs":"","type":"local","path":"/tmp/path","options":{},"mounts":[]}]`,
+		filepath.Join(testDir, "vol1"), time.Now().Format(time.RFC3339))
+	statePath := filepath.Join(testDir, stateFile)
+	require.NoError(t, os.WriteFile(statePath, []byte(state), 0600))
+
+	drv := &Driver{
+		root:      testDir,
+		statePath: statePath,
+		volumes:   map[string]*Volume{},
+		dummy:     true,
+	}
+	require.NoError(t, drv.restoreState(ctx))
+
+	vol, err := drv.getVolume("vol1")
+	require.NoError(t, err)
+	assert.Equal(t, ":local:/tmp/path", vol.fsString)
+	assert.Equal(t, "/tmp/path", vol.Path)
+}


### PR DESCRIPTION
#### What does this change do?

`rclone serve docker` persists each volume's `path` option in `docker-plugin.state`, but never fed it back when
reloading. `applyOptions` consumes `"path"` into `vol.Path` rather than leaving it in `vol.Options`, and
`restoreState` rebuilt the options with only `fs` and `type`, so the rebuilt `fsString` lost the on-remote path
and the volume was remounted at the root of the remote.

Two volume shapes were affected:

| volume options | `fsString` after a restart, before | after |
|---|---|---|
| `type` + `path` | `:local:/tmp/path` → `:local:` | path kept |
| `remote` + `path` | `:local:/tmp/path` → `:local:/tmp/remote` | path kept |

The second one is not in the issue. An explicit `path` overrides the connection string's path when the volume is
created, but on restore it silently reverted to the connection string's path. Feeding the persisted path back
unconditionally lets `applyOptions` apply the same precedence on restore that it applies at create time, and is a
no-op for volumes that have no path.

For a backend whose credentials are scoped to the subpath — the reporter's case, S3 on Cloudflare R2 with a
bucket-scoped token — the restored mount does not merely serve the wrong directory: every operation at the new
root needs `ListBuckets`, which is denied, so all I/O through the mount returns `EIO` after each reboot.

The issue also reports that stale `mounts` entries can block plugin start. That one is already fixed on master by
the deferred `pendingMounts` restore, so this PR only addresses the path.

#### Testing

`cmd/serve/docker/volume_test.go` adds:

- `TestRestoreStatePath` — a table test over the four option combinations that can carry a path (`type`+`path`,
  `remote` only, `remote`+`path`, `type` only), round-tripping the volume through its JSON persisted form and
  asserting `fsString` comes back unchanged.
- `TestDriverRestoreStatePath` — the same through a real `docker-plugin.state` file and `Driver.restoreState`.

I checked the tests actually pin the behaviour by mutating the fix:

- removing it entirely: `type_and_path`, `remote_and_path` and `TestDriverRestoreStatePath` fail, while the two
  shapes that were never broken still pass;
- restricting it to `vol.Path != "" && vol.Fs == ""`: only `remote_and_path` fails, which is the case that would
  otherwise have been missed.

`go build ./...`, `make quicktest` and `golangci-lint run ./cmd/serve/docker/...` all pass.

No documentation change: the "Restarting or upgrading the plugin" section of `docker.md` already describes volumes
being restored across a restart, which this fixes rather than changes.

#### Linked issue

Fixes #9853

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate. (No doc change needed — see above.)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend — not a backend change.
- [x] This Pull Request is ready for review.
