### PR TITLE
onedrive: allow upload_cutoff up to the documented API limit of 250 MiB

### DIFF
--- a/backend/onedrive/onedrive.go
+++ b/backend/onedrive/onedrive.go
@@ -56,7 +56,15 @@ const (
 	driveTypeSharepoint         = "documentLibrary"
 	defaultChunkSize            = 10 * fs.Mebi
 	chunkSizeMultiple           = 320 * fs.Kibi
-	maxSinglePartSize           = 4 * fs.Mebi
+	// maxSinglePartSize is the size at which Graph stops accepting an upload in a
+	// single request (PUT /items/{id}/content). Microsoft documents this as
+	// "250 MB", see
+	// https://learn.microsoft.com/en-us/graph/api/driveitem-put-content
+	// Measured against SharePoint Online the figure is binary and exclusive: a
+	// body of 262143999 bytes is accepted, one of 262144000 is not. That matches
+	// upload_cutoff being an exclusive threshold in Update below, so a cutoff of
+	// exactly 250Mi sends everything the server would refuse to multipart.
+	maxSinglePartSize = 250 * fs.Mebi
 
 	regionGlobal = "global"
 	regionUS     = "us"
@@ -2786,13 +2794,13 @@ func (o *Object) uploadMultipart(ctx context.Context, in io.Reader, src fs.Objec
 	return info, o.setMetaData(info)
 }
 
-// Update the content of a remote file within 4 MiB size in one single request
+// Update the content of a remote file smaller than maxSinglePartSize in one single request
 // (currently only used when size is exactly 0)
 // This function will set modtime and metadata after uploading, which will create a new version for the remote file
 func (o *Object) uploadSinglepart(ctx context.Context, in io.Reader, src fs.ObjectInfo, options ...fs.OpenOption) (info *api.Item, err error) {
 	size := src.Size()
-	if size < 0 || size > int64(maxSinglePartSize) {
-		return nil, fmt.Errorf("size passed into uploadSinglepart must be >= 0 and <= %v", maxSinglePartSize)
+	if size < 0 || size >= int64(maxSinglePartSize) {
+		return nil, fmt.Errorf("size passed into uploadSinglepart must be >= 0 and < %v", maxSinglePartSize)
 	}
 
 	fs.Debugf(o, "Starting singlepart upload")

--- a/backend/onedrive/onedrive_internal_test.go
+++ b/backend/onedrive/onedrive_internal_test.go
@@ -516,6 +516,30 @@ func (f *Fs) resetTestDefaults(r *fstest.Run) {
 	r.Finalise()
 }
 
+// TestCheckUploadCutoff checks the bounds of the --onedrive-upload-cutoff
+// validation, in particular that the documented API maximum is accepted.
+func TestCheckUploadCutoff(t *testing.T) {
+	for _, test := range []struct {
+		in      fs.SizeSuffix
+		wantErr bool
+	}{
+		{in: 0, wantErr: false},
+		{in: 4 * fs.Mebi, wantErr: false},
+		// maxSinglePartSize is a legal cutoff even though the server refuses a
+		// body of that size, because the cutoff is an exclusive threshold: at
+		// this setting a file of exactly maxSinglePartSize goes multipart.
+		{in: maxSinglePartSize, wantErr: false},
+		{in: maxSinglePartSize + 1, wantErr: true},
+	} {
+		err := checkUploadCutoff(test.in)
+		if test.wantErr {
+			assert.Error(t, err, test.in.String())
+		} else {
+			assert.NoError(t, err, test.in.String())
+		}
+	}
+}
+
 // InternalTest dispatches all internal tests
 func (f *Fs) InternalTest(t *testing.T) {
 	newTestF := func() (*Fs, *fstest.Run) {


### PR DESCRIPTION
## What is the purpose of this change?

`maxSinglePartSize` in the onedrive backend is `4 * fs.Mebi`, which caps
`--onedrive-upload-cutoff` at 4 MiB:

```
CRITICAL: Failed to create file system for "sharepoint:folder/":
onedrive: upload cutoff: 50Mi is greater than 4Mi
```

There is no comment explaining the figure. It appears to come from Microsoft's *"if your file is
less than 4 MB, use a single request"* guidance, which is advice about which method to prefer
rather than a limit. Microsoft documents the actual limit for a single-request upload as **250 MB**
— [Upload small files](https://learn.microsoft.com/en-us/graph/api/driveitem-put-content?view=graph-rest-1.0):

> Provide the contents of a new file or update the contents of an existing file in a single API
> call. **This method only supports files up to 250 MB in size.**

That same page documents replacing an existing item, which is the case that matters here:

```
PUT /drives/{drive-id}/items/{item-id}/content
```

The check runs in `NewFs`, so there is no way around it — the flag, the
`RCLONE_ONEDRIVE_UPLOAD_CUTOFF` environment variable and an `upload_cutoff` line in the config file
are all rejected identically.

## Why this matters on SharePoint

Raising the cutoff is currently the only way to make **replacing an Office document larger than
4 MiB work at all**.

SharePoint rewrites OOXML files on ingest, so the stored item is never the bytes rclone uploaded —
measured on our tenant, an 8,389,805-byte `.xlsx` is stored as 8,398,624. Replacing such an item via
`createUploadSession` fails: the session is created, then the first content `PUT` returns
`404 itemNotFound: The upload session was not found`, and the item stays unwritable at that path.
Creating a new file is fine; only replacing fails. `--ignore-checksum --ignore-size` are set, as the
SharePoint docs recommend.

`--onedrive-upload-cutoff 4M` already fixes this below 4 MiB, because a single `PUT` updates the
existing item in place. Above 4 MiB there is no way to opt in.

## Paired A/B

Same file, same lab, same flags apart from the binary and the cutoff. `bisync` with
`--ignore-checksum --ignore-size --resilient --recover` against a SharePoint document library,
app-only auth, rclone v1.75.1:

| File | Stock v1.75.1, cutoff 4M | This change, cutoff 50M |
|---|---|---|
| 8.00 MiB `.xlsx` | exit 7, `Bisync critical error`, remote unchanged | `Copied (replaced existing)`, 5 s — repeatable |
| 9.20 MiB `.docx` | exit 7, `Bisync critical error`, remote unchanged | `Copied (replaced existing)`, 5 s |
| 45.00 MiB `.xlsx` | exit 7, `Bisync critical error` | one 45 MiB single `PUT`, 8 s |
| 68.92 MiB `.xlsx` | — | exit 7 — above the cutoff, so multipart, so the original failure |

Sizes are actual on-disk bytes, and each file was confirmed repackaged by SharePoint before the run
counted (remote size ≠ local size), so these exercise the failing path rather than a blob stored
as-is.

The patched runs preserve `createdDateTime`, so the item is updated rather than replaced and version
history is retained. Two integrity checks: the 45 MiB remote copy was downloaded and verified as a
sound package (47,195,427 bytes, zip integrity OK, `[Content_Types].xml` present); and a throttled
45 MiB upload killed 12 s in left the remote item byte-identical, so no partial is committed when
`Content-Length` goes unsatisfied.

For reference, the same 45 MiB replace via `PUT /drives/{id}/items/{id}/content` called directly
with an app-only token returns `HTTP 200` on the same item id, three times in a row — so the API
accepts the operation the backend currently declines to attempt.

## Logs

Rejected outright:

```
CRITICAL: Failed to create file system for "sharepoint:Client Portals":
onedrive: upload cutoff: 50Mi is greater than 4Mi
```

With the cutoff at its 4 MiB maximum, replacing an 8 MiB `.xlsx`:

```
DEBUG : big.xlsx: Starting multipart upload
DEBUG : big.xlsx: Uploading segment 0/8389947
DEBUG : big.xlsx: Received 404 error: upload session not found - not retrying:
        HTTP error 404 (404 Not Found) returned body:
        "{\"error\":{\"code\":\"itemNotFound\",\"message\":\"The upload session was not found\"}}"
ERROR : Bisync critical error: itemNotFound: The upload session was not found
ERROR : Bisync aborted. Must run --resync to recover.
```

With this change and `--onedrive-upload-cutoff 50M`, the same edit:

```
DEBUG : big.xlsx: Starting singlepart upload
INFO  : big.xlsx: Copied (replaced existing)
INFO  : Bisync successful
```

## Scope and risk

The constant is referenced in exactly two places, both guards — `checkUploadCutoff` and the size
check at the top of `uploadSinglepart`. The single-vs-multipart routing decision in `Update` uses
`o.fs.opt.UploadCutoff`, the operator's flag.

**The default is unchanged** (`upload_cutoff = -1`, always chunk), so nothing changes for anyone who
does not raise the cutoff deliberately. Leaving the default alone seems right, because a single
`PUT` has no resume — a failed 200 MB upload restarts from zero.

## Checklist

- [x] Change is tested — `TestCheckUploadCutoff` added, covering 0, 4 MiB, the maximum and
      maximum + 1
- [x] `gofmt` clean, `go vet` clean, `go test ./backend/onedrive/` passes
- [x] Built and run against a live SharePoint tenant, not a plausible-looking guess
- [x] First commit line prefixed with the directory of the change
