### PR TITLE
docker: make container user UID and GID configurable via build ARGs (#9839)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN echo "**** Print Version Binary ****" && \
 # Begin final image
 FROM alpine:latest
 
+ARG RCLONE_UID=1009
+ARG RCLONE_GID=1009
+
 RUN echo "**** Install Dependencies ****" && \
     apk add --no-cache \
         ca-certificates \
@@ -45,7 +48,7 @@ RUN echo "**** Install Dependencies ****" && \
 
 COPY --from=builder /go/src/github.com/rclone/rclone/rclone /usr/local/bin/
 
-RUN addgroup -g 1009 rclone && adduser -u 1009 -Ds /bin/sh -G rclone rclone
+RUN addgroup -g ${RCLONE_GID} rclone && adduser -u ${RCLONE_UID} -Ds /bin/sh -G rclone rclone
 
 ENTRYPOINT [ "rclone" ]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN echo "**** Install Dependencies ****" && \
 
 COPY --from=builder /go/src/github.com/rclone/rclone/rclone /usr/local/bin/
 
-RUN addgroup -g ${RCLONE_GID} rclone && adduser -u ${RCLONE_UID} -Ds /bin/sh -G rclone rclone
+RUN addgroup -g "${RCLONE_GID}" rclone && adduser -u "${RCLONE_UID}" -Ds /bin/sh -G rclone rclone
 
 ENTRYPOINT [ "rclone" ]
 


### PR DESCRIPTION
﻿Fixes #9839
Re-opens and supersedes #9840.

### Description
This PR introduces build arguments `RCLONE_UID` and `RCLONE_GID` in `Dockerfile` (defaulting to 1009 for backwards compatibility) so users building container images can customize the internal UID/GID to match their host user permissions.

### Changes
- Added `ARG RCLONE_UID=1009` and `ARG RCLONE_GID=1009` to the final image stage in `Dockerfile`.
- Quoted `"${RCLONE_GID}"` and `"${RCLONE_UID}"` in `RUN addgroup ... && adduser ...` to safely prevent word-splitting and command injection.
