### PR TITLE
archive: fix crash when creating archive to stdout - fixes #9910

### DIFF
--- a/cmd/archive/archive_test.go
+++ b/cmd/archive/archive_test.go
@@ -4,6 +4,8 @@ import (
 	"archive/zip"
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -132,6 +134,47 @@ func testArchiveRemote(t *testing.T, fromLocal bool, subDir string, extension st
 		}
 	}
 	fstest.CheckListingWithPrecision(t, src, items, nil, fs.ModTimeNotSupported)
+}
+
+// test archiving to stdout when no destination is given
+func TestArchiveStdout(t *testing.T) {
+	ctx := context.Background()
+	r := fstest.NewRun(t)
+
+	f1 := r.WriteObject(ctx, "file1.txt", "content 1", t1)
+	f2 := r.WriteObject(ctx, "dir1/sub1.txt", "sub content 1", t1)
+	fstest.CheckItems(t, r.Fremote, f1, f2)
+
+	// redirect stdout into a file on the local fs
+	archiveName := "stdout.zip"
+	require.NoError(t, r.Flocal.Mkdir(ctx, ""))
+	out, err := os.Create(filepath.Join(r.LocalName, archiveName))
+	require.NoError(t, err)
+	oldStdout := os.Stdout
+	os.Stdout = out
+	err = create.ArchiveCreate(ctx, nil, "", r.Fremote, "zip", "")
+	os.Stdout = oldStdout
+	require.NoError(t, out.Close())
+	require.NoError(t, err)
+
+	// check the archive written to stdout is readable
+	expected := map[string]bool{
+		"file1.txt":     true,
+		"dir1/":         true,
+		"dir1/sub1.txt": true,
+	}
+	listFile := func(ctx context.Context, f archives.FileInfo) error {
+		name := f.NameInArchive
+		if f.IsDir() && !strings.HasSuffix(name, "/") {
+			name += "/"
+		}
+		assert.True(t, expected[name], name)
+		delete(expected, name)
+		return nil
+	}
+	err = list.ArchiveList(ctx, r.Flocal, archiveName, listFile)
+	require.NoError(t, err)
+	assert.Equal(t, 0, len(expected), expected)
 }
 
 func testArchive(t *testing.T) {

--- a/cmd/archive/create/create.go
+++ b/cmd/archive/create/create.go
@@ -118,7 +118,6 @@ will make an archive with the contents:
 			cmd.CheckArgs(1, 2, command, args)
 		}
 		cmd.Run(false, false, command, func() error {
-			fmt.Printf("dst=%v, dstFile=%q, src=%v, format=%q, prefix=%q\n", dst, dstFile, src, format, prefix)
 			if prefix != "" {
 				return ArchiveCreate(context.Background(), dst, dstFile, src, format, prefix)
 			} else if fullPath {
@@ -301,10 +300,12 @@ func ArchiveCreate(ctx context.Context, dst fs.Fs, dstFile string, src fs.Fs, fo
 	var compArchive archives.CompressedArchive
 	var totalLength int64
 
-	// check id dst is valid
-	err = CheckValidDestination(ctx, dst, dstFile)
-	if err != nil {
-		return err
+	// check if dst is valid, nil dst means write to stdout
+	if dst != nil {
+		err = CheckValidDestination(ctx, dst, dstFile)
+		if err != nil {
+			return err
+		}
 	}
 
 	ci := fs.GetConfig(ctx)


### PR DESCRIPTION
#### What does this change do?

`rclone archive create <source>` (no destination, archive to stdout) crashed with a nil pointer dereference: `ArchiveCreate` always called `CheckValidDestination(ctx, dst, dstFile)`, but `dst` is nil in the stdout case, so `dst.NewObject` panicked. This skips the destination check when there is no destination — the existing `dst == nil` branch later in the function already handles writing to stdout.

It also removes a leftover debug `fmt.Printf("dst=%v, ...")` in the command's `RunE`, which wrote a text line to stdout before the archive bytes (visible in the issue's log) and would corrupt a piped archive.

Adds `TestArchiveStdout` in `cmd/archive/archive_test.go`: archives a remote to stdout (redirected to a file) with `dst == nil`, then lists the resulting zip to check it is a valid archive with the expected entries.

Verification (Go 1.26.6, linux/amd64):

- `go test ./cmd/archive/ -run TestArchiveStdout` with the fix stashed → panics at `create.go:272` (`CheckValidDestination`), same trace as the issue.
- With the fix → `PASS`.
- `go test ./cmd/archive/...` → all green; `go vet` / `gofmt` clean.
- Built the binary and ran `rclone archive create --format tar.gz /tmp/srcdir > out.tgz` → exit 0, `tar tzf out.tgz` lists the files; `--dry-run` also works.

#### Linked issue

Fixes #9910

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
