### PR TITLE
protondrive: re-read stored credentials before refreshing so a second Fs can't break login

### DIFF
--- a/backend/protondrive/auth_hooks_test.go
+++ b/backend/protondrive/auth_hooks_test.go
@@ -1,0 +1,74 @@
+package protondrive
+
+import (
+	"testing"
+
+	"github.com/rclone/go-proton-api"
+	"github.com/rclone/rclone/fs/config/configmap"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func storedCredentials(uid, accessToken, refreshToken, saltedKeyPass string) configmap.Simple {
+	m := configmap.Simple{}
+	setConfigMap(m, uid, accessToken, refreshToken, saltedKeyPass)
+	return m
+}
+
+func TestConfigAuthHooks_AuthHandlerPersistsRotatedTokens(t *testing.T) {
+	m := storedCredentials("uid", "acc1", "ref1", "salt")
+	authHandler, _, _ := configAuthHooks(m)
+
+	authHandler(proton.Auth{UID: "uid", AccessToken: "acc2", RefreshToken: "ref2"})
+
+	uid, acc, ref, salt, ok := getConfigMap(m)
+	require.True(t, ok)
+	assert.Equal(t, "uid", uid)
+	assert.Equal(t, "acc2", acc)
+	assert.Equal(t, "ref2", ref)
+	assert.Equal(t, "salt", salt, "salted key pass must survive a token rotation")
+}
+
+func TestConfigAuthHooks_DeAuthHandlerClearsCredentials(t *testing.T) {
+	m := storedCredentials("uid", "acc1", "ref1", "salt")
+	_, deAuthHandler, _ := configAuthHooks(m)
+
+	deAuthHandler()
+
+	_, _, _, _, ok := getConfigMap(m)
+	assert.False(t, ok)
+}
+
+func TestConfigAuthHooks_RefreshHookReturnsStoredCredentials(t *testing.T) {
+	m := storedCredentials("uid", "acc1", "ref1", "salt")
+	_, _, refreshHook := configAuthHooks(m)
+
+	uid, acc, ref, ok := refreshHook()
+	require.True(t, ok)
+	assert.Equal(t, "uid", uid)
+	assert.Equal(t, "acc1", acc)
+	assert.Equal(t, "ref1", ref)
+}
+
+func TestConfigAuthHooks_RefreshHookRejectsIncompleteCredentials(t *testing.T) {
+	m := storedCredentials("uid", "acc1", "", "salt")
+	_, _, refreshHook := configAuthHooks(m)
+
+	_, _, _, ok := refreshHook()
+	assert.False(t, ok)
+}
+
+// Two Fs on the same remote each get their own hooks over the same config.
+// When one persists a rotated token the other's refresh hook must see it.
+func TestConfigAuthHooks_RefreshHookSeesRotationByAnotherFs(t *testing.T) {
+	m := storedCredentials("uid", "acc1", "ref1", "salt")
+	authHandlerA, _, _ := configAuthHooks(m)
+	_, _, refreshHookB := configAuthHooks(m)
+
+	authHandlerA(proton.Auth{UID: "uid", AccessToken: "acc2", RefreshToken: "ref2"})
+
+	_, acc, ref, ok := refreshHookB()
+	require.True(t, ok)
+	assert.Equal(t, "acc2", acc)
+	assert.Equal(t, "ref2", ref)
+}

--- a/backend/protondrive/protondrive.go
+++ b/backend/protondrive/protondrive.go
@@ -54,10 +54,6 @@ var (
 	errCanNotUploadFileWithUnknownSize = errors.New("proton Drive can't upload files with unknown size")
 	errCanNotPurgeRootDirectory        = errors.New("can't purge root directory")
 	protonDriveInvalidVersionChars     = regexp.MustCompile(`[^0-9A-Za-z.+-]+`)
-
-	// for the auth/deauth handler
-	_mapper        configmap.Mapper
-	_saltedKeyPass string
 )
 
 // Register with Fs
@@ -330,7 +326,6 @@ func getConfigMap(m configmap.Mapper) (uid, accessToken, refreshToken, saltedKey
 	if saltedKeyPass, ok = m.Get(clientSaltedKeyPassKey); !ok {
 		return
 	}
-	_saltedKeyPass = saltedKeyPass
 
 	// empty strings are considered "ok" by m.Get, which is not true business-wise
 	ok = accessToken != "" && uid != "" && refreshToken != "" && saltedKeyPass != ""
@@ -343,22 +338,34 @@ func setConfigMap(m configmap.Mapper, uid, accessToken, refreshToken, saltedKeyP
 	m.Set(clientAccessTokenKey, accessToken)
 	m.Set(clientRefreshTokenKey, refreshToken)
 	m.Set(clientSaltedKeyPassKey, saltedKeyPass)
-	_saltedKeyPass = saltedKeyPass
 }
 
 func clearConfigMap(m configmap.Mapper) {
 	setConfigMap(m, "", "", "", "")
-	_saltedKeyPass = ""
 }
 
-func authHandler(auth proton.Auth) {
-	// fs.Debugf("authHandler called")
-	setConfigMap(_mapper, auth.UID, auth.AccessToken, auth.RefreshToken, _saltedKeyPass)
-}
-
-func deAuthHandler() {
-	// fs.Debugf("deAuthHandler called")
-	clearConfigMap(_mapper)
+// configAuthHooks returns the session callbacks for one Fs, all closing over
+// its config.
+//
+// Proton rotates the refresh token on every use, so two clients started from
+// the same stored credentials can't both refresh: the second presents a spent
+// token and is rejected. The refresh hook lets a client re-read the config
+// before refreshing, and again after a rejection, and adopt credentials that
+// another Fs (or another rclone process, since the config file is re-read
+// when it changes) has stored since.
+func configAuthHooks(m configmap.Mapper) (proton.AuthHandler, proton.Handler, proton.AuthRefreshHook) {
+	authHandler := func(auth proton.Auth) {
+		saltedKeyPass, _ := m.Get(clientSaltedKeyPassKey)
+		setConfigMap(m, auth.UID, auth.AccessToken, auth.RefreshToken, saltedKeyPass)
+	}
+	deAuthHandler := func() {
+		clearConfigMap(m)
+	}
+	refreshHook := func() (uid, accessToken, refreshToken string, ok bool) {
+		uid, accessToken, refreshToken, _, ok = getConfigMap(m)
+		return uid, accessToken, refreshToken, ok
+	}
+	return authHandler, deAuthHandler, refreshHook
 }
 
 func protonDriveAppVersionFromRcloneVersion(version string) string {
@@ -481,7 +488,8 @@ func newProtonDrive(ctx context.Context, f *Fs, opt *Options, m configmap.Mapper
 
 	// let's see if we have the cached access credential
 	uid, accessToken, refreshToken, saltedKeyPass, hasUseReusableLoginCredentials := getConfigMap(m)
-	_saltedKeyPass = saltedKeyPass
+	authHandler, deAuthHandler, refreshHook := configAuthHooks(m)
+	config.AuthRefreshHook = refreshHook
 
 	if hasUseReusableLoginCredentials {
 		fs.Debugf(f, "Has cached credentials")
@@ -536,7 +544,6 @@ func newProtonDrive(ctx context.Context, f *Fs, opt *Options, m configmap.Mapper
 // NewFs constructs an Fs from the path, container:path
 func NewFs(ctx context.Context, name, root string, m configmap.Mapper) (fs.Fs, error) {
 	// pacer is not used in NewFs()
-	_mapper = m
 
 	// Parse config into Options struct
 	opt := new(Options)


### PR DESCRIPTION
#### What does this change do?

Fixes a Proton Drive session wipe that happens reliably about 25 minutes into
any sync that uses `--backup-dir` on the same remote. Full analysis is in the
linked issue; the short version:

Proton refresh tokens are single use. `--backup-dir` on the same remote makes
rclone build a second `Fs`, and each `Fs` opens its own Proton session from the
same cached `client_refresh_token`. When the access tokens expire the two
sessions race. The winner rotates the token; the loser refreshes with the token
that was just spent and gets `400 Invalid refresh token (Code=10013)`.
go-proton-api treats that as permanent and calls the de-auth handler, which
blanks all four `client_*` keys in the config file. Every later operation then
falls back to a password login, which Proton's anti-abuse limiter answers with
`429 Code=2011`. On a 2FA account the run cannot recover without a human.

This follows the approach @ncw suggested in review, the same one
`lib/oauthutil` uses in `reReadToken`: before a client refreshes, and again if
the refresh is rejected, it re-reads the stored credentials and adopts them if
another `Fs` (or another rclone process, since the config file is re-read when
it changes) has rotated them since. It only de-auths when nothing newer exists.

The hook lives in the two libraries, because the backend never sees the
`proton.Client`:

- rclone/go-proton-api#10 adds `Client.AddAuthRefreshHook` and the
  consult-before-refresh / consult-after-rejection logic.
- rclone/Proton-API-Bridge#9 adds `Config.AuthRefreshHook` and registers it
  right after the client is created, on both login paths.

Here the backend sets `config.AuthRefreshHook` to a closure that reads the
config, and the auth and de-auth handlers now close over each `Fs`'s config
instead of the `_mapper` / `_saltedKeyPass` package globals. `Disconnect` is
unchanged. The `clearConfigMap` on a failed cached login in `newProtonDrive` is
deliberately untouched; that is #8135 and needs its own decision.

**Sequencing:** this PR needs a `go.mod` bump to tagged releases of the two
library PRs once they land. I tested it with local `replace` directives that
are not in the commit.

#### Linked issue

Fixes #9880

Related: #8135 (same symptom, different trigger, not fixed here)

#### For new or changed backends

I have not run `test_all` against Proton Drive. I only have a production account
with live data on it and no test account to offer, so I did not want to point the
integration suite at it. Happy to be told how you would like this covered.

What I did run, all in `golang:1.26` with the two libraries pointed at the PR
branches:

- `go build ./...` and `make quicktest` pass. (One `vfs` test,
  `TestWriteFileHandleReadonly`, fails only when run as root in Docker and
  passes as a normal user; unrelated.)
- `go test -race ./backend/protondrive/` passes, including the new
  `auth_hooks_test.go`, which covers the closures and the two-`Fs` case where
  one persists a rotated token and the other's refresh hook must see it.
- go-proton-api: full suite with `-race`, plus four new tests against the fake
  server: adopt before refresh, recover after a rejected refresh, still de-auth
  when the token was revoked, and a control showing a hook-less second client is
  still de-authed.
- Proton-API-Bridge: full suite with `-race`, plus a test that logs two clients
  in from one session, lets the first rotate, and checks the second keeps working
  and is not de-authed.

The earlier version of this PR (shared session per remote) ran my nightly
production backup through the exact point where the bug used to fire, with zero
`Code=10013`. This version has the same unit-level coverage of that scenario but
I have not yet had a production run on it; I will report back after the next
nightly.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate. (No user-facing option or behaviour change to document - happy to add a note if you would like one.)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend - see above, I have no test account.
- [x] This Pull Request is ready for review.
