### PR TITLE
drime: add optional presigned uploads and cleanup support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ rclone.iml
 .idea
 .history
 .vscode
+rclone.code-workspace
 *.test
 *.iml
 fuzz-build.zip

--- a/backend/drime/api/types.go
+++ b/backend/drime/api/types.go
@@ -115,13 +115,19 @@ func (e Error) Error() string {
 // Check Error satisfies the error interface
 var _ error = (*Error)(nil)
 
-// DeleteRequest is the input to DELETE /file-entries
+// DeleteRequest is the input to POST /file-entries/delete
 type DeleteRequest struct {
 	EntryIDs      []string `json:"entryIds"`
 	DeleteForever bool     `json:"deleteForever"`
 }
 
-// DeleteResponse is the input to DELETE /file-entries
+// EmptyTrashRequest is the input to POST /file-entries/delete when emptying the trash
+type EmptyTrashRequest struct {
+	EntryIDs   []string `json:"entryIds"`
+	EmptyTrash bool     `json:"emptyTrash"`
+}
+
+// DeleteResponse is returned by POST /file-entries/delete
 type DeleteResponse struct {
 	Status  string            `json:"status"`
 	Message string            `json:"message"`

--- a/backend/drime/api/types.go
+++ b/backend/drime/api/types.go
@@ -146,6 +146,24 @@ type UpdateItemResponse struct {
 	FileEntry Item   `json:"fileEntry"`
 }
 
+// SimpleUploadPresignRequest is the input to POST /s3/simple/presign
+type SimpleUploadPresignRequest struct {
+	Filename    string      `json:"filename"`
+	Mime        string      `json:"mime"`
+	Size        int64       `json:"size"`
+	Extension   string      `json:"extension"`
+	WorkspaceID json.Number `json:"workspaceId"`
+	ParentID    json.Number `json:"parentId"`
+}
+
+// SimpleUploadPresignResponse is returned by POST /s3/simple/presign
+type SimpleUploadPresignResponse struct {
+	URL    string `json:"url"`
+	Key    string `json:"key"`
+	ACL    string `json:"acl"`
+	Status string `json:"status"`
+}
+
 // MoveRequest is the input to /file-entries/move
 type MoveRequest struct {
 	EntryIDs      []string `json:"entryIds"`
@@ -220,20 +238,20 @@ type MultiPartCompleteResponse struct {
 	Location string `json:"location"`
 }
 
-// MultiPartEntriesRequest is the input to POST /s3/entries
-type MultiPartEntriesRequest struct {
+// S3EntriesRequest is the input to POST /s3/entries
+type S3EntriesRequest struct {
 	ClientMime      string      `json:"clientMime"`
 	ClientName      string      `json:"clientName"`
 	Filename        string      `json:"filename"`
 	Size            int64       `json:"size"`
 	ClientExtension string      `json:"clientExtension"`
 	ParentID        json.Number `json:"parentId"`
-	RelativePath    string      `json:"relativePath"`
-	WorkspaceID     string      `json:"workspaceId,omitempty"`
+	RelativePath    string      `json:"relativePath,omitempty"`
+	WorkspaceID     json.Number `json:"workspaceId"`
 }
 
-// MultiPartEntriesResponse is the result of POST /s3/entries
-type MultiPartEntriesResponse struct {
+// S3EntriesResponse is the result of POST /s3/entries
+type S3EntriesResponse struct {
 	FileEntry Item `json:"fileEntry"`
 }
 

--- a/backend/drime/drime.go
+++ b/backend/drime/drime.go
@@ -1595,11 +1595,15 @@ func (f *Fs) workspaceID() json.Number {
 func (o *Object) uploadPresigned(ctx context.Context, in io.Reader, src fs.ObjectInfo, leaf, directoryID string) error {
 	mimeType := fs.MimeType(ctx, src)
 	encodedLeaf := o.fs.opt.Enc.FromStandardName(leaf)
+	extension := strings.TrimPrefix(path.Ext(encodedLeaf), ".")
+	if extension == "" {
+		extension = "bin"
+	}
 	presignRequest := api.SimpleUploadPresignRequest{
 		Filename:    encodedLeaf,
 		Mime:        mimeType,
 		Size:        src.Size(),
-		Extension:   strings.TrimPrefix(path.Ext(encodedLeaf), "."),
+		Extension:   extension,
 		WorkspaceID: o.fs.workspaceID(),
 		ParentID:    json.Number(directoryID),
 	}
@@ -1644,7 +1648,7 @@ func (o *Object) uploadPresigned(ctx context.Context, in io.Reader, src fs.Objec
 		ClientName:      encodedLeaf,
 		Filename:        path.Base(presignResponse.Key),
 		Size:            size,
-		ClientExtension: strings.TrimPrefix(path.Ext(encodedLeaf), "."),
+		ClientExtension: extension,
 		ParentID:        json.Number(directoryID),
 		WorkspaceID:     o.fs.workspaceID(),
 	}

--- a/backend/drime/drime.go
+++ b/backend/drime/drime.go
@@ -47,14 +47,15 @@ import (
 )
 
 const (
-	minSleep            = 10 * time.Millisecond
-	maxSleep            = 20 * time.Second
-	decayConstant       = 1 // bigger for slower decay, exponential
-	baseURL             = "https://app.drime.cloud/"
-	rootURL             = baseURL + "api/v1"
-	maxUploadParts      = 10000 // maximum allowed number of parts in a multi-part upload
-	minChunkSize        = fs.SizeSuffix(1024 * 1024 * 5)
-	defaultUploadCutoff = fs.SizeSuffix(5 * 1024 * 1024) // as per https://docs.drime.cloud/uploads-guide
+	minSleep             = 10 * time.Millisecond
+	maxSleep             = 20 * time.Second
+	decayConstant        = 1 // bigger for slower decay, exponential
+	baseURL              = "https://app.drime.cloud/"
+	rootURL              = baseURL + "api/v1"
+	maxUploadParts       = 10000 // maximum allowed number of parts in a multi-part upload
+	minChunkSize         = fs.SizeSuffix(1024 * 1024 * 5)
+	defaultUploadCutoff  = fs.SizeSuffix(5 * 1024 * 1024) // as per https://docs.drime.cloud/uploads-guide
+	presignedUploadLimit = fs.SizeSuffix(5 * 1024 * 1024)
 )
 
 // Register with Fs
@@ -98,6 +99,14 @@ Leave this blank normally unless you wish to specify a Workspace ID.
 		}, {
 			Name:     "hard_delete",
 			Help:     "Delete files permanently rather than putting them into the trash.",
+			Default:  false,
+			Advanced: true,
+		}, {
+			Name: "use_presigned_uploads",
+			Help: `Use presigned URLs for files smaller than 5 MiB.
+
+This adds an extra API request for each eligible file. Files larger than
+upload_cutoff and files with unknown size use multipart uploads instead.`,
 			Default:  false,
 			Advanced: true,
 		}, {
@@ -178,15 +187,16 @@ base32768isOK = true // make sure maxFileLength for 2 byte unicode chars is the 
 
 // Options defines the configuration for this backend
 type Options struct {
-	AccessToken       string               `config:"access_token"`
-	RootFolderID      string               `config:"root_folder_id"`
-	WorkspaceID       string               `config:"workspace_id"`
-	UploadConcurrency int                  `config:"upload_concurrency"`
-	ChunkSize         fs.SizeSuffix        `config:"chunk_size"`
-	HardDelete        bool                 `config:"hard_delete"`
-	UploadCutoff      fs.SizeSuffix        `config:"upload_cutoff"`
-	ListChunk         int                  `config:"list_chunk"`
-	Enc               encoder.MultiEncoder `config:"encoding"`
+	AccessToken         string               `config:"access_token"`
+	RootFolderID        string               `config:"root_folder_id"`
+	WorkspaceID         string               `config:"workspace_id"`
+	UploadConcurrency   int                  `config:"upload_concurrency"`
+	ChunkSize           fs.SizeSuffix        `config:"chunk_size"`
+	HardDelete          bool                 `config:"hard_delete"`
+	UsePresignedUploads bool                 `config:"use_presigned_uploads"`
+	UploadCutoff        fs.SizeSuffix        `config:"upload_cutoff"`
+	ListChunk           int                  `config:"list_chunk"`
+	Enc                 encoder.MultiEncoder `config:"encoding"`
 }
 
 // Fs represents a remote drime
@@ -1397,7 +1407,7 @@ func (s *drimeChunkWriter) Close(ctx context.Context) error {
 	}
 
 	// s3/entries request to create drime object from multipart upload
-	req := api.MultiPartEntriesRequest{
+	req := api.S3EntriesRequest{
 		ClientMime:      s.mime,
 		ClientName:      s.leaf,
 		Filename:        s.uploadName,
@@ -1405,7 +1415,7 @@ func (s *drimeChunkWriter) Close(ctx context.Context) error {
 		ClientExtension: s.extension,
 		ParentID:        s.parentID,
 		RelativePath:    s.relativePath,
-		WorkspaceID:     s.f.opt.WorkspaceID,
+		WorkspaceID:     s.f.workspaceID(),
 	}
 
 	entriesOpts := rest.Opts{
@@ -1413,7 +1423,7 @@ func (s *drimeChunkWriter) Close(ctx context.Context) error {
 		Path:   "/s3/entries",
 	}
 
-	var res api.MultiPartEntriesResponse
+	var res api.S3EntriesResponse
 	err = s.f.pacer.Call(func() (bool, error) {
 		res, err := s.f.srv.CallJSON(ctx, &entriesOpts, req, &res)
 		return shouldRetry(ctx, res, err)
@@ -1565,6 +1575,94 @@ func (o *Object) Storable() bool {
 	return true
 }
 
+// shouldUsePresignedUpload reports whether size should use a presigned URL.
+func (f *Fs) shouldUsePresignedUpload(size int64) bool {
+	return f.opt.UsePresignedUploads &&
+		size >= 0 &&
+		size <= int64(f.opt.UploadCutoff) &&
+		size < int64(presignedUploadLimit)
+}
+
+// workspaceID returns the configured workspace or the personal workspace.
+func (f *Fs) workspaceID() json.Number {
+	if f.opt.WorkspaceID == "" {
+		return "0"
+	}
+	return json.Number(f.opt.WorkspaceID)
+}
+
+// uploadPresigned uploads an object through a presigned URL.
+func (o *Object) uploadPresigned(ctx context.Context, in io.Reader, src fs.ObjectInfo, leaf, directoryID string) error {
+	mimeType := fs.MimeType(ctx, src)
+	encodedLeaf := o.fs.opt.Enc.FromStandardName(leaf)
+	presignRequest := api.SimpleUploadPresignRequest{
+		Filename:    encodedLeaf,
+		Mime:        mimeType,
+		Size:        src.Size(),
+		Extension:   strings.TrimPrefix(path.Ext(encodedLeaf), "."),
+		WorkspaceID: o.fs.workspaceID(),
+		ParentID:    json.Number(directoryID),
+	}
+	presignOpts := rest.Opts{
+		Method: "POST",
+		Path:   "/s3/simple/presign",
+	}
+	var presignResponse api.SimpleUploadPresignResponse
+	err := o.fs.pacer.Call(func() (bool, error) {
+		resp, err := o.fs.srv.CallJSON(ctx, &presignOpts, &presignRequest, &presignResponse)
+		return shouldRetry(ctx, resp, err)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get presigned upload URL: %w", err)
+	}
+	if presignResponse.URL == "" || presignResponse.Key == "" {
+		return errors.New("failed to get presigned upload URL: response has no URL or key")
+	}
+
+	size := src.Size()
+	uploadOpts := rest.Opts{
+		Method:        "PUT",
+		RootURL:       presignResponse.URL,
+		Body:          in,
+		ContentType:   mimeType,
+		ContentLength: &size,
+		NoResponse:    true,
+		ExtraHeaders: map[string]string{
+			"Authorization": "",
+		},
+	}
+	err = o.fs.pacer.CallNoRetry(func() (bool, error) {
+		resp, err := o.fs.srv.Call(ctx, &uploadOpts)
+		return shouldRetry(ctx, resp, err)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to upload with presigned URL: %w", err)
+	}
+
+	entryRequest := api.S3EntriesRequest{
+		ClientMime:      mimeType,
+		ClientName:      encodedLeaf,
+		Filename:        path.Base(presignResponse.Key),
+		Size:            size,
+		ClientExtension: strings.TrimPrefix(path.Ext(encodedLeaf), "."),
+		ParentID:        json.Number(directoryID),
+		WorkspaceID:     o.fs.workspaceID(),
+	}
+	entryOpts := rest.Opts{
+		Method: "POST",
+		Path:   "/s3/entries",
+	}
+	var entryResponse api.S3EntriesResponse
+	err = o.fs.pacer.Call(func() (bool, error) {
+		resp, err := o.fs.srv.CallJSON(ctx, &entryOpts, &entryRequest, &entryResponse)
+		return shouldRetry(ctx, resp, err)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create entry after presigned upload: %w", err)
+	}
+	return o.setMetaData(&entryResponse.FileEntry)
+}
+
 // Open an object for read
 func (o *Object) Open(ctx context.Context, options ...fs.OpenOption) (in io.ReadCloser, err error) {
 	if o.id == "" {
@@ -1641,6 +1739,9 @@ func (o *Object) Update(ctx context.Context, in io.Reader, src fs.ObjectInfo, op
 		s := chunkWriter.(*drimeChunkWriter)
 
 		return o.setMetaData(&s.fileEntry)
+	}
+	if o.fs.shouldUsePresignedUpload(size) {
+		return o.uploadPresigned(ctx, in, src, leaf, directoryID)
 	}
 
 	// Do the upload

--- a/backend/drime/drime.go
+++ b/backend/drime/drime.go
@@ -720,6 +720,30 @@ func (f *Fs) deleteObject(ctx context.Context, id string) error {
 	return nil
 }
 
+// CleanUp empties the trash
+func (f *Fs) CleanUp(ctx context.Context) error {
+	opts := rest.Opts{
+		Method: "POST",
+		Path:   "/file-entries/delete",
+	}
+	request := api.EmptyTrashRequest{
+		EntryIDs:   []string{},
+		EmptyTrash: true,
+	}
+	var result api.DeleteResponse
+	err := f.pacer.Call(func() (bool, error) {
+		resp, err := f.srv.CallJSON(ctx, &opts, &request, &result)
+		return shouldRetry(ctx, resp, err)
+	})
+	if err != nil {
+		return fmt.Errorf("failed to empty trash: %w", err)
+	}
+	for name, errstring := range result.Errors {
+		return fmt.Errorf("failed to empty trash item %q: %s", name, errstring)
+	}
+	return nil
+}
+
 // purgeCheck removes the root directory, if check is set then it
 // refuses to do so if it has anything in
 func (f *Fs) purgeCheck(ctx context.Context, dir string, check bool) error {
@@ -1677,6 +1701,7 @@ var (
 	_ fs.DirMover        = (*Fs)(nil)
 	_ fs.DirCacheFlusher = (*Fs)(nil)
 	_ fs.Abouter         = (*Fs)(nil)
+	_ fs.CleanUpper      = (*Fs)(nil)
 	_ fs.OpenChunkWriter = (*Fs)(nil)
 	_ fs.Object          = (*Object)(nil)
 	_ fs.IDer            = (*Object)(nil)

--- a/backend/drime/drime_test.go
+++ b/backend/drime/drime_test.go
@@ -2,11 +2,42 @@
 package drime
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fstest/fstests"
+	"github.com/rclone/rclone/lib/pacer"
+	"github.com/rclone/rclone/lib/rest"
+	"github.com/stretchr/testify/require"
 )
+
+func TestCleanUp(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, "/file-entries/delete", r.URL.Path)
+
+		var request map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+		require.Equal(t, map[string]any{
+			"emptyTrash": true,
+			"entryIds":   []any{},
+		}, request)
+
+		_, err := w.Write([]byte(`{"status":"success"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	f := &Fs{
+		srv:   rest.NewClient(server.Client()).SetRoot(server.URL),
+		pacer: fs.NewPacer(context.Background(), pacer.NewDefault()),
+	}
+	require.NoError(t, f.CleanUp(context.Background()))
+}
 
 // TestIntegration runs integration tests against the remote
 func TestIntegration(t *testing.T) {

--- a/backend/drime/drime_test.go
+++ b/backend/drime/drime_test.go
@@ -2,18 +2,112 @@
 package drime
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/object"
 	"github.com/rclone/rclone/fstest/fstests"
 	"github.com/rclone/rclone/lib/pacer"
 	"github.com/rclone/rclone/lib/rest"
 	"github.com/stretchr/testify/require"
 )
+
+func TestShouldUsePresignedUpload(t *testing.T) {
+	const fiveMiB = int64(5 * fs.Mebi)
+	for _, test := range []struct {
+		name    string
+		enabled bool
+		cutoff  int64
+		size    int64
+		want    bool
+	}{
+		{name: "disabled", cutoff: int64(10 * fs.Mebi), size: 1, want: false},
+		{name: "unknown size", enabled: true, cutoff: int64(10 * fs.Mebi), size: -1, want: false},
+		{name: "below limits", enabled: true, cutoff: int64(10 * fs.Mebi), size: fiveMiB - 1, want: true},
+		{name: "at presign limit", enabled: true, cutoff: int64(10 * fs.Mebi), size: fiveMiB, want: false},
+		{name: "at cutoff", enabled: true, cutoff: int64(2 * fs.Mebi), size: int64(2 * fs.Mebi), want: true},
+		{name: "above cutoff", enabled: true, cutoff: int64(2 * fs.Mebi), size: int64(2*fs.Mebi + 1), want: false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := Fs{opt: Options{
+				UsePresignedUploads: test.enabled,
+				UploadCutoff:        fs.SizeSuffix(test.cutoff),
+			}}
+			require.Equal(t, test.want, f.shouldUsePresignedUpload(test.size))
+		})
+	}
+}
+
+func TestUploadPresigned(t *testing.T) {
+	const (
+		contents      = "hello"
+		authorization = "Bearer secret"
+	)
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/s3/simple/presign":
+			require.Equal(t, authorization, r.Header.Get("Authorization"))
+			var request map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+			require.Equal(t, map[string]any{
+				"extension":   "txt",
+				"filename":    "file.txt",
+				"mime":        "text/plain",
+				"parentId":    float64(42),
+				"size":        float64(len(contents)),
+				"workspaceId": float64(0),
+			}, request)
+			_, err := w.Write([]byte(`{"url":"` + server.URL + `/storage/object","key":"uploads/uuid/uuid","status":"success"}`))
+			require.NoError(t, err)
+		case "/storage/object":
+			require.Equal(t, http.MethodPut, r.Method)
+			require.Empty(t, r.Header.Get("Authorization"))
+			require.Equal(t, "text/plain", r.Header.Get("Content-Type"))
+			require.Equal(t, int64(len(contents)), r.ContentLength)
+			body, err := io.ReadAll(r.Body)
+			require.NoError(t, err)
+			require.Equal(t, contents, string(body))
+		case "/s3/entries":
+			require.Equal(t, authorization, r.Header.Get("Authorization"))
+			var request map[string]any
+			require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
+			require.Equal(t, map[string]any{
+				"clientExtension": "txt",
+				"clientMime":      "text/plain",
+				"clientName":      "file.txt",
+				"filename":        "uuid",
+				"parentId":        float64(42),
+				"size":            float64(len(contents)),
+				"workspaceId":     float64(0),
+			}, request)
+			_, err := w.Write([]byte(`{"fileEntry":{"id":123,"name":"file.txt","file_size":5,"mime":"text/plain"},"status":"success"}`))
+			require.NoError(t, err)
+		default:
+			t.Fatalf("unexpected request path %q", r.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	client := rest.NewClient(server.Client()).SetRoot(server.URL)
+	client.SetHeader("Authorization", authorization)
+	f := &Fs{
+		opt:   Options{},
+		srv:   client,
+		pacer: fs.NewPacer(context.Background(), pacer.NewDefault()),
+	}
+	o := &Object{fs: f, remote: "file.txt"}
+	src := object.NewStaticObjectInfo("file.txt", time.Now(), int64(len(contents)), true, nil, nil).WithMimeType("text/plain")
+	require.NoError(t, o.uploadPresigned(context.Background(), bytes.NewBufferString(contents), src, "file.txt", "42"))
+	require.Equal(t, "123", o.id)
+}
 
 func TestCleanUp(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/backend/drime/drime_test.go
+++ b/backend/drime/drime_test.go
@@ -49,6 +49,7 @@ func TestUploadPresigned(t *testing.T) {
 	const (
 		contents      = "hello"
 		authorization = "Bearer secret"
+		filename      = "371add24d1b9ee47aa4912e2a5f9f608"
 	)
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -58,8 +59,8 @@ func TestUploadPresigned(t *testing.T) {
 			var request map[string]any
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
 			require.Equal(t, map[string]any{
-				"extension":   "txt",
-				"filename":    "file.txt",
+				"extension":   "bin",
+				"filename":    filename,
 				"mime":        "text/plain",
 				"parentId":    float64(42),
 				"size":        float64(len(contents)),
@@ -80,15 +81,15 @@ func TestUploadPresigned(t *testing.T) {
 			var request map[string]any
 			require.NoError(t, json.NewDecoder(r.Body).Decode(&request))
 			require.Equal(t, map[string]any{
-				"clientExtension": "txt",
+				"clientExtension": "bin",
 				"clientMime":      "text/plain",
-				"clientName":      "file.txt",
+				"clientName":      filename,
 				"filename":        "uuid",
 				"parentId":        float64(42),
 				"size":            float64(len(contents)),
 				"workspaceId":     float64(0),
 			}, request)
-			_, err := w.Write([]byte(`{"fileEntry":{"id":123,"name":"file.txt","file_size":5,"mime":"text/plain"},"status":"success"}`))
+			_, err := w.Write([]byte(`{"fileEntry":{"id":123,"name":"` + filename + `","file_size":5,"mime":"text/plain"},"status":"success"}`))
 			require.NoError(t, err)
 		default:
 			t.Fatalf("unexpected request path %q", r.URL.Path)
@@ -103,9 +104,9 @@ func TestUploadPresigned(t *testing.T) {
 		srv:   client,
 		pacer: fs.NewPacer(context.Background(), pacer.NewDefault()),
 	}
-	o := &Object{fs: f, remote: "file.txt"}
-	src := object.NewStaticObjectInfo("file.txt", time.Now(), int64(len(contents)), true, nil, nil).WithMimeType("text/plain")
-	require.NoError(t, o.uploadPresigned(context.Background(), bytes.NewBufferString(contents), src, "file.txt", "42"))
+	o := &Object{fs: f, remote: filename}
+	src := object.NewStaticObjectInfo(filename, time.Now(), int64(len(contents)), true, nil, nil).WithMimeType("text/plain")
+	require.NoError(t, o.uploadPresigned(context.Background(), bytes.NewBufferString(contents), src, filename, "42"))
 	require.Equal(t, "123", o.id)
 }
 


### PR DESCRIPTION
#### What does this change do?

This adds optional single-part presigned uploads to the Drime backend. When `use_presigned_uploads` is enabled, files with a known size below 5 MiB and at or below `upload_cutoff` are uploaded through Drime's presigned S3 flow. Larger files continue to use the existing standard or multipart paths according to `upload_cutoff`, and files with an unknown size continue to use multipart uploads.

The implementation requests a presigned URL, uploads the content without forwarding the Drime authorization header, and creates the Drime file entry afterwards. Extensionless names, including names produced by a crypt remote, use `bin` as the required client extension.

This also implements the backend `CleanUp` feature using Drime's `/file-entries/delete` endpoint with `emptyTrash` enabled.

Unit tests cover the upload selection boundaries, the complete presigned request/upload/entry flow, extensionless filenames, and emptying the trash.

Validation performed:

- `go build`
- `go test ./backend/drime`
- `make quicktest`
- Live uploads to Drime were tested both directly and through a crypt remote with files from 0.5 MiB to 10 MiB, covering presigned, standard, and multipart upload paths; downloaded content matched the source data
- Live cleanup was tested against Drime

#### Linked issue

Fixes #9750

#### For new or changed backends

This changes an existing backend. The focused tests and live backend checks described above pass. A full `test_all` run was not performed.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
