### PR TITLE
 s3: verify bucket ownership when create error is ambiguous

### DIFF
--- a/backend/s3/provider/Hetzner.yaml
+++ b/backend/s3/provider/Hetzner.yaml
@@ -13,3 +13,4 @@ acl: {}
 bucket_acl: true
 quirks:
   use_already_exists: false
+  check_bucket_ownership: true

--- a/backend/s3/providers.go
+++ b/backend/s3/providers.go
@@ -25,6 +25,7 @@ type Quirks struct {
 	ListURLEncode               *bool  `yaml:"list_url_encode,omitempty"`
 	UseMultipartEtag            *bool  `yaml:"use_multipart_etag,omitempty"`
 	UseAlreadyExists            *bool  `yaml:"use_already_exists,omitempty"`
+	CheckBucketOwnership        *bool  `yaml:"check_bucket_ownership,omitempty"`
 	UseAcceptEncodingGzip       *bool  `yaml:"use_accept_encoding_gzip,omitempty"`
 	UseDataIntegrityProtections *bool  `yaml:"use_data_integrity_protections,omitempty"`
 	MightGzip                   *bool  `yaml:"might_gzip,omitempty"`

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -1132,6 +1132,7 @@ type Options struct {
 	UseAcceptEncodingGzip       fs.Tristate          `config:"use_accept_encoding_gzip"`
 	NoSystemMetadata            bool                 `config:"no_system_metadata"`
 	UseAlreadyExists            fs.Tristate          `config:"use_already_exists"`
+	CheckBucketOwnership        fs.Tristate          `config:"check_bucket_ownership"`
 	UseMultipartUploads         fs.Tristate          `config:"use_multipart_uploads"`
 	UseUnsignedPayload          fs.Tristate          `config:"use_unsigned_payload"`
 	SDKLogMode                  sdkLogMode           `config:"sdk_log_mode"`
@@ -1802,6 +1803,7 @@ func setQuirks(opt *Options, provider *Provider) {
 	set(&opt.UseDataIntegrityProtections, false, provider.Quirks.UseDataIntegrityProtections)
 	set(&opt.MightGzip, true, provider.Quirks.MightGzip)
 	set(&opt.UseAlreadyExists, true, provider.Quirks.UseAlreadyExists)
+	set(&opt.CheckBucketOwnership, false, provider.Quirks.CheckBucketOwnership)
 	set(&opt.UseMultipartUploads, true, provider.Quirks.UseMultipartUploads)
 	if !opt.UseMultipartUploads.Value {
 		opt.UploadCutoff = math.MaxInt64
@@ -2964,10 +2966,13 @@ func (f *Fs) bucketCreateError(ctx context.Context, bucket string, err error) er
 			// We can trust the error to mean not owned by us, so make it non retriable
 			return fserrors.NoRetryError(err)
 		}
-		if exists, _ := f.bucketExists(ctx, bucket); exists {
-			return nil
+		if f.opt.CheckBucketOwnership.Value {
+			if exists, _ := f.bucketExists(ctx, bucket); exists {
+				return nil
+			}
+			return fserrors.NoRetryError(err)
 		}
-		return fserrors.NoRetryError(err)
+		return nil
 	}
 	return err
 }

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -735,6 +735,23 @@ knows about - please make a bug report if not.
 			Default:  fs.Tristate{},
 			Advanced: true,
 		}, {
+			Name: "check_bucket_ownership",
+			Help: strings.ReplaceAll(`Check that the bucket exists and is accessible before treating a
+|BucketAlreadyExists| or |BucketNameUnavailable| error on bucket
+creation as success.
+
+Some providers return the same error for creating a
+bucket the user already owns and for creating a bucket owned by
+someone else, so rclone can't tell which case it is. On those
+providers rclone checks the bucket is accessible before treating the
+error as success and reports the error if it can't access the bucket.
+
+This should be automatically set correctly for all providers rclone
+knows about - please make a bug report if not.
+`, "|", "`"),
+			Default:  fs.Tristate{},
+			Advanced: true,
+		}, {
 			Name: "use_multipart_uploads",
 			Help: `Set if rclone should use multipart uploads.
 
@@ -2959,7 +2976,6 @@ func (f *Fs) bucketCreateError(ctx context.Context, bucket string, err error) er
 	}
 	switch awsErr.ErrorCode() {
 	case "BucketAlreadyOwnedByYou":
-		// we already own the bucket so it exists
 		return nil
 	case "BucketAlreadyExists", "BucketNameUnavailable":
 		if f.opt.UseAlreadyExists.Value {

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2983,10 +2983,11 @@ func (f *Fs) bucketCreateError(ctx context.Context, bucket string, err error) er
 			return fserrors.NoRetryError(err)
 		}
 		if f.opt.CheckBucketOwnership.Value {
-			if exists, _ := f.bucketExists(ctx, bucket); exists {
-				return nil
+			// Error is returned for both owned and unowned fs objects,
+			// so check ownership
+			if exists, _ := f.bucketExists(ctx, bucket); !exists {
+				return fserrors.NoRetryError(err)
 			}
-			return fserrors.NoRetryError(err)
 		}
 		return nil
 	}

--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -2942,24 +2942,34 @@ func (f *Fs) makeBucket(ctx context.Context, bucket string) error {
 		if err == nil {
 			fs.Infof(f, "Bucket %q created with ACL %q", bucket, f.opt.BucketACL)
 		}
-		if awsErr, ok := errors.AsType[smithy.APIError](err); ok {
-			switch awsErr.ErrorCode() {
-			case "BucketAlreadyOwnedByYou":
-				err = nil
-			case "BucketAlreadyExists", "BucketNameUnavailable":
-				if f.opt.UseAlreadyExists.Value {
-					// We can trust BucketAlreadyExists to mean not owned by us, so make it non retriable
-					err = fserrors.NoRetryError(err)
-				} else {
-					// We can't trust BucketAlreadyExists to mean not owned by us, so ignore it
-					err = nil
-				}
-			}
-		}
-		return err
+		return f.bucketCreateError(ctx, bucket, err)
 	}, func() (bool, error) {
 		return f.bucketExists(ctx, bucket)
 	})
+}
+
+// bucketCreateError maps the error returned when creating a bucket to the
+// error rclone should report
+func (f *Fs) bucketCreateError(ctx context.Context, bucket string, err error) error {
+	awsErr, ok := errors.AsType[smithy.APIError](err)
+	if !ok {
+		return err
+	}
+	switch awsErr.ErrorCode() {
+	case "BucketAlreadyOwnedByYou":
+		// we already own the bucket so it exists
+		return nil
+	case "BucketAlreadyExists", "BucketNameUnavailable":
+		if f.opt.UseAlreadyExists.Value {
+			// We can trust the error to mean not owned by us, so make it non retriable
+			return fserrors.NoRetryError(err)
+		}
+		if exists, _ := f.bucketExists(ctx, bucket); exists {
+			return nil
+		}
+		return fserrors.NoRetryError(err)
+	}
+	return err
 }
 
 // Rmdir deletes the bucket if the fs is at the root

--- a/backend/s3/s3_test.go
+++ b/backend/s3/s3_test.go
@@ -523,7 +523,7 @@ func newTestS3Fs(t *testing.T, provider, serverURL string) *Fs {
 // fakeBucketServer emulates a Hetzner style bucket endpoint: CreateBucket
 // (PUT) always returns 409 with the given S3 error code, and HeadBucket
 // (HEAD) returns the given status
-func fakeBucketServer(t *testing.T, putCode string, headStatus int) *httptest.Server {
+func fakeBucketServer(t *testing.T, putCode string, headStatus int, headAllowed bool) *httptest.Server {
 	var requests []string
 	t.Cleanup(func() {
 		for _, req := range requests {
@@ -539,6 +539,9 @@ func fakeBucketServer(t *testing.T, putCode string, headStatus int) *httptest.Se
 			body := "<Error><Code>" + putCode + "</Code><Message>The requested bucket name is not available</Message></Error>"
 			_, _ = w.Write([]byte(body))
 		case http.MethodHead:
+			if !headAllowed {
+				t.Errorf("HEAD %s should not have been attempted", r.URL.Path)
+			}
 			w.WriteHeader(headStatus)
 		default:
 			w.WriteHeader(http.StatusNotFound)
@@ -549,17 +552,18 @@ func fakeBucketServer(t *testing.T, putCode string, headStatus int) *httptest.Se
 // TestMakeBucketOwnBucket reports success for an ambiguous 409 error (e.g.
 // Hetzner) when the bucket is accessible
 func TestMakeBucketOwnBucket(t *testing.T) {
-	server := fakeBucketServer(t, "BucketNameUnavailable", http.StatusOK)
+	server := fakeBucketServer(t, "BucketNameUnavailable", http.StatusOK, true)
 	defer server.Close()
 	f := newTestS3Fs(t, "Hetzner", server.URL)
 	require.False(t, f.opt.UseAlreadyExists.Value, "expected Hetzner to clear the use_already_exists quirk")
+	require.True(t, f.opt.CheckBucketOwnership.Value, "expected Hetzner to set the check_bucket_ownership quirk")
 	assert.NoError(t, f.makeBucket(context.Background(), "test-bucket"))
 }
 
 // TestMakeBucketNotOurBucket reports an error for an ambiguous 409 error
 // (e.g. Hetzner) when the bucket is not accessible
 func TestMakeBucketNotOurBucket(t *testing.T) {
-	server := fakeBucketServer(t, "BucketNameUnavailable", http.StatusNotFound)
+	server := fakeBucketServer(t, "BucketNameUnavailable", http.StatusNotFound, true)
 	defer server.Close()
 	f := newTestS3Fs(t, "Hetzner", server.URL)
 	err := f.makeBucket(context.Background(), "test-bucket")
@@ -567,17 +571,28 @@ func TestMakeBucketNotOurBucket(t *testing.T) {
 	assert.True(t, fserrors.IsNoRetryError(err), "%v", err)
 }
 
+// TestMakeBucketAmbiguousUnverified keeps the old behaviour of swallowing
+// ambiguous 409 errors for providers without the quirk
+func TestMakeBucketAmbiguousUnverified(t *testing.T) {
+	server := fakeBucketServer(t, "BucketNameUnavailable", http.StatusNotFound, false)
+	defer server.Close()
+	f := newTestS3Fs(t, "Ceph", server.URL)
+	require.False(t, f.opt.UseAlreadyExists.Value, "expected Ceph to clear the use_already_exists quirk")
+	require.False(t, f.opt.CheckBucketOwnership.Value, "expected Ceph not to set the check_bucket_ownership quirk")
+	assert.NoError(t, f.makeBucket(context.Background(), "test-bucket"))
+}
+
 // TestMakeBucketErrorCodes covers the other bucket error codes
 func TestMakeBucketErrorCodes(t *testing.T) {
 	// BucketAlreadyOwnedByYou always reports success
-	server := fakeBucketServer(t, "BucketAlreadyOwnedByYou", http.StatusNotFound)
+	server := fakeBucketServer(t, "BucketAlreadyOwnedByYou", http.StatusNotFound, true)
 	defer server.Close()
 	f := newTestS3Fs(t, "Hetzner", server.URL)
 	assert.NoError(t, f.makeBucket(context.Background(), "test-bucket"))
 
 	// With use_already_exists set (the default) the ambiguous error always
 	// reports failure
-	server = fakeBucketServer(t, "BucketNameUnavailable", http.StatusNotFound)
+	server = fakeBucketServer(t, "BucketNameUnavailable", http.StatusNotFound, false)
 	defer server.Close()
 	f = newTestS3Fs(t, "AWS", server.URL)
 	require.True(t, f.opt.UseAlreadyExists.Value, "expected AWS to keep the use_already_exists quirk")

--- a/backend/s3/s3_test.go
+++ b/backend/s3/s3_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/fserrors"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/fstest/fstests"
 	"github.com/rclone/rclone/lib/bucket"
@@ -497,4 +498,90 @@ func TestParseRetainUntilDate(t *testing.T) {
 			}
 		})
 	}
+}
+
+// newTestS3Fs builds a minimal Fs pointed at serverURL, applying the
+// quirks of the given provider
+func newTestS3Fs(t *testing.T, provider, serverURL string) *Fs {
+	ctx := context.Background()
+	opt := &Options{
+		Provider:       provider,
+		Endpoint:       serverURL,
+		ForcePathStyle: true,
+	}
+	client := getClient(ctx, opt)
+	s3Client, _, err := s3Connection(ctx, opt, client)
+	require.NoError(t, err)
+	return &Fs{
+		opt:   *opt,
+		c:     s3Client,
+		cache: bucket.NewCache(),
+		pacer: fs.NewPacer(ctx, pacer.NewS3(pacer.MinSleep(minSleep))),
+	}
+}
+
+// fakeBucketServer emulates a Hetzner style bucket endpoint: CreateBucket
+// (PUT) always returns 409 with the given S3 error code, and HeadBucket
+// (HEAD) returns the given status
+func fakeBucketServer(t *testing.T, putCode string, headStatus int) *httptest.Server {
+	var requests []string
+	t.Cleanup(func() {
+		for _, req := range requests {
+			t.Log(req)
+		}
+	})
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.Method+" "+r.URL.Path)
+		switch r.Method {
+		case http.MethodPut:
+			w.Header().Set("Content-Type", "application/xml")
+			w.WriteHeader(http.StatusConflict)
+			body := "<Error><Code>" + putCode + "</Code><Message>The requested bucket name is not available</Message></Error>"
+			_, _ = w.Write([]byte(body))
+		case http.MethodHead:
+			w.WriteHeader(headStatus)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+}
+
+// TestMakeBucketOwnBucket reports success for an ambiguous 409 error (e.g.
+// Hetzner) when the bucket is accessible
+func TestMakeBucketOwnBucket(t *testing.T) {
+	server := fakeBucketServer(t, "BucketNameUnavailable", http.StatusOK)
+	defer server.Close()
+	f := newTestS3Fs(t, "Hetzner", server.URL)
+	require.False(t, f.opt.UseAlreadyExists.Value, "expected Hetzner to clear the use_already_exists quirk")
+	assert.NoError(t, f.makeBucket(context.Background(), "test-bucket"))
+}
+
+// TestMakeBucketNotOurBucket reports an error for an ambiguous 409 error
+// (e.g. Hetzner) when the bucket is not accessible
+func TestMakeBucketNotOurBucket(t *testing.T) {
+	server := fakeBucketServer(t, "BucketNameUnavailable", http.StatusNotFound)
+	defer server.Close()
+	f := newTestS3Fs(t, "Hetzner", server.URL)
+	err := f.makeBucket(context.Background(), "test-bucket")
+	assert.Error(t, err)
+	assert.True(t, fserrors.IsNoRetryError(err), "%v", err)
+}
+
+// TestMakeBucketErrorCodes covers the other bucket error codes
+func TestMakeBucketErrorCodes(t *testing.T) {
+	// BucketAlreadyOwnedByYou always reports success
+	server := fakeBucketServer(t, "BucketAlreadyOwnedByYou", http.StatusNotFound)
+	defer server.Close()
+	f := newTestS3Fs(t, "Hetzner", server.URL)
+	assert.NoError(t, f.makeBucket(context.Background(), "test-bucket"))
+
+	// With use_already_exists set (the default) the ambiguous error always
+	// reports failure
+	server = fakeBucketServer(t, "BucketNameUnavailable", http.StatusNotFound)
+	defer server.Close()
+	f = newTestS3Fs(t, "AWS", server.URL)
+	require.True(t, f.opt.UseAlreadyExists.Value, "expected AWS to keep the use_already_exists quirk")
+	err := f.makeBucket(context.Background(), "test-bucket")
+	assert.Error(t, err)
+	assert.True(t, fserrors.IsNoRetryError(err), "%v", err)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to rclone!

Please discuss anything more than a trivial fix in an issue FIRST - see the
"Linked issue" section below. Then fill in the questions to help us review.
-->

#### What does this change do?
This PR implements a check for bucket ownership when `BucketAlreadyExists` error is ambiguous.
Specifically, Hetzner uses this error for both owned and unowned buckets, meaning `rclone create remote:unowned_bucket_name` would return success even though no bucket is created. 

#### Linked issue

<!--
Put `Fixes #1234` here if this closes an issue, or `#1234` to link without closing.

IMPORTANT: Anything beyond a trivial fix (typo, doc tweak, small obvious bug fix)
should be discussed and agreed in an issue BEFORE you open a pull request.
Pull requests for larger changes that have not been discussed in an issue first
may be closed. This saves everyone's time if the change needs a different approach
or isn't a good fit.
-->

Fixes #9890

#### For new or changed backends

<!--
Backend pull requests are often sent without the integration tests having been run.
We cannot merge a backend change until it passes the integration tests.

To be merged, a backend change REQUIRES:
  1. A clean run of `go run ./fstest/test_all -backends <remote>` (summarise the
     result below or paste a screenshot of the test_all output in the web browser).
  2. A test account so the maintainers can run the integration tests daily against
     the backend on the integration test server.

If the tests aren't quite passing yet and you need help getting them
to pass, then submit the PR and we can help getting you over the line.

See https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#writing-a-new-backend
and https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests
-->

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.


#### AI disclosure

Code in this PR was made with help from Qwen3.8-27b running locally. The PR + issue are both written by me. 