### PR TITLE
chunkedreader: fix deadlocks when reading and seeking with parallel streams

### DIFF
--- a/fs/chunkedreader/parallel.go
+++ b/fs/chunkedreader/parallel.go
@@ -91,6 +91,25 @@ func (s *stream) eof() bool {
 	return s.readBytes >= s.size
 }
 
+// checkErr returns an error if the background stream has failed or finished
+// prematurely before providing the expected bytes.
+func (s *stream) checkErr() error {
+	select {
+	case err := <-s.err:
+		if err == nil || err == io.EOF {
+			if s.rw.Size() >= s.size {
+				s.err <- err
+				return nil
+			}
+			err = io.ErrUnexpectedEOF
+		}
+		s.err <- err // restore error for stream.close()
+		return err
+	default:
+		return nil
+	}
+}
+
 // read reads up to len(p) bytes into p. It returns the number of
 // bytes read (0 <= n <= len(p)) and any error encountered. If some
 // data is available but not len(p) bytes, read returns what is
@@ -115,6 +134,14 @@ func (s *stream) read(p []byte) (n int, err error) {
 		// Received a faux io.EOF because we haven't read all the data yet
 		if n >= len(p) {
 			break
+		}
+		// If more data has arrived in the buffer, loop to read it
+		if s.rw.Size() > s.readBytes {
+			continue
+		}
+		// Check if the background stream has errored or finished prematurely
+		if streamErr := s.checkErr(); streamErr != nil {
+			return n, streamErr
 		}
 		// Wait for a write to happen to read more
 		s.rw.WaitWrite(s.ctx)
@@ -265,7 +292,8 @@ func (cr *parallel) Read(p []byte) (n int, err error) {
 
 		// Read from the stream
 		stream := cr.streams[0]
-		nn, err := stream.read(p[n:])
+		var nn int
+		nn, err = stream.read(p[n:])
 		n += nn
 		cr.offset += int64(nn)
 		if err == io.EOF {
@@ -363,6 +391,9 @@ func (cr *parallel) Seek(offset int64, whence int) (int64, error) {
 	fs.Debugf(cr.o, "parallel chunked reader: seek the current stream to %d", streamOffset)
 	// Wait for the read to the correct part of the data
 	for stream.rw.Size() < streamOffset {
+		if streamErr := stream.checkErr(); streamErr != nil {
+			return cr.offset, fmt.Errorf("parallel chunked reader: failed to seek stream: %w", streamErr)
+		}
 		stream.rw.WaitWrite(cr.ctx)
 	}
 	_, err := stream.rw.Seek(streamOffset, io.SeekStart)

--- a/fs/chunkedreader/parallel_test.go
+++ b/fs/chunkedreader/parallel_test.go
@@ -1,11 +1,14 @@
 package chunkedreader
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"io"
 	"math/rand"
 	"testing"
 
+	"github.com/rclone/rclone/fs"
 	"github.com/rclone/rclone/fstest/mockobject"
 	"github.com/rclone/rclone/lib/multipart"
 	"github.com/stretchr/testify/assert"
@@ -99,4 +102,177 @@ func TestParallelLarge(t *testing.T) {
 		require.NoError(t, cr.Close())
 	})
 
+}
+
+// errorReader reads up to failAfter bytes then returns err
+type errorReader struct {
+	r         io.Reader
+	remaining int
+	err       error
+}
+
+func (er *errorReader) Read(p []byte) (n int, err error) {
+	if er.remaining <= 0 {
+		return 0, er.err
+	}
+	if len(p) > er.remaining {
+		p = p[:er.remaining]
+	}
+	n, err = er.r.Read(p)
+	er.remaining -= n
+	if err == nil && er.remaining <= 0 {
+		err = er.err
+	}
+	return n, err
+}
+
+func (er *errorReader) Close() error {
+	return nil
+}
+
+// errorMockObject mocks an fs.Object whose Open returns an errorReader
+type errorMockObject struct {
+	mockobject.Object
+	content   []byte
+	failAfter int
+	err       error
+}
+
+func (o *errorMockObject) Size() int64 {
+	return int64(len(o.content))
+}
+
+func (o *errorMockObject) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
+	var offset int64
+	for _, opt := range options {
+		if ro, ok := opt.(*fs.RangeOption); ok {
+			offset = ro.Start
+		}
+	}
+	var r io.Reader = bytes.NewReader(nil)
+	if offset < int64(len(o.content)) {
+		r = bytes.NewReader(o.content[offset:])
+	}
+	remaining := o.failAfter - int(offset)
+	if remaining < 0 {
+		remaining = 0
+	}
+	return &errorReader{
+		r:         r,
+		remaining: remaining,
+		err:       o.err,
+	}, nil
+}
+
+func TestParallelReadError(t *testing.T) {
+	ctx := context.Background()
+	expectedErr := errors.New("simulated remote connection failure")
+	content := makeContent(t, 2*multipart.BufferSize)
+	o := &errorMockObject{
+		Object:    mockobject.New("error-test.bin"),
+		content:   content,
+		failAfter: 1024,
+		err:       expectedErr,
+	}
+
+	cr := New(ctx, o, multipart.BufferSize, 0, 2)
+	defer func() {
+		_ = cr.Close()
+	}()
+
+	buf := make([]byte, 8192)
+	var err error
+	for {
+		_, err = cr.Read(buf)
+		if err != nil {
+			break
+		}
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+type openErrorMockObject struct {
+	mockobject.Object
+	size int64
+	err  error
+}
+
+func (o *openErrorMockObject) Size() int64 {
+	return o.size
+}
+
+func (o *openErrorMockObject) Open(ctx context.Context, options ...fs.OpenOption) (io.ReadCloser, error) {
+	return nil, o.err
+}
+
+func TestParallelOpenError(t *testing.T) {
+	ctx := context.Background()
+	expectedErr := errors.New("simulated 404 not found")
+	o := &openErrorMockObject{
+		Object: mockobject.New("notfound.bin"),
+		size:   2 * multipart.BufferSize,
+		err:    expectedErr,
+	}
+
+	cr := New(ctx, o, multipart.BufferSize, 0, 2)
+	defer func() {
+		_ = cr.Close()
+	}()
+
+	buf := make([]byte, 1024)
+	_, err := cr.Read(buf)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, expectedErr)
+}
+
+func TestParallelPrematureEOF(t *testing.T) {
+	ctx := context.Background()
+	content := makeContent(t, 2*multipart.BufferSize)
+	o := &errorMockObject{
+		Object:    mockobject.New("premature-eof-test.bin"),
+		content:   content,
+		failAfter: 1024,
+		err:       io.EOF,
+	}
+
+	cr := New(ctx, o, multipart.BufferSize, 0, 2)
+	defer func() {
+		_ = cr.Close()
+	}()
+
+	buf := make([]byte, 8192)
+	var err error
+	for {
+		_, err = cr.Read(buf)
+		if err != nil {
+			break
+		}
+	}
+	require.Error(t, err)
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestParallelSeekError(t *testing.T) {
+	ctx := context.Background()
+	content := makeContent(t, 2*multipart.BufferSize)
+	o := &errorMockObject{
+		Object:    mockobject.New("seek-error-test.bin"),
+		content:   content,
+		failAfter: 1024,
+		err:       io.EOF,
+	}
+
+	cr := New(ctx, o, multipart.BufferSize, 0, 2)
+	defer func() {
+		_ = cr.Close()
+	}()
+
+	_, err := cr.Open()
+	require.NoError(t, err)
+
+	// Seek past available data into the truncated portion of the stream
+	_, err = cr.Seek(2048, io.SeekStart)
+	require.Error(t, err)
+	assert.ErrorIs(t, err, io.ErrUnexpectedEOF)
 }


### PR DESCRIPTION
<!--
Thank you for contributing to rclone!

Please discuss anything more than a trivial fix in an issue FIRST - see the
"Linked issue" section below. Then fill in the questions to help us review.
-->

#### What does this change do?

<!-- Describe the change here. -->

Fixes an indefinite hang(s) in the parallel chunked reader (`--vfs-read-chunk-streams >= 2`) when a background stream encounters an error or ends prematurely.

I use rclone with `--vfs-read-chunk-streams >= 2` on my own server, and decided to look into this issue after dealing with processes interacting with an rclone mount getting stuck in D state indefinitely. I did a goroutine dump and observed multiple goroutines stuck on `WaitWrite` which was a big clue as to what was happening. I've been using an rclone docker image with this patch for a few weeks now and haven't observed any issues (whereas I had multiple problems within a similar timeframe prior to the patch), so I'm pretty confident this PR would be a meaningful fix.

Specifically:
1. `stream.read()` and `parallel.Seek()` were waiting in `s.rw.WaitWrite()` without inspecting `s.err`. If the background downloader failed (e.g. backend 404, connection reset, or premature EOF), `readFrom` exited without writing any data, causing `WaitWrite()` to block indefinitely.
2. Premature stream termination (reaching EOF before delivering the expected chunk size) was not flagged, causing callers to loop in `WaitWrite()`.
3. In `parallel.Read()`, `err` was shadowed inside the read loop (`nn, err := stream.read(...)`), preventing any error from being returned to the caller.

This fix:
- Adds `stream.checkErr()` to check `s.err` before waiting in `WaitWrite()`, and normalizes premature EOFs to `io.ErrUnexpectedEOF`.
- Fixes variable shadowing of `err` in `parallel.Read()`.
- Adds unit tests covering read errors, open errors (e.g. 404), premature EOFs, and seek errors.

*Note: This appears to share the root cause described in #9900 (and #9901), where a failed stream causes `stream.read()` to loop on `WaitWrite()` and blocks `StopBuffering()`. In addition to fixing that read loop and the `err` variable shadowing, this PR also fixes the identical deadlock in `parallel.Seek()` and includes unit tests for read, open, EOF, and seek errors.*

#### Linked issue

<!--
Put `Fixes #1234` here if this closes an issue, or `#1234` to link without closing.

IMPORTANT: Anything beyond a trivial fix (typo, doc tweak, small obvious bug fix)
should be discussed and agreed in an issue BEFORE you open a pull request.
Pull requests for larger changes that have not been discussed in an issue first
may be closed. This saves everyone's time if the change needs a different approach
or isn't a good fit.
-->

See above note

#### For new or changed backends

<!--
Backend pull requests are often sent without the integration tests having been run.
We cannot merge a backend change until it passes the integration tests.

To be merged, a backend change REQUIRES:
  1. A clean run of `go run ./fstest/test_all -backends <remote>` (summarise the
     result below or paste a screenshot of the test_all output in the web browser).
  2. A test account so the maintainers can run the integration tests daily against
     the backend on the integration test server.

If the tests aren't quite passing yet and you need help getting them
to pass, then submit the PR and we can help getting you over the line.

See https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#writing-a-new-backend
and https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests
-->

N/A

#### Checklist

- [x] This change is trivial **OR** it has been discussed and agreed in the linked issue.
- [x] I have read the [contribution guidelines](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#submitting-a-new-feature-or-bug-fix).
- [x] **(If I used AI tools to help write this code)** I have read and understood the [AI-assisted contributions guidance](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#ai-assisted-contributions), and I have tested and take ownership of this change myself.
- [x] I have added tests for all changes in this PR if appropriate.
- [ ] I have added documentation for the changes if appropriate.
- [x] All commit messages are in [house style](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#commit-messages).
- [ ] **(Backend changes only)** `test_all` passes for this backend and if submitting a new backend can provide a test account for the integration tester - see [CONTRIBUTING.md](https://github.com/rclone/rclone/blob/master/CONTRIBUTING.md#integration-tests).
- [x] This Pull Request is ready for review.