### PR TITLE
lshelp: explain that a directory on a bucket-based remote is a key prefix

### DIFF
--- a/cmd/ls/lshelp/lshelp.go
+++ b/cmd/ls/lshelp/lshelp.go
@@ -26,6 +26,10 @@ Note that |ls| and |lsl| recurse by default - use |--max-depth 1| to stop the re
 The other list commands |lsd|,|lsf|,|lsjson| do not recurse by default -
 use |-R| to make them recurse.
 
+On the bucket-based remotes (e.g. s3, gcs, b2) a directory is a key prefix
+rather than an object, so a listing without |-R| shows each prefix as one
+directory entry and not the objects stored under it.
+
 List commands prefer a recursive method that uses more memory but fewer
 transactions by default. Use |--disable ListR| to suppress the behavior.
 See [|--fast-list|](/docs/#fast-list) for more details.


### PR DESCRIPTION
In #9797 someone concluded ~900 objects had gone missing from a bucket, and told the bucket owner so, because `lsjson` returned fewer entries than `lsf --recursive`. Their own numbers add up to correct behaviour: 11,826 objects minus 909 under prefixes is 10,917, plus the 6 prefixes as directory entries is the 10,923 they saw.

The help does say the list commands do not recurse by default. What it does not say is that a directory on a bucket-based remote is a key prefix rather than an object, which is the part that makes a non-recursive listing look truncated if you think of a bucket as a flat keyspace.

So this is one paragraph in `lshelp`, which puts it in `ls`, `lsd`, `lsf`, `lsjson` and `lsl` at once.

The regenerated command docs are included. I only kept the five files this paragraph actually changed; `gendocs` here also wanted to drop the `--rc-web-gui` flags from a dozen other pages, which is a build tag difference on my machine rather than anything to do with this.
