### PR TITLE
fs: fix about showing a negative total when a quota reaches the int64 maximum

### DIFF
--- a/fs/types.go
+++ b/fs/types.go
@@ -340,7 +340,8 @@ func NewUsageValue[T interface {
 	int64 | uint64 | float64
 }](value T) *int64 {
 	p := new(int64)
-	if value > T(int64(math.MaxInt64)) {
+	// float64(math.MaxInt64) rounds up to 2**63 which doesn't fit in an int64
+	if value >= T(int64(math.MaxInt64)) {
 		*p = math.MaxInt64
 	} else {
 		*p = int64(value)

--- a/fs/types_test.go
+++ b/fs/types_test.go
@@ -1,0 +1,53 @@
+package fs
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewUsageValueInt64(t *testing.T) {
+	for _, test := range []struct {
+		in   int64
+		want int64
+	}{
+		{0, 0},
+		{1 << 60, 1 << 60},
+		{math.MaxInt64, math.MaxInt64},
+	} {
+		assert.Equal(t, test.want, *NewUsageValue(test.in), "in=%d", test.in)
+	}
+}
+
+func TestNewUsageValueUint64(t *testing.T) {
+	for _, test := range []struct {
+		in   uint64
+		want int64
+	}{
+		{0, 0},
+		{math.MaxInt64, math.MaxInt64},
+		{math.MaxInt64 + 1, math.MaxInt64},
+		{math.MaxUint64, math.MaxInt64},
+	} {
+		assert.Equal(t, test.want, *NewUsageValue(test.in), "in=%d", test.in)
+	}
+}
+
+func TestNewUsageValueFloat64(t *testing.T) {
+	// Largest float64 strictly below 2**63 - this still fits in an int64.
+	const belowMax = float64(9223372036854773760)
+	for _, test := range []struct {
+		in   float64
+		want int64
+	}{
+		{0, 0},
+		{1e18, 1000000000000000000}, // Box reports space_amount like this
+		{belowMax, 9223372036854773760},
+		{float64(math.MaxInt64), math.MaxInt64}, // rounds up to 2**63
+		{1e19, math.MaxInt64},
+		{math.Inf(1), math.MaxInt64},
+	} {
+		assert.Equal(t, test.want, *NewUsageValue(test.in), "in=%v", test.in)
+	}
+}


### PR DESCRIPTION
### What

`NewUsageValue` (`fs/types.go:338`) exists to clip an oversized quota to the maximum value of an `int64`. `dc95f36bc` added it when Box raised the Enterprise `space_amount` to 1e+18 and started returning it as a float, and the commit message states the intent plainly: *"This fix reads it as a float64 and clips it to the maximum value of an int64 if necessary."*

For the `float64` instantiation the guard misses its own boundary. `float64(math.MaxInt64)` is not `2**63-1`; it rounds up to `2**63`. So `value > T(int64(math.MaxInt64))` is `2**63 > 2**63`, which is false, and the value falls through to `int64(value)` — a conversion the spec leaves implementation dependent when the value is unrepresentable.

Measured by decoding a Box `/users/me` body through the production `api.User` and running the expression at `backend/box/box.go:1111-1113` verbatim:

```
decoded space_amount=9.223372036854776e+18  is exactly 2**63: true

before:  rclone about -> Total=-9223372036854775808 Used=1024 Free=9223372036854774784
after:   rclone about -> Total=9223372036854775807  Used=1024 Free=9223372036854774784
```

### Why it matters beyond the number

A negative total is read downstream as a missing quota, not as a large one:

- `vfs/vfs.go:668` documents `-1` as "The values will be -1 if they aren't known"
- `vfs.fillInMissingSizes` branches on `total < 0`, sets `total = free`, then `total += used` — which overflows a second time straight back to `MinInt64`, so it does not rescue the value
- `cmd/serve/sftp/connection.go:90` only computes its usage percentage when `total > 0`

### The odd one out

The same guard is correct for the other two type parameters, because `T(int64(math.MaxInt64))` is exact for them:

| `T` | `T(int64(math.MaxInt64))` | behaviour |
|---|---|---|
| `int64` | `2**63-1` exactly | correct |
| `uint64` | `2**63-1` exactly | correct |
| `float64` | rounds up to `2**63` | falls through |

`float64` is the one instantiation the guard was written for.

### The change

```go
-	if value > T(int64(math.MaxInt64)) {
+	// float64(math.MaxInt64) rounds up to 2**63 which doesn't fit in an int64
+	if value >= T(int64(math.MaxInt64)) {
```

A no-op for `int64` and `uint64` (clipping `MaxInt64` to `MaxInt64`). For `float64` it is exactly right: the largest float64 strictly below `2**63` is `9223372036854773760`, which fits in an int64 and is still accepted unclamped.

`backend/premiumizeme/premiumizeme.go:796` is the other `float64` call site and is fixed by the same change.

### Testing

`fs/types_test.go` is new — `NewUsageValue` had no tests. Rows cover all three type parameters and pin **both** sides of the boundary: `9223372036854773760` must be accepted unclamped, `float64(math.MaxInt64)` must clamp.

- On master `TestNewUsageValueFloat64` fails with `expected: 9223372036854775807, actual: -9223372036854775808`; it passes here.
- Mutation-checked both directions. Reverting `>=` to `>` reproduces that failure. Guarding one ulp too early (`>= ...-2048`) fails the other row with `expected: 9223372036854773760, actual: 9223372036854775807`, so the accepted side is pinned too.
- `go build ./...` passes. `RCLONE_CONFIG=/notfound go test -timeout 15m ./fs/ ./vfs/ ./backend/box/` passes. `make quicktest` shows the same pre-existing failures in `cmd/gitannex` and `cmd/serve/docker` with and without this change.
- `gofmt` clean, `go vet` clean, `golangci-lint run ./fs/...` reports only the pre-existing `fs/log.go:17` revive issue.

### Caveat I want to state plainly

I have not observed Box emitting a `space_amount` that rounds to `2**63`; I do not have an account that would. The argument I am making is the narrower one: this helper's only job is to clip, and it does not clip at its own boundary. `9223372036854775807` is the obvious candidate input since it is the usual int64 "unlimited" sentinel, and Box has already moved this number once, but that is a plausible input rather than a measured one. The wrapped result is also implementation dependent per the spec — I measured `MinInt64` on linux/amd64 — which is itself a reason not to let the value through.

Deliberately not in this PR: `backend/box/box.go:1598` does an unguarded `int64(info.Size)` on the same kind of float field. Happy to follow up separately if you want it.

---

AI assistance disclosure: this patch was found and written with Claude Code, following `AGENTS.md`. Every number above is verbatim output from running the tests and probe against master and against this branch.
