### PR TITLE
oracleobjectstorage: fix: encode carriage returns and line feeds

### DIFF
--- a/backend/oracleobjectstorage/options.go
+++ b/backend/oracleobjectstorage/options.go
@@ -257,7 +257,8 @@ to start uploading.`,
 		// so that OSS keys are always valid file names
 		Default: encoder.EncodeInvalidUtf8 |
 			encoder.EncodeSlash |
-			encoder.EncodeDot,
+			encoder.EncodeDot |
+			encoder.EncodeCrLf,
 	}, {
 		Name: "leave_parts_on_error",
 		Help: `If true avoid calling abort upload on a failure, leaving all successfully uploaded parts for manual recovery.

--- a/fstest/test_all/config.yaml
+++ b/fstest/test_all/config.yaml
@@ -644,12 +644,6 @@ backends:
    remote: "TestOracleObjectStorage:"
    fastlist: true
    ignore:
-     - TestIntegration/FsMkdir/FsEncoding/control_chars
-     - TestIntegration/FsMkdir/FsEncoding/leading_CR
-     - TestIntegration/FsMkdir/FsEncoding/leading_LF
-     - TestIntegration/FsMkdir/FsEncoding/trailing_CR
-     - TestIntegration/FsMkdir/FsEncoding/trailing_LF
-     - TestIntegration/FsMkdir/FsEncoding/leading_HT
      - TestIntegration/FsMkdir/FsPutFiles/FsPutStream/0
    ignoretests:
      - cmd/bisync


### PR DESCRIPTION
OCI Object Storage rejects NUL, carriage return and line feed in object names. NUL is already encoded by rclone, while carriage returns and line feeds need EncodeCrLf so rclone can represent those names without issuing invalid OCI requests.

https://docs.oracle.com/en-us/iaas/Content/Object/Tasks/managingobjects.htm

#### What does this change do?

OCI rejects NUL, carriage return, and line feed in object names. The backend previously passed these characters directly to OCI, causing requests for such names to fail with `InvalidObjectName`. The updated encoding lets rclone represent them safely.

Fix the Oracle Object Storage backend’s `FsEncoding` integration-test failures.

The remaining Oracle Object Storage integration failure for zero-length streamed uploads is unrelated and will be addressed in a separate PR.

#### Linked issue

No issue - trivial backend bug fix.

#### For new or changed backends

Tested against a configured Oracle Object Storage remote:

`go test -v -run 'TestIntegration/FsMkdir/FsEncoding' ./backend/oracleobjectstorage`

`FsEncoding` passes. A full backend integration run still reports the known, unrelated zero-length `FsPutStream` failure; its fix is intentionally split into a separate PR.

#### Checklist

- [x] This change is trivial OR it has been discussed and agreed in the linked issue.
- [x] I have read the contribution guidelines (https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] (If I used AI tools to help write this code) I have read and understood the AI-assisted contributions guidance (https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in house style (https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] (Backend changes only) test_all passes for this backend and if submitting a new backend can provide a test account for the integration tester - see CONTRIBUTING.md (https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.