### PR TITLE
chunker: fix single-file operations over union remotes

### DIFF
--- a/backend/chunker/chunker.go
+++ b/backend/chunker/chunker.go
@@ -294,14 +294,10 @@ func NewFs(ctx context.Context, name, rpath string, m configmap.Mapper) (fs.Fs, 
 	}
 	// Look for a file first
 	remotePath := fspath.JoinRootPath(basePath, rpath)
-	baseFs, err := cache.Get(ctx, baseName+remotePath)
+	baseFs, err := getBaseFs(ctx, baseName+remotePath)
 	if err != fs.ErrorIsFile && err != nil {
 		return nil, fmt.Errorf("failed to make remote %q to wrap: %w", baseName+remotePath, err)
 	}
-	if !operations.CanServerSideMove(baseFs) {
-		return nil, errors.New("can't use chunker on a backend which doesn't support server-side move or copy")
-	}
-
 	f := &Fs{
 		base: baseFs,
 		name: name,
@@ -310,24 +306,23 @@ func NewFs(ctx context.Context, name, rpath string, m configmap.Mapper) (fs.Fs, 
 	}
 	f.dirSort = true // processEntries requires that meta Objects prerun data chunks atm.
 
-	if err := f.configure(opt.NameFormat, opt.MetaFormat, opt.HashType, opt.Transactions); err != nil {
-		return nil, err
-	}
-
 	// Handle the tricky case detected by FsMkdir/FsPutFiles/FsIsFile
 	// when `rpath` points to a composite multi-chunk file without metadata,
 	// i.e. `rpath` does not exist in the wrapped remote, but chunker
 	// detects a composite file because it finds the first chunk!
 	// (yet can't satisfy fstest.CheckListing, will ignore)
-	if err == nil && !f.useMeta {
+	if err == nil && opt.MetaFormat == "none" {
+		if formatErr := f.setChunkNameFormat(opt.NameFormat); formatErr != nil {
+			return nil, fmt.Errorf("invalid name format '%s': %w", opt.NameFormat, formatErr)
+		}
 		firstChunkPath := f.makeChunkName(remotePath, 0, "", "")
-		newBase, testErr := cache.Get(ctx, baseName+firstChunkPath)
+		newBase, testErr := getBaseFs(ctx, baseName+firstChunkPath)
 		if testErr == fs.ErrorIsFile {
+			baseFs = newBase
 			f.base = newBase
 			err = testErr
 		}
 	}
-	cache.PinUntilFinalized(f.base, f)
 
 	// Correct root if definitely pointing to a file
 	if err == fs.ErrorIsFile {
@@ -336,6 +331,14 @@ func NewFs(ctx context.Context, name, rpath string, m configmap.Mapper) (fs.Fs, 
 			f.root = ""
 		}
 	}
+
+	if !operations.CanServerSideMove(baseFs) {
+		return nil, errors.New("can't use chunker on a backend which doesn't support server-side move or copy")
+	}
+	if err := f.configure(opt.NameFormat, opt.MetaFormat, opt.HashType, opt.Transactions); err != nil {
+		return nil, err
+	}
+	cache.PinUntilFinalized(baseFs, f)
 
 	// Note 1: the features here are ones we could support, and they are
 	// ANDed with the ones from wrappedFs.
@@ -360,6 +363,24 @@ func NewFs(ctx context.Context, name, rpath string, m configmap.Mapper) (fs.Fs, 
 	f.features.ListP = nil // ListP not supported yet
 
 	return f, err
+}
+
+// getBaseFs opens the full parent of a file, including siblings on other upstreams.
+func getBaseFs(ctx context.Context, remote string) (fs.Fs, error) {
+	parent, leaf, err := fspath.Split(remote)
+	if err != nil {
+		return nil, err
+	}
+	if leaf != "" {
+		// Detect files through their parent: a file-rooted backend can
+		// restrict which siblings are accessible, e.g. union upstreams.
+		if f, err := cache.Get(ctx, parent); err == nil {
+			if _, err := f.NewObject(ctx, leaf); err == nil {
+				return f, fs.ErrorIsFile
+			}
+		}
+	}
+	return cache.Get(ctx, remote)
 }
 
 // Options defines the configuration for this backend

--- a/backend/chunker/chunker_test.go
+++ b/backend/chunker/chunker_test.go
@@ -2,15 +2,24 @@
 package chunker_test
 
 import (
+	"context"
 	"flag"
+	"fmt"
 	"os"
+	"path"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	_ "github.com/rclone/rclone/backend/all" // for integration tests
 	"github.com/rclone/rclone/backend/chunker"
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fs/cache"
+	"github.com/rclone/rclone/fs/operations"
 	"github.com/rclone/rclone/fstest"
 	"github.com/rclone/rclone/fstest/fstests"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // Command line flags
@@ -60,4 +69,67 @@ func TestIntegration(t *testing.T) {
 		opt.QuickTestOK = true
 	}
 	fstests.Run(t, &opt)
+}
+
+func TestNewFsUnionSingleFile(t *testing.T) {
+	fstest.Initialise()
+	for _, meta := range []string{"simplejson", "none"} {
+		for _, root := range []struct{ base, parent string }{{"", ""}, {"", "subdir"}, {"base", ""}, {"base", "subdir"}} {
+			base, parent := root.base, root.parent
+			t.Run(meta+"/"+path.Join(base, parent), func(t *testing.T) {
+				ctx := context.Background()
+				dirs := []string{t.TempDir(), t.TempDir(), t.TempDir()}
+				const contents = "abcdefghijklmnop"
+				const name = "file.txt"
+				remote := path.Join(parent, name)
+				upload, err := fs.NewFs(ctx, fmt.Sprintf(":chunker,remote=%q,chunk_size=3b,hash_type=none,meta_format=%s:", filepath.Join(dirs[0], base), meta))
+				require.NoError(t, err)
+				item := fstest.NewItem(remote, contents, fstest.Time("2001-02-03T04:05:06Z"))
+				fstests.PutTestContents(ctx, t, upload, &item, contents, true)
+
+				// Leave the metadata on its own upstream and split the chunks
+				// between two others, independently of the create policy.
+				chunks, err := filepath.Glob(filepath.Join(dirs[0], base, parent, name+".rclone_chunk.*"))
+				require.NoError(t, err)
+				require.Len(t, chunks, 6)
+				for i, chunk := range chunks {
+					dst := filepath.Join(dirs[1+i%2], base, parent, filepath.Base(chunk))
+					require.NoError(t, os.MkdirAll(filepath.Dir(dst), 0700))
+					require.NoError(t, os.Rename(chunk, dst))
+				}
+
+				t.Setenv("RCLONE_CONFIG_TESTCHUNKERUNION_TYPE", "union")
+				t.Setenv("RCLONE_CONFIG_TESTCHUNKERUNION_UPSTREAMS", strings.Join(dirs, " "))
+				fsString := fmt.Sprintf(":chunker,remote=%q,chunk_size=3b,hash_type=none,meta_format=%s:", "TestChunkerUnion:"+base, meta)
+				// A cached directory Fs would hide single-file upstream selection.
+				cache.Clear()
+				t.Cleanup(cache.Clear)
+				fileFs, err := fs.NewFs(ctx, fsString+remote)
+				require.ErrorIs(t, err, fs.ErrorIsFile)
+				assert.Equal(t, parent, fileFs.Root())
+				obj, err := fileFs.NewObject(ctx, name)
+				require.NoError(t, err)
+				data, err := operations.ReadFile(ctx, obj)
+				require.NoError(t, err)
+				assert.Equal(t, contents, string(data))
+
+				again, err := fs.NewFs(ctx, fsString+remote)
+				require.ErrorIs(t, err, fs.ErrorIsFile)
+				assert.Same(t, fileFs.(*chunker.Fs).UnWrap(), again.(*chunker.Fs).UnWrap())
+
+				entries, err := fileFs.List(ctx, "")
+				require.NoError(t, err)
+				require.Len(t, entries, 1)
+				assert.Equal(t, name, entries[0].Remote())
+
+				dirFs, err := fs.NewFs(ctx, fsString+parent)
+				require.NoError(t, err)
+				obj, err = dirFs.NewObject(ctx, name)
+				require.NoError(t, err)
+				data, err = operations.ReadFile(ctx, obj)
+				require.NoError(t, err)
+				assert.Equal(t, contents, string(data))
+			})
+		}
+	}
 }


### PR DESCRIPTION
#### What does this change do?

Fix single-file listing, copying and moving when chunker wraps a union whose chunks are distributed across upstreams. Opening the union at the metadata file (or first chunk) can restrict it to the upstream containing that file, leaving other chunks inaccessible even though directory reads work.

Detect a file through its cached parent and keep that complete parent as chunker's base. Configure hashing, transaction mode and features from the final base. This also handles metadata-free files and preserves the standard cache lifecycle and path handling. The extra parent-object probe is confined to chunker; ordinary union single-file behavior is unchanged.

Add eight regression cases covering both metadata formats, configured and nested roots, metadata-only upstreams, distributed chunks, repeated file opens and directory reads. All eight fail against the unmodified production code and pass with this change.

This contribution was implemented and tested with OpenAI Codex assistance.

#### Linked issue

Fixes #7955

The issue includes the maintainer's [reproduction and analysis](https://github.com/rclone/rclone/issues/7955#issuecomment-2233054722).

#### For new or changed backends

- `go build`: passed.
- `go test ./backend/chunker ./backend/union/... -count=1`: passed.
- `make quicktest`: passed as an unprivileged user. FTP loopback tests ran in a private network namespace to avoid host Kubernetes NodePort conflicts.
- `go run ./fstest/test_all -backends chunker,union -tests backend -config <local-test-config> -n 2 -maxtries 1`: **4/4 passed**, against chunker/union, chunker/local, metadata-free chunker/local and ordinary union, all backed by temporary local directories.
- The additional full `test_all` matrix encounters an existing bisync setup failure on chunker/union: `sync.CopyDir` returns `object not found` while setting up `path1`. This is reproduced on unmodified master `ef6968730fc5582aa2a1db028440f3acc48b4e27` with the same configuration and unprivileged user using `go test ./cmd/bisync -run '^TestBisyncRemoteLocal$/^all_changed$' -remote TestChunkerUnion: -count=1 -v`. The extra full-matrix attempt was stopped after confirming this baseline failure; a complete full-matrix pass is not claimed.
- CLI reproduction: with a naturally distributed 5 MiB file, directory copying succeeds before the fix while single-file listing is empty and `copyto`/`moveto` fail. All commands pass after the fix. An independent run with 5 MiB + 137 bytes of random data passes listing, copy, move and renamed-file copy with matching SHA-256 hashes and removal of the old remote file/chunks.
- `golangci-lint run --new-from-rev ef6968730fc5582aa2a1db028440f3acc48b4e27`: 0 issues. Full lint reports the same existing `revive` warning at `fs/log.go:17` on both the unmodified base and this patch.

The integration remotes use existing backends and temporary local storage; no cloud account or new backend is involved.

#### Checklist

- [ ] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [ ] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate. (No configuration or user-facing documentation change is needed.)
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
