### PR TITLE
s3: fix v2 auth failing when path style addressing is off

### DIFF
--- a/backend/s3/v2sign.go
+++ b/backend/s3/v2sign.go
@@ -45,6 +45,54 @@ type v2Signer struct {
 	opt *Options
 }
 
+// canonicalResourceBucket returns the bucket named by host, or "" if host
+// addresses the endpoint directly and the bucket is already in the path.
+//
+// v2 signs "/bucket/key" regardless of addressing style, so with virtual host
+// style the bucket has to come from the Host header. endpoint may be empty,
+// in which case host is assumed to be AWS.
+//
+// See https://docs.aws.amazon.com/AmazonS3/latest/dev/RESTAuthentication.html
+func canonicalResourceBucket(host, endpoint string) string {
+	if host == "" {
+		return ""
+	}
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i]
+	}
+	base := endpoint
+	if base != "" {
+		// Strip the scheme and any port to get the endpoint host
+		if i := strings.Index(base, "://"); i >= 0 {
+			base = base[i+3:]
+		}
+		base = strings.TrimSuffix(base, "/")
+		if i := strings.IndexByte(base, '/'); i >= 0 {
+			base = base[:i]
+		}
+		if i := strings.IndexByte(base, ':'); i >= 0 {
+			base = base[:i]
+		}
+	} else {
+		// AWS hosts are bucket.s3.amazonaws.com or
+		// bucket.s3.region.amazonaws.com, so the s3 label starts the endpoint
+		labels := strings.Split(host, ".")
+		for i, label := range labels {
+			if label == "s3" || strings.HasPrefix(label, "s3-") {
+				base = strings.Join(labels[i:], ".")
+				break
+			}
+		}
+		if base == "" {
+			return ""
+		}
+	}
+	if !strings.HasSuffix(host, "."+base) {
+		return ""
+	}
+	return strings.TrimSuffix(host, "."+base)
+}
+
 // SignHTTP signs requests using v2 auth.
 //
 // Cobbled together from goamz and aws-sdk-go.
@@ -59,6 +107,11 @@ func (v2 *v2Signer) SignHTTP(ctx context.Context, credentials aws.Credentials, r
 	uri := req.URL.EscapedPath()
 	if uri == "" {
 		uri = "/"
+	}
+	// v2 signs the bucket as part of the resource, but with virtual host
+	// style addressing it is in the Host header rather than the path
+	if bucket := canonicalResourceBucket(req.URL.Host, v2.opt.Endpoint); bucket != "" {
+		uri = "/" + bucket + uri
 	}
 
 	// Look through headers of interest

--- a/backend/s3/v2sign_test.go
+++ b/backend/s3/v2sign_test.go
@@ -1,0 +1,92 @@
+package s3
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCanonicalResourceBucket(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		host     string
+		endpoint string
+		want     string
+	}{
+		// AWS, no endpoint configured
+		{"aws virtual host", "bucket.s3.amazonaws.com", "", "bucket"},
+		{"aws virtual host region", "bucket.s3.eu-west-1.amazonaws.com", "", "bucket"},
+		{"aws virtual host dash region", "bucket.s3-eu-west-1.amazonaws.com", "", "bucket"},
+		{"aws path style", "s3.amazonaws.com", "", ""},
+		{"aws path style region", "s3.eu-west-1.amazonaws.com", "", ""},
+
+		// Configured endpoint
+		{"endpoint virtual host", "bucket.example.com", "https://example.com", "bucket"},
+		{"endpoint path style", "example.com", "https://example.com", ""},
+		{"endpoint with port", "bucket.example.com:9000", "http://example.com:9000", "bucket"},
+		{"endpoint no scheme", "bucket.example.com", "example.com", "bucket"},
+		{"endpoint with path", "bucket.example.com", "https://example.com/", "bucket"},
+
+		// Bucket names may contain dots on a custom endpoint
+		{"dotted bucket", "my.bucket.example.com", "https://example.com", "my.bucket"},
+
+		// Nothing to do
+		{"empty host", "", "", ""},
+		{"unrecognised host", "localhost:8080", "", ""},
+		{"host not under endpoint", "elsewhere.com", "https://example.com", ""},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.want, canonicalResourceBucket(test.host, test.endpoint))
+		})
+	}
+}
+
+// The same bucket and key addressed either way signs identically, since v2
+// signs "/bucket/key" in both cases.
+func TestV2SignVirtualHostMatchesPathStyle(t *testing.T) {
+	creds := aws.Credentials{AccessKeyID: "accesskey", SecretAccessKey: "secretkey"}
+	signer := &v2Signer{opt: &Options{
+		AccessKeyID:     creds.AccessKeyID,
+		SecretAccessKey: creds.SecretAccessKey,
+	}}
+
+	sign := func(url string) (auth, date string) {
+		req, err := http.NewRequest("GET", url, nil)
+		require.NoError(t, err)
+		require.NoError(t, signer.SignHTTP(context.Background(), creds, req, "", "s3", "us-east-1", time.Now()))
+		return req.Header.Get("Authorization"), req.Header.Get("Date")
+	}
+
+	// SignHTTP stamps Date from time.Now with second resolution, so retry if
+	// the two land either side of a tick
+	var pathAuth, hostAuth string
+	for range 5 {
+		var pathDate, hostDate string
+		pathAuth, pathDate = sign("https://s3.amazonaws.com/bucket/some/key")
+		hostAuth, hostDate = sign("https://bucket.s3.amazonaws.com/some/key")
+		if pathDate == hostDate {
+			break
+		}
+	}
+	assert.Equal(t, pathAuth, hostAuth)
+}
+
+// A path style request already carries the bucket in its path, so nothing is
+// prefixed.
+func TestV2SignPathStyleUnchanged(t *testing.T) {
+	creds := aws.Credentials{AccessKeyID: "accesskey", SecretAccessKey: "secretkey"}
+	signer := &v2Signer{opt: &Options{
+		AccessKeyID:     creds.AccessKeyID,
+		SecretAccessKey: creds.SecretAccessKey,
+		Endpoint:        "https://example.com",
+	}}
+	req, err := http.NewRequest("GET", "https://example.com/bucket/some/key", nil)
+	require.NoError(t, err)
+	require.NoError(t, signer.SignHTTP(context.Background(), creds, req, "", "s3", "us-east-1", time.Now()))
+	assert.Contains(t, req.Header.Get("Authorization"), "AWS accesskey:")
+}


