### PR TITLE
oracleobjectstorage: fix SSE-C server-side copies

### DIFF
--- a/backend/oracleobjectstorage/byok.go
+++ b/backend/oracleobjectstorage/byok.go
@@ -115,11 +115,14 @@ func useBYOKCopyObject(fs *Fs, request *objectstorage.CopyObjectRequest) {
 	}
 	if fs.opt.SSECustomerAlgorithm != "" {
 		request.OpcSseCustomerAlgorithm = new(fs.opt.SSECustomerAlgorithm)
+		request.OpcSourceSseCustomerAlgorithm = new(fs.opt.SSECustomerAlgorithm)
 	}
 	if fs.opt.SSECustomerKey != "" {
 		request.OpcSseCustomerKey = new(fs.opt.SSECustomerKey)
+		request.OpcSourceSseCustomerKey = new(fs.opt.SSECustomerKey)
 	}
 	if fs.opt.SSECustomerKeySha256 != "" {
 		request.OpcSseCustomerKeySha256 = new(fs.opt.SSECustomerKeySha256)
+		request.OpcSourceSseCustomerKeySha256 = new(fs.opt.SSECustomerKeySha256)
 	}
 }

--- a/backend/oracleobjectstorage/byok_test.go
+++ b/backend/oracleobjectstorage/byok_test.go
@@ -1,0 +1,25 @@
+//go:build !plan9 && !solaris && !js
+
+package oracleobjectstorage
+
+import (
+	"testing"
+
+	"github.com/oracle/oci-go-sdk/v65/objectstorage"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUseBYOKCopyObject(t *testing.T) {
+	f := &Fs{opt: Options{
+		SSECustomerAlgorithm: "AES256",
+		SSECustomerKey:       "customer-key",
+		SSECustomerKeySha256: "customer-key-sha256",
+	}}
+	req := &objectstorage.CopyObjectRequest{}
+
+	useBYOKCopyObject(f, req)
+
+	assert.Equal(t, &f.opt.SSECustomerAlgorithm, req.OpcSourceSseCustomerAlgorithm)
+	assert.Equal(t, &f.opt.SSECustomerKey, req.OpcSourceSseCustomerKey)
+	assert.Equal(t, &f.opt.SSECustomerKeySha256, req.OpcSourceSseCustomerKeySha256)
+}


### PR DESCRIPTION
Set the OCI source SSE-C request headers when using a customer key. Server-side copies need these headers to decrypt the source object, in addition to the existing headers that encrypt the destination.

#### What does this change do?

Allows the Oracle Object Storage remote configured with Server-Side Encryption with Customer Key to perform a Server Side Copy. Current implementation misses the decryption of the source object and only encrypts the target, which results in failure.

The fixed behavior (expecting the same SSE-C key to both decrypt source and encrypt target) aligns with the generic S3 implementation.

#### Linked issue

No issue set up (simple fix)

#### For new or changed backends

Ran the Oracle Object Storage integration suite against an SSE-C-enabled
`TestOracleObjectStorage:` remote (sse_customer_key_file option set):

```console
cd backend/oracleobjectstorage
go test -v
```

##### Reproduction on master

With SSE-C enabled, unmodified master fails server-side-copy operations with
OCI MissingSSECustomerHeaders:

- TestIntegration/FsMkdir/FsPutFiles/FsCopy
- TestIntegration/FsMkdir/FsPutFiles/ObjectSetModTime

ObjectSetModTime uses server-side copy internally, so it has the same missing
source-decryption-header problem.

##### Result with this change

The same SSE-C integration run completes FsCopy successfully. The focused unit
test also verifies that CopyObjectRequest receives all three required
OpcSourceSseCustomer* headers.

##### Pre-existing integration failures

The full Oracle suite remains non-green for failures unrelated to this change,
which reproduce on both master and this branch and match the official rclone
integration server:

- FsEncoding/control_chars
- FsEncoding/leading_CR
- FsEncoding/leading_LF
- FsEncoding/trailing_CR
- FsEncoding/trailing_LF
- FsPutStream/0 (zero-byte streaming multipart upload)

The official Oracle backend integration log shows the same filename-encoding and
zero-byte streaming-upload failures:
https://pub.rclone.org/integration-tests/current/oracleobjectstorage-backend.oracleobjectstorage-TestOracleObjectStorage-1.txt

#### Checklist

- [X] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [X] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [X] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [X] I have added tests for all changes in this PR if appropriate.
- [X] I have added documentation for the changes if appropriate.
- [X] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [X] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [X] This Pull Request is ready for review.
