### PR TITLE
drive: send acknowledgeAbuse=true on every download when --drive-acknowledge-abuse

### DIFF
--- a/backend/drive/drive.go
+++ b/backend/drive/drive.go
@@ -543,6 +543,10 @@ as malware or spam and cannot be downloaded" with the error code
 indicate you acknowledge the risks of downloading the file and rclone
 will download it anyway.
 
+With this flag set rclone sends acknowledgeAbuse=true on every download.
+Google otherwise holds each download of an executable for ~30s to scan it
+for malware on every request, so this also makes those downloads fast.
+
 Note that if you are using service account it will need Manager
 permission (not Content Manager) to for this flag to work. If the SA
 does not have the right permission, Google will just ignore the flag.`,
@@ -4386,19 +4390,29 @@ func isGoogleError(err error, what string) bool {
 	return false
 }
 
+// withAcknowledgeAbuse adds the acknowledgeAbuse=true query parameter to url
+func withAcknowledgeAbuse(url string) string {
+	if strings.ContainsRune(url, '?') {
+		url += "&"
+	} else {
+		url += "?"
+	}
+	return url + "acknowledgeAbuse=true"
+}
+
 // open a url for reading
 func (o *baseObject) open(ctx context.Context, url string, options ...fs.OpenOption) (in io.ReadCloser, err error) {
+	if o.fs.opt.AcknowledgeAbuse {
+		// Send it up front: Google otherwise holds every download of an
+		// executable for ~30s to scan it for malware on each request.
+		url = withAcknowledgeAbuse(url)
+	}
 	_, res, err := o.httpResponse(ctx, url, "GET", options)
 	if err != nil {
 		if isGoogleError(err, "cannotDownloadAbusiveFile") {
 			if o.fs.opt.AcknowledgeAbuse {
 				// Retry acknowledging abuse
-				if strings.ContainsRune(url, '?') {
-					url += "&"
-				} else {
-					url += "?"
-				}
-				url += "acknowledgeAbuse=true"
+				url = withAcknowledgeAbuse(url)
 				_, res, err = o.httpResponse(ctx, url, "GET", options)
 			} else {
 				err = fmt.Errorf("use the --drive-acknowledge-abuse flag to download this file: %w", err)

--- a/docs/content/drive.md
+++ b/docs/content/drive.md
@@ -1094,6 +1094,10 @@ as malware or spam and cannot be downloaded" with the error code
 indicate you acknowledge the risks of downloading the file and rclone
 will download it anyway.
 
+With this flag set rclone sends acknowledgeAbuse=true on every download.
+Google otherwise holds each download of an executable for ~30s to scan it
+for malware on every request, so this also makes those downloads fast.
+
 Note that if you are using service account it will need Manager
 permission (not Content Manager) to for this flag to work. If the SA
 does not have the right permission, Google will just ignore the flag.


### PR DESCRIPTION
#### What does this change do?

Google holds every download of an executable for about 27 seconds before the first byte, whatever the file size, to malware-scan it on each request. Nautilus asks GIO for the content type of every file, and GIO opens any file whose extension is ambiguous to sniff its bytes. Four system mime types claim .exe, so it is always ambiguous. Three .exe files in the root of a Google Drive, each sniffed twice for type and icon, gave a 3-minute "Loading" hang in Nautilus on an rclone mount.

A user-level or system-level mime override to stop GIO from sniffing .exe does not work. GLib merges all mime caches and ignores the delete markers. Both attempts were reverted.

Adding acknowledgeAbuse=true to the download request skips the scan entirely: 0.4 seconds instead of 27. rclone only sent that parameter after a cannotDownloadAbusiveFile error, so --drive-acknowledge-abuse never helped with downloads that succeed slowly. Send it up front when the option is set.

Measured with this patch: 3 seconds versus 30 seconds for the same 4 KiB read of an .exe, and the Nautilus listing of a folder with multiple .exe dropped from 175 s to 3 s.


#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [ ] I have added tests for all changes in this PR if appropriate.
- [x] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [x] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.
