### PR TITLE
fs/accounting: add --min-bandwidth / --min-bandwidth-time to detect stalled transfers

### DIFF
--- a/fs/accounting/accounting.go
+++ b/fs/accounting/accounting.go
@@ -58,18 +58,19 @@ type Account struct {
 	// in http transport calls Read() after Do() returns on
 	// CancelRequest so this race can happen when it apparently
 	// shouldn't.
-	mu       sync.Mutex // mutex protects these values
-	in       io.Reader
-	ctx      context.Context // current context for transfer - may change
-	ci       *fs.ConfigInfo
-	origIn   io.ReadCloser
-	close    io.Closer
-	size     int64
-	name     string
-	closed   bool          // set if the file is closed
-	exit     chan struct{} // channel that will be closed when transfer is finished
-	withBuf  bool          // is using a buffered in
-	checking bool          // set if attached transfer is checking
+	mu        sync.Mutex // mutex protects these values
+	in        io.Reader
+	ctx       context.Context         // current context for transfer - may change
+	ctxCancel context.CancelCauseFunc // cancels ctx above -- see Context(), stallCheck()
+	ci        *fs.ConfigInfo
+	origIn    io.ReadCloser
+	close     io.Closer
+	size      int64
+	name      string
+	closed    bool          // set if the file is closed
+	exit      chan struct{} // channel that will be closed when transfer is finished
+	withBuf   bool          // is using a buffered in
+	checking  bool          // set if attached transfer is checking
 
 	tokenBucket buckets // per file bandwidth limiter (may be nil)
 
@@ -78,30 +79,56 @@ type Account struct {
 
 // accountValues holds statistics for this Account
 type accountValues struct {
-	mu      sync.Mutex // Mutex for stat values.
-	bytes   int64      // Total number of bytes read
-	max     int64      // if >=0 the max number of bytes to transfer
-	start   time.Time  // Start time of first read
-	lpTime  time.Time  // Time of last average measurement
-	lpBytes int64      // Number of bytes read since last measurement
-	avg     float64    // Moving average of last few measurements in Byte/s
+	mu            sync.Mutex // Mutex for stat values.
+	bytes         int64      // Total number of bytes read
+	max           int64      // if >=0 the max number of bytes to transfer
+	start         time.Time  // Start time of first read
+	lpTime        time.Time  // Time of last average measurement
+	lpBytes       int64      // Number of bytes read since last measurement
+	avg           float64    // Moving average of last few measurements in Byte/s
+	belowMinSince time.Time  // zero if avg is currently >= ci.MinBandwidth (or checking is disabled)
+	stallFired    bool       // set once the stall cancellation has been raised, so it is raised only once
 }
+
+// ErrorTransferStalled is returned (wrapped, via context.Cause) when a
+// transfer is cancelled for running below --min-bandwidth for longer than
+// --min-bandwidth-time.
+//
+// Marked retryable so --retries re-drives the transfer: a stall is the case
+// most likely to succeed on a fresh attempt, and StatsInfo.Error routes on
+// fserrors.IsRetryError, which reads the Retry() interface a bare
+// errors.New does not implement.
+//
+// This does not reach --low-level-retries. That loop runs inside the
+// backend on fserrors.ShouldRetry, which consults Timeout()/Temporary()
+// rather than Retry() -- and the backend sees the transport's
+// context.Canceled from the cancelled request, never this error.
+var ErrorTransferStalled = fserrors.RetryError(errors.New("transfer stalled: below --min-bandwidth for longer than --min-bandwidth-time"))
 
 const averagePeriod = 16 // period to do exponentially weighted averages over
 
 // newAccountSizeName makes an Account reader for an io.ReadCloser of
 // the given size and name
 func newAccountSizeName(ctx context.Context, stats *StatsInfo, in io.ReadCloser, size int64, name string) *Account {
+	// Derive a cancelable context so stallCheck (run from averageLoop, in the
+	// background, independent of whether anything is currently calling
+	// Read/AccountRead) can abort THIS transfer specifically on a sustained
+	// --min-bandwidth violation, without affecting sibling transfers sharing
+	// the parent ctx. See Context() -- callers that create an Account must
+	// use it (not the original ctx) for the actual Open/Put/Update call for
+	// cancellation to reach an in-flight request.
+	cctx, cancel := context.WithCancelCause(ctx)
 	acc := &Account{
-		stats:  stats,
-		in:     in,
-		ctx:    ctx,
-		ci:     fs.GetConfig(ctx),
-		close:  in,
-		origIn: in,
-		size:   size,
-		name:   name,
-		exit:   make(chan struct{}),
+		stats:     stats,
+		in:        in,
+		ctx:       cctx,
+		ctxCancel: cancel,
+		ci:        fs.GetConfig(ctx),
+		close:     in,
+		origIn:    in,
+		size:      size,
+		name:      name,
+		exit:      make(chan struct{}),
 		values: accountValues{
 			avg:    0,
 			lpTime: time.Now(),
@@ -196,8 +223,14 @@ func (acc *Account) UpdateReader(ctx context.Context, in io.ReadCloser) {
 		acc.Abandon()
 		acc.withBuf = false
 	}
+	// Release the previous attempt's derived context before replacing it --
+	// see newAccountSizeName. A retry gets its own fresh stall-detection
+	// window rather than inheriting a cancellation (or a head start on one)
+	// from whatever the last attempt was doing.
+	oldCancel := acc.ctxCancel
+	acc.ctx, acc.ctxCancel = context.WithCancelCause(ctx)
+	oldCancel(nil)
 	acc.in = in
-	acc.ctx = ctx
 	acc.close = in
 	acc.origIn = in
 	acc.closed = false
@@ -210,7 +243,22 @@ func (acc *Account) UpdateReader(ctx context.Context, in io.ReadCloser) {
 	acc.values.mu.Lock()
 	acc.values.lpBytes = 0
 	acc.values.bytes = 0
+	acc.values.belowMinSince = time.Time{}
+	acc.values.stallFired = false
 	acc.values.mu.Unlock()
+}
+
+// Context returns the context governing this Account's current transfer
+// attempt. Unlike the ctx originally passed to NewAccountSizeName/
+// UpdateReader, this one can be cancelled independently by stallCheck (a
+// sustained --min-bandwidth violation) without touching the parent -- so it
+// must be what callers pass on to the actual Open/Put/Update call for that
+// cancellation to reach an in-flight request rather than only being visible
+// on the NEXT call into this Account.
+func (acc *Account) Context() context.Context {
+	acc.mu.Lock()
+	defer acc.mu.Unlock()
+	return acc.ctx
 }
 
 // averageLoop calculates averages for the stats in the background
@@ -235,19 +283,73 @@ func (acc *Account) averageLoop() {
 			acc.values.avg = (avg + (period-1)*acc.values.avg) / period
 			acc.values.lpBytes = 0
 			acc.values.lpTime = now
+			cancel, cause := acc.stallCheckLocked(now)
 			// Unlock stats
 			acc.values.mu.Unlock()
+			if cancel {
+				acc.cancelStalled(cause)
+			}
 		case <-acc.exit:
 			return
 		}
 	}
 }
 
+// stallCheckLocked decides whether this transfer has been below
+// --min-bandwidth for longer than --min-bandwidth-time. Must be called with
+// acc.values.mu held (from averageLoop, once per completed average -- see
+// its comment). Disabled entirely (returns false, always) when
+// ci.MinBandwidth is 0, the default -- zero behavior change unless set.
+//
+// This checks the smoothed EWMA (acc.values.avg), not the instantaneous
+// bytes-this-second figure: a transfer that legitimately dips for a couple
+// of seconds (a short stall in a server-side operation, a network blip)
+// must not be cancelled for it -- only a SUSTAINED shortfall should be,
+// which is exactly what --min-bandwidth-time is for.
+func (acc *Account) stallCheckLocked(now time.Time) (shouldCancel bool, cause error) {
+	if acc.ci.MinBandwidth <= 0 || acc.values.stallFired {
+		return false, nil
+	}
+	if acc.values.avg >= float64(acc.ci.MinBandwidth) {
+		acc.values.belowMinSince = time.Time{}
+		return false, nil
+	}
+	if acc.values.belowMinSince.IsZero() {
+		acc.values.belowMinSince = now
+		return false, nil
+	}
+	if now.Sub(acc.values.belowMinSince) < time.Duration(acc.ci.MinBandwidthTime) {
+		return false, nil
+	}
+	acc.values.stallFired = true
+	return true, fmt.Errorf("%w: %v/s averaged over the last %v (want >= %v/s)",
+		ErrorTransferStalled, fs.SizeSuffix(acc.values.avg), time.Duration(acc.ci.MinBandwidthTime), acc.ci.MinBandwidth)
+}
+
+// cancelStalled cancels this Account's Context() (see its doc comment for
+// why that -- not the original ctx passed in -- is what callers must use
+// for cancellation to reach an in-flight request) with cause, and logs
+// once. Idempotent: context.CancelCauseFunc is a no-op once already
+// cancelled, so a transfer that finishes normally right as this fires
+// is not affected -- checkReadBefore's ctx.Err() check on the NEXT call
+// is what actually surfaces the error, and there may be no next call if
+// the transfer already completed.
+func (acc *Account) cancelStalled(cause error) {
+	fs.Errorf(acc.name, "%v", cause)
+	acc.mu.Lock()
+	cancel := acc.ctxCancel
+	acc.mu.Unlock()
+	cancel(cause)
+}
+
 // Check the read before it has happened is valid returning the number
 // of bytes remaining to read.
 func (acc *Account) checkReadBefore() (bytesUntilLimit int64, err error) {
-	// Check to see if context is cancelled
-	if err = acc.ctx.Err(); err != nil {
+	// Check to see if context is cancelled. context.Cause, not ctx.Err --
+	// when stallCheckLocked cancelled this via cancelStalled, Err() alone
+	// would only report "context canceled", losing the actual reason
+	// (ErrorTransferStalled, with the measured speed) that Cause carries.
+	if err = context.Cause(acc.ctx); err != nil {
 		return 0, err
 	}
 	acc.values.mu.Lock()
@@ -593,6 +695,10 @@ func (acc *Account) Done() {
 	defer acc.mu.Unlock()
 	close(acc.exit)
 	acc.stats.inProgress.clear(acc.name)
+	// Release Context()'s resources now the transfer is over -- a no-op if
+	// stallCheckLocked already cancelled it, per context.CancelCauseFunc's
+	// own idempotency.
+	acc.ctxCancel(nil)
 }
 
 // progress returns bytes read as well as the size.

--- a/fs/accounting/min_bandwidth_test.go
+++ b/fs/accounting/min_bandwidth_test.go
@@ -1,0 +1,227 @@
+package accounting
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/fserrors"
+	"github.com/stretchr/testify/require"
+)
+
+// averageLoop evaluates the stall check once per second, so every timing
+// below is expressed in whole ticks. A window of 2s means a cancellation
+// cannot land before the third tick: one to arm belowMinSince, then a full
+// window on top of it.
+const (
+	testMinBandwidth     = 1000            // bytes/sec required
+	testMinBandwidthTime = 2 * time.Second // ...sustained this long
+	testTrickleInterval  = 200 * time.Millisecond
+	testTrickleBytes     = 2       // 2 bytes/200ms = 10 bytes/sec, well under testMinBandwidth
+	testBurstChunk       = 1 << 16 // 64KiB/200ms ~= 327KiB/s, comfortably over it
+)
+
+// minBandwidthContext returns a context carrying a PRIVATE config with the
+// min-bandwidth knobs set, plus the Account built from it.
+//
+// The config must be private: ci.MinBandwidth and ci.MinBandwidthTime are
+// read every second from averageLoop's goroutine for every live Account in
+// the process, including ones belonging to other tests in this package. A
+// test that set them on the shared global config would race those reads and
+// cancel unrelated transfers.
+func minBandwidthContext(t *testing.T, name string, minBandwidth fs.SizeSuffix) (*Account, context.Context) {
+	t.Helper()
+	ctx, ci := fs.AddConfig(context.Background())
+	ci.MinBandwidth = minBandwidth
+	ci.MinBandwidthTime = fs.Duration(testMinBandwidthTime)
+
+	in := io.NopCloser(bytes.NewBuffer(make([]byte, 100)))
+	acc := newAccountSizeName(ctx, NewStats(ctx), in, -1, name)
+	t.Cleanup(acc.Done)
+	return acc, ctx
+}
+
+// TestAccountMinBandwidthDisabledByDefault proves --min-bandwidth's default
+// (0, disabled) is a genuine no-op: a transfer moving well under any
+// reasonable rate is never cancelled when the check isn't opted into.
+//
+// The trickle runs longer than testMinBandwidthTime plus the tick needed to
+// arm it, so this is the same shape of transfer that
+// TestAccountMinBandwidthDetectsStall cancels -- the only difference is that
+// MinBandwidth is left at 0. Flipping that default, or making the check fire
+// when it is unset, therefore fails here.
+func TestAccountMinBandwidthDisabledByDefault(t *testing.T) {
+	require.Equal(t, fs.SizeSuffix(0), fs.GetConfig(context.Background()).MinBandwidth,
+		"test assumes default config -- MinBandwidth should be 0/unset")
+
+	acc, _ := minBandwidthContext(t, "test-disabled", 0)
+
+	deadline := time.Now().Add(testMinBandwidthTime + 2*time.Second)
+	for time.Now().Before(deadline) {
+		require.NoError(t, acc.AccountRead(testTrickleBytes))
+		time.Sleep(testTrickleInterval)
+	}
+
+	require.NoError(t, context.Cause(acc.Context()),
+		"Context() was cancelled despite --min-bandwidth being unset (0)")
+}
+
+// TestAccountMinBandwidthDetectsStall is the fix side of the fshttp repro in
+// issue #9841. That repro showed a connection trickling data slower than a
+// real transfer, but faster than --timeout, can hold a request open
+// indefinitely with no error. This drives the exact same shape of trickle
+// through the real accounting path (AccountRead, the same call
+// rw.SetAccounting wires up for multipart chunk uploads -- see
+// lib/multipart.UploadMultipart) and proves the transfer's own Context()
+// gets cancelled once it has been below --min-bandwidth for
+// --min-bandwidth-time, with a cause any caller can inspect via
+// context.Cause.
+func TestAccountMinBandwidthDetectsStall(t *testing.T) {
+	acc, _ := minBandwidthContext(t, "test-stalled", testMinBandwidth)
+
+	stop := make(chan struct{})
+	defer close(stop)
+	go func() {
+		for {
+			select {
+			case <-stop:
+				return
+			case <-time.After(testTrickleInterval):
+				// Errors expected once the stall is detected -- this
+				// goroutine's job is just to keep trickling, not to assert.
+				_ = acc.AccountRead(testTrickleBytes)
+			}
+		}
+	}()
+
+	start := time.Now()
+	require.Eventually(t, func() bool {
+		return context.Cause(acc.Context()) != nil
+	}, testMinBandwidthTime+3*time.Second, 50*time.Millisecond,
+		"stall was not detected within minBandwidthTime + slack")
+	elapsed := time.Since(start)
+
+	cause := context.Cause(acc.Context())
+	require.ErrorIs(t, cause, ErrorTransferStalled)
+	require.GreaterOrEqual(t, elapsed, testMinBandwidthTime,
+		"detected before a full --min-bandwidth-time window even completed")
+
+	// Whatever is driving this transfer's real Read/AccountRead calls must
+	// see the same failure -- this is what actually stops the transfer and
+	// feeds --retries, not the context cancellation alone.
+	require.ErrorIs(t, acc.AccountRead(1), ErrorTransferStalled)
+
+	// The stall is raised once, not once per tick: on the paths where the
+	// cancellation cannot take effect the transfer keeps running, and an
+	// unlatched check would log for its entire remaining lifetime.
+	acc.values.mu.Lock()
+	fired := acc.values.stallFired
+	acc.values.mu.Unlock()
+	require.True(t, fired, "stall should be latched after firing")
+	acc.values.mu.Lock()
+	again, _ := acc.stallCheckLocked(time.Now().Add(time.Hour))
+	acc.values.mu.Unlock()
+	require.False(t, again, "stall re-fired on a later tick -- it must be raised only once")
+
+	t.Logf("--min-bandwidth=%d/s --min-bandwidth-time=%v; stall against a ~10 bytes/sec trickle "+
+		"detected after %v with: %v", testMinBandwidth, testMinBandwidthTime, elapsed, cause)
+}
+
+// TestAccountMinBandwidthStallIsRetryable proves the stall error is marked
+// retryable, so --retries re-drives the transfer deliberately rather than
+// incidentally: a stall is the case most likely to succeed on a fresh
+// attempt. StatsInfo.Error routes on IsRetryError, so an unmarked error
+// would be counted as a plain failure.
+//
+// Note this covers --retries, NOT --low-level-retries: that loop runs inside
+// the backend on fserrors.ShouldRetry, which consults Timeout()/Temporary()
+// rather than Retry(), and in any case the backend sees the transport's
+// context.Canceled, never this error.
+func TestAccountMinBandwidthStallIsRetryable(t *testing.T) {
+	require.True(t, fserrors.IsRetryError(ErrorTransferStalled),
+		"ErrorTransferStalled must be marked retryable or --retries counts a stall as a hard failure")
+	require.False(t, fserrors.IsNoRetryError(ErrorTransferStalled))
+
+	// The wrapping stallCheckLocked applies must preserve both properties.
+	wrapped := fmt.Errorf("%w: 9/s averaged over the last 2s (want >= 1000/s)", ErrorTransferStalled)
+	require.True(t, fserrors.IsRetryError(wrapped))
+	require.ErrorIs(t, wrapped, ErrorTransferStalled)
+}
+
+// TestStallCheckResetsWindowOnRecovery drives stallCheckLocked directly, at
+// chosen instants, because the reset it covers cannot be reached in
+// reasonable wall-clock time through AccountRead: avg is an EWMA over 16
+// samples, so falling back below the threshold after a burst takes ~33
+// one-second ticks.
+//
+// What the reset buys is that a dip which recovers does not leave a stale
+// belowMinSince behind, so a LATER dip gets a full --min-bandwidth-time
+// window of its own rather than inheriting the first dip's head start.
+// Without it, the second dip here cancels immediately.
+func TestStallCheckResetsWindowOnRecovery(t *testing.T) {
+	acc, _ := minBandwidthContext(t, "test-reset", testMinBandwidth)
+
+	// Held throughout: averageLoop calls stallCheckLocked under this same
+	// lock, and would otherwise overwrite avg between steps.
+	acc.values.mu.Lock()
+	defer acc.values.mu.Unlock()
+	t0 := time.Now()
+
+	acc.values.avg = 10 // below the minimum: arms the window
+	cancel, _ := acc.stallCheckLocked(t0)
+	require.False(t, cancel)
+	require.Equal(t, t0, acc.values.belowMinSince)
+
+	acc.values.avg = 2 * testMinBandwidth // recovered: must clear the window
+	cancel, _ = acc.stallCheckLocked(t0.Add(time.Second))
+	require.False(t, cancel)
+	require.True(t, acc.values.belowMinSince.IsZero(),
+		"recovering above --min-bandwidth must reset the stall window")
+
+	acc.values.avg = 10 // dips again, a full --min-bandwidth-time after t0
+	cancel, _ = acc.stallCheckLocked(t0.Add(testMinBandwidthTime))
+	require.False(t, cancel,
+		"a fresh dip must start a new window, not inherit the first dip's elapsed time")
+
+	// ...and only then, a full window after the SECOND dip began.
+	cancel, cause := acc.stallCheckLocked(t0.Add(2 * testMinBandwidthTime))
+	require.True(t, cancel)
+	require.ErrorIs(t, cause, ErrorTransferStalled)
+}
+
+// TestAccountMinBandwidthRecovers proves a transfer that dips below
+// --min-bandwidth briefly, then recovers before --min-bandwidth-time
+// elapses, is NOT cancelled -- only a SUSTAINED shortfall should be. This
+// matters because legitimate short stalls are common: a bursty network is
+// routine, and a server-side operation can pause mid-transfer.
+//
+// stallCheckLocked resets belowMinSince the moment avg clears the threshold
+// again, and that reset is what is under test: the run must outlive
+// belowMinSince + --min-bandwidth-time, or the assertion holds for the
+// trivial reason that no tick could have cancelled yet. Deleting the reset
+// branch must make this fail, so the burst phase runs past the third tick.
+func TestAccountMinBandwidthRecovers(t *testing.T) {
+	acc, _ := minBandwidthContext(t, "test-recovers", testMinBandwidth)
+
+	// Under the minimum for ~1.5s: the tick at ~1s arms belowMinSince.
+	dipUntil := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(dipUntil) {
+		require.NoError(t, acc.AccountRead(testTrickleBytes))
+		time.Sleep(testTrickleInterval)
+	}
+
+	// Then comfortably over it, past belowMinSince + --min-bandwidth-time
+	// (~3s). Without the reset, the tick at ~3s cancels.
+	burstUntil := time.Now().Add(2500 * time.Millisecond)
+	for time.Now().Before(burstUntil) {
+		require.NoError(t, acc.AccountRead(testBurstChunk))
+		time.Sleep(testTrickleInterval)
+	}
+
+	require.NoError(t, context.Cause(acc.Context()),
+		"cancelled despite recovering above --min-bandwidth before --min-bandwidth-time elapsed")
+}

--- a/fs/config.go
+++ b/fs/config.go
@@ -122,6 +122,16 @@ var ConfigOptionsInfo = Options{{
 	Help:    "IO idle timeout",
 	Groups:  "Networking",
 }, {
+	Name:    "min_bandwidth",
+	Default: SizeSuffix(0),
+	Help:    "Minimum average transfer speed required over --min-bandwidth-time before a transfer is considered stalled (e.g. 1k). 0 disables (default)",
+	Groups:  "Networking",
+}, {
+	Name:    "min_bandwidth_time",
+	Default: 60 * time.Second,
+	Help:    "How long a transfer may run below --min-bandwidth before it is cancelled as stalled",
+	Groups:  "Networking",
+}, {
 	Name:    "expect_continue_timeout",
 	Default: 1 * time.Second,
 	Help:    "Timeout when using expect / 100-continue in HTTP",
@@ -584,8 +594,10 @@ type ConfigInfo struct {
 	ModifyWindow               Duration          `config:"modify_window"`
 	Checkers                   int               `config:"checkers"`
 	Transfers                  int               `config:"transfers"`
-	ConnectTimeout             Duration          `config:"contimeout"` // Connect timeout
-	Timeout                    Duration          `config:"timeout"`    // Data channel timeout
+	ConnectTimeout             Duration          `config:"contimeout"`         // Connect timeout
+	Timeout                    Duration          `config:"timeout"`            // Data channel timeout
+	MinBandwidth               SizeSuffix        `config:"min_bandwidth"`      // Minimum avg bytes/sec required over MinBandwidthTime, 0 disables
+	MinBandwidthTime           Duration          `config:"min_bandwidth_time"` // Window MinBandwidth is measured over
 	ExpectContinueTimeout      Duration          `config:"expect_continue_timeout"`
 	Dump                       DumpFlags         `config:"dump"`
 	InsecureSkipVerify         bool              `config:"no_check_certificate"` // Skip server certificate verification

--- a/fs/operations/copy.go
+++ b/fs/operations/copy.go
@@ -219,14 +219,31 @@ func (c *copy) updateOrPut(ctx context.Context, in io.ReadCloser, uploadOptions 
 	if c.src.Remote() != c.remoteForCopy {
 		wrappedSrc = fs.NewOverrideRemote(c.src, c.remoteForCopy)
 	}
+	// inAcc.Context(), NOT ctx: a --min-bandwidth stall is detected in the
+	// background (Account's averageLoop), independent of whatever this
+	// Update/Put call is currently blocked doing, and can only reach an
+	// in-flight request by cancelling the SAME context that request is
+	// running under. Passing plain ctx here would make the cancellation
+	// invisible until this call already returns on its own.
+	stallCtx := inAcc.Context()
 	if c.doUpdate && c.inplace {
-		err = c.dst.Update(ctx, inAcc, wrappedSrc, uploadOptions...)
+		err = c.dst.Update(stallCtx, inAcc, wrappedSrc, uploadOptions...)
 		// Make sure newDst is c.dst since we updated it
 		if err == nil {
 			newDst = c.dst
 		}
 	} else {
-		newDst, err = c.f.Put(ctx, inAcc, wrappedSrc, uploadOptions...)
+		newDst, err = c.f.Put(stallCtx, inAcc, wrappedSrc, uploadOptions...)
+	}
+	// A cancelled request surfaces as ctx.Err() -- a bare context.Canceled --
+	// because that is all the HTTP transport propagates; context.Cause is
+	// never consulted. Recover the cause so a --min-bandwidth stall reaches
+	// the caller as the stall itself (measured speed included, and marked
+	// retryable) rather than as "context canceled".
+	if err != nil {
+		if cause := context.Cause(stallCtx); errors.Is(cause, accounting.ErrorTransferStalled) {
+			err = cause
+		}
 	}
 	closeErr := inAcc.Close()
 	if err == nil {


### PR DESCRIPTION
Fixes #9841

> **Draft.** An earlier revision of this description claimed the `CompleteMultipartUpload` case was handled. It is not — see [this comment](https://github.com/rclone/rclone/pull/9895#issuecomment-5607763827) and the "Known limitation" section below. The description has been corrected; the comment is kept for the record.

Adds `--min-bandwidth` (bytes/sec, default `0`/disabled) and `--min-bandwidth-time` (default `60s`): if a transfer averages below `--min-bandwidth` for a full `--min-bandwidth-time` window it is cancelled with a retryable error, so `--retries` can engage. Zero behaviour change when unset.

This is the two-knob shape @ncw described in #9841, matching curl's `--speed-limit`/`--speed-time` and google-drive-ocamlfuse's `low_speed_limit`/`low_speed_time` — the semantics asked for in #887 and #2122.

### Known limitation — the `CompleteMultipartUpload` objection is NOT yet resolved

`stallCheckLocked` cancels purely on the EWMA falling below the threshold. It has no notion of a legitimate zero-progress phase — no completion gate, no source-EOF gate, no not-yet-started gate. So:

- **`CompleteMultipartUpload`**: once the destination has consumed the whole source reader and is waiting on the server to finalise, no further `AccountRead` occurs, so `avg` decays toward 0 while `updateOrPut` is passing `inAcc.Context()` to that very finalisation request. At `--min-bandwidth=1M` on a 5 MB/s upload the cancel lands ~85s in, orphaning the multipart upload.
- **Server-side copy**: bytes are booked in one lump at `ServerSideCopyEnd`, so `avg` is 0 throughout. It does not abort the copy (that runs under a different context), so the effect is a spurious stall report.
- A transfer that has not yet moved its first byte arms the timer on the first tick.

Moving from `timeoutConn` to `Account` **does** fix keep-alive pooling and the measures-the-wrong-thing problem, but not this: the check fires on the *absence* of accounted bytes, and legitimate finalisation is exactly that absence. Fixing it needs an explicit exempt state rather than a guard, which changes what the feature promises — hence draft, pending @ncw's view on the shape.

### Why `fs/accounting` and not `timeoutConn`

Per @ncw's review on #9841, and two of the three objections do hold here:

- **HTTP keep-alive pooling** — the check is per-transfer, not per-connection, so a pooled connection cannot carry stall state into an unrelated request.
- **Measuring the wrong thing** — `Account` tracks per-transfer progress rather than bytes-on-the-wire, and is fed real network bytes for multipart chunk uploads via `rw.SetAccounting(acc.AccountRead)` (`lib/multipart.UploadMultipart`).
- **Legitimate trickles** — not resolved; see above.

### Mechanism

Checked once per completed `--min-bandwidth-time` window against `Account`'s existing EWMA (`acc.values.avg` — the same figure `--stats` uses), not the instantaneous rate, so a short dip does not trip it. Raised at most once per attempt (latched, reset in `UpdateReader`).

A sustained shortfall cancels the transfer's own context via `context.WithCancelCause`, so the cause (`ErrorTransferStalled`, carrying the measured speed) survives. `ErrorTransferStalled` is wrapped in `fserrors.RetryError` so `StatsInfo.Error` classifies it as retryable and `--retries` re-drives the transfer. `updateOrPut` maps `context.Cause` back onto the returned error, because the HTTP transport propagates only `ctx.Err()` and the reason would otherwise surface as `context canceled`.

Note this does **not** reach `--low-level-retries`: that loop runs inside the backend on `fserrors.ShouldRetry`, which consults `Timeout()`/`Temporary()` rather than `Retry()`, and the backend sees the transport's `context.Canceled` rather than this error. An earlier revision of this description claimed otherwise.

`Account.Context()` is new. Callers that create an `Account` must pass **that** — not the original `ctx` — to the subsequent `Open`/`Put`/`Update`, because the cancellation fires from `averageLoop`'s background goroutine and only reaches an in-flight request running under the same context.

### Scope

Wired into `fs/operations/copy.go`'s `updateOrPut`, the single-file Put/Update path that the incident in #9841 hit.

**Not** migrated, and this is a defect rather than merely unfinished work — on these paths a stall is detected and logged but the abort cannot land:

- `fs/operations/multithread.go` (`multiThreadCopy` / `mc.acc = tr.Account(gCtx, nil)`) — the default path above `--multi-thread-cutoff 256Mi`, i.e. exactly the wedged large-file upload from #9841
- `fs/operations/check.go` (three `.Account(ctx, ...)` sites)

Either those get migrated, or the stall check should not run for Accounts whose context is not wired through. Happy to do either in this PR.

Also worth a decision: the check hangs off every `Account`, not just sync transfers — `vfs/read.go` open handles, `serve http`/webdav GETs, `HashSum`, `catObject`. Being idle is normal for those, so a global `--min-bandwidth` would cancel an idle `mount` read handle after `--min-bandwidth-time`. Probably wants scoping or explicit documentation.

### Tests

`fs/accounting/min_bandwidth_test.go`, driven through the real `AccountRead` path, each on a private config via `fs.AddConfig` (a shared global `fs.ConfigInfo` races `averageLoop`, which is what made CI red on an earlier revision):

- `TestAccountMinBandwidthDetectsStall` — 10 bytes/sec against a 1000 bytes/sec minimum; surfaced via `Context()` and a subsequent `AccountRead`, and asserts the stall latches rather than re-firing every tick.
- `TestStallCheckResetsWindowOnRecovery` — drives `stallCheckLocked` at chosen instants: a dip that recovers must not leave a stale window behind, so a later dip gets a full `--min-bandwidth-time` of its own.
- `TestAccountMinBandwidthRecovers` — a dip that clears is not cancelled, run past the point where a non-resetting implementation would have fired.
- `TestAccountMinBandwidthStallIsRetryable` — the error is marked retryable and survives wrapping.
- `TestAccountMinBandwidthDisabledByDefault` — no behaviour change when unset.

Verified on go1.26: `go vet ./fs/...` and `gofmt -l fs` clean; `go test -race ./fs/accounting/ ./fs/operations/ ./fs/` clean over the whole packages. `make racequicktest` shows the same nine failing packages as pristine `master` in the same container (root user defeats the permission-denial tests, no FUSE, NFS symlinks unsupported) and no others.

Each fix is mutation-checked: deleting the recovery reset, removing the whole recovery branch, unlatching the stall, and un-marking the error retryable each turn the corresponding test red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Cp6djGjYDg518RujgZwMsr
