### PR TITLE
fs: make BwTimetable.Set replace the timetable instead of appending to it

### DIFF
--- a/fs/bwtimetable.go
+++ b/fs/bwtimetable.go
@@ -150,6 +150,8 @@ func (x *BwTimetable) Set(s string) error {
 		return nil
 	}
 
+	var newTimetable BwTimetable
+
 	// Split the timetable string by both spaces and semicolons
 	for tok := range strings.FieldsFuncSeq(s, func(r rune) bool {
 		return r == ' ' || r == ';'
@@ -178,7 +180,7 @@ func (x *BwTimetable) Set(s string) error {
 				if err := ts.Bandwidth.Set(tv[1]); err != nil {
 					return err
 				}
-				*x = append(*x, ts)
+				newTimetable = append(newTimetable, ts)
 			}
 		} else {
 			timespec := strings.Split(tv[0], "-")
@@ -205,9 +207,10 @@ func (x *BwTimetable) Set(s string) error {
 			if err := ts.Bandwidth.Set(tv[1]); err != nil {
 				return err
 			}
-			*x = append(*x, ts)
+			newTimetable = append(newTimetable, ts)
 		}
 	}
+	*x = newTimetable
 	return nil
 }
 

--- a/fs/bwtimetable_test.go
+++ b/fs/bwtimetable_test.go
@@ -316,6 +316,52 @@ func TestBwTimetableSet(t *testing.T) {
 	}
 }
 
+func TestBwTimetableSetReplaces(t *testing.T) {
+	for _, test := range []struct {
+		first  string
+		second string
+		want   string
+	}{
+		{"Sun-00:00,10M", "Mon-10:00,1M", "Mon-10:00,1Mi"},
+		{"Mon-10:00,1M", "Mon-10:00,1M", "Mon-10:00,1Mi"},
+		{"Mon-10:00,1M", "2M", "2Mi"},
+		{"2M", "Mon-10:00,1M", "Mon-10:00,1Mi"},
+		{"11:00,333;13:40,666", "Mon-10:00,1M", "Mon-10:00,1Mi"},
+	} {
+		tt := BwTimetable{}
+		require.NoError(t, tt.Set(test.first), test.first)
+		require.NoError(t, tt.Set(test.second), test.second)
+		assert.Equal(t, test.want, tt.String(), "%q then %q", test.first, test.second)
+
+		var want BwTimetable
+		require.NoError(t, want.Set(test.second))
+		assert.Equal(t, want, tt, "%q then %q", test.first, test.second)
+	}
+}
+
+func TestBwTimetableSetErrorKeepsPrevious(t *testing.T) {
+	for _, in := range []string{
+		"Mon-11:00,333 bad",
+		"Mon-11:00,333 Tue-13:40,bad",
+		"Mon-11:00,333 24:01,666",
+		"11:00,333;bad",
+	} {
+		tt := BwTimetable{}
+		require.NoError(t, tt.Set("Sun-20:00,10M"))
+		require.Error(t, tt.Set(in), in)
+		assert.Equal(t, "Sun-20:00,10Mi", tt.String(), in)
+	}
+}
+
+func TestBwTimetableUnmarshalJSONReplaces(t *testing.T) {
+	var tt BwTimetable
+	require.NoError(t, json.Unmarshal([]byte(`"Sun-00:00,10M"`), &tt))
+	require.NoError(t, json.Unmarshal([]byte(`"Mon-10:00,1M"`), &tt))
+	assert.Equal(t, BwTimetable{
+		BwTimeSlot{DayOfTheWeek: 1, HHMM: 1000, Bandwidth: BwPair{Tx: 1024 * 1024, Rx: 1024 * 1024}},
+	}, tt)
+}
+
 func TestBwTimetableLimitAt(t *testing.T) {
 	for _, test := range []struct {
 		tt   BwTimetable


### PR DESCRIPTION
### What is the purpose of this change?

`(*BwTimetable).Set` appended to the receiver instead of replacing it, so setting a bandwidth timetable on a value that already held one kept both schedules.

```
step                        timetable                        LimitAt(Sun 12:00)
Set("10Mi")                 "10Mi"                           10Mi
then Set("Mon-10:00,1Mi")   "Sun-00:00,10Mi Mon-10:00,1Mi"   10Mi      <- stale slot wins
```

The odd one out is inside the same function: the single-value branch at `fs/bwtimetable.go:149` does `*x = BwTimetable{ts}`, while both timetable branches did `*x = append(*x, ts)`. The other multi-token `Set` methods in this package build into a local and assign at the end — `fs/bits.go:113` `*b = flags`, `fs/config_list.go:81` `*gl = record`.

### Where it shows

The `"main"` options block registered by `fs.RegisterGlobalOptions` (`fs/config.go:690`) *is* the live `globalConfig`, and `rcOptionsSet` reshapes JSON straight into it (`fs/rc/config.go:181` → `fs/rc/params.go:74-85` → `json.Unmarshal` → `BwTimetable.UnmarshalJSON` → `Set`). So

```
rclone rc options/set --json '{"main": {"BwLimit": "Mon-10:00,1Mi"}}'
```

added to the running daemon's timetable rather than replacing it, and the older slot kept winning — `LimitAt` for a Sunday returned the previous `10Mi` where the requested timetable gives `1Mi`. `fs/accounting/token_bucket.go` then throttles at the stale rate.

The same applies to a `_config` override on a single call: `AddConfig` (`fs/config.go:824-830`) shallow-copies the global `ConfigInfo`, so the copy still holds the global's slots and `ParseOptions` appends to them.

The CLI path is not affected — `configstruct.StringToInterface` does `reflect.New(typ)`, so a repeated `--bwlimit` flag gets a fresh value each time.

Building into a local also stops a failed parse from leaving the previous timetable partly overwritten:

```
before Set(bad): "Mon-10:00,1Mi"
after  Set(bad): "Mon-10:00,1Mi Mon-10:00,1Mi"   (err returned, value mutated anyway)
```

The existing error rows in `TestBwTimetableSet` already assert `BwTimetable{}` afterwards, so no-mutation-on-error was the intent; there was simply no row where an earlier token succeeds and a later one fails.

### Was the change discussed in an issue or in the forum before?

No. `fs/bwtimetable.go` was last touched in `4553c3de7` ("fs: fix bwlimit: correctly report minutes"), and no open issue or PR matches this.

### Checklist

- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bugfix).
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(If I used AI tools to help write this code)** I have read and understood the AI-assisted contributions guidance, and I have tested and take ownership of this change myself.

Testing: `TestBwTimetableSetReplaces`, `TestBwTimetableSetErrorKeepsPrevious` and `TestBwTimetableUnmarshalJSONReplaces` added. All three fail on `master` and the four existing `TestBwTimetable*` tests pass on both trees. Mutation-checked both ways: restoring the append breaks the replace tests, and clearing `*x` on entry instead of using a local breaks the error-path test and the existing `TestBwTimetableSet`. `go build ./...` plus `GOOS=windows`/`GOOS=darwin`, `go vet ./fs/...`, `go test ./fs/...` and `go test -race -short ./fs/ ./fs/rc/... ./fs/accounting/` all pass. `golangci-lint run ./fs/` reports only the pre-existing revive hit in `fs/log.go`.

AI assistance disclosure: written with Claude Code. I understand the change and can explain it; the tables above are verbatim from running it against `master`, and the fix ships without narrating comments per `AGENTS.md`.
