### PR TITLE
selfupdate: fix TestInstallOnLinux panicking when the build is the latest beta

### DIFF
--- a/cmd/selfupdate/selfupdate_test.go
+++ b/cmd/selfupdate/selfupdate_test.go
@@ -56,6 +56,12 @@ func TestInstallOnLinux(t *testing.T) {
 	testDir := t.TempDir()
 	path := filepath.Join(testDir, "rclone")
 
+	// Pin the running version so the checks below do not depend on
+	// whether this build happens to be the latest beta.
+	oldVersion := fs.Version
+	fs.Version = "v1.0.0"
+	t.Cleanup(func() { fs.Version = oldVersion })
+
 	regexVer := regexp.MustCompile(`v[0-9]\S+`)
 
 	betaVer, _, err := GetVersion(ctx, true, "")
@@ -71,7 +77,7 @@ func TestInstallOnLinux(t *testing.T) {
 		_ = os.Chmod(path, 0644)
 	}()
 	err = (InstallUpdate(ctx, &Options{Beta: true, Output: path}))
-	assert.Error(t, err)
+	require.Error(t, err)
 	assert.Contains(t, err.Error(), "run self-update as root")
 
 	// Must keep non-standard permissions


### PR DESCRIPTION
#### What does this change do?

Makes `TestInstallOnLinux` in `cmd/selfupdate` independent of the version compiled into the test binary.

The test asks `InstallUpdate` to install the latest beta into an unwritable file and expects an error. If the binary under test reports exactly the latest published beta, `InstallUpdate` correctly decides there is nothing to do and returns nil, and the test then dereferences the nil error:

```
--- FAIL: TestInstallOnLinux (0.66s)
panic: runtime error: invalid memory address or nil pointer dereference
    selfupdate_test.go:75
```

This happens with `make quicktest` on a fresh clone of master, run before creating a branch, while master is still at the commit the current beta was built from: the Makefile passes that exact version via `-ldflags`. It is invisible everywhere else, each for a different reason:

- GitHub Actions: the test is skipped by `testy.SkipUnreliable` (`CI` is set).
- The integration test server: `test_all` builds the test binary without ldflags, so it reports `v1.76.0-DEV`, which never equals the beta.
- On any branch or after any commit the version string changes (branch suffix / commit count), so it passes.

Reproduced on clean master with `go test --ldflags "-X github.com/rclone/rclone/fs.Version=v1.76.0-beta.10312.3d7b101c7" ./cmd/selfupdate/` while that was the published beta, with both the official go1.27.1 toolchain and a distro build.

The fix pins `fs.Version` to a fixed old value for the duration of the test (restored with `t.Cleanup`) so an update is always attempted, and switches the assertion to `require.Error` so a missing error fails the test instead of crashing it, following f98e672f3 which did the same for the beta-not-found case. Test-only change; the test passes both with and without the version flag afterwards. The package has no parallel tests, so the pinned value cannot leak into another test.

#### Linked issue

Trivial test fix, no issue.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate. (the change is to the test itself)
- [ ] I have added documentation for the changes if appropriate. (not applicable)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend ... (not applicable)
- [x] This Pull Request is ready for review.
