### PR TITLE
accounting: stop averaging when the last check finishes

### DIFF
--- a/fs/accounting/stats.go
+++ b/fs/accounting/stats.go
@@ -831,6 +831,9 @@ func (s *StatsInfo) DoneChecking(remote string) {
 	s.checking.del(remote)
 	s.mu.Lock()
 	s.checks++
+	if s.transferring.empty() && s.checking.empty() {
+		s._stopAverageLoop()
+	}
 	s.mu.Unlock()
 }
 

--- a/fs/accounting/stats_test.go
+++ b/fs/accounting/stats_test.go
@@ -9,9 +9,32 @@ import (
 
 	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fs/fserrors"
+	"github.com/rclone/rclone/fstest/mockobject"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestAverageLoopStopsAfterLastCheck(t *testing.T) {
+	ctx := context.Background()
+	stats := NewStats(ctx)
+	t.Cleanup(func() {
+		stats.mu.Lock()
+		defer stats.mu.Unlock()
+		stats._stopAverageLoop()
+	})
+	transfer := stats.NewTransferRemoteSize("transfer", 0, nil, nil)
+	firstCheck := stats.NewCheckingTransfer(mockobject.New("first"), "checking")
+	lastCheck := stats.NewCheckingTransfer(mockobject.New("last"), "checking")
+
+	transfer.Done(ctx, nil)
+	firstCheck.Done(ctx, nil)
+	assert.True(t, stats.average.started, "a check is still active")
+
+	lastCheck.Done(ctx, nil)
+	assert.False(t, stats.average.started, "completed checks must release the averaging goroutine")
+	assert.Equal(t, int64(2), stats.GetChecks())
+	assert.Equal(t, int64(1), stats.GetTransfers())
+}
 
 func TestETA(t *testing.T) {
 	for _, test := range []struct {


### PR DESCRIPTION
#### What does this change do?

Stop the statistics averaging goroutine when the last check finishes after the last transfer. In a job containing both transfers and checks, `DoneTransferring` keeps the loop alive while checks remain. `DoneChecking` previously only incremented the check count, so this completion order left the loop running after all work finished.

Apply the same idle condition when a check completes, under the existing stats mutex. The regression test starts one transfer and two checks, verifies that the loop stays active while the final check remains, then verifies it stops and both counters are correct. It fails on the base revision and passes with this change.

Validation on macOS / Go 1.26.3:

- `go build`
- `go test -race ./fs/accounting`
- `PATH="$PWD:$PATH" make quicktest` (the git-annex tests invoke the built `rclone` executable)

AI-assisted: OpenAI Codex assisted with diagnosis, implementation and testing.

#### Linked issue

Related to #9567: this covers a different completion path from the already-fixed zero-transfer stats-group leak. It does not change when an averaging loop starts.

#### For new or changed backends

Not applicable.

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the contribution guidelines.
- [x] I have read and understood the AI-assisted contributions guidance, tested the change and take responsibility for it.
- [x] I have added tests for the changes.
- [x] I have added documentation if appropriate (no API or configuration change).
- [x] Commit messages are in house style.
- [ ] Backend integration tests (not applicable).
- [x] This Pull Request is ready for review.
