### PR TITLE
chunkedreader: fix parallel reader hanging forever when a stream fails

### DIFF
--- a/fs/chunkedreader/parallel.go
+++ b/fs/chunkedreader/parallel.go
@@ -40,6 +40,8 @@ type stream struct {
 	readBytes int64           // bytes read from the stream
 	rw        *pool.RW        // buffer for read
 	err       chan error      // error returned from the read
+	done      chan struct{}   // closed when readFrom has finished
+	readErr   error           // error readFrom finished with - valid after done is closed
 	name      string          // name of this stream for debugging
 }
 
@@ -57,6 +59,7 @@ func (cr *parallel) newStream(ctx context.Context, offset, size int64) (s *strea
 		size:   size,
 		rw:     rw,
 		err:    make(chan error, 1),
+		done:   make(chan struct{}),
 	}
 	s.name = fmt.Sprintf("stream(%d,%d,%p)", s.offset, s.size, s)
 
@@ -69,13 +72,19 @@ func (cr *parallel) newStream(ctx context.Context, offset, size int64) (s *strea
 
 // read the file into the buffer
 func (s *stream) readFrom(ctx context.Context) {
+	var err error
+	defer func() {
+		s.readErr = err
+		close(s.done)
+		s.err <- err
+	}()
 	// Open the object at the correct range
 	fs.Debugf(s.cr.o, "%s: open", s.name)
 	rc, err := operations.Open(ctx, s.cr.o,
 		&fs.HashesOption{Hashes: hash.Set(hash.None)},
 		&fs.RangeOption{Start: s.offset, End: s.offset + s.size - 1})
 	if err != nil {
-		s.err <- fmt.Errorf("parallel chunked reader: failed to open stream at %d size %d: %w", s.offset, s.size, err)
+		err = fmt.Errorf("parallel chunked reader: failed to open stream at %d size %d: %w", s.offset, s.size, err)
 		return
 	}
 	s.rc = rc
@@ -83,7 +92,6 @@ func (s *stream) readFrom(ctx context.Context) {
 	fs.Debugf(s.cr.o, "%s: readfrom started", s.name)
 	_, err = s.rw.ReadFrom(s.rc)
 	fs.Debugf(s.cr.o, "%s: readfrom finished (%d bytes): %v", s.name, s.rw.Size(), err)
-	s.err <- err
 }
 
 // eof is true when we've read all the data we are expecting
@@ -100,6 +108,7 @@ func (s *stream) read(p []byte) (n int, err error) {
 	if len(p) == 0 {
 		return n, nil
 	}
+	finished := false // done seen once - one more Read drains the buffer
 	for {
 		var nn int
 		nn, err = s.rw.Read(p[n:])
@@ -115,6 +124,21 @@ func (s *stream) read(p []byte) (n int, err error) {
 		// Received a faux io.EOF because we haven't read all the data yet
 		if n >= len(p) {
 			break
+		}
+		// Once readFrom has finished no more data is coming: drain
+		// what it buffered, then return its error instead of waiting
+		// for a write that will never happen.
+		select {
+		case <-s.done:
+			if finished {
+				if s.readErr != nil && s.readErr != io.EOF {
+					return n, s.readErr
+				}
+				return n, io.ErrUnexpectedEOF
+			}
+			finished = true
+			continue
+		default:
 		}
 		// Wait for a write to happen to read more
 		s.rw.WaitWrite(s.ctx)
@@ -263,9 +287,11 @@ func (cr *parallel) Read(p []byte) (n int, err error) {
 			return n, io.EOF
 		}
 
-		// Read from the stream
+		// Read from the stream - assign to err (don't shadow it)
+		// so the error is returned below
 		stream := cr.streams[0]
-		nn, err := stream.read(p[n:])
+		var nn int
+		nn, err = stream.read(p[n:])
 		n += nn
 		cr.offset += int64(nn)
 		if err == io.EOF {

--- a/fs/chunkedreader/parallel_stream_error_test.go
+++ b/fs/chunkedreader/parallel_stream_error_test.go
@@ -1,0 +1,97 @@
+package chunkedreader
+
+import (
+	"context"
+	"errors"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/rclone/rclone/fs"
+	"github.com/rclone/rclone/fstest/mockobject"
+	"github.com/rclone/rclone/lib/multipart"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var errStreamFailed = errors.New("stream failed")
+
+// failingReader delivers `left` bytes of the wrapped reader, then fails.
+type failingReader struct {
+	rc   io.ReadCloser
+	left int
+}
+
+func (fr *failingReader) Read(p []byte) (int, error) {
+	if fr.left <= 0 {
+		return 0, errStreamFailed
+	}
+	if len(p) > fr.left {
+		p = p[:fr.left]
+	}
+	n, err := fr.rc.Read(p)
+	fr.left -= n
+	return n, err
+}
+
+func (fr *failingReader) Close() error { return fr.rc.Close() }
+
+// failingObject fails the chunk starting at failOffset permanently: the
+// first open delivers failAfter bytes then errors, and every re-open
+// inside that chunk errors, like an object deleted mid-read.
+type failingObject struct {
+	*mockobject.ContentMockObject
+	failOffset int64
+	chunkSize  int64
+	failAfter  int
+	opened     atomic.Bool
+}
+
+func (o *failingObject) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
+	for _, opt := range options {
+		r, ok := opt.(*fs.RangeOption)
+		if !ok || r.Start < o.failOffset || r.Start >= o.failOffset+o.chunkSize {
+			continue
+		}
+		if o.opened.Swap(true) {
+			return nil, errStreamFailed
+		}
+		rc, err := o.ContentMockObject.Open(ctx, options...)
+		if err != nil {
+			return nil, err
+		}
+		return &failingReader{rc: rc, left: o.failAfter}, nil
+	}
+	return o.ContentMockObject.Open(ctx, options...)
+}
+
+// A stream that fails before delivering its chunk must return the error
+// from Read rather than wait forever for more data.
+func TestParallelStreamErrorDoesNotHang(t *testing.T) {
+	ctx := context.Background()
+	const streams = 3
+	const chunkSize = multipart.BufferSize
+	content := makeContent(t, 5*chunkSize)
+	o := &failingObject{
+		ContentMockObject: mockobject.New("test.bin").WithContent(content, mockobject.SeekModeNone),
+		failOffset:        2 * chunkSize,
+		chunkSize:         chunkSize,
+		failAfter:         100,
+	}
+	cr := New(ctx, o, chunkSize, 0, streams)
+
+	done := make(chan error, 1)
+	go func() {
+		_, err := io.ReadAll(cr)
+		done <- err
+	}()
+	select {
+	case err := <-done:
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errStreamFailed)
+	case <-time.After(10 * time.Second):
+		t.Fatal("Read hung after a stream failed mid-chunk")
+	}
+	_ = cr.Close() // reports the stream error too; must not hang
+}


### PR DESCRIPTION
#### What does this change do?

Fixes the parallel chunked reader (`--vfs-read-chunk-streams > 0`) hanging forever when one of its streams fails part way through a chunk. On an S3 mount with `--vfs-cache-mode full` this showed up as a directory rename that never returned while a file in that directory was being read (details and goroutine dump in #9900).

Two changes in `fs/chunkedreader/parallel.go`:

- `stream.read` now notices when the stream's background read has finished. It drains what was buffered and then returns the error the stream finished with, instead of looping on `WaitWrite` for data that will never arrive.
- `parallel.Read` declared `nn, err :=` inside its loop, so a stream error never reached the `return n, err` after the loop and the caller got `(0, nil)` repeatedly. It now assigns to `err`.

`TestParallelStreamErrorDoesNotHang` uses an object whose stream fails mid-chunk; it hangs without the change.

Tested with `go build`, `go test -race ./fs/chunkedreader/ -count=3`, and `make quicktest` (178 packages pass; `cmd/nfsmount` and `fs/logger` fail identically on unpatched master in this environment, no NFS mount available). On the S3 mount from the issue, the rename-while-reading case now completes and the readers get an error instead of hanging; repeated a few dozen times.

#### Linked issue

Fixes #9900

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions).
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester.
- [x] This Pull Request is ready for review.