### PR DESCRIPTION
Fixes #8520.

I hit the same thing writing an S3-compatible store against a custom endpoint, and came looking to see how rclone handled it.

v2 signs the bucket as part of the canonical resource:

```
CanonicalizedResource = [ "/" + Bucket ] + <HTTP-Request-URI, from the protocol
name up to the query string> + [ subresource, if present ]
```

`SignHTTP` takes that resource straight from `req.URL.EscapedPath()`. With path style the path is already `/bucket/key`, so it comes out right by accident. With virtual host style the bucket is in the Host header and the path is only `/key`, so it never reaches the string to sign and the server computes a different signature.

That matches the report: dropping either `--s3-v2-auth` or `--s3-force-path-style=false` fixes it, because one puts the bucket back in the path and the other switches to v4, which signs Host anyway.

This pulls the bucket back out of the Host. With an endpoint configured that is exact; without one it looks for the `s3` label, since AWS hosts are `bucket.s3.amazonaws.com` or `bucket.s3.<region>.amazonaws.com`.

There were no tests on the v2 signer, so I have added some. The one that matters asserts that the same bucket and key sign identically whether addressed path style or virtual host style, which is the invariant that was broken. Without the fix:

```
--- FAIL: TestV2SignVirtualHostMatchesPathStyle
    expected: "AWS accesskey:yzu+SH0vG0JLfNfVkIZJazPJxy0="
    actual  : "AWS accesskey:YaxEj2fIy2IYDVmbX6aU1bY1BIA="
```

What I have not done is test against real AWS, since I do not have a bucket set up for v2 auth to point at. So this is verified against the spec and the unit tests, not end to end. @lewoberst if you are still around, it would be worth a run.

One thing I noticed and left alone: `SignHTTP` ignores its `signingTime` argument and uses `time.Now()`, which is why that test has a retry around the Date header. Happy to do it separately if you want it.

`make quicktest` passes other than `cmd/gitannex` and `cmd/nfsmount`, which fail the same way on a clean checkout here (no `rclone` on PATH, and mount permissions).
